### PR TITLE
docs: unified AGENTS.md, README agent callout; fmt sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,111 @@
-AGENTS quickstart (for agentic contributors)
+# AGENTS.md
 
-Build/run
-- Frontend dev: npm run dev (Vite)
-- App dev: npm run tauri dev | RUST_LOG=debug npm run tauri dev
-- Production build: npm run app:build (Tauri), or (frontend only) npm run build
+This file guides AI coding agents working on Audiobook Boss. For the philosophy and precedence rules of AGENTS.md, see the public spec at [agents.md](https://agents.md/). The closest AGENTS.md to an edited file wins; explicit user chat prompts override; agents may auto-run listed checks; treat this as living documentation.
 
-Test/lint (Rust in src-tauri/)
-- All: (cd src-tauri && cargo test)
-- Single test: (cd src-tauri && cargo test <name-fragment>)  # e.g., cargo test path_validation
-- Lint: (cd src-tauri && cargo clippy -- -D warnings) | Format: cargo fmt --all -- --check
+## What to do before editing
+- Validate your plan with the repository owner before implementing non-trivial changes or refactors (prefer smallest safe diffs).
+- Run quick checks (must pass before and after changes):
+  - Rust (from `src-tauri/`):
+    - `cargo test`
+    - `cargo clippy -- -D warnings`
+    - `cargo fmt --all -- --check`
+  - Frontend (from repo root):
+    - `tsc --noEmit`
+    - `npm run build` (or `npm run dev` during iteration)
+- Read these first:
+  - `AGENTS.md` (this file)
+  - `README.md` (human-facing overview + links)
+  - `src-tauri/src/commands/*` and `src-tauri/src/audio/*` (integration points)
+  - `docs/external-apis/*.md` for ffmpeg-next, lofty, tauri, and path handling
 
-Repo rules (Cursor/Copilot)
-- Follow .cursor/rules/repo-guidance.mdc (alwaysApply). Key: single engine (ffmpeg-next), validate all paths, progress via Tauri events, Lofty for metadata.
-- Apply .github/copilot-instructions.md engagement rubric (L6 mindset, terse "Topline → Next steps", minimal diffs, smallest safe change).
+## Build, run, and logs
+- Frontend dev: `npm run dev`
+- App dev: `npm run tauri dev`
+- App dev (verbose backend logs): `RUST_LOG=debug npm run tauri dev`
+- Production build (Tauri): `npm run app:build`
+- Rust tests/lints (from `src-tauri/`):
+  - `cargo test`
+  - `cargo clippy -- -D warnings`
+  - Name-filtered subset: `cargo test path_validation`
 
-Style guidelines
-- TypeScript: strict; explicit types; avoid any; PascalCase types, camelCase vars/functions, file names camelCase; small, cohesive modules; prefer pure helpers.
-- Rust: snake_case modules, CamelCase types; no unwrap/expect (deny clippy::unwrap_used); return Result<T, AppError> and use ?; keep items non-pub unless needed.
-- Imports: group std | third-party | local; no wildcard prelude re-exports; stable ordering (rustfmt/prettier defaults).
-- Formatting: rustfmt defaults; TS via Vite/tsc; keep functions ≤55 LOC; prefer guard clauses.
-- Errors/logging: map external errors into AppError (src-tauri/src/errors.rs); log context, never leak paths in user-facing errors; validate inputs via audio::path_validation.
+## Architecture and rules of the road
+- Single engine: `FfmpegNextProcessor` via ffmpeg-next bindings; no shell FFmpeg usage or engine feature flags.
+- Path security: all input paths must pass `audio::path_validation::validate_input_audio_path()` (canonicalize, whitelist extensions, traverse-safe, symlink warnings).
+- Progress system: progress is computed from ffmpeg-next timestamps; backend emits `processing-progress` Tauri events; frontend listens in `src/ui/statusPanel`.
+- Metadata: Lofty for read/write; custom `AudiobookMetadata` structure in between.
 
-Testing notes
-- Prefer external tests in src-tauri/tests; UI is manual via window.testCommands; name tests clearly to enable name-fragment filtering.
+### Critical flows
+- File import: UI drag/drop → `analyze_audio_files` → `audio::file_list::get_file_list_info`
+- Processing pipeline: `process_audiobook_files` (and v2) → `MediaProcessor::execute` → progress events
+- Metadata: Lofty read → custom model → Lofty write (with native cover art path as available)
+
+### Integration touchpoints
+- Tauri commands: `src-tauri/src/commands/` (all user actions go through `#[tauri::command]` handlers; use `ProcessingState` for cancellation).
+- Engine selection: `src-tauri/src/audio/processor/selection.rs` (single engine).
+- Progress emission: `src-tauri/src/audio/progress/reporter.rs` (emits to window).
+- Input validation occurs in `audio::path_validation` and must be respected in any new code.
+
+## Coding standards and constraints
+- TypeScript:
+  - Strict mode; explicit types; avoid `any`.
+  - File names camelCase; types/interfaces PascalCase.
+  - Class-based UI modules with DOM caching; event-driven via `listen()`; strong boundary types for Rust/TS crossing (`src/types/*`).
+- Rust:
+  - `#![deny(clippy::unwrap_used)]`; prefer `Result<T, AppError>` and `?`.
+  - Keep internals non-`pub` unless required across modules.
+  - Format with rustfmt defaults.
+- Size/complexity limits (cultural gate):
+  - File ≤ 400 LOC; function ≤ 55 LOC; ≤ 7 params; ≤ 4 nesting depth.
+  - Prefer guard clauses; DRY; high cohesion; single responsibility; clear separation of concerns and enforce orthogonality.
+  - If exceeding limits for protocol/adapter/generated code, annotate with `// EXCEPTION: [reason]`.
+- Imports: group std | third-party | local; no wildcard re-exports.
+- Errors/logging: map external errors into `AppError` (`src-tauri/src/errors.rs`); don’t leak raw paths in user-facing errors.
+
+## Security & validation
+- Only accept input files with allowed extensions (see whitelist).
+- Resolve symlinks with warnings; canonicalize to prevent traversal.
+- Probe/validate output directories for write perms before processing.
+
+## Platform and environment
+- Primary development target: macOS (Apple Silicon) only.
+- ffmpeg-next links against system libraries; no bundled ffmpeg binary discovery logic.
+
+## Testing guidance
+- Prefer external tests in `src-tauri/tests/` (public APIs). Inline tests are okay for private/`pub(crate)` items that are otherwise unreachable.
+- Useful subsets:
+  - Path security-only: `cargo test path_validation`
+- Manual UI testing via `window.testCommands` in `src/main.ts`.
+
+## Change management expectations
+- Minimize diffs; prefer smallest safe change; avoid broad refactors unless asked.
+- Do not reintroduce shell-based FFmpeg usage or engine feature flags.
+- Keep progress emission behavior intact and reflected in UI types.
+- Validate inputs with `validate_input_audio_path()` in any new code paths.
+- Keep TS/Rust boundaries type-safe and explicit; update shared types if events change.
+
+## Current state and near-term constraints
+- ffmpeg-next migration is complete. Remove any lingering shell-based artifacts when discovered.
+- Avoid adding new logic to `media_pipeline.rs`; new code should live under `audio/processor/{encoder.rs,streams.rs,frame_pipeline.rs}`.
+- Keep finite/clamp sanitization centralized in `audio/buffer.rs`.
+- Consider adding debug-only frame contract validation around encoder boundaries (nb_samples/alignment/PTS).
+- Fix the “output settings not honored” issue before touching fast-path optimizations.
+
+## Event contracts
+- Event name: `processing-progress`
+- Rust source of truth: `src-tauri/src/audio/progress/reporter.rs::ProgressEvent`
+- TS source of truth: `src/types/events.ts::ProcessingProgressEvent`
+- Backward-compat policy:
+  - Additive fields should be optional in TS and defaulted in Rust if needed.
+  - Do not rename/remove existing fields without updating all listeners and UI surfaces.
+- Verification:
+  - Run: `RUST_LOG=debug npm run tauri dev`, process a short sample, confirm stage transitions, percentage progression, and UI renders.
+  - Then: `cargo test && cargo clippy -- -D warnings`.
+
+## Pre-submit checklist
+- `cargo test`
+- `cargo clippy -- -D warnings`
+- `cargo fmt --all -- --check`
+- `tsc --noEmit`
+- `npm run build`
+
+References: [agents.md](https://agents.md/) — an open, community spec for guiding coding agents.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Internal docs:
 - `docs/external-apis/tauri-patterns.md` — event lifecycle & IPC patterns
 - `docs/external-apis/path-handling.md` — macOS-focused path validation and atomic moves
 
+## For AI agents
+
+If you are an AI coding agent, start with the project’s agent guide in `AGENTS.md`. It defines setup, checks to run automatically, architectural boundaries (single ffmpeg-next engine, path validation, progress events), and coding standards tailored for agents. See the AGENTS.md spec at [agents.md](https://agents.md/) for precedence rules.
+
 ## Architecture & Key Patterns
 - Single Processing Engine: `FfmpegNextProcessor` implements `MediaProcessor`
 - Media Abstraction: `MediaProcessingPlan` → `execute()`

--- a/src-tauri/src/audio/buffer.rs
+++ b/src-tauri/src/audio/buffer.rs
@@ -31,7 +31,9 @@ impl SampleAccumulator {
             sample_rate,
             channel_layout,
             format,
-            buffers: (0..channels).map(|_| Vec::with_capacity(frame_size * 2)).collect(),
+            buffers: (0..channels)
+                .map(|_| Vec::with_capacity(frame_size * 2))
+                .collect(),
         }
     }
 
@@ -39,11 +41,15 @@ impl SampleAccumulator {
     pub fn push_frame(&mut self, frame: &ff::frame::Audio) -> Vec<ff::frame::Audio> {
         let mut ready = Vec::new();
         let in_samples = frame.samples();
-        if in_samples == 0 { return ready; }
+        if in_samples == 0 {
+            return ready;
+        }
         unsafe {
             for ch in 0..self.channels {
                 let plane = frame.data(ch);
-                if plane.is_empty() { continue; }
+                if plane.is_empty() {
+                    continue;
+                }
                 let available_floats = plane.len() / 4; // bytes -> f32 count
                 let copy_len = available_floats.min(in_samples);
                 if copy_len < in_samples {
@@ -52,22 +58,23 @@ impl SampleAccumulator {
                         ch, copy_len, in_samples
                     );
                 }
-                let slice = std::slice::from_raw_parts(
-                    plane.as_ptr() as *const f32,
-                    copy_len,
-                );
+                let slice = std::slice::from_raw_parts(plane.as_ptr() as *const f32, copy_len);
                 self.buffers[ch].extend_from_slice(slice);
             }
         }
-    while self.frame_size > 0 && self.buffers[0].len() >= self.frame_size {
-            if let Some(f) = self.drain_one(false) { ready.push(f); }
+        while self.frame_size > 0 && self.buffers[0].len() >= self.frame_size {
+            if let Some(f) = self.drain_one(false) {
+                ready.push(f);
+            }
         }
         ready
     }
 
     /// Flush tail (pad to full frame if pad=true) returning optional final frame.
     pub fn flush_tail(&mut self, pad: bool) -> Option<ff::frame::Audio> {
-        if self.buffers[0].is_empty() { return None; }
+        if self.buffers[0].is_empty() {
+            return None;
+        }
         if pad && self.buffers[0].len() < self.frame_size {
             let missing = self.frame_size - self.buffers[0].len();
             for ch in 0..self.channels {
@@ -79,22 +86,29 @@ impl SampleAccumulator {
 
     fn drain_one(&mut self, allow_short: bool) -> Option<ff::frame::Audio> {
         let available = self.buffers[0].len();
-        if available == 0 { return None; }
-        if !allow_short && available < self.frame_size { return None; }
+        if available == 0 {
+            return None;
+        }
+        if !allow_short && available < self.frame_size {
+            return None;
+        }
         let take = available.min(self.frame_size);
         let mut frame = ff::frame::Audio::empty();
         frame.set_format(self.format);
         frame.set_channel_layout(self.channel_layout);
         frame.set_rate(self.sample_rate);
         frame.set_samples(take);
-        unsafe { frame.alloc(self.format, take, self.channel_layout); }
+        unsafe {
+            frame.alloc(self.format, take, self.channel_layout);
+        }
         let mut total_repairs = 0usize;
         for ch in 0..self.channels {
             let plane = frame.data_mut(ch);
-            if plane.is_empty() { continue; }
-            let dst: &mut [f32] = unsafe {
-                std::slice::from_raw_parts_mut(plane.as_mut_ptr() as *mut f32, take)
-            };
+            if plane.is_empty() {
+                continue;
+            }
+            let dst: &mut [f32] =
+                unsafe { std::slice::from_raw_parts_mut(plane.as_mut_ptr() as *mut f32, take) };
             let src = &self.buffers[ch][..take];
             let mut repaired = 0usize;
             for i in 0..take {
@@ -115,7 +129,11 @@ impl SampleAccumulator {
             self.buffers[ch].drain(..take);
         }
         if total_repairs > 0 {
-            log::warn!("Accumulator sanitized {} samples before encoding (frame_size={})", total_repairs, take);
+            log::warn!(
+                "Accumulator sanitized {} samples before encoding (frame_size={})",
+                total_repairs,
+                take
+            );
         }
         Some(frame)
     }
@@ -138,7 +156,9 @@ mod tests {
         f.set_channel_layout(ff::channel_layout::ChannelLayout::MONO);
         f.set_rate(44100);
         f.set_samples(2048);
-        unsafe { f.alloc(f.format(), 2048, f.channel_layout()); }
+        unsafe {
+            f.alloc(f.format(), 2048, f.channel_layout());
+        }
         let produced = acc.push_frame(&f);
         assert_eq!(produced.len(), 2);
         assert!(acc.flush_tail(true).is_none());

--- a/src-tauri/src/audio/cleanup/guard.rs
+++ b/src-tauri/src/audio/cleanup/guard.rs
@@ -69,7 +69,10 @@ impl CleanupGuard {
 
     /// Disables cleanup for debugging purposes
     pub fn disable_cleanup(&mut self) {
-        debug!("Session {}: Cleanup disabled for debugging", self.session_id);
+        debug!(
+            "Session {}: Cleanup disabled for debugging",
+            self.session_id
+        );
         self.enabled = false;
     }
 
@@ -136,13 +139,10 @@ impl Drop for CleanupGuard {
         if let Err(e) = self.perform_cleanup(&paths) {
             error!(
                 "Session {}: Cleanup failed during drop: {}",
-                self.session_id,
-                e
+                self.session_id, e
             );
         }
     }
 }
 
 // ProcessGuard removed.
-
-

--- a/src-tauri/src/audio/cleanup/mod.rs
+++ b/src-tauri/src/audio/cleanup/mod.rs
@@ -2,5 +2,3 @@ pub mod guard;
 pub mod ops;
 
 pub use guard::CleanupGuard; // ProcessGuard removed during nuclear cleanup
-
-

--- a/src-tauri/src/audio/cleanup/ops.rs
+++ b/src-tauri/src/audio/cleanup/ops.rs
@@ -66,5 +66,3 @@ impl CleanupGuard {
         Ok(())
     }
 }
-
-

--- a/src-tauri/src/audio/constants.rs
+++ b/src-tauri/src/audio/constants.rs
@@ -1,5 +1,5 @@
 //! Constants for audio processing operations
-//! 
+//!
 //! This module contains all magic numbers and constants used throughout
 //! the audio processing pipeline, grouped by functional area.
 
@@ -46,8 +46,6 @@ pub const ANALYSIS_PROGRESS_MULTIPLIER: f64 = 1.4;
 // Time formatting constants
 /// Seconds per minute for time calculations
 pub const SECONDS_PER_MINUTE: f64 = 60.0;
-
-
 
 // Default values
 /// Default bitrate in kbps

--- a/src-tauri/src/audio/context.rs
+++ b/src-tauri/src/audio/context.rs
@@ -1,17 +1,17 @@
 //! Context structures for reducing parameter passing in audio processing
-//! 
+//!
 //! This module provides ProcessingContext and ProgressContext structures
 //! that group related parameters together, reducing function parameter counts
 //! and improving code organization.
 
-use super::AudioSettings;
-use super::settings_encoder::EncoderSettings;
-use crate::audio::ProcessingStage;
 use super::session::ProcessingSession;
+use super::settings_encoder::EncoderSettings;
+use super::AudioSettings;
+use crate::audio::ProcessingStage;
 use crate::errors::Result;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tauri::Window;
-use serde::{Deserialize, Serialize};
 
 /// Preview configuration for early-stop preview encodes
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,7 +21,7 @@ pub struct PreviewConfig {
 }
 
 /// Groups core processing dependencies together
-/// 
+///
 /// This context contains the essential components needed for audio processing,
 /// reducing the need to pass multiple parameters through function calls.
 #[derive(Clone, Debug)]
@@ -49,31 +49,35 @@ impl ProcessingContext {
             preview: None,
         }
     }
-    
+
     /// Emits an event to the frontend
-    pub fn emit_event<S: serde::Serialize + Clone>(&self, event_name: &str, payload: S) -> Result<()> {
+    pub fn emit_event<S: serde::Serialize + Clone>(
+        &self,
+        event_name: &str,
+        payload: S,
+    ) -> Result<()> {
         use tauri::Emitter;
-        self.window
-            .emit(event_name, payload)
-            .map_err(|e| crate::errors::AppError::General(format!(
+        self.window.emit(event_name, payload).map_err(|e| {
+            crate::errors::AppError::General(format!(
                 "Failed to emit event '{}' for session {}: {}",
                 event_name,
                 self.session.id(),
                 e
-            )))?;
+            ))
+        })?;
         Ok(())
     }
-    
+
     /// Checks if the current processing has been cancelled
     pub fn is_cancelled(&self) -> bool {
         self.session.is_cancelled()
     }
-    
+
     /// Checks if processing is currently active
     pub fn is_processing(&self) -> bool {
         self.session.is_processing()
     }
-    
+
     /// Creates an error with session context
     pub fn create_error(&self, operation: &str, reason: &str) -> crate::errors::AppError {
         crate::errors::AppError::General(format!(
@@ -81,16 +85,21 @@ impl ProcessingContext {
             self.session.id()
         ))
     }
-    
+
     /// Creates a file validation error with session and file context
-    pub fn create_file_error(&self, operation: &str, file_path: &str, reason: &str) -> crate::errors::AppError {
+    pub fn create_file_error(
+        &self,
+        operation: &str,
+        file_path: &str,
+        reason: &str,
+    ) -> crate::errors::AppError {
         crate::errors::AppError::FileValidation(format!(
             "Failed to {operation} file '{}' in session {}: {reason}",
             file_path,
             self.session.id()
         ))
     }
-    
+
     /// Creates an input validation error with session context
     pub fn create_input_error(&self, field: &str, reason: &str) -> crate::errors::AppError {
         crate::errors::AppError::InvalidInput(format!(
@@ -116,34 +125,36 @@ impl ProcessingContextBuilder {
             settings: None,
         }
     }
-    
+
     /// Sets the Tauri window
     pub fn window(mut self, window: Window) -> Self {
         self.window = Some(window);
         self
     }
-    
+
     /// Sets the processing session
     pub fn session(mut self, session: Arc<ProcessingSession>) -> Self {
         self.session = Some(session);
         self
     }
-    
+
     /// Sets the audio settings
     pub fn settings(mut self, settings: AudioSettings) -> Self {
         self.settings = Some(settings);
         self
     }
-    
+
     /// Builds the ProcessingContext
-    /// 
+    ///
     /// # Errors
     /// Returns an error if any required field is missing
     pub fn build(self) -> Result<ProcessingContext> {
-        let window = self.window
-            .ok_or_else(|| crate::errors::AppError::InvalidInput(
-                "Failed to build ProcessingContext: Tauri window is required for event emission".to_string()
-            ))?;
+        let window = self.window.ok_or_else(|| {
+            crate::errors::AppError::InvalidInput(
+                "Failed to build ProcessingContext: Tauri window is required for event emission"
+                    .to_string(),
+            )
+        })?;
         let session = self.session
             .ok_or_else(|| crate::errors::AppError::InvalidInput(
                 "Failed to build ProcessingContext: Processing session is required for state management".to_string()
@@ -152,7 +163,7 @@ impl ProcessingContextBuilder {
             .ok_or_else(|| crate::errors::AppError::InvalidInput(
                 "Failed to build ProcessingContext: Audio settings are required for processing configuration".to_string()
             ))?;
-            
+
         Ok(ProcessingContext::new(window, session, settings))
     }
 }
@@ -164,7 +175,7 @@ impl Default for ProcessingContextBuilder {
 }
 
 /// Groups progress-related parameters together
-/// 
+///
 /// This context contains all the information needed for progress reporting
 /// and tracking during audio processing operations.
 #[derive(Clone)]
@@ -198,38 +209,38 @@ impl ProgressContext {
             eta_seconds: None,
         }
     }
-    
+
     /// Updates the progress percentage
     pub fn with_progress(mut self, progress: f32) -> Self {
         self.progress = progress.clamp(0.0, 100.0);
         self
     }
-    
+
     /// Sets the message
     pub fn with_message<S: Into<String>>(mut self, message: S) -> Self {
         self.message = Some(message.into());
         self
     }
-    
+
     /// Sets the current file being processed
     pub fn with_current_file<S: Into<String>>(mut self, file: S) -> Self {
         self.current_file = Some(file.into());
         self
     }
-    
+
     /// Sets the file completion status
     pub fn with_file_progress(mut self, completed: usize, total: usize) -> Self {
         self.files_completed = completed;
         self.total_files = total;
         self
     }
-    
+
     /// Sets the estimated time remaining
     pub fn with_eta(mut self, seconds: f64) -> Self {
         self.eta_seconds = Some(seconds);
         self
     }
-    
+
     /// Calculates progress based on files completed
     pub fn calculate_file_progress(&self) -> f32 {
         if self.total_files == 0 {
@@ -237,32 +248,35 @@ impl ProgressContext {
         }
         (self.files_completed as f32 / self.total_files as f32) * 100.0
     }
-    
+
     /// Creates a formatted progress message with file context
     pub fn format_progress_message(&self) -> String {
         let mut message = format!("Stage: {:?}, Progress: {:.1}%", self.stage, self.progress);
-        
+
         if let Some(ref current_file) = self.current_file {
             message.push_str(&format!(" | Current file: {current_file}"));
         }
-        
+
         if self.total_files > 0 {
-            message.push_str(&format!(" | Files: {}/{}", self.files_completed, self.total_files));
+            message.push_str(&format!(
+                " | Files: {}/{}",
+                self.files_completed, self.total_files
+            ));
         }
-        
+
         if let Some(eta) = self.eta_seconds {
             let minutes = (eta / 60.0) as i32;
             let seconds = (eta % 60.0) as i32;
             message.push_str(&format!(" | ETA: {minutes}m {seconds}s"));
         }
-        
+
         if let Some(ref msg) = self.message {
             message.push_str(&format!(" | {msg}"));
         }
-        
+
         message
     }
-    
+
     /// Creates an error with progress context
     pub fn create_error(&self, operation: &str, reason: &str) -> crate::errors::AppError {
         let progress_info = self.format_progress_message();
@@ -296,38 +310,38 @@ impl ProgressContextBuilder {
             eta_seconds: None,
         }
     }
-    
+
     /// Sets the progress percentage
     pub fn progress(mut self, progress: f32) -> Self {
         self.progress = progress.clamp(0.0, 100.0);
         self
     }
-    
+
     /// Sets the message
     pub fn message<S: Into<String>>(mut self, message: S) -> Self {
         self.message = Some(message.into());
         self
     }
-    
+
     /// Sets the current file
     pub fn current_file<S: Into<String>>(mut self, file: S) -> Self {
         self.current_file = Some(file.into());
         self
     }
-    
+
     /// Sets the file progress
     pub fn file_progress(mut self, completed: usize, total: usize) -> Self {
         self.files_completed = completed;
         self.total_files = total;
         self
     }
-    
+
     /// Sets the ETA
     pub fn eta(mut self, seconds: f64) -> Self {
         self.eta_seconds = Some(seconds);
         self
     }
-    
+
     /// Builds the ProgressContext
     pub fn build(self) -> ProgressContext {
         ProgressContext {
@@ -341,4 +355,3 @@ impl ProgressContextBuilder {
         }
     }
 }
-

--- a/src-tauri/src/audio/file_list.rs
+++ b/src-tauri/src/audio/file_list.rs
@@ -2,10 +2,10 @@
 
 use super::AudioFile;
 use crate::errors::{AppError, Result};
-use lofty::probe::Probe;
 use lofty::file::AudioFile as LoftyAudioFile;
-use std::path::Path;
+use lofty::probe::Probe;
 use std::fs;
+use std::path::Path;
 
 /// Summary information for a file list
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -24,29 +24,27 @@ pub struct FileListInfo {
 }
 
 /// Validates a list of file paths and returns audio file information
-pub fn validate_audio_files<P: AsRef<Path>>(
-    file_paths: &[P]
-) -> Result<Vec<AudioFile>> {
+pub fn validate_audio_files<P: AsRef<Path>>(file_paths: &[P]) -> Result<Vec<AudioFile>> {
     if file_paths.is_empty() {
         return Err(AppError::InvalidInput(
-            "No files provided for validation".to_string()
+            "No files provided for validation".to_string(),
         ));
     }
 
     let mut audio_files = Vec::new();
-    
+
     for path in file_paths {
         let audio_file = validate_single_file(path.as_ref())?;
         audio_files.push(audio_file);
     }
-    
+
     Ok(audio_files)
 }
 
 /// Validates a single audio file
 fn validate_single_file(path: &Path) -> Result<AudioFile> {
     let mut audio_file = AudioFile::new(path.to_path_buf());
-    
+
     // Use shared validation first
     let canonical_path = match crate::audio::path_validation::validate_input_audio_path(path) {
         Ok(canonical) => {
@@ -59,7 +57,7 @@ fn validate_single_file(path: &Path) -> Result<AudioFile> {
             return Ok(audio_file);
         }
     };
-    
+
     // Get file size (canonical path should exist)
     match fs::metadata(&canonical_path) {
         Ok(metadata) => audio_file.size = Some(metadata.len() as f64),
@@ -68,7 +66,7 @@ fn validate_single_file(path: &Path) -> Result<AudioFile> {
             return Ok(audio_file);
         }
     }
-    
+
     // Validate audio format and get comprehensive metadata using canonical path
     match validate_audio_format(&canonical_path) {
         Ok((format, duration, bitrate, sample_rate, channels)) => {
@@ -83,7 +81,7 @@ fn validate_single_file(path: &Path) -> Result<AudioFile> {
             audio_file.error = Some(e.to_string());
         }
     }
-    
+
     Ok(audio_file)
 }
 
@@ -96,16 +94,20 @@ fn validate_audio_format(path: &Path) -> Result<AudioProperties> {
         Some("mp3") => "MP3",
         Some("m4a") | Some("m4b") => "M4A/M4B",
         Some("aac") => "AAC",
-        Some("wav") => "WAV", 
+        Some("wav") => "WAV",
         Some("flac") => "FLAC",
-        Some(ext) => return Err(AppError::InvalidInput(
-            format!("Unsupported audio format: {ext}")
-        )),
-        None => return Err(AppError::InvalidInput(
-            "Cannot determine file format - file has no extension".to_string()
-        )),
+        Some(ext) => {
+            return Err(AppError::InvalidInput(format!(
+                "Unsupported audio format: {ext}"
+            )))
+        }
+        None => {
+            return Err(AppError::InvalidInput(
+                "Cannot determine file format - file has no extension".to_string(),
+            ))
+        }
     };
-    
+
     // Try to read the file with Lofty
     let tagged_file = match Probe::open(path) {
         Ok(probe) => match probe.read() {
@@ -114,36 +116,34 @@ fn validate_audio_format(path: &Path) -> Result<AudioProperties> {
         },
         Err(e) => return Err(AppError::Metadata(e)),
     };
-    
+
     let properties = tagged_file.properties();
     let duration = properties.duration().as_secs_f64();
-    
+
     // Validate that we got a reasonable duration
     if duration <= 0.0 {
         return Err(AppError::InvalidInput(
-            "Audio file has invalid duration (0 seconds)".to_string()
+            "Audio file has invalid duration (0 seconds)".to_string(),
         ));
     }
-    
+
     // Extract technical metadata
     let bitrate = properties.audio_bitrate();
     let sample_rate = properties.sample_rate();
     let channels = properties.channels().map(|ch| ch as u32);
-    
+
     Ok((format.to_string(), duration, bitrate, sample_rate, channels))
 }
 
 /// Gets comprehensive information about a file list
-pub fn get_file_list_info<P: AsRef<Path>>(
-    file_paths: &[P]
-) -> Result<FileListInfo> {
+pub fn get_file_list_info<P: AsRef<Path>>(file_paths: &[P]) -> Result<FileListInfo> {
     let files = validate_audio_files(file_paths)?;
-    
+
     let mut total_duration = 0.0;
     let mut total_size = 0.0;
     let mut valid_count = 0;
     let mut invalid_count = 0;
-    
+
     for file in &files {
         if file.is_valid {
             total_duration += file.duration.unwrap_or(0.0);
@@ -153,7 +153,7 @@ pub fn get_file_list_info<P: AsRef<Path>>(
             invalid_count += 1;
         }
     }
-    
+
     Ok(FileListInfo {
         files,
         total_duration,
@@ -166,8 +166,8 @@ pub fn get_file_list_info<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn test_validate_empty_file_list() {
@@ -180,10 +180,14 @@ mod tests {
     #[test]
     fn test_validate_nonexistent_file() {
         let files = vec!["nonexistent.mp3"];
-        let result = validate_audio_files(&files).expect("validation should succeed, marking file invalid");
+        let result =
+            validate_audio_files(&files).expect("validation should succeed, marking file invalid");
         assert_eq!(result.len(), 1);
         assert!(!result[0].is_valid);
-        let msg = result[0].error.as_ref().expect("error message for invalid file");
+        let msg = result[0]
+            .error
+            .as_ref()
+            .expect("error message for invalid file");
         // Updated to reflect shared validation error messages
         assert!(msg.contains("Cannot read file metadata") || msg.contains("File not found"));
     }
@@ -193,9 +197,10 @@ mod tests {
         let temp_dir = TempDir::new().expect("create temp dir");
         let file_path = temp_dir.path().join("invalid.mp3");
         fs::write(&file_path, b"not audio data").expect("write temp file");
-        
+
         let files = vec![file_path];
-        let result = validate_audio_files(&files).expect("validation should succeed, marking file invalid");
+        let result =
+            validate_audio_files(&files).expect("validation should succeed, marking file invalid");
         assert_eq!(result.len(), 1);
         assert!(!result[0].is_valid);
         assert!(result[0].error.is_some());
@@ -223,11 +228,11 @@ mod tests {
         for filename in test_cases {
             println!("Testing filename: {filename}");
             let path = std::path::Path::new(filename);
-            
+
             // Test extension detection
             let extension = path.extension().and_then(|s| s.to_str());
             println!("  Extension detected: {extension:?}");
-            
+
             // Test format mapping
             if let Some(ext) = extension {
                 let format_result = match ext {
@@ -240,7 +245,7 @@ mod tests {
                 };
                 println!("  Format mapping: {format_result:?}");
             }
-            
+
             println!("  Path display: {}", path.display());
             println!("  Path debug: {path:?}");
             println!();
@@ -250,57 +255,60 @@ mod tests {
     #[test]
     fn test_debug_real_mp3_file() {
         use lofty::file::TaggedFileExt;
-        
+
         // Test the actual file that's failing
         let test_mp3 = "/Users/jstar/Projects/audiobook-boss/media/01 - Introduction.mp3";
-        
+
         if !std::path::Path::new(test_mp3).exists() {
             println!("Test MP3 file not found, skipping test");
             return;
         }
-        
+
         println!("Testing real MP3 file: {test_mp3}");
-        
+
         // Test the validate_single_file function directly
         let result = validate_single_file(std::path::Path::new(test_mp3));
         println!("validate_single_file result: {result:?}");
-        
+
         // Test JSON serialization to see field names
         if let Ok(audio_file) = result {
-            let json = serde_json::to_string_pretty(&audio_file).expect("serialize audio file to json");
+            let json =
+                serde_json::to_string_pretty(&audio_file).expect("serialize audio file to json");
             println!("AudioFile JSON serialization:\n{json}");
         }
-        
+
         // Also test get_file_list_info to see full serialization
         let file_list_result = get_file_list_info(&[test_mp3]);
         if let Ok(file_list) = file_list_result {
-            let json = serde_json::to_string_pretty(&file_list).expect("serialize file list to json");
+            let json =
+                serde_json::to_string_pretty(&file_list).expect("serialize file list to json");
             println!("FileListInfo JSON serialization:\n{json}");
         }
-        
+
         // Also test the lofty probe directly
         match Probe::open(test_mp3) {
-            Ok(probe) => {
-                match probe.read() {
-                    Ok(tagged_file) => {
-                        let properties = tagged_file.properties();
-                        println!("  Lofty probe SUCCESS:");
-                        println!("    Duration: {:?} seconds", properties.duration().as_secs_f64());
-                        println!("    File type: {:?}", tagged_file.file_type());
-                        println!("    Properties: {properties:?}");
-                    }
-                    Err(e) => {
-                        println!("  Lofty read error: {e}");
-                        println!("  Error debug: {e:?}");
-                    }
+            Ok(probe) => match probe.read() {
+                Ok(tagged_file) => {
+                    let properties = tagged_file.properties();
+                    println!("  Lofty probe SUCCESS:");
+                    println!(
+                        "    Duration: {:?} seconds",
+                        properties.duration().as_secs_f64()
+                    );
+                    println!("    File type: {:?}", tagged_file.file_type());
+                    println!("    Properties: {properties:?}");
                 }
-            }
+                Err(e) => {
+                    println!("  Lofty read error: {e}");
+                    println!("  Error debug: {e:?}");
+                }
+            },
             Err(e) => {
                 println!("  Lofty probe error: {e}");
                 println!("  Error debug: {e:?}");
             }
         }
-        
+
         // Test our format validation specifically
         match validate_audio_format(std::path::Path::new(test_mp3)) {
             Ok((format, duration, bitrate, sample_rate, channels)) => {
@@ -316,81 +324,76 @@ mod tests {
     #[test]
     fn test_debug_lofty_m4b_errors() {
         use lofty::probe::Probe;
-        
+
         // Create temp files with different invalid content to see what Lofty errors we get
         let temp_dir = TempDir::new().expect("create temp dir");
-        
+
         // Test 1: Empty file
         let empty_m4b = temp_dir.path().join("empty.m4b");
         fs::write(&empty_m4b, b"").expect("write empty file");
-        
+
         println!("Testing empty M4B file:");
         match Probe::open(&empty_m4b) {
-            Ok(probe) => {
-                match probe.read() {
-                    Ok(tagged_file) => {
-                        println!("  Unexpectedly succeeded reading empty file");
-                        let properties = tagged_file.properties();
-                        println!("  Duration: {:?}", properties.duration());
-                    }
-                    Err(e) => {
-                        println!("  Lofty read error: {e}");
-                        println!("  Error kind: {e:?}");
-                    }
+            Ok(probe) => match probe.read() {
+                Ok(tagged_file) => {
+                    println!("  Unexpectedly succeeded reading empty file");
+                    let properties = tagged_file.properties();
+                    println!("  Duration: {:?}", properties.duration());
                 }
-            }
+                Err(e) => {
+                    println!("  Lofty read error: {e}");
+                    println!("  Error kind: {e:?}");
+                }
+            },
             Err(e) => {
                 println!("  Lofty probe error: {e}");
                 println!("  Error kind: {e:?}");
             }
         }
-        
+
         // Test 2: Invalid M4B content
         let invalid_m4b = temp_dir.path().join("invalid.m4b");
-        fs::write(&invalid_m4b, b"This is not a valid M4B file content").expect("write invalid file");
-        
+        fs::write(&invalid_m4b, b"This is not a valid M4B file content")
+            .expect("write invalid file");
+
         println!("\nTesting invalid M4B file:");
         match Probe::open(&invalid_m4b) {
-            Ok(probe) => {
-                match probe.read() {
-                    Ok(tagged_file) => {
-                        println!("  Unexpectedly succeeded reading invalid file");
-                        let properties = tagged_file.properties();
-                        println!("  Duration: {:?}", properties.duration());
-                    }
-                    Err(e) => {
-                        println!("  Lofty read error: {e}");
-                        println!("  Error kind: {e:?}");
-                    }
+            Ok(probe) => match probe.read() {
+                Ok(tagged_file) => {
+                    println!("  Unexpectedly succeeded reading invalid file");
+                    let properties = tagged_file.properties();
+                    println!("  Duration: {:?}", properties.duration());
                 }
-            }
+                Err(e) => {
+                    println!("  Lofty read error: {e}");
+                    println!("  Error kind: {e:?}");
+                }
+            },
             Err(e) => {
                 println!("  Lofty probe error: {e}");
                 println!("  Error kind: {e:?}");
             }
         }
-        
+
         // Test 3: Truncated MP4 header (M4B is MP4-based)
         let truncated_m4b = temp_dir.path().join("truncated.m4b");
         // MP4 files start with an ftyp box
         let mp4_header = b"\x00\x00\x00\x20ftypM4B ";
         fs::write(&truncated_m4b, mp4_header).expect("write truncated header");
-        
+
         println!("\nTesting truncated M4B file:");
         match Probe::open(&truncated_m4b) {
-            Ok(probe) => {
-                match probe.read() {
-                    Ok(tagged_file) => {
-                        println!("  Unexpectedly succeeded reading truncated file");
-                        let properties = tagged_file.properties();
-                        println!("  Duration: {:?}", properties.duration());
-                    }
-                    Err(e) => {
-                        println!("  Lofty read error: {e}");
-                        println!("  Error kind: {e:?}");
-                    }
+            Ok(probe) => match probe.read() {
+                Ok(tagged_file) => {
+                    println!("  Unexpectedly succeeded reading truncated file");
+                    let properties = tagged_file.properties();
+                    println!("  Duration: {:?}", properties.duration());
                 }
-            }
+                Err(e) => {
+                    println!("  Lofty read error: {e}");
+                    println!("  Error kind: {e:?}");
+                }
+            },
             Err(e) => {
                 println!("  Lofty probe error: {e}");
                 println!("  Error kind: {e:?}");

--- a/src-tauri/src/audio/media_pipeline.rs
+++ b/src-tauri/src/audio/media_pipeline.rs
@@ -60,7 +60,7 @@ impl MediaProcessingPlan {
 
     /// Executes the processing plan with context-based progress tracking
     pub async fn execute_with_context(
-        &self, 
+        &self,
         context: &ProcessingContext,
         metadata: Option<&crate::metadata::AudiobookMetadata>,
     ) -> Result<()> {
@@ -112,23 +112,39 @@ impl FfmpegNextProcessor {
     ) -> Result<()> {
         use crate::errors::AppError;
 
-        log::info!("🎵 Starting to process input file: {}", input_path.display());
+        log::info!(
+            "🎵 Starting to process input file: {}",
+            input_path.display()
+        );
 
         if ctx.context.is_cancelled() {
-            log::warn!("Processing was cancelled before processing file: {}", input_path.display());
+            log::warn!(
+                "Processing was cancelled before processing file: {}",
+                input_path.display()
+            );
             ctx.emitter.emit_cancelled("Processing was cancelled");
             return Err(AppError::InvalidInput("Processing was cancelled".into()));
         }
 
-        log::info!("Setting up decoder and resampler for: {}", input_path.display());
+        log::info!(
+            "Setting up decoder and resampler for: {}",
+            input_path.display()
+        );
         let (mut ictx, mut decoder, mut resampler, stream_index) =
             crate::audio::processor::streams::setup_decoder_and_resampler(input_path, encoder)?;
-        log::info!("✓ Decoder and resampler setup complete for stream index: {}", stream_index);
+        log::info!(
+            "✓ Decoder and resampler setup complete for stream index: {}",
+            stream_index
+        );
 
         // Update context indices for this file (P1.4) then process packets
         ctx.current_file_index = file_index;
         ctx.current_stream_index = stream_index;
-        log::info!("Updated context: file_index={}, stream_index={}", file_index, stream_index);
+        log::info!(
+            "Updated context: file_index={}, stream_index={}",
+            file_index,
+            stream_index
+        );
 
         log::info!("Processing input packets from: {}", input_path.display());
         crate::audio::processor::frame_pipeline::process_input_packets(
@@ -144,7 +160,7 @@ impl FfmpegNextProcessor {
 
         // Flush decoder for this input
         log::info!("Flushing decoder frames for: {}", input_path.display());
-        
+
         // Skip the old flush for now - the simple truncation approach should work
         log::info!("✓ Decoder frames flushed successfully (skipped for simplicity)");
         log::info!("✓ Decoder frames flushed successfully");
@@ -219,7 +235,10 @@ impl MediaProcessor for FfmpegNextProcessor {
             };
 
             // Process each input file
-            log::info!("Starting audio processing for {} input files", plan.input_file_paths.len());
+            log::info!(
+                "Starting audio processing for {} input files",
+                plan.input_file_paths.len()
+            );
             let mut accumulator = crate::audio::buffer::SampleAccumulator::new(
                 enc_ctx.channel_layout().channels() as usize,
                 enc_ctx.frame_size() as usize,
@@ -228,9 +247,25 @@ impl MediaProcessor for FfmpegNextProcessor {
                 enc_ctx.format(),
             );
             for (idx, in_path) in plan.input_file_paths.iter().enumerate() {
-                log::info!("Processing input file {}/{}: {}", idx + 1, plan.input_file_paths.len(), in_path.display());
-                Self::process_input_file(in_path, &mut enc_ctx, &mut octx, idx, &mut ctx, &mut accumulator)?;
-                log::info!("✓ Completed processing input file {}/{}", idx + 1, plan.input_file_paths.len());
+                log::info!(
+                    "Processing input file {}/{}: {}",
+                    idx + 1,
+                    plan.input_file_paths.len(),
+                    in_path.display()
+                );
+                Self::process_input_file(
+                    in_path,
+                    &mut enc_ctx,
+                    &mut octx,
+                    idx,
+                    &mut ctx,
+                    &mut accumulator,
+                )?;
+                log::info!(
+                    "✓ Completed processing input file {}/{}",
+                    idx + 1,
+                    plan.input_file_paths.len()
+                );
                 if *ctx.early_stop {
                     log::info!("Preview early-stop engaged after file {}; stopping further input processing", idx + 1);
                     break;
@@ -240,7 +275,12 @@ impl MediaProcessor for FfmpegNextProcessor {
 
             // Finalize encoding (same path for full encode or preview early-stop)
             log::info!("🏁 Starting encoding finalization...");
-            crate::audio::processor::encoder::finalize_encoding_after_preview(&mut enc_ctx, &mut octx, ost_index, ost_time_base)?;
+            crate::audio::processor::encoder::finalize_encoding_after_preview(
+                &mut enc_ctx,
+                &mut octx,
+                ost_index,
+                ost_time_base,
+            )?;
             log::info!("✓ Encoding finalization completed successfully");
 
             // Preserve output on success (Phase 11: re-enabled after legacy purge)
@@ -256,5 +296,3 @@ impl MediaProcessor for FfmpegNextProcessor {
         })
     }
 }
-
-

--- a/src-tauri/src/audio/metrics.rs
+++ b/src-tauri/src/audio/metrics.rs
@@ -1,5 +1,5 @@
 //! Audio processing metrics tracking
-//! 
+//!
 //! This module provides metrics tracking for audio processing operations,
 //! including throughput calculation and performance monitoring.
 
@@ -63,7 +63,7 @@ impl ProcessingMetrics {
         let throughput = self.throughput_mbps();
         let audio_hours = self.total_duration.as_secs_f64() / 3600.0;
         let mb_processed = self.bytes_processed as f64 / 1_048_576.0;
-        
+
         format!(
             "Processing Complete:\n\
              - Files processed: {}\n\

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -7,12 +7,12 @@ use self::constants::{DEFAULT_BITRATE, DEFAULT_OUTPUT_EXTENSION, DEFAULT_SAMPLE_
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub mod buffer;
 pub mod cleanup;
 pub mod constants;
 pub mod context;
 pub mod file_list;
 pub mod media_pipeline;
-pub mod buffer;
 pub mod metrics;
 pub mod path_validation;
 pub mod processor;
@@ -156,7 +156,7 @@ pub use processor::{detect_input_sample_rate, process_audiobook_with_context};
 pub use context::ProcessingContext;
 
 // Builders and progress context always available after cleanup
-pub use context::{ProcessingContextBuilder, ProgressContextBuilder, ProgressContext};
+pub use context::{ProcessingContextBuilder, ProgressContext, ProgressContextBuilder};
 
 // Cleanup infrastructure - CleanupGuard used, ProcessGuard feature-gated
 pub use cleanup::CleanupGuard;

--- a/src-tauri/src/audio/path_validation.rs
+++ b/src-tauri/src/audio/path_validation.rs
@@ -12,22 +12,26 @@ use crate::errors::{AppError, Result};
 pub fn validate_input_audio_path(path: &Path) -> Result<PathBuf> {
     // Strip invalid chars (CR/LF/NUL)
     validate_path_characters(path)?;
-    
+
     // Check exists and is regular file
     validate_file_existence_and_type(path)?;
-    
+
     // Extension whitelist check
     validate_audio_extension(path)?;
-    
+
     // Check if it's a symlink before canonicalization (for logging)
-    let is_symlink = path.symlink_metadata()
+    let is_symlink = path
+        .symlink_metadata()
         .map(|meta| meta.file_type().is_symlink())
         .unwrap_or(false);
-        
+
     if is_symlink {
-        log::warn!("Input file is a symlink: {} -> resolving to target", path.display());
+        log::warn!(
+            "Input file is a symlink: {} -> resolving to target",
+            path.display()
+        );
     }
-    
+
     // Canonicalize to prevent path traversal and resolve symlinks
     let canonical = path.canonicalize().map_err(|e| {
         AppError::FileValidation(format!(
@@ -36,11 +40,11 @@ pub fn validate_input_audio_path(path: &Path) -> Result<PathBuf> {
             e
         ))
     })?;
-    
+
     if is_symlink {
         log::warn!("Symlink resolved to: {}", canonical.display());
     }
-    
+
     Ok(canonical)
 }
 
@@ -71,7 +75,7 @@ fn validate_file_existence_and_type(path: &Path) -> Result<()> {
             path.display()
         )));
     }
-    
+
     Ok(())
 }
 
@@ -88,7 +92,7 @@ fn validate_audio_extension(path: &Path) -> Result<()> {
             "Unsupported audio format: {ext}"
         )));
     }
-    
+
     Ok(())
 }
 
@@ -160,7 +164,7 @@ mod tests {
     fn test_accepts_all_supported_extensions() {
         let dir = tempdir().unwrap();
         let extensions = ["mp3", "m4a", "m4b", "aac", "wav", "flac"];
-        
+
         for ext in extensions {
             let path = dir.path().join(format!("test.{}", ext));
             File::create(&path).unwrap();
@@ -201,11 +205,9 @@ mod tests {
         let target = dir.path().join("nonexistent.mp3");
         let link = dir.path().join("broken_link.mp3");
         symlink(&target, &link).unwrap();
-        
+
         let err = validate_input_audio_path(&link).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Cannot read file metadata") || msg.contains("canonicalize"));
     }
 }
-
-

--- a/src-tauri/src/audio/processor/encoder.rs
+++ b/src-tauri/src/audio/processor/encoder.rs
@@ -11,12 +11,12 @@ fn find_encoder_by_name(name: &str) -> Result<ff::Codec> {
     unsafe {
         let c_name = CString::new(name)
             .map_err(|e| AppError::General(format!("Invalid encoder name '{}': {}", name, e)))?;
-        
+
         let codec_ptr = ffmpeg_next::sys::avcodec_find_encoder_by_name(c_name.as_ptr());
         if codec_ptr.is_null() {
             return Err(AppError::General(format!("Encoder '{}' not found", name)));
         }
-        
+
         Ok(ff::Codec::wrap(codec_ptr))
     }
 }
@@ -29,12 +29,13 @@ fn try_configure_variable_frame_size(encoder_ctx: &mut ff::codec::context::Conte
     unsafe {
         let av_ctx = encoder_ctx.as_mut_ptr();
         if av_ctx.is_null() {
-            return Err(AppError::General("Invalid encoder context pointer".to_string()));
+            return Err(AppError::General(
+                "Invalid encoder context pointer".to_string(),
+            ));
         }
 
-        let strict_key = CString::new("strict").map_err(|e| {
-            AppError::General(format!("Failed to create strict key string: {}", e))
-        })?;
+        let strict_key = CString::new("strict")
+            .map_err(|e| AppError::General(format!("Failed to create strict key string: {}", e)))?;
         let experimental_value = CString::new("experimental").map_err(|e| {
             AppError::General(format!("Failed to create experimental value string: {}", e))
         })?;
@@ -47,7 +48,10 @@ fn try_configure_variable_frame_size(encoder_ctx: &mut ff::codec::context::Conte
         );
 
         if result < 0 {
-            log::debug!("Could not set strict=experimental: FFmpeg error code {}", result);
+            log::debug!(
+                "Could not set strict=experimental: FFmpeg error code {}",
+                result
+            );
         } else {
             log::debug!("Set strict=experimental on encoder context");
         }
@@ -64,15 +68,15 @@ fn try_enable_twoloop_aac(encoder_ctx: &mut ff::codec::context::Context) -> Resu
     unsafe {
         let av_ctx = encoder_ctx.as_mut_ptr();
         if av_ctx.is_null() {
-            return Err(AppError::General("Invalid encoder context pointer".to_string()));
+            return Err(AppError::General(
+                "Invalid encoder context pointer".to_string(),
+            ));
         }
 
-        let key = CString::new("aac_coder").map_err(|e| {
-            AppError::General(format!("Failed to create key string: {}", e))
-        })?;
-        let value = CString::new("twoloop").map_err(|e| {
-            AppError::General(format!("Failed to create value string: {}", e))
-        })?;
+        let key = CString::new("aac_coder")
+            .map_err(|e| AppError::General(format!("Failed to create key string: {}", e)))?;
+        let value = CString::new("twoloop")
+            .map_err(|e| AppError::General(format!("Failed to create value string: {}", e)))?;
 
         let result = ffmpeg_next::sys::av_opt_set(
             av_ctx as *mut std::ffi::c_void,
@@ -97,11 +101,13 @@ fn try_enable_twoloop_aac(encoder_ctx: &mut ff::codec::context::Context) -> Resu
 fn resolve_target_audio_params(
     plan: &crate::audio::media_pipeline::MediaProcessingPlan,
 ) -> Result<(u32, i32)> {
-    use crate::audio::{SampleRateConfig};
+    use crate::audio::SampleRateConfig;
     use crate::errors::AppError;
 
     match &plan.settings.sample_rate {
-        SampleRateConfig::Explicit(rate) => Ok((*rate, plan.settings.channels.channel_count() as i32)),
+        SampleRateConfig::Explicit(rate) => {
+            Ok((*rate, plan.settings.channels.channel_count() as i32))
+        }
         SampleRateConfig::Auto => {
             let first = plan
                 .input_file_paths
@@ -109,10 +115,9 @@ fn resolve_target_audio_params(
                 .ok_or_else(|| AppError::InvalidInput("No input files provided".to_string()))?;
             let ictx = ff::format::input(&first)
                 .map_err(|e| AppError::General(format!("Open input failed: {e}")))?;
-            let stream = ictx
-                .streams()
-                .best(ff::media::Type::Audio)
-                .ok_or_else(|| AppError::InvalidInput("No audio stream in first input".to_string()))?;
+            let stream = ictx.streams().best(ff::media::Type::Audio).ok_or_else(|| {
+                AppError::InvalidInput("No audio stream in first input".to_string())
+            })?;
             let codec_ctx = ff::codec::context::Context::from_parameters(stream.parameters())
                 .map_err(|e| AppError::General(format!("Decoder ctx from params failed: {e}")))?;
             let decoder = codec_ctx
@@ -120,7 +125,10 @@ fn resolve_target_audio_params(
                 .audio()
                 .map_err(|e| AppError::General(format!("Open audio decoder failed: {e}")))?;
             // Pass through sample rate; channels always come from UI settings
-            Ok((decoder.rate(), plan.settings.channels.channel_count() as i32))
+            Ok((
+                decoder.rate(),
+                plan.settings.channels.channel_count() as i32,
+            ))
         }
     }
 }
@@ -140,7 +148,9 @@ pub(crate) fn create_audio_encoder(
         if let Some(v2) = &plan.encoder_settings_v2 {
             match v2.encoder_type {
                 crate::audio::settings_encoder::EncoderType::AacAt => {
-                    crate::audio::settings_encoder::resolve_encoder_name(crate::audio::settings_encoder::EncoderType::AacAt)
+                    crate::audio::settings_encoder::resolve_encoder_name(
+                        crate::audio::settings_encoder::EncoderType::AacAt,
+                    )
                 }
                 _ => "aac",
             }
@@ -172,24 +182,40 @@ pub(crate) fn create_audio_encoder(
 
     match try_configure_variable_frame_size(&mut opened) {
         Ok(()) => log::info!("AAC encoder configured for variable frame sizes"),
-        Err(e) => log::warn!("Could not configure variable frame sizes ({}), may have frame size issues", e),
+        Err(e) => log::warn!(
+            "Could not configure variable frame sizes ({}), may have frame size issues",
+            e
+        ),
     }
 
     // Option mapping from v2 settings (profile, coder, threads)
     if let Some(v2) = &plan.encoder_settings_v2 {
         // HE-AAC profiles (best-effort, native AAC)
-        if matches!(v2.encoder_type, crate::audio::settings_encoder::EncoderType::HeAacV1 | crate::audio::settings_encoder::EncoderType::HeAacV2) {
+        if matches!(
+            v2.encoder_type,
+            crate::audio::settings_encoder::EncoderType::HeAacV1
+                | crate::audio::settings_encoder::EncoderType::HeAacV2
+        ) {
             unsafe {
                 use std::ffi::CString;
                 let av_ctx = opened.as_mut_ptr();
                 let key = CString::new("profile").expect("profile key should be valid");
                 // Values from FFmpeg headers
                 let value = match v2.encoder_type {
-                    crate::audio::settings_encoder::EncoderType::HeAacV1 => ffmpeg_next::sys::FF_PROFILE_AAC_HE,
-                    crate::audio::settings_encoder::EncoderType::HeAacV2 => ffmpeg_next::sys::FF_PROFILE_AAC_HE_V2,
+                    crate::audio::settings_encoder::EncoderType::HeAacV1 => {
+                        ffmpeg_next::sys::FF_PROFILE_AAC_HE
+                    }
+                    crate::audio::settings_encoder::EncoderType::HeAacV2 => {
+                        ffmpeg_next::sys::FF_PROFILE_AAC_HE_V2
+                    }
                     _ => ffmpeg_next::sys::FF_PROFILE_AAC_LOW,
                 } as i64;
-                let _ = ffmpeg_next::sys::av_opt_set_int(av_ctx as *mut std::ffi::c_void, key.as_ptr(), value, 0);
+                let _ = ffmpeg_next::sys::av_opt_set_int(
+                    av_ctx as *mut std::ffi::c_void,
+                    key.as_ptr(),
+                    value,
+                    0,
+                );
             }
         }
 
@@ -205,8 +231,15 @@ pub(crate) fn create_audio_encoder(
                         crate::audio::settings_encoder::AacCoder::Fast => "fast",
                     };
                     let value = CString::new(val_str).expect("aac_coder value should be valid");
-                    let rc = ffmpeg_next::sys::av_opt_set(av_ctx as *mut std::ffi::c_void, key.as_ptr(), value.as_ptr(), 0);
-                    if rc < 0 { log::debug!("Failed to set aac_coder={} rc={}", val_str, rc); }
+                    let rc = ffmpeg_next::sys::av_opt_set(
+                        av_ctx as *mut std::ffi::c_void,
+                        key.as_ptr(),
+                        value.as_ptr(),
+                        0,
+                    );
+                    if rc < 0 {
+                        log::debug!("Failed to set aac_coder={} rc={}", val_str, rc);
+                    }
                 }
             }
         }
@@ -223,7 +256,12 @@ pub(crate) fn create_audio_encoder(
                 use std::ffi::CString;
                 let av_ctx = opened.as_mut_ptr();
                 let key = CString::new("threads").expect("threads key should be valid");
-                let _ = ffmpeg_next::sys::av_opt_set_int(av_ctx as *mut std::ffi::c_void, key.as_ptr(), threads_value as i64, 0);
+                let _ = ffmpeg_next::sys::av_opt_set_int(
+                    av_ctx as *mut std::ffi::c_void,
+                    key.as_ptr(),
+                    threads_value as i64,
+                    0,
+                );
             }
         }
 
@@ -240,8 +278,13 @@ pub(crate) fn create_audio_encoder(
             log::info!("Twoloop AAC enhancement disabled via environment override");
         } else {
             match try_enable_twoloop_aac(&mut opened) {
-                Ok(()) => log::info!("Twoloop AAC enhancement enabled successfully - expect improved audio quality"),
-                Err(e) => log::warn!("Twoloop AAC enhancement unavailable ({}), falling back to standard AAC-LC", e),
+                Ok(()) => log::info!(
+                    "Twoloop AAC enhancement enabled successfully - expect improved audio quality"
+                ),
+                Err(e) => log::warn!(
+                    "Twoloop AAC enhancement unavailable ({}), falling back to standard AAC-LC",
+                    e
+                ),
             }
         }
     }
@@ -278,7 +321,10 @@ pub(crate) fn setup_encoder(
     if let Some(metadata) = metadata {
         match crate::metadata::set_container_metadata(&mut octx, metadata) {
             Ok(()) => log::debug!("Container metadata set successfully"),
-            Err(e) => log::warn!("Failed to set container metadata: {} - continuing with audio processing", e),
+            Err(e) => log::warn!(
+                "Failed to set container metadata: {} - continuing with audio processing",
+                e
+            ),
         }
     }
 
@@ -312,12 +358,19 @@ pub(crate) fn setup_encoder(
         if let Some(ref cover_data) = metadata.cover_art {
             let bytes = cover_data.len();
             log::info!("cover_art_plan decision=native_attempt bytes={}", bytes);
-            log::info!("Attempting native cover art embedding - {} bytes of cover data", bytes);
-            cover_art_stream_info = crate::metadata::add_cover_art_stream_pre_header(&mut octx, cover_data);
+            log::info!(
+                "Attempting native cover art embedding - {} bytes of cover data",
+                bytes
+            );
+            cover_art_stream_info =
+                crate::metadata::add_cover_art_stream_pre_header(&mut octx, cover_data);
             if let Some((stream_idx, format)) = cover_art_stream_info {
                 log::info!("✓ Native cover art stream added successfully (stream={}, format={:?}) - will embed during encoding", stream_idx, format);
             } else {
-                log::warn!("cover_art_plan decision=fallback reason=stream_creation_failed bytes={}", bytes);
+                log::warn!(
+                    "cover_art_plan decision=fallback reason=stream_creation_failed bytes={}",
+                    bytes
+                );
                 log::warn!("✗ Native cover art stream creation failed - will fallback to Lofty embedding in finalize stage");
             }
         } else {
@@ -333,10 +386,25 @@ pub(crate) fn setup_encoder(
 
     // Post-header cover art packet
     if let Some(metadata) = metadata {
-        if let (Some((stream_index, format)), Some(cover_data)) = (cover_art_stream_info, metadata.cover_art.as_ref()) {
-            log::info!("Writing cover art packet to stream {} ({:?} format, {} bytes)", stream_index, format, cover_data.len());
-            crate::metadata::write_cover_art_packet_post_header(&mut octx, stream_index, cover_data, format);
-            log::info!("✓ Native cover art packet written successfully to stream {}", stream_index);
+        if let (Some((stream_index, format)), Some(cover_data)) =
+            (cover_art_stream_info, metadata.cover_art.as_ref())
+        {
+            log::info!(
+                "Writing cover art packet to stream {} ({:?} format, {} bytes)",
+                stream_index,
+                format,
+                cover_data.len()
+            );
+            crate::metadata::write_cover_art_packet_post_header(
+                &mut octx,
+                stream_index,
+                cover_data,
+                format,
+            );
+            log::info!(
+                "✓ Native cover art packet written successfully to stream {}",
+                stream_index
+            );
         } else if metadata.cover_art.is_some() {
             log::warn!("Cover art data present but no stream created - will rely on finalize stage fallback");
         }
@@ -361,8 +429,16 @@ fn debug_validate_frame_contract(
     encoder: &ff::codec::encoder::audio::Encoder,
 ) {
     // Format/layout/rate must match encoder
-    debug_assert_eq!(frame.format(), encoder.format(), "Frame format must match encoder format");
-    debug_assert_eq!(frame.channel_layout(), encoder.channel_layout(), "Channel layout mismatch");
+    debug_assert_eq!(
+        frame.format(),
+        encoder.format(),
+        "Frame format must match encoder format"
+    );
+    debug_assert_eq!(
+        frame.channel_layout(),
+        encoder.channel_layout(),
+        "Channel layout mismatch"
+    );
     debug_assert_eq!(frame.rate(), encoder.rate(), "Sample rate mismatch");
 
     // Samples must be > 0 and respect encoder frame size if non-zero
@@ -370,11 +446,17 @@ fn debug_validate_frame_contract(
     debug_assert!(samples_i64 > 0, "Frame must contain at least one sample");
     let enc_frame_size_i64 = encoder.frame_size() as i64;
     if enc_frame_size_i64 > 0 {
-        debug_assert!(samples_i64 <= enc_frame_size_i64, "Frame samples exceed encoder.frame_size()");
+        debug_assert!(
+            samples_i64 <= enc_frame_size_i64,
+            "Frame samples exceed encoder.frame_size()"
+        );
     }
 
     // PTS should be set
-    debug_assert!(frame.pts().is_some(), "Frame PTS must be set before encoding");
+    debug_assert!(
+        frame.pts().is_some(),
+        "Frame PTS must be set before encoding"
+    );
 }
 
 /// Encodes frame and writes packets to output
@@ -386,7 +468,7 @@ pub(crate) fn encode_and_write_frame(
     output_time_base: ff::Rational,
 ) -> Result<()> {
     use crate::errors::AppError;
-    
+
     #[cfg(debug_assertions)]
     {
         // Validate structural contract
@@ -395,9 +477,8 @@ pub(crate) fn encode_and_write_frame(
         for ch in 0..encoder.channel_layout().channels() as usize {
             let plane = frame.data(ch);
             let len_f32 = plane.len() / 4;
-            let src: &[f32] = unsafe {
-                std::slice::from_raw_parts(plane.as_ptr() as *const f32, len_f32)
-            };
+            let src: &[f32] =
+                unsafe { std::slice::from_raw_parts(plane.as_ptr() as *const f32, len_f32) };
             for &v in src.iter().take(frame.samples()) {
                 debug_assert!(v.is_finite(), "Non-finite sample encountered");
                 debug_assert!((-1.0..=1.0).contains(&v), "Sample out of range [-1,1]");
@@ -417,7 +498,9 @@ pub(crate) fn encode_and_write_frame(
         clean.set_channel_layout(frame.channel_layout());
         clean.set_rate(frame.rate());
         clean.set_samples(frame.samples());
-        unsafe { clean.alloc(frame.format(), frame.samples(), frame.channel_layout()); }
+        unsafe {
+            clean.alloc(frame.format(), frame.samples(), frame.channel_layout());
+        }
         clean.set_pts(frame.pts());
 
         if frame.samples() > 0 {
@@ -426,18 +509,35 @@ pub(crate) fn encode_and_write_frame(
                 let src_plane = frame.data(ch);
                 let dst_plane = clean.data_mut(ch);
                 let len_f32 = (dst_plane.len() / 4).min(src_plane.len() / 4);
-                let src: &[f32] = unsafe { std::slice::from_raw_parts(src_plane.as_ptr() as *const f32, len_f32) };
-                let dst: &mut [f32] = unsafe { std::slice::from_raw_parts_mut(dst_plane.as_mut_ptr() as *mut f32, len_f32) };
+                let src: &[f32] = unsafe {
+                    std::slice::from_raw_parts(src_plane.as_ptr() as *const f32, len_f32)
+                };
+                let dst: &mut [f32] = unsafe {
+                    std::slice::from_raw_parts_mut(dst_plane.as_mut_ptr() as *mut f32, len_f32)
+                };
                 let mut repaired = 0usize;
                 for i in 0..len_f32 {
                     let mut v = src[i];
-                    if !v.is_finite() { v = 0.0; repaired += 1; }
-                    if v > 1.0 { v = 1.0; repaired += 1; }
-                    if v < -1.0 { v = -1.0; repaired += 1; }
+                    if !v.is_finite() {
+                        v = 0.0;
+                        repaired += 1;
+                    }
+                    if v > 1.0 {
+                        v = 1.0;
+                        repaired += 1;
+                    }
+                    if v < -1.0 {
+                        v = -1.0;
+                        repaired += 1;
+                    }
                     dst[i] = v;
                 }
                 if repaired > 0 {
-                    log::warn!("Sanitized {} samples on channel {} before encoding", repaired, ch);
+                    log::warn!(
+                        "Sanitized {} samples on channel {} before encoding",
+                        repaired,
+                        ch
+                    );
                 }
             }
         }
@@ -492,7 +592,10 @@ pub(crate) fn finalize_encoding_after_preview(
     output_time_base: ff::Rational,
 ) -> Result<()> {
     // Currently identical to finalize_encoding; separated for clarity and future hooks
-    finalize_encoding(encoder, output_context, output_stream_index, output_time_base)
+    finalize_encoding(
+        encoder,
+        output_context,
+        output_stream_index,
+        output_time_base,
+    )
 }
-
-

--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -24,8 +24,6 @@
 //!
 //! Phase: 2 (Execute Stage Extraction)
 
-
-
 use std::path::{Path, PathBuf};
 
 use crate::audio::constants::TEMP_MERGED_FILENAME;

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -44,8 +44,6 @@
 //!
 //! NOTE: Orchestrator moved to mod.rs in Phase 5.
 
-
-
 // Imports
 use std::path::{Path, PathBuf};
 
@@ -68,22 +66,27 @@ fn derive_preview_output_path(final_output: &Path) -> PathBuf {
 }
 
 /// Checks if native cover art embedding was successful by examining the output file
-/// 
+///
 /// This function uses Lofty to probe the file and check for existing cover art,
 /// which helps determine if the native FFmpeg embedding worked correctly.
 fn check_native_cover_art_success(file_path: &Path) -> Result<bool> {
     use lofty::prelude::*;
     use lofty::probe::Probe;
-    
+
     match Probe::open(file_path) {
         Ok(probe) => {
             match probe.read() {
                 Ok(tagged_file) => {
                     // Check if any tag contains pictures/cover art
-                    let has_cover = tagged_file.tags().iter().any(|tag| !tag.pictures().is_empty());
-                    log::debug!("Native cover art check: {} (file: {})", 
-                              if has_cover { "found" } else { "not found" }, 
-                              file_path.display());
+                    let has_cover = tagged_file
+                        .tags()
+                        .iter()
+                        .any(|tag| !tag.pictures().is_empty());
+                    log::debug!(
+                        "Native cover art check: {} (file: {})",
+                        if has_cover { "found" } else { "not found" },
+                        file_path.display()
+                    );
                     Ok(has_cover)
                 }
                 Err(e) => {
@@ -114,7 +117,10 @@ pub(crate) fn move_to_final_location(temp_output: PathBuf, final_path: &Path) ->
     }
     match std::fs::rename(&temp_output, final_path) {
         Ok(()) => {
-            log::info!("finalize_move method=rename status=ok dest={}", final_path.display());
+            log::info!(
+                "finalize_move method=rename status=ok dest={}",
+                final_path.display()
+            );
             Ok(final_path.to_path_buf())
         }
         Err(rename_err) => {
@@ -138,7 +144,10 @@ pub(crate) fn move_to_final_location(temp_output: PathBuf, final_path: &Path) ->
             if let Err(e) = std::fs::remove_file(&temp_output) {
                 log::warn!("finalize_move temp removal failed: {}", e);
             }
-            log::info!("finalize_move method=copy-replace status=ok dest={}", final_path.display());
+            log::info!(
+                "finalize_move method=copy-replace status=ok dest={}",
+                final_path.display()
+            );
             Ok(final_path.to_path_buf())
         }
     }
@@ -177,17 +186,23 @@ pub(crate) fn write_metadata_stage(
         let ui = crate::audio::progress::ProgressEmitter::new(context.window.clone());
         ui.emit_metadata_start("Writing metadata...");
         reporter.set_stage(ProcessingStage::WritingMetadata);
-        
-        log::info!("Starting finalize stage metadata writing for: {}", merged_output.display());
-        
+
+        log::info!(
+            "Starting finalize stage metadata writing for: {}",
+            merged_output.display()
+        );
+
         // Write basic metadata tags
         write_metadata(merged_output, &metadata)?;
         log::info!("✓ Basic metadata tags written successfully");
-        
+
         // Handle cover art with fallback detection
         if let Some(cover) = metadata.cover_art.as_ref() {
-            log::info!("Attempting Lofty cover art embedding as fallback - {} bytes", cover.len());
-            
+            log::info!(
+                "Attempting Lofty cover art embedding as fallback - {} bytes",
+                cover.len()
+            );
+
             // Check if native embedding succeeded by examining the file
             match check_native_cover_art_success(merged_output) {
                 Ok(true) => {
@@ -217,13 +232,13 @@ pub(crate) fn write_metadata_stage(
         } else {
             log::debug!("No cover art data to write in finalize stage");
         }
-        
+
         if context.is_cancelled() {
             return Err(AppError::InvalidInput(
                 "Processing was cancelled".to_string(),
             ));
         }
-        
+
         log::info!("✓ Finalize stage metadata writing completed successfully");
     } else {
         log::debug!("No metadata provided for finalize stage");
@@ -240,29 +255,32 @@ pub(crate) fn complete_processing(
 ) -> Result<String> {
     log::info!("🚀 Starting complete_processing stage");
     log::info!("Temporary file: {}", merged_output.display());
-    log::info!("Final output path: {}", context.settings.output_path.display());
-    
+    log::info!(
+        "Final output path: {}",
+        context.settings.output_path.display()
+    );
+
     let ui = crate::audio::progress::ProgressEmitter::new(context.window.clone());
     ui.emit_cleanup("Cleaning up...");
-    
+
     log::info!("Moving temporary file to final location...");
     let final_output = move_to_final_location(merged_output, &context.settings.output_path)?;
     log::info!("✓ File moved successfully to: {}", final_output.display());
-    
+
     if context.is_cancelled() {
         log::warn!("Processing was cancelled during completion");
         return Err(AppError::InvalidInput(
             "Processing was cancelled".to_string(),
         ));
     }
-    
+
     log::info!("Cleaning up temporary directory...");
     cleanup_temp_directory_with_session(&context.session.id(), workflow.temp_dir)?;
     log::info!("✓ Temporary directory cleaned up successfully");
-    
+
     reporter.complete();
     ui.emit_complete("Processing complete");
-    
+
     let success_message = format!("Successfully created audiobook: {}", final_output.display());
     log::info!("🎉 {}", success_message);
     Ok(success_message)
@@ -290,7 +308,11 @@ pub(crate) async fn finalize_processing(
         // Overwrite any existing preview file
         if preview_path.exists() {
             if let Err(e) = std::fs::remove_file(&preview_path) {
-                log::warn!("Failed to remove existing preview file ({}): {}", preview_path.display(), e);
+                log::warn!(
+                    "Failed to remove existing preview file ({}): {}",
+                    preview_path.display(),
+                    e
+                );
             }
         }
         let moved = move_to_final_location(merged_output.clone(), &preview_path)?;

--- a/src-tauri/src/audio/processor/frame_pipeline.rs
+++ b/src-tauri/src/audio/processor/frame_pipeline.rs
@@ -31,7 +31,11 @@ fn emit_progress_update(ctx: &mut FramePipelineCtx) {
         ctx.emitter.emit_converting_progress(
             percentage.min(crate::audio::constants::PROGRESS_CONVERTING_MAX as f64) as f32,
             "Converting and merging audio files...",
-            Some(format!("Input {} of {}", ctx.current_file_index + 1, ctx.total_files)),
+            Some(format!(
+                "Input {} of {}",
+                ctx.current_file_index + 1,
+                ctx.total_files
+            )),
             None,
         );
     }
@@ -76,16 +80,17 @@ pub(crate) fn process_decoded_frames(
         let mut frame = ff::frame::Audio::empty();
         match decoder.receive_frame(&mut frame) {
             Ok(()) => {
-                let decoder_matches_encoder =
-                    frame.format() == encoder.format()
-                        && frame.channel_layout() == encoder.channel_layout()
-                        && frame.rate() == encoder.rate();
+                let decoder_matches_encoder = frame.format() == encoder.format()
+                    && frame.channel_layout() == encoder.channel_layout()
+                    && frame.rate() == encoder.rate();
                 let disable_fastpath = std::env::var("ABB_DISABLE_FASTPATH")
                     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false);
 
                 if decoder_matches_encoder && !disable_fastpath {
-                    log::debug!("Fast-path: decoder frame matches encoder format – skipping resampler");
+                    log::debug!(
+                        "Fast-path: decoder frame matches encoder format – skipping resampler"
+                    );
                     if frame.samples() == 0 {
                         log::warn!("Decoder produced 0 samples – skipping frame");
                         continue;
@@ -115,7 +120,9 @@ pub(crate) fn process_decoded_frames(
                 out.set_channel_layout(encoder.channel_layout());
                 out.set_rate(encoder.rate());
                 out.set_samples(frame.samples());
-                unsafe { out.alloc(encoder.format(), frame.samples(), encoder.channel_layout()); }
+                unsafe {
+                    out.alloc(encoder.format(), frame.samples(), encoder.channel_layout());
+                }
 
                 resampler
                     .run(&frame, &mut out)
@@ -165,7 +172,10 @@ pub(crate) fn process_input_packets(
     use crate::errors::AppError;
 
     if log::log_enabled!(log::Level::Info) {
-        log::info!("📦 Starting packet processing for stream index: {}", ctx.current_stream_index);
+        log::info!(
+            "📦 Starting packet processing for stream index: {}",
+            ctx.current_stream_index
+        );
     }
     let mut packet_count = 0;
     log::info!("Starting packet iteration...");
@@ -181,14 +191,16 @@ pub(crate) fn process_input_packets(
             return Err(AppError::InvalidInput("Processing was cancelled".into()));
         }
         if si.index() != ctx.current_stream_index {
-            log::debug!("Skipping packet from stream {} (expecting {})", si.index(), ctx.current_stream_index);
+            log::debug!(
+                "Skipping packet from stream {} (expecting {})",
+                si.index(),
+                ctx.current_stream_index
+            );
             continue;
         }
 
         packet_count += 1;
-        if packet_count % 100 == 0
-            && log::log_enabled!(log::Level::Info)
-        {
+        if packet_count % 100 == 0 && log::log_enabled!(log::Level::Info) {
             log::info!("Processed {} packets so far", packet_count);
         }
 
@@ -199,15 +211,32 @@ pub(crate) fn process_input_packets(
             Ok(()) => log::debug!("✓ Packet {} sent to decoder successfully", packet_count),
             Err(e) => {
                 log::error!("✗ Failed to send packet {} to decoder: {}", packet_count, e);
-                return Err(AppError::General(format!("Decoder send packet failed: {}", e)));
+                return Err(AppError::General(format!(
+                    "Decoder send packet failed: {}",
+                    e
+                )));
             }
         }
 
         log::debug!("Processing decoded frames for packet {}", packet_count);
-        match process_decoded_frames(decoder, encoder, resampler, output_context, ctx, accumulator) {
-            Ok(()) => log::debug!("✓ Decoded frames processed successfully for packet {}", packet_count),
+        match process_decoded_frames(
+            decoder,
+            encoder,
+            resampler,
+            output_context,
+            ctx,
+            accumulator,
+        ) {
+            Ok(()) => log::debug!(
+                "✓ Decoded frames processed successfully for packet {}",
+                packet_count
+            ),
             Err(e) => {
-                log::error!("✗ Failed to process decoded frames for packet {}: {}", packet_count, e);
+                log::error!(
+                    "✗ Failed to process decoded frames for packet {}: {}",
+                    packet_count,
+                    e
+                );
                 return Err(e);
             }
         }
@@ -222,5 +251,3 @@ pub(crate) fn process_input_packets(
     log::info!("✓ Processed {} packets total", packet_count);
     Ok(())
 }
-
-

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -25,25 +25,23 @@
 //!
 //! Note: Monolithic file removal / full legacy isolation continues in subsequent phases.
 
-
-
 // Imports for orchestrator function
-use std::time::Duration;
 use crate::audio::context::ProcessingContext;
 use crate::audio::metrics::ProcessingMetrics;
 use crate::audio::{AudioFile, ProcessingStage, ProgressReporter};
 use crate::errors::Result;
 use crate::metadata::AudiobookMetadata;
+use std::time::Duration;
 
 // Submodules
 pub mod execute;
 pub mod finalize;
 // Legacy module removed during nuclear cleanup - single-engine architecture achieved
+pub mod encoder;
+pub mod frame_pipeline;
 pub mod prepare;
 pub mod selection;
-pub mod encoder;
 pub mod streams;
-pub mod frame_pipeline;
 
 // Re-exports (current public / crate API)
 // Underlying items are currently pub(crate); visibility can be expanded if needed
@@ -66,10 +64,7 @@ pub(crate) struct ProcessingWorkflow {
 
 impl ProcessingWorkflow {
     /// Constructor helper to keep instantiation explicit at call sites.
-    pub(crate) fn new(
-        temp_dir: std::path::PathBuf,
-        total_duration: f64,
-    ) -> Self {
+    pub(crate) fn new(temp_dir: std::path::PathBuf, total_duration: f64) -> Self {
         Self {
             temp_dir,
             total_duration,
@@ -83,7 +78,7 @@ impl ProcessingWorkflow {
 }
 
 /// Orchestrator: Main processing entrypoint (Phase 5: moved from finalize.rs)
-/// 
+///
 /// Coordinates the three-stage processing pipeline:
 /// 1. Validate & Prepare
 /// 2. Execute Processing  
@@ -111,12 +106,19 @@ pub async fn process_audiobook_with_context(
     }
 
     // Stage 2: Execute (execute module)
-    let merged_output =
-        execute::execute_processing(&context, &workflow, &files, metadata.as_ref(), &mut reporter).await?;
+    let merged_output = execute::execute_processing(
+        &context,
+        &workflow,
+        &files,
+        metadata.as_ref(),
+        &mut reporter,
+    )
+    .await?;
 
     // Stage 3: Finalize
     let result =
-        finalize::finalize_processing(&context, workflow, merged_output, metadata, &mut reporter).await?;
+        finalize::finalize_processing(&context, workflow, merged_output, metadata, &mut reporter)
+            .await?;
 
     // Suppress full-run metrics summary during preview; log preview-specific stats instead
     if context.preview.is_some() {
@@ -132,7 +134,7 @@ pub async fn process_audiobook_with_context(
 // NOTE (Phase 5 Complete):
 // - Preparation + validation + workflow construction migrated (prepare.rs)
 // - Execution layer extracted (execute.rs) with feature-gated processor selection
-// - Finalization logic migrated (finalize.rs) 
+// - Finalization logic migrated (finalize.rs)
 // Nuclear cleanup complete: simplified single-engine processing
 // - Orchestrator consolidated in mod.rs calling staged functions
 // Next Steps:

--- a/src-tauri/src/audio/processor/prepare.rs
+++ b/src-tauri/src/audio/processor/prepare.rs
@@ -24,8 +24,6 @@
 //!
 //! Phase: 1 (Prepare Stage Extraction)
 
-
-
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -82,9 +80,9 @@ pub fn detect_input_sample_rate(file_paths: &[PathBuf]) -> Result<u32> {
 
 /// Private helper to retrieve sample rate from a single file.
 fn get_file_sample_rate(path: &Path) -> Result<u32> {
-    use lofty::probe::Probe;
     use lofty::file::AudioFile as LoftyAudioFile;
-    
+    use lofty::probe::Probe;
+
     let tagged_file = Probe::open(path)
         .map_err(AppError::Metadata)?
         .read()
@@ -163,7 +161,7 @@ pub(crate) fn prepare_workspace(
     emitter.set_stage(ProcessingStage::Analyzing);
 
     let temp_dir = create_temp_directory_with_session(&context.session.id())?;
-    
+
     // Single engine: no concat file needed
 
     let total_duration: f64 = files
@@ -178,10 +176,7 @@ pub(crate) fn prepare_workspace(
         ));
     }
 
-    Ok(ProcessingWorkflow::new(
-        temp_dir,
-        total_duration,
-    ))
+    Ok(ProcessingWorkflow::new(temp_dir, total_duration))
 }
 
 /// Orchestrates validation + workspace preparation.

--- a/src-tauri/src/audio/processor/selection.rs
+++ b/src-tauri/src/audio/processor/selection.rs
@@ -4,7 +4,7 @@
 //! after the nuclear transition from dual-engine to ffmpeg-next only.
 //!
 //! ## Processing Engine
-//! 
+//!
 //! - **Single Engine**: Uses `FfmpegNextProcessor` - Rust FFmpeg bindings
 //!
 //! ## Engine Characteristics
@@ -26,7 +26,9 @@ pub type DefaultProcessor = FfmpegNextProcessor;
 /// Returns a description of the currently selected engine for logging and diagnostics.
 ///
 /// After the nuclear transition, this always returns the same engine description.
-pub fn get_engine_description() -> &'static str { "FfmpegNextProcessor (single-engine)" }
+pub fn get_engine_description() -> &'static str {
+    "FfmpegNextProcessor (single-engine)"
+}
 
 /// Creates an instance of the default media processor.
 ///

--- a/src-tauri/src/audio/processor/streams.rs
+++ b/src-tauri/src/audio/processor/streams.rs
@@ -16,7 +16,10 @@ pub(crate) fn setup_decoder_and_resampler(
 )> {
     use crate::errors::AppError;
 
-    log::info!("🔧 Setting up decoder for input file: {}", input_path.display());
+    log::info!(
+        "🔧 Setting up decoder for input file: {}",
+        input_path.display()
+    );
 
     if !input_path.exists() {
         return Err(AppError::FileValidation(format!(
@@ -47,20 +50,24 @@ pub(crate) fn setup_decoder_and_resampler(
     log::info!("✓ Found audio stream at index: {}", stream_index);
 
     log::info!("Creating decoder context from stream parameters...");
-    let dec_ctx = ff::codec::context::Context::from_parameters(istream.parameters()).map_err(|e| {
+    let dec_ctx =
+        ff::codec::context::Context::from_parameters(istream.parameters()).map_err(|e| {
+            AppError::General(format!(
+                "Failed to create decoder context from parameters for '{}': {}",
+                input_path.display(),
+                e
+            ))
+        })?;
+    log::info!("✓ Decoder context created successfully");
+
+    log::info!("Opening audio decoder...");
+    let decoder = dec_ctx.decoder().audio().map_err(|e| {
         AppError::General(format!(
-            "Failed to create decoder context from parameters for '{}': {}",
+            "Failed to open audio decoder for '{}': {}",
             input_path.display(),
             e
         ))
     })?;
-    log::info!("✓ Decoder context created successfully");
-
-    log::info!("Opening audio decoder...");
-    let decoder = dec_ctx
-        .decoder()
-        .audio()
-        .map_err(|e| AppError::General(format!("Failed to open audio decoder for '{}': {}", input_path.display(), e)))?;
     log::info!("✓ Audio decoder opened successfully");
 
     // Build resampler for this input stream
@@ -89,11 +96,18 @@ pub(crate) fn setup_decoder_and_resampler(
         encoder.channel_layout(),
         encoder.rate(),
     )
-    .map_err(|e| AppError::General(format!("Failed to create resampler for '{}': {}", input_path.display(), e)))?;
+    .map_err(|e| {
+        AppError::General(format!(
+            "Failed to create resampler for '{}': {}",
+            input_path.display(),
+            e
+        ))
+    })?;
     log::info!("✓ Resampler created successfully");
 
-    log::info!("🎉 Decoder and resampler setup completed for: {}", input_path.display());
+    log::info!(
+        "🎉 Decoder and resampler setup completed for: {}",
+        input_path.display()
+    );
     Ok((ictx, decoder, resampler, stream_index))
 }
-
-

--- a/src-tauri/src/audio/progress/mod.rs
+++ b/src-tauri/src/audio/progress/mod.rs
@@ -5,12 +5,7 @@ pub mod reporter;
 
 // Re-export everything from reporter
 pub use reporter::{
-    ProgressEmitter,
-    ProgressEvent,
-    ProgressReporter,
-    converting_percentage_from_seconds,
+    converting_percentage_from_seconds, ProgressEmitter, ProgressEvent, ProgressReporter,
 };
 
 // Runtime uses encoder PTS/duration for progress
-
-

--- a/src-tauri/src/audio/progress/reporter.rs
+++ b/src-tauri/src/audio/progress/reporter.rs
@@ -1,7 +1,7 @@
 //! Progress event emission and reporting for audio processing
 
-use crate::audio::{ProcessingProgress, ProcessingStage};
 use crate::audio::constants::*;
+use crate::audio::{ProcessingProgress, ProcessingStage};
 use serde::Serialize;
 use std::time::Instant;
 use tauri::{Emitter, Window};
@@ -213,8 +213,7 @@ pub fn converting_percentage_from_seconds(current_seconds: f64, total_duration: 
         return PROGRESS_CONVERTING_START;
     }
     let ratio = (current_seconds / total_duration).clamp(0.0, 1.0);
-    let pct = PROGRESS_CONVERTING_START as f64
-        + ratio * PROGRESS_RANGE_MULTIPLIER;
+    let pct = PROGRESS_CONVERTING_START as f64 + ratio * PROGRESS_RANGE_MULTIPLIER;
     pct as f32
 }
 
@@ -243,29 +242,29 @@ impl ProgressReporter {
             current_file: None,
         }
     }
-    
+
     /// Updates processing stage
     pub fn set_stage(&mut self, stage: ProcessingStage) {
         self.current_stage = stage;
     }
-    
+
     /// Sets current file being processed
     pub fn set_current_file<S: Into<String>>(&mut self, filename: S) {
         self.current_file = Some(filename.into());
     }
-    
+
     /// Increments completed file count  
     pub fn complete_file(&mut self) {
         self.files_completed += 1;
         self.current_file = None;
     }
-    
+
     /// Calculates current progress percentage
     pub fn calculate_progress(&self) -> f32 {
         if self.total_files == 0 {
             return 0.0;
         }
-        
+
         // Base progress on stage and files completed
         let _stage_weight = match self.current_stage {
             ProcessingStage::Analyzing => 0.1,
@@ -274,30 +273,34 @@ impl ProgressReporter {
             ProcessingStage::Completed => 1.0,
             ProcessingStage::Failed(_) => 0.0,
         };
-        
+
         let file_progress = self.files_completed as f32 / self.total_files as f32;
-        
+
         match self.current_stage {
             ProcessingStage::Analyzing => PROGRESS_ANALYZING_END * file_progress,
-            ProcessingStage::Converting => PROGRESS_CONVERTING_START + (PROGRESS_CONVERTING_RANGE * file_progress),
-            ProcessingStage::WritingMetadata => PROGRESS_FINALIZING + (PROGRESS_METADATA_WEIGHT * file_progress),
+            ProcessingStage::Converting => {
+                PROGRESS_CONVERTING_START + (PROGRESS_CONVERTING_RANGE * file_progress)
+            }
+            ProcessingStage::WritingMetadata => {
+                PROGRESS_FINALIZING + (PROGRESS_METADATA_WEIGHT * file_progress)
+            }
             ProcessingStage::Completed => PROGRESS_COMPLETE,
             ProcessingStage::Failed(_) => 0.0,
         }
     }
-    
+
     /// Estimates remaining time based on progress
     pub fn estimate_time_remaining(&self) -> Option<f64> {
         let progress = self.calculate_progress();
         if progress <= 0.0 || progress >= 100.0 {
             return None;
         }
-        
+
         let elapsed = self.start_time.elapsed().as_secs_f64();
         let total_estimated = elapsed / (progress as f64 / 100.0);
         Some(total_estimated - elapsed)
     }
-    
+
     /// Gets current progress information
     pub fn get_progress(&self) -> ProcessingProgress {
         ProcessingProgress {
@@ -309,14 +312,14 @@ impl ProgressReporter {
             eta_seconds: self.estimate_time_remaining(),
         }
     }
-    
+
     /// Marks processing as completed
     pub fn complete(&mut self) {
         self.current_stage = ProcessingStage::Completed;
         self.files_completed = self.total_files;
         self.current_file = None;
     }
-    
+
     /// Marks processing as failed
     pub fn fail<S: Into<String>>(&mut self, error: S) {
         self.current_stage = ProcessingStage::Failed(error.into());
@@ -343,7 +346,7 @@ mod tests {
             ProgressEmitter::calculate_stage_progress(100.0, 100.0, 10.0, 80.0),
             80.0
         );
-        
+
         // Test edge cases
         assert_eq!(
             ProgressEmitter::calculate_stage_progress(50.0, 0.0, 10.0, 80.0),
@@ -373,15 +376,15 @@ mod tests {
     #[test]
     fn test_calculate_progress() {
         let mut reporter = ProgressReporter::new(4);
-        
+
         // Initial progress
         assert_eq!(reporter.calculate_progress(), 0.0);
-        
+
         // Complete analyzing stage
         reporter.complete_file();
         reporter.set_stage(ProcessingStage::Converting);
         assert!(reporter.calculate_progress() > 10.0);
-        
+
         // Complete all files
         reporter.complete();
         assert_eq!(reporter.calculate_progress(), 100.0);
@@ -396,5 +399,3 @@ mod tests {
 
     // parse_* tests moved to parser.rs in Phase 1
 }
-
-

--- a/src-tauri/src/audio/session.rs
+++ b/src-tauri/src/audio/session.rs
@@ -1,5 +1,5 @@
 //! Session management for audio processing operations
-//! 
+//!
 //! Provides a wrapper around ProcessingState with unique session identification
 //! and convenience methods for state management.
 
@@ -7,7 +7,7 @@ use crate::ProcessingState;
 use uuid::Uuid;
 
 /// A unique processing session that wraps ProcessingState
-/// 
+///
 /// Each session has a unique UUID identifier and provides
 /// convenience methods for checking processing status.
 #[derive(Debug)]

--- a/src-tauri/src/audio/settings.rs
+++ b/src-tauri/src/audio/settings.rs
@@ -15,9 +15,9 @@ pub fn validate_audio_settings(settings: &AudioSettings) -> Result<()> {
 /// Validates bitrate is within acceptable range
 fn validate_bitrate(bitrate: u32) -> Result<()> {
     if !(32..=128).contains(&bitrate) {
-        return Err(AppError::InvalidInput(
-            format!("Bitrate must be between 32-128 kbps, got: {bitrate}")
-        ));
+        return Err(AppError::InvalidInput(format!(
+            "Bitrate must be between 32-128 kbps, got: {bitrate}"
+        )));
     }
     Ok(())
 }
@@ -34,9 +34,9 @@ fn validate_sample_rate_config(config: &SampleRateConfig) -> Result<()> {
 fn validate_explicit_sample_rate(sample_rate: u32) -> Result<()> {
     let valid_rates = [22050, 32000, 44100, 48000];
     if !valid_rates.contains(&sample_rate) {
-        return Err(AppError::InvalidInput(
-            format!("Unsupported sample rate: {sample_rate}. Valid rates: {valid_rates:?}")
-        ));
+        return Err(AppError::InvalidInput(format!(
+            "Unsupported sample rate: {sample_rate}. Valid rates: {valid_rates:?}"
+        )));
     }
     Ok(())
 }
@@ -44,19 +44,21 @@ fn validate_explicit_sample_rate(sample_rate: u32) -> Result<()> {
 /// Validates output directory is writable by creating and removing a temp file
 fn validate_output_directory_writable<P: AsRef<Path>>(dir_path: P) -> Result<()> {
     let dir = dir_path.as_ref();
-    
+
     if !dir.exists() {
-        return Err(AppError::FileValidation(
-            format!("Output directory does not exist: {}", dir.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "Output directory does not exist: {}",
+            dir.display()
+        )));
     }
-    
+
     if !dir.is_dir() {
-        return Err(AppError::FileValidation(
-            format!("Output path is not a directory: {}", dir.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "Output path is not a directory: {}",
+            dir.display()
+        )));
     }
-    
+
     // Probe write permission by creating and removing a temp file
     let temp_file = dir.join(".audiobook_boss_write_test");
     match std::fs::write(&temp_file, b"test") {
@@ -65,29 +67,29 @@ fn validate_output_directory_writable<P: AsRef<Path>>(dir_path: P) -> Result<()>
             let _ = std::fs::remove_file(&temp_file);
             Ok(())
         }
-        Err(e) => Err(AppError::FileValidation(
-            format!("Output directory not writable: {e}")
-        ))
+        Err(e) => Err(AppError::FileValidation(format!(
+            "Output directory not writable: {e}"
+        ))),
     }
 }
 
 /// Validates output path is writable
 fn validate_output_path<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path.as_ref();
-    
+
     // Validate parent directory exists and is writable
     if let Some(parent) = path.parent() {
         validate_output_directory_writable(parent)?;
     }
-    
+
     // Check file extension
     match path.extension().and_then(|s| s.to_str()) {
         Some("m4b") => Ok(()),
-        Some(ext) => Err(AppError::InvalidInput(
-            format!("Output must be .m4b file, got: .{ext}")
-        )),
+        Some(ext) => Err(AppError::InvalidInput(format!(
+            "Output must be .m4b file, got: .{ext}"
+        ))),
         None => Err(AppError::InvalidInput(
-            "Output file must have .m4b extension".to_string()
+            "Output file must have .m4b extension".to_string(),
         )),
     }
 }
@@ -141,7 +143,7 @@ impl ChannelConfig {
             ChannelConfig::Stereo => 2,
         }
     }
-    
+
     // Removed: ffmpeg_layout() (CLI-oriented helper not used at runtime)
 }
 
@@ -150,7 +152,7 @@ impl SampleRateConfig {
     pub fn requires_detection(&self) -> bool {
         matches!(self, SampleRateConfig::Auto)
     }
-    
+
     /// Returns the sample rate value if explicit, None if auto
     pub fn explicit_rate(&self) -> Option<u32> {
         match self {
@@ -228,13 +230,16 @@ mod tests {
         let temp_dir = TempDir::new().expect("create temp dir");
         let result = validate_output_directory_writable(temp_dir.path());
         assert!(result.is_ok(), "Temp directory should be writable");
-        
+
         // Test with file instead of directory
         let temp_file = temp_dir.path().join("not_a_dir.txt");
         std::fs::write(&temp_file, b"test").expect("create temp file");
         let result = validate_output_directory_writable(&temp_file);
         assert!(result.is_err(), "File should not be valid as directory");
-        assert!(result.expect_err("expected not directory error").to_string().contains("not a directory"));
+        assert!(result
+            .expect_err("expected not directory error")
+            .to_string()
+            .contains("not a directory"));
     }
 
     #[cfg(unix)]
@@ -242,17 +247,24 @@ mod tests {
     fn test_read_only_output_directory() {
         use std::fs::Permissions;
         use std::os::unix::fs::PermissionsExt;
-        
+
         let temp_dir = TempDir::new().expect("create temp dir");
-        
+
         // Make directory read-only
         let readonly_perms = Permissions::from_mode(0o444);
-        std::fs::set_permissions(temp_dir.path(), readonly_perms).expect("set readonly permissions");
-        
+        std::fs::set_permissions(temp_dir.path(), readonly_perms)
+            .expect("set readonly permissions");
+
         let result = validate_output_directory_writable(temp_dir.path());
-        assert!(result.is_err(), "Read-only directory should fail write test");
-        assert!(result.expect_err("expected write permission error").to_string().contains("not writable"));
-        
+        assert!(
+            result.is_err(),
+            "Read-only directory should fail write test"
+        );
+        assert!(result
+            .expect_err("expected write permission error")
+            .to_string()
+            .contains("not writable"));
+
         // Restore permissions for cleanup
         let normal_perms = Permissions::from_mode(0o755);
         std::fs::set_permissions(temp_dir.path(), normal_perms).expect("restore permissions");
@@ -270,12 +282,12 @@ mod tests {
         let auto_config = SampleRateConfig::Auto;
         assert!(auto_config.requires_detection());
         assert_eq!(auto_config.explicit_rate(), None);
-        
+
         // Test Explicit configuration
         let explicit_config = SampleRateConfig::Explicit(44100);
         assert!(!explicit_config.requires_detection());
         assert_eq!(explicit_config.explicit_rate(), Some(44100));
-        
+
         // Test different explicit rates
         let rates = [22050, 32000, 44100, 48000];
         for rate in rates {

--- a/src-tauri/src/audio/settings_encoder.rs
+++ b/src-tauri/src/audio/settings_encoder.rs
@@ -70,12 +70,8 @@ pub fn validate_encoder_settings(settings: &EncoderSettings) -> Result<()> {
     validate_threads(settings.threads)?;
 
     // Afterburner notice: only applicable to libfdk_aac encoders.
-    if settings.afterburner.unwrap_or(false)
-        && !is_encoder_available_by_name("libfdk_aac")
-    {
-        log::info!(
-            "afterburner flag present but libfdk_aac unavailable - will be ignored"
-        );
+    if settings.afterburner.unwrap_or(false) && !is_encoder_available_by_name("libfdk_aac") {
+        log::info!("afterburner flag present but libfdk_aac unavailable - will be ignored");
     }
 
     // aac_coder is best-effort; no validation error even if not honored.
@@ -207,37 +203,39 @@ mod tests {
     #[test]
     fn test_threads_validation() {
         let mut s = base_settings();
-        
+
         // Valid cases
         s.threads = ThreadSetting::Auto;
         assert!(validate_encoder_settings(&s).is_ok());
-        
+
         s.threads = ThreadSetting::Off;
         assert!(validate_encoder_settings(&s).is_ok());
-        
+
         s.threads = ThreadSetting::Fixed(1);
         assert!(validate_encoder_settings(&s).is_ok());
-        
+
         s.threads = ThreadSetting::Fixed(4);
         assert!(validate_encoder_settings(&s).is_ok());
-        
+
         s.threads = ThreadSetting::Fixed(1024);
         assert!(validate_encoder_settings(&s).is_ok());
-        
+
         // Invalid cases - below range
         s.threads = ThreadSetting::Fixed(0);
         let err = validate_encoder_settings(&s).expect_err("expected rejection for thread count 0");
         assert!(err.to_string().contains("Invalid threads value: 0"));
         assert!(err.to_string().contains("1..=1024"));
-        
+
         // Invalid cases - above range
         s.threads = ThreadSetting::Fixed(1025);
-        let err = validate_encoder_settings(&s).expect_err("expected rejection for thread count 1025");
+        let err =
+            validate_encoder_settings(&s).expect_err("expected rejection for thread count 1025");
         assert!(err.to_string().contains("Invalid threads value: 1025"));
         assert!(err.to_string().contains("1..=1024"));
-        
+
         s.threads = ThreadSetting::Fixed(2000);
-        let err = validate_encoder_settings(&s).expect_err("expected rejection for thread count 2000");
+        let err =
+            validate_encoder_settings(&s).expect_err("expected rejection for thread count 2000");
         assert!(err.to_string().contains("Invalid threads value: 2000"));
         assert!(err.to_string().contains("1..=1024"));
     }
@@ -255,20 +253,18 @@ mod tests {
         // Test the validate_threads function directly
         assert!(validate_threads(ThreadSetting::Auto).is_ok());
         assert!(validate_threads(ThreadSetting::Off).is_ok());
-        
+
         // Test boundary values
         assert!(validate_threads(ThreadSetting::Fixed(1)).is_ok());
         assert!(validate_threads(ThreadSetting::Fixed(1024)).is_ok());
-        
+
         // Test invalid values
         assert!(validate_threads(ThreadSetting::Fixed(0)).is_err());
         assert!(validate_threads(ThreadSetting::Fixed(1025)).is_err());
-        
+
         // Verify error message format
         let err = validate_threads(ThreadSetting::Fixed(0)).expect_err("expected error");
         assert!(err.to_string().contains("Invalid threads value: 0"));
         assert!(err.to_string().contains("(allowed 1..=1024)"));
     }
 }
-
-

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,9 +1,9 @@
-use crate::errors::{AppError, Result};
-use crate::audio::{self, AudioSettings};
-use crate::audio::settings_encoder::{EncoderSettings, validate_encoder_settings};
-use crate::audio::{ChannelConfig, SampleRateConfig};
-use std::path::{Path, PathBuf};
 use crate::audio::file_list::FileListInfo;
+use crate::audio::settings_encoder::{validate_encoder_settings, EncoderSettings};
+use crate::audio::{self, AudioSettings};
+use crate::audio::{ChannelConfig, SampleRateConfig};
+use crate::errors::{AppError, Result};
+use std::path::{Path, PathBuf};
 // removed duplicate PathBuf import
 
 /// Validates that all provided file paths exist and are files
@@ -137,9 +137,10 @@ pub async fn process_audiobook_files_v2(
 
     // Set processing state
     {
-        let mut is_processing = state.is_processing.lock().map_err(|_| {
-            AppError::InvalidInput("Failed to acquire processing lock".to_string())
-        })?;
+        let mut is_processing = state
+            .is_processing
+            .lock()
+            .map_err(|_| AppError::InvalidInput("Failed to acquire processing lock".to_string()))?;
         *is_processing = true;
 
         let mut is_cancelled = state.is_cancelled.lock().map_err(|_| {
@@ -156,14 +157,17 @@ pub async fn process_audiobook_files_v2(
     let (message, preview_path_opt, preview_seconds_used) = {
         let session = audio::session::ProcessingSession::new();
         let settings_for_path = settings_v1.clone();
-        let mut context = audio::ProcessingContext::new(window, std::sync::Arc::new(session), settings_v1);
+        let mut context =
+            audio::ProcessingContext::new(window, std::sync::Arc::new(session), settings_v1);
         // Attach v2 encoder settings to context for downstream mapping
         context.encoder_settings_v2 = Some(payload.settings.clone());
 
         // Resolve preview seconds
         let mut preview_seconds_resolved: Option<f64> = None;
         if let Some(sec) = preview_seconds.or_else(|| {
-            std::env::var("ABB_PREVIEW_SECONDS").ok().and_then(|s| s.parse::<f64>().ok())
+            std::env::var("ABB_PREVIEW_SECONDS")
+                .ok()
+                .and_then(|s| s.parse::<f64>().ok())
         }) {
             if sec.is_finite() && sec > 0.0 {
                 context.preview = Some(crate::audio::context::PreviewConfig { seconds: sec });
@@ -172,10 +176,14 @@ pub async fn process_audiobook_files_v2(
             }
         }
         let is_preview = context.preview.is_some();
-        let msg = audio::processor::process_audiobook_with_context(context, file_info.files, metadata).await?;
+        let msg =
+            audio::processor::process_audiobook_with_context(context, file_info.files, metadata)
+                .await?;
         let preview_path = if is_preview {
             let final_output = &settings_for_path.output_path;
-            let parent = final_output.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let parent = final_output
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
             let stem = final_output
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -190,13 +198,18 @@ pub async fn process_audiobook_files_v2(
 
     // Reset processing state
     {
-        let mut is_processing = state.is_processing.lock().map_err(|_| {
-            AppError::InvalidInput("Failed to acquire processing lock".to_string())
-        })?;
+        let mut is_processing = state
+            .is_processing
+            .lock()
+            .map_err(|_| AppError::InvalidInput("Failed to acquire processing lock".to_string()))?;
         *is_processing = false;
     }
 
-    Ok(ProcessCommandResult { message, preview_file_path: preview_path_opt, preview_actual_seconds: preview_seconds_used })
+    Ok(ProcessCommandResult {
+        message,
+        preview_file_path: preview_path_opt,
+        preview_actual_seconds: preview_seconds_used,
+    })
 }
 
 /// Processes multiple audio files into a single M4B audiobook
@@ -220,9 +233,10 @@ pub async fn process_audiobook_files(
 ) -> Result<ProcessCommandResult> {
     // Set processing state
     {
-        let mut is_processing = state.is_processing.lock().map_err(|_| {
-            AppError::InvalidInput("Failed to acquire processing lock".to_string())
-        })?;
+        let mut is_processing = state
+            .is_processing
+            .lock()
+            .map_err(|_| AppError::InvalidInput("Failed to acquire processing lock".to_string()))?;
         *is_processing = true;
 
         let mut is_cancelled = state.is_cancelled.lock().map_err(|_| {
@@ -241,11 +255,14 @@ pub async fn process_audiobook_files(
         let session = audio::session::ProcessingSession::new();
         // Clone settings for deriving preview path later (original moved into context)
         let settings_for_path = settings.clone();
-        let mut context = audio::ProcessingContext::new(window, std::sync::Arc::new(session), settings);
+        let mut context =
+            audio::ProcessingContext::new(window, std::sync::Arc::new(session), settings);
         // Resolve preview seconds from payload or environment fallback
         let mut preview_seconds_resolved: Option<f64> = None;
         if let Some(sec) = preview_seconds.or_else(|| {
-            std::env::var("ABB_PREVIEW_SECONDS").ok().and_then(|s| s.parse::<f64>().ok())
+            std::env::var("ABB_PREVIEW_SECONDS")
+                .ok()
+                .and_then(|s| s.parse::<f64>().ok())
         }) {
             if sec.is_finite() && sec > 0.0 {
                 context.preview = Some(crate::audio::context::PreviewConfig { seconds: sec });
@@ -254,11 +271,15 @@ pub async fn process_audiobook_files(
             }
         }
         let is_preview = context.preview.is_some();
-        let msg = audio::processor::process_audiobook_with_context(context, file_info.files, metadata).await?;
+        let msg =
+            audio::processor::process_audiobook_with_context(context, file_info.files, metadata)
+                .await?;
         let preview_path = if is_preview {
             // Derive preview path deterministically based on output settings
             let final_output = &settings_for_path.output_path;
-            let parent = final_output.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let parent = final_output
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
             let stem = final_output
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -273,26 +294,30 @@ pub async fn process_audiobook_files(
 
     // Reset processing state
     {
-        let mut is_processing = state.is_processing.lock().map_err(|_| {
-            AppError::InvalidInput("Failed to acquire processing lock".to_string())
-        })?;
+        let mut is_processing = state
+            .is_processing
+            .lock()
+            .map_err(|_| AppError::InvalidInput("Failed to acquire processing lock".to_string()))?;
         *is_processing = false;
     }
 
-    Ok(ProcessCommandResult { message, preview_file_path: preview_path_opt, preview_actual_seconds: preview_seconds_used })
+    Ok(ProcessCommandResult {
+        message,
+        preview_file_path: preview_path_opt,
+        preview_actual_seconds: preview_seconds_used,
+    })
 }
 
 /// Cancels the current audio processing operation
 /// Sets the cancellation flag in the shared processing state
 #[tauri::command]
 pub fn cancel_processing(state: tauri::State<crate::ProcessingState>) -> Result<String> {
-    let mut is_cancelled = state.is_cancelled.lock().map_err(|_| {
-        AppError::InvalidInput("Failed to acquire cancellation lock".to_string())
-    })?;
+    let mut is_cancelled = state
+        .is_cancelled
+        .lock()
+        .map_err(|_| AppError::InvalidInput("Failed to acquire cancellation lock".to_string()))?;
     *is_cancelled = true;
     Ok("Processing cancellation requested".to_string())
 }
 
 // Removed legacy merge_audio_files command and shell-based implementation during nuclear cleanup.
-
-

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -12,10 +12,7 @@ pub fn read_audio_metadata(file_path: String) -> Result<AudiobookMetadata> {
 /// Writes metadata to an existing M4B file
 /// Accepts file path and metadata object
 #[tauri::command]
-pub fn write_audio_metadata(
-    file_path: String,
-    metadata: AudiobookMetadata,
-) -> Result<()> {
+pub fn write_audio_metadata(file_path: String, metadata: AudiobookMetadata) -> Result<()> {
     write_metadata(&file_path, &metadata)
 }
 
@@ -97,25 +94,29 @@ fn validate_image_format(data: &[u8], extension: &str) -> Result<()> {
             if data.len() >= JPEG_HEADER.len() && data[..JPEG_HEADER.len()] == JPEG_HEADER {
                 Ok(())
             } else {
-                Err(AppError::InvalidInput("Invalid JPEG file format".to_string()))
+                Err(AppError::InvalidInput(
+                    "Invalid JPEG file format".to_string(),
+                ))
             }
         }
         "png" => {
             if data.len() >= MIN_PNG_SIZE && data[..PNG_HEADER.len()] == PNG_HEADER {
                 Ok(())
             } else {
-                Err(AppError::InvalidInput("Invalid PNG file format".to_string()))
+                Err(AppError::InvalidInput(
+                    "Invalid PNG file format".to_string(),
+                ))
             }
         }
         "webp" => {
             if data.len() >= MIN_WEBP_SIZE && &data[0..4] == b"RIFF" && &data[8..12] == b"WEBP" {
                 Ok(())
             } else {
-                Err(AppError::InvalidInput("Invalid WebP file format".to_string()))
+                Err(AppError::InvalidInput(
+                    "Invalid WebP file format".to_string(),
+                ))
             }
         }
         _ => Ok(()),
     }
 }
-
-

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,5 +5,3 @@ pub mod system;
 pub use audio::*;
 pub use metadata::*;
 pub use system::*;
-
-

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -15,5 +15,3 @@ pub fn echo(input: String) -> Result<String> {
 }
 
 // Removed get_ffmpeg_version command during nuclear transition (ffmpeg-next only).
-
-

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -5,25 +5,25 @@ use thiserror::Error;
 pub enum AppError {
     #[error("File validation failed: {0}")]
     FileValidation(String),
-    
+
     #[error("Invalid input: {0}")]
     InvalidInput(String),
-    
+
     #[error("IO operation failed: {0}")]
     Io(#[from] std::io::Error),
-    
+
     #[error("Audio metadata error: {0}")]
     Metadata(#[from] lofty::error::LoftyError),
-    
+
     #[error("Process termination failed: {0}")]
     ProcessTermination(String),
-    
+
     #[error("Temporary directory creation failed: {0}")]
     TempDirectoryCreation(String),
-    
+
     #[error("Resource cleanup failed: {0}")]
     ResourceCleanup(String),
-    
+
     #[error("Operation failed: {0}")]
     General(String),
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,27 +7,26 @@ pub mod commands;
 mod errors;
 mod metadata;
 // Re-export key public types needed by external integration tests without exposing full internal module structure
-pub use metadata::AudiobookMetadata;
 pub use metadata::ffmpeg_bridge::{
-    set_container_metadata as ffmpeg_set_container_metadata,
     add_cover_art_stream_pre_header as ffmpeg_add_cover_art_stream_pre_header,
-    write_cover_art_packet_post_header as ffmpeg_write_cover_art_packet_post_header,
     detect_cover_art_format as ffmpeg_detect_cover_art_format,
+    set_container_metadata as ffmpeg_set_container_metadata,
     validate_metadata_compatibility as ffmpeg_validate_metadata_compatibility,
+    write_cover_art_packet_post_header as ffmpeg_write_cover_art_packet_post_header,
     CoverFormat as FfmpegCoverFormat,
 };
 pub use metadata::writer::{
-    write_cover_art as lofty_write_cover_art,
-    write_metadata as lofty_write_metadata,
+    write_cover_art as lofty_write_cover_art, write_metadata as lofty_write_metadata,
 };
+pub use metadata::AudiobookMetadata;
 pub mod audio;
 
 #[cfg(test)]
 pub mod tests_integration;
 pub mod tests_metadata_integration; // formerly feature-gated
 
-use std::sync::{Arc, Mutex};
 use audio::ProcessingProgress;
+use std::sync::{Arc, Mutex};
 
 /// Shared state for tracking processing status and cancellation
 #[derive(Default, Debug)]
@@ -40,13 +39,12 @@ pub struct ProcessingState {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Initialize logging with INFO level for production
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .init();
-    
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     log::info!("Starting Audiobook Boss application");
-    
+
     let processing_state = ProcessingState::default();
-    
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/metadata/ffmpeg_bridge.rs
+++ b/src-tauri/src/metadata/ffmpeg_bridge.rs
@@ -1,4 +1,3 @@
-
 //! FFmpeg-Next metadata integration bridge
 //!
 //! This module provides conversion and integration between our AudiobookMetadata
@@ -26,117 +25,133 @@ use ffmpeg_next as ff;
 /// `validate_metadata_compatibility` beforehand so callers can surface warnings.
 pub fn metadata_to_ffmpeg_dict(metadata: &AudiobookMetadata) -> Result<ff::Dictionary<'_>> {
     let mut dict = ff::Dictionary::new();
-    
+
     // Standard audiobook metadata fields
     if let Some(ref title) = metadata.title {
         dict.set("title", title);
     }
-    
+
     if let Some(ref artist) = metadata.artist {
         dict.set("artist", artist);
         dict.set("album_artist", artist); // For audiobooks, artist = album_artist
     }
-    
+
     if let Some(ref album) = metadata.album {
         dict.set("album", album);
     }
-    
+
     if let Some(ref composer) = metadata.composer {
         dict.set("composer", composer);
     }
-    
+
     if let Some(ref genre) = metadata.genre {
         dict.set("genre", genre);
     }
-    
+
     if let Some(date) = metadata.date {
         dict.set("date", &date.to_string());
         dict.set("year", &date.to_string()); // Some containers prefer year
     }
-    
+
     if let Some(ref comment) = metadata.comment {
         dict.set("comment", comment);
     }
-    
+
     if let Some(ref description) = metadata.description {
         dict.set("description", description);
     }
-    
+
     // M4B-specific audiobook metadata
     dict.set("media_type", "2"); // Audiobook media type for iTunes
-    
+
     Ok(dict)
 }
 
-
-
-
-
-
-
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum CoverFormat { Jpeg, Png }
+pub enum CoverFormat {
+    Jpeg,
+    Png,
+}
 
 /// Detects JPEG or PNG format from raw bytes
 pub fn detect_cover_art_format(cover_data: &[u8]) -> Option<CoverFormat> {
-    if cover_data.len() >= 3 && cover_data[0] == 0xFF && cover_data[1] == 0xD8 && cover_data[2] == 0xFF {
+    if cover_data.len() >= 3
+        && cover_data[0] == 0xFF
+        && cover_data[1] == 0xD8
+        && cover_data[2] == 0xFF
+    {
         return Some(CoverFormat::Jpeg);
     }
-    if cover_data.len() >= 8 && cover_data[0..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
+    if cover_data.len() >= 8 && cover_data[0..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]
+    {
         return Some(CoverFormat::Png);
     }
     None
 }
 
 /// Adds a cover art stream prior to header writing. Returns output stream index if added.
-/// 
+///
 /// For M4B/MP4 containers, this properly sets the `attached_pic` disposition using
 /// FFI to ensure the stream is treated as cover art rather than a regular video stream.
 pub fn add_cover_art_stream_pre_header(
     octx: &mut ff::format::context::Output,
     cover_data: &[u8],
 ) -> Option<(usize, CoverFormat)> {
-    if cover_data.is_empty() { return None; }
+    if cover_data.is_empty() {
+        return None;
+    }
     let Some(format) = detect_cover_art_format(cover_data) else {
         log::warn!("Unsupported cover art format (only JPEG/PNG). Deferring to finalize stage");
         return None;
     };
 
-    let codec_id = match format { CoverFormat::Jpeg => ff::codec::Id::MJPEG, CoverFormat::Png => ff::codec::Id::PNG };
+    let codec_id = match format {
+        CoverFormat::Jpeg => ff::codec::Id::MJPEG,
+        CoverFormat::Png => ff::codec::Id::PNG,
+    };
     let Some(codec) = ff::encoder::find(codec_id) else {
-        log::warn!("Cover art codec {:?} missing in ffmpeg build; fallback to finalize stage", format);
+        log::warn!(
+            "Cover art codec {:?} missing in ffmpeg build; fallback to finalize stage",
+            format
+        );
         return None;
     };
-    
+
     match octx.add_stream(codec) {
         Ok(mut stream) => {
             let idx = stream.index();
-            
+
             // Configure stream parameters for cover art
             if let Err(e) = configure_cover_art_stream_parameters(&mut stream, format, cover_data) {
                 log::warn!("Failed to configure cover art stream parameters ({}); fallback to finalize stage", e);
                 return None;
             }
-            
+
             // Set the ATTACHED_PIC disposition using FFI
             // This is crucial for M4B/MP4 containers to properly recognize cover art
             if let Err(e) = set_attached_pic_disposition(octx, idx) {
-                log::warn!("Failed to set attached_pic disposition ({}); trying without disposition", e);
+                log::warn!(
+                    "Failed to set attached_pic disposition ({}); trying without disposition",
+                    e
+                );
             }
-            
+
             log::info!("Added cover art stream with attached_pic disposition (index={}, format={:?}, bytes={})", 
                       idx, format, cover_data.len());
             Some((idx, format))
         }
         Err(e) => {
-            log::warn!("Failed adding cover art stream ({}); fallback to finalize stage", e);
+            log::warn!(
+                "Failed adding cover art stream ({}); fallback to finalize stage",
+                e
+            );
             None
         }
     }
 }
 
 /// Configures stream parameters for cover art embedding
-/// 
+///
 /// This creates a proper codec context for the cover art stream to ensure it
 /// is recognized correctly by the container format.
 fn configure_cover_art_stream_parameters(
@@ -145,50 +160,56 @@ fn configure_cover_art_stream_parameters(
     cover_data: &[u8],
 ) -> Result<()> {
     use crate::errors::AppError;
-    
+
     // Create a codec context for the cover art
     let codec_id = match format {
         CoverFormat::Jpeg => ff::codec::Id::MJPEG,
         CoverFormat::Png => ff::codec::Id::PNG,
     };
-    
+
     let codec = ff::encoder::find(codec_id)
         .ok_or_else(|| AppError::General(format!("Codec {:?} not found", codec_id)))?;
-    
+
     let mut ctx = ff::codec::context::Context::new()
         .encoder()
         .video()
         .map_err(|e| AppError::General(format!("Failed to create video encoder context: {}", e)))?;
-    
+
     // Try to detect image dimensions for better compatibility
     let (width, height) = detect_image_dimensions(cover_data, format).unwrap_or((600, 600));
-    
+
     ctx.set_width(width as u32);
     ctx.set_height(height as u32);
-    
+
     // Set pixel format for the codec
     let pixel_format = match format {
         CoverFormat::Jpeg => ff::format::Pixel::YUVJ420P, // Common JPEG pixel format
         CoverFormat::Png => ff::format::Pixel::RGBA,      // PNG with alpha
     };
     ctx.set_format(pixel_format);
-    
+
     // Set time base for single frame
     ctx.set_time_base(ff::Rational(1, 1));
-    
+
     // Open the encoder to finalize parameters
-    let encoder = ctx.open_as(codec)
+    let encoder = ctx
+        .open_as(codec)
         .map_err(|e| AppError::General(format!("Failed to open cover art encoder: {}", e)))?;
-    
+
     // Set the stream parameters from the encoder context
     stream.set_parameters(&encoder);
-    
-    log::debug!("Configured cover art stream parameters for {:?} format ({}x{})", format, width, height);
+
+    log::debug!(
+        "Configured cover art stream parameters for {:?} format ({}x{})",
+        format,
+        width,
+        height
+    );
     Ok(())
 }
 
 /// Detects image dimensions from raw image data
-/// 
+///
 /// This is a simple implementation that handles basic JPEG and PNG headers.
 /// Returns None if dimensions cannot be detected.
 fn detect_image_dimensions(data: &[u8], format: CoverFormat) -> Option<(i32, i32)> {
@@ -200,21 +221,26 @@ fn detect_image_dimensions(data: &[u8], format: CoverFormat) -> Option<(i32, i32
 
 /// Detects JPEG image dimensions from JPEG header
 fn detect_jpeg_dimensions(data: &[u8]) -> Option<(i32, i32)> {
-    if data.len() < 10 { return None; }
-    
+    if data.len() < 10 {
+        return None;
+    }
+
     let mut i = 2; // Skip SOI marker (FF D8)
     while i + 8 < data.len() {
-        if data[i] != 0xFF { break; }
-        
+        if data[i] != 0xFF {
+            break;
+        }
+
         let marker = data[i + 1];
-        if marker == 0xC0 || marker == 0xC2 { // SOF0 or SOF2
+        if marker == 0xC0 || marker == 0xC2 {
+            // SOF0 or SOF2
             if i + 9 < data.len() {
                 let height = u16::from_be_bytes([data[i + 5], data[i + 6]]) as i32;
                 let width = u16::from_be_bytes([data[i + 7], data[i + 8]]) as i32;
                 return Some((width, height));
             }
         }
-        
+
         // Skip to next marker
         if i + 3 < data.len() {
             let length = u16::from_be_bytes([data[i + 2], data[i + 3]]) as usize;
@@ -228,62 +254,67 @@ fn detect_jpeg_dimensions(data: &[u8]) -> Option<(i32, i32)> {
 
 /// Detects PNG image dimensions from PNG header
 fn detect_png_dimensions(data: &[u8]) -> Option<(i32, i32)> {
-    if data.len() < 24 { return None; }
-    
+    if data.len() < 24 {
+        return None;
+    }
+
     // PNG signature: 89 50 4E 47 0D 0A 1A 0A
     if data[0..8] != [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
         return None;
     }
-    
+
     // IHDR chunk should be next (starts at byte 8)
     if &data[12..16] != b"IHDR" {
         return None;
     }
-    
+
     // Width and height are at bytes 16-23
     let width = u32::from_be_bytes([data[16], data[17], data[18], data[19]]) as i32;
     let height = u32::from_be_bytes([data[20], data[21], data[22], data[23]]) as i32;
-    
+
     Some((width, height))
 }
 
 /// Sets the ATTACHED_PIC disposition on a stream using FFI
-/// 
+///
 /// This uses unsafe FFI to access the underlying AVStream and set the disposition
 /// flag directly, which is necessary because ffmpeg-next doesn't expose this functionality.
-fn set_attached_pic_disposition(octx: &mut ff::format::context::Output, stream_index: usize) -> Result<()> {
+fn set_attached_pic_disposition(
+    octx: &mut ff::format::context::Output,
+    stream_index: usize,
+) -> Result<()> {
     use crate::errors::AppError;
-    
+
     unsafe {
         // Get the format context
         let format_ctx = octx.as_mut_ptr();
         if format_ctx.is_null() {
             return Err(AppError::General("Invalid format context".to_string()));
         }
-        
+
         // Access the streams array
         let streams_ptr = (*format_ctx).streams;
         if streams_ptr.is_null() || stream_index >= (*format_ctx).nb_streams as usize {
             return Err(AppError::General("Invalid stream index".to_string()));
         }
-        
+
         // Get the specific stream
         let stream_ptr = *streams_ptr.add(stream_index);
         if stream_ptr.is_null() {
             return Err(AppError::General("Invalid stream pointer".to_string()));
         }
-        
-    // Set the ATTACHED_PIC disposition without clobbering existing flags
-    // AV_DISPOSITION_ATTACHED_PIC = 0x0400
-    (*stream_ptr).disposition |= 0x0400;
-        
+
+        // Set the ATTACHED_PIC disposition without clobbering existing flags
+        // AV_DISPOSITION_ATTACHED_PIC = 0x0400
+        (*stream_ptr).disposition |= 0x0400;
+
         log::debug!("Set ATTACHED_PIC disposition on stream {}", stream_index);
         Ok(())
     }
 }
 
 /// Writes the cover art packet after header if a stream was added.
-/// 
+///
 /// For attached pics in M4B/MP4 containers, this writes a single packet with
 /// specific flags that mark it as cover art. The packet should have PTS/DTS of 0
 /// and KEY flag to indicate it's a standalone image.
@@ -293,22 +324,31 @@ pub fn write_cover_art_packet_post_header(
     cover_data: &[u8],
     format: CoverFormat,
 ) {
-    if cover_data.is_empty() { return; }
-    
+    if cover_data.is_empty() {
+        return;
+    }
+
     let mut pkt = ff::Packet::copy(cover_data);
     pkt.set_stream(stream_index);
     pkt.set_flags(ff::packet::flag::Flags::KEY);
-    
+
     // For attached pics, set PTS and DTS to 0
     // This indicates it's a single frame that should be treated as cover art
     pkt.set_pts(Some(0));
     pkt.set_dts(Some(0));
-    
+
     if let Err(e) = pkt.write_interleaved(octx) {
-        log::warn!("Failed writing cover art packet ({}); finalize stage will attempt embedding", e);
+        log::warn!(
+            "Failed writing cover art packet ({}); finalize stage will attempt embedding",
+            e
+        );
     } else {
-        log::info!("Cover art packet written as attached pic (stream={}, format={:?}, size={} bytes)", 
-                  stream_index, format, cover_data.len());
+        log::info!(
+            "Cover art packet written as attached pic (stream={}, format={:?}, size={} bytes)",
+            stream_index,
+            format,
+            cover_data.len()
+        );
     }
 }
 
@@ -320,7 +360,7 @@ pub fn set_container_metadata(
 ) -> Result<()> {
     let dict = metadata_to_ffmpeg_dict(metadata)?;
     octx.set_metadata(dict);
-    
+
     log::debug!("Container metadata set via ffmpeg-next");
     Ok(())
 }
@@ -329,16 +369,16 @@ pub fn set_container_metadata(
 /// Returns warnings for unsupported fields
 pub fn validate_metadata_compatibility(metadata: &AudiobookMetadata) -> Vec<String> {
     let mut warnings = Vec::new();
-    
+
     // Check for fields that might not be well-supported by ffmpeg-next
     if metadata.track.is_some() {
         warnings.push("Track number metadata may not be preserved in M4B format".to_string());
     }
-    
+
     if metadata.disk.is_some() {
         warnings.push("Disk number metadata may not be preserved in M4B format".to_string());
     }
-    
+
     // Validate cover art comprehensively
     if let Some(ref cover_data) = metadata.cover_art {
         // Detect format up-front so we can tailor size heuristics
@@ -347,7 +387,8 @@ pub fn validate_metadata_compatibility(metadata: &AudiobookMetadata) -> Vec<Stri
         // Size validation (allow tiny placeholder images if format is detectable)
         if cover_data.is_empty() {
             warnings.push("Cover art data is empty".to_string());
-        } else if cover_data.len() > 10 * 1024 * 1024 { // 10MB limit
+        } else if cover_data.len() > 10 * 1024 * 1024 {
+            // 10MB limit
             warnings.push("Cover art exceeds recommended size limit (10MB)".to_string());
         } else if cover_data.len() < 100 {
             // Only warn about being too small if we *cannot* positively detect a supported format.
@@ -367,11 +408,16 @@ pub fn validate_metadata_compatibility(metadata: &AudiobookMetadata) -> Vec<Stri
                     if width > 2000 || height > 2000 {
                         warnings.push(format!("Cover art dimensions ({}x{}) are very large and may cause compatibility issues", width, height));
                     } else if width < 100 || height < 100 {
-                        warnings.push(format!("Cover art dimensions ({}x{}) are very small and may not display well", width, height));
+                        warnings.push(format!(
+                            "Cover art dimensions ({}x{}) are very small and may not display well",
+                            width, height
+                        ));
                     }
                 } else if cover_data.len() >= 100 {
                     // Suppress dimension warning for tiny (<100B) placeholder images
-                    warnings.push("Could not detect JPEG dimensions - file may be corrupted".to_string());
+                    warnings.push(
+                        "Could not detect JPEG dimensions - file may be corrupted".to_string(),
+                    );
                 }
             }
             Some(CoverFormat::Png) => {
@@ -380,21 +426,27 @@ pub fn validate_metadata_compatibility(metadata: &AudiobookMetadata) -> Vec<Stri
                     if width > 2000 || height > 2000 {
                         warnings.push(format!("Cover art dimensions ({}x{}) are very large and may cause compatibility issues", width, height));
                     } else if width < 100 || height < 100 {
-                        warnings.push(format!("Cover art dimensions ({}x{}) are very small and may not display well", width, height));
+                        warnings.push(format!(
+                            "Cover art dimensions ({}x{}) are very small and may not display well",
+                            width, height
+                        ));
                     }
                 } else if cover_data.len() >= 100 {
-                    warnings.push("Could not detect PNG dimensions - file may be corrupted".to_string());
+                    warnings.push(
+                        "Could not detect PNG dimensions - file may be corrupted".to_string(),
+                    );
                 }
             }
             None => {
                 // Only warn if the bytes clearly identify a known-but-unsupported image format.
                 // Arbitrary placeholder/random data (e.g. zero-filled buffer used in tests) should not
                 // produce a user-facing warning; we'll silently fall back to Lofty embedding.
-                let looks_ascii_upper = cover_data.len() >= 8 && cover_data.iter()
-                    .take(24)
-                    .all(|b| b.is_ascii_uppercase() || *b == b'_' || *b == b' ');
-                let known_unsupported =
-                    cover_data.starts_with(b"GIF87a") ||
+                let looks_ascii_upper = cover_data.len() >= 8
+                    && cover_data
+                        .iter()
+                        .take(24)
+                        .all(|b| b.is_ascii_uppercase() || *b == b'_' || *b == b' ');
+                let known_unsupported = cover_data.starts_with(b"GIF87a") ||
                     cover_data.starts_with(b"GIF89a") ||
                     (cover_data.len() >= 12 && &cover_data[0..4] == b"RIFF" && &cover_data[8..12] == b"WEBP") || // WebP
                     cover_data.starts_with(b"BM") ||                 // BMP
@@ -422,7 +474,7 @@ pub fn validate_metadata_compatibility(metadata: &AudiobookMetadata) -> Vec<Stri
             }
         }
     }
-    
+
     warnings
 }
 
@@ -430,7 +482,7 @@ pub fn validate_metadata_compatibility(metadata: &AudiobookMetadata) -> Vec<Stri
 mod tests {
     use super::*;
     use ffmpeg_next as ff;
-    
+
     #[test]
     fn test_metadata_conversion() {
         let metadata = AudiobookMetadata {
@@ -442,16 +494,16 @@ mod tests {
             description: Some("Test description".to_string()),
             ..Default::default()
         };
-        
+
         let dict = metadata_to_ffmpeg_dict(&metadata).expect("Metadata conversion should work");
-        
+
         // Verify essential fields are present
         assert!(dict.get("title").is_some());
         assert!(dict.get("artist").is_some());
         assert!(dict.get("album").is_some());
         assert!(dict.get("media_type").is_some());
     }
-    
+
     #[test]
     fn test_metadata_validation() {
         let metadata = AudiobookMetadata {
@@ -460,7 +512,7 @@ mod tests {
             cover_art: Some(vec![0u8; 15 * 1024 * 1024]), // 15MB - too large
             ..Default::default()
         };
-        
+
         let warnings = validate_metadata_compatibility(&metadata);
         assert!(warnings.len() >= 2); // Should warn about track and cover art size
     }
@@ -519,13 +571,14 @@ mod tests {
     #[test]
     fn test_validate_metadata_compatibility_enhanced() {
         // Test with valid JPEG cover art
-        let valid_jpeg = b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
+        let valid_jpeg =
+            b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
         let metadata_with_jpeg = AudiobookMetadata {
             title: Some("Test".to_string()),
             cover_art: Some(valid_jpeg.to_vec()),
             ..Default::default()
         };
-        
+
         let warnings = validate_metadata_compatibility(&metadata_with_jpeg);
         // Should not warn about format since JPEG is supported
         assert!(!warnings.iter().any(|w| w.contains("format not supported")));
@@ -537,7 +590,7 @@ mod tests {
             cover_art: Some(gif_data.to_vec()),
             ..Default::default()
         };
-        
+
         let warnings = validate_metadata_compatibility(&metadata_with_gif);
         assert!(warnings.iter().any(|w| w.contains("format not supported")));
 
@@ -547,7 +600,7 @@ mod tests {
             cover_art: Some(vec![]),
             ..Default::default()
         };
-        
+
         let warnings = validate_metadata_compatibility(&metadata_empty_cover);
         assert!(warnings.iter().any(|w| w.contains("empty")));
     }

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -1,5 +1,5 @@
 //! Metadata handling for audiobook files
-//! 
+//!
 //! This module provides functionality to read and write metadata
 //! from/to audio files using the Lofty crate.
 
@@ -70,9 +70,6 @@ pub use writer::write_metadata;
 
 // Re-export ffmpeg-next bridge functions for native metadata and cover art embedding
 pub use ffmpeg_bridge::{
-    add_cover_art_stream_pre_header,
-    write_cover_art_packet_post_header, 
-    set_container_metadata,
-    validate_metadata_compatibility,
-    CoverFormat,
+    add_cover_art_stream_pre_header, set_container_metadata, validate_metadata_compatibility,
+    write_cover_art_packet_post_header, CoverFormat,
 };

--- a/src-tauri/src/metadata/reader.rs
+++ b/src-tauri/src/metadata/reader.rs
@@ -10,25 +10,26 @@ use std::path::Path;
 /// Reads metadata from an audio file
 pub fn read_metadata<P: AsRef<Path>>(file_path: P) -> Result<AudiobookMetadata> {
     let path = file_path.as_ref();
-    
+
     if !path.exists() {
-        return Err(AppError::FileValidation(
-            format!("File not found: {}", path.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "File not found: {}",
+            path.display()
+        )));
     }
-    
-    let tagged_file = Probe::open(path)?
-        .read()?;
-    
-    let tag = tagged_file.primary_tag()
+
+    let tagged_file = Probe::open(path)?.read()?;
+
+    let tag = tagged_file
+        .primary_tag()
         .or_else(|| tagged_file.first_tag());
-    
+
     let mut metadata = AudiobookMetadata::new();
-    
+
     if let Some(tag) = tag {
         extract_tag_data(tag, &mut metadata);
     }
-    
+
     Ok(metadata)
 }
 
@@ -42,10 +43,10 @@ fn extract_tag_data(tag: &Tag, metadata: &mut AudiobookMetadata) {
     }
     metadata.date = tag.year();
     metadata.genre = tag.genre().map(|s| s.to_string());
-    
+
     // Extract description from comment
     metadata.description = tag.comment().map(|s| s.to_string());
-    
+
     // Extract cover art
     let pictures = tag.pictures();
     if let Some(picture) = pictures.first() {
@@ -70,7 +71,7 @@ mod tests {
         let temp_dir = TempDir::new().expect("create temp dir");
         let file_path = temp_dir.path().join("empty.txt");
         fs::write(&file_path, b"").expect("write empty file");
-        
+
         let result = read_metadata(&file_path);
         assert!(matches!(result, Err(AppError::Metadata(_))));
     }

--- a/src-tauri/src/metadata/writer.rs
+++ b/src-tauri/src/metadata/writer.rs
@@ -3,25 +3,23 @@
 use super::AudiobookMetadata;
 use crate::errors::{AppError, Result};
 use lofty::file::AudioFile;
+use lofty::picture::{MimeType, Picture, PictureType};
 use lofty::prelude::{Accessor, ItemKey, TagExt, TaggedFileExt};
 use lofty::probe::Probe;
-use lofty::picture::{Picture, PictureType, MimeType};
-use lofty::tag::{Tag, TagItem, ItemValue, TagType};
+use lofty::tag::{ItemValue, Tag, TagItem, TagType};
 use std::path::Path;
 
 /// Writes metadata to an existing M4B file
-pub fn write_metadata<P: AsRef<Path>>(
-    file_path: P,
-    metadata: &AudiobookMetadata,
-) -> Result<()> {
+pub fn write_metadata<P: AsRef<Path>>(file_path: P, metadata: &AudiobookMetadata) -> Result<()> {
     let path = file_path.as_ref();
-    
+
     if !path.exists() {
-        return Err(AppError::FileValidation(
-            format!("File not found: {}", path.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "File not found: {}",
+            path.display()
+        )));
     }
-    
+
     let mut tagged_file = Probe::open(path)?.read()?;
 
     // Ensure a primary tag exists – some freshly muxed MP4/M4B files may have
@@ -29,18 +27,18 @@ pub fn write_metadata<P: AsRef<Path>>(
     // list (MP4ILST) tag so metadata writing does not abort the finalize stage
     // leaving the temp output un‑moved.
     if tagged_file.primary_tag().is_none() {
-    log::debug!("No primary tag present – creating new Mp4Ilst tag");
-    tagged_file.insert_tag(Tag::new(TagType::Mp4Ilst));
+        log::debug!("No primary tag present – creating new Mp4Ilst tag");
+        tagged_file.insert_tag(Tag::new(TagType::Mp4Ilst));
     }
     let tag = tagged_file.primary_tag_mut().ok_or_else(|| {
         AppError::Metadata(lofty::error::LoftyError::new(
             lofty::error::ErrorKind::UnknownFormat,
         ))
     })?;
-    
+
     update_tag_data(tag, metadata)?;
     tagged_file.save_to_path(path, Default::default())?;
-    
+
     Ok(())
 }
 
@@ -48,7 +46,7 @@ pub fn write_metadata<P: AsRef<Path>>(
 fn update_tag_data(tag: &mut Tag, metadata: &AudiobookMetadata) -> Result<()> {
     // Clear existing metadata
     tag.clear();
-    
+
     // Set basic metadata
     if let Some(title) = &metadata.title {
         tag.set_title(title.clone());
@@ -60,7 +58,10 @@ fn update_tag_data(tag: &mut Tag, metadata: &AudiobookMetadata) -> Result<()> {
         tag.set_album(album.clone());
     }
     if let Some(narrator) = &metadata.composer {
-        tag.insert(TagItem::new(ItemKey::AlbumArtist, ItemValue::Text(narrator.clone())));
+        tag.insert(TagItem::new(
+            ItemKey::AlbumArtist,
+            ItemValue::Text(narrator.clone()),
+        ));
     }
     if let Some(year) = metadata.date {
         tag.set_year(year);
@@ -71,75 +72,75 @@ fn update_tag_data(tag: &mut Tag, metadata: &AudiobookMetadata) -> Result<()> {
     if let Some(description) = &metadata.description {
         tag.set_comment(description.clone());
     }
-    
+
     Ok(())
 }
 
 /// Writes cover art to an M4B file
-pub fn write_cover_art<P: AsRef<Path>>(
-    file_path: P,
-    cover_data: &[u8],
-) -> Result<()> {
+pub fn write_cover_art<P: AsRef<Path>>(file_path: P, cover_data: &[u8]) -> Result<()> {
     let path = file_path.as_ref();
-    
+
     if !path.exists() {
-        return Err(AppError::FileValidation(
-            format!("File not found: {}", path.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "File not found: {}",
+            path.display()
+        )));
     }
-    
-    let mut tagged_file = Probe::open(path)?
-        .read()?;
-    
-    let tag = tagged_file.primary_tag_mut()
-        .ok_or_else(|| AppError::Metadata(
-            lofty::error::LoftyError::new(lofty::error::ErrorKind::UnknownFormat)
-        ))?;
-    
+
+    let mut tagged_file = Probe::open(path)?.read()?;
+
+    let tag = tagged_file.primary_tag_mut().ok_or_else(|| {
+        AppError::Metadata(lofty::error::LoftyError::new(
+            lofty::error::ErrorKind::UnknownFormat,
+        ))
+    })?;
+
     // Detect the correct MIME type based on image format
     let mime_type = detect_image_mime_type(cover_data)?;
-    
+
     let picture = Picture::new_unchecked(
         PictureType::CoverFront,
         Some(mime_type),
         None,
         cover_data.to_vec(),
     );
-    
+
     tag.push_picture(picture);
     tagged_file.save_to_path(path, Default::default())?;
-    
+
     Ok(())
 }
 
 /// Detects MIME type from image data headers
 fn detect_image_mime_type(data: &[u8]) -> Result<MimeType> {
     if data.len() < 8 {
-        return Err(AppError::InvalidInput("Image data too small to determine format".to_string()));
+        return Err(AppError::InvalidInput(
+            "Image data too small to determine format".to_string(),
+        ));
     }
-    
+
     // Check for JPEG (starts with FF D8 FF)
     if data.len() >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
         return Ok(MimeType::Jpeg);
     }
-    
+
     // Check for PNG (starts with 89 50 4E 47 0D 0A 1A 0A)
     if data.len() >= 8 && data[0..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
         return Ok(MimeType::Png);
     }
-    
+
     // Check for GIF (GIF87a or GIF89a)
     if data.len() >= 6 && (&data[0..6] == b"GIF87a" || &data[0..6] == b"GIF89a") {
         return Ok(MimeType::Gif);
     }
-    
+
     // For WebP and other formats, default to JPEG for compatibility
     // (lofty may not support all MIME types we want to detect)
     if data.len() >= 12 && &data[0..4] == b"RIFF" && &data[8..12] == b"WEBP" {
         log::info!("WebP format detected, using JPEG MIME type for compatibility");
         return Ok(MimeType::Jpeg);
     }
-    
+
     // Default to JPEG for unknown formats (maintains backward compatibility)
     log::warn!("Unknown image format, defaulting to JPEG MIME type");
     Ok(MimeType::Jpeg)
@@ -148,8 +149,8 @@ fn detect_image_mime_type(data: &[u8]) -> Result<MimeType> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn test_write_to_nonexistent_file() {
@@ -170,7 +171,7 @@ mod tests {
         let temp_dir = TempDir::new().expect("create temp dir");
         let file_path = temp_dir.path().join("invalid.txt");
         fs::write(&file_path, b"not audio").expect("write temp file");
-        
+
         let metadata = AudiobookMetadata::new();
         let result = write_metadata(&file_path, &metadata);
         assert!(matches!(result, Err(AppError::Metadata(_))));
@@ -179,7 +180,8 @@ mod tests {
     #[test]
     fn test_detect_image_mime_type() {
         // Test JPEG detection
-        let jpeg_data = b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
+        let jpeg_data =
+            b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
         let mime_type = detect_image_mime_type(jpeg_data).expect("Should detect JPEG");
         assert!(matches!(mime_type, MimeType::Jpeg));
 

--- a/src-tauri/src/tests_integration.rs
+++ b/src-tauri/src/tests_integration.rs
@@ -1,13 +1,15 @@
 //! Integration tests for Phase 0 refactoring safety net
-//! 
+//!
 //! These tests capture the EXACT current behavior of the audiobook processing
 //! pipeline to ensure no regressions occur during refactoring.
-//! 
+//!
 //! DO NOT MODIFY THESE TESTS - they document how the system works now.
 //! Any changes should only be made if the current behavior is incorrect.
 
 use crate::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
-use crate::commands::{validate_files, analyze_audio_files, validate_audio_settings, read_audio_metadata};
+use crate::commands::{
+    analyze_audio_files, read_audio_metadata, validate_audio_settings, validate_files,
+};
 use crate::errors::{AppError, Result};
 use crate::metadata::AudiobookMetadata;
 use std::path::PathBuf;
@@ -41,15 +43,16 @@ fn create_mock_processing_state() -> crate::ProcessingState {
 fn verify_test_media_exists() -> Result<PathBuf> {
     let media_path = PathBuf::from(TEST_MEDIA_FILE);
     if !media_path.exists() {
-        return Err(AppError::FileValidation(
-            format!("Test media file not found: {}. This test requires the media file to be present.", 
-                    media_path.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "Test media file not found: {}. This test requires the media file to be present.",
+            media_path.display()
+        )));
     }
     if !media_path.is_file() {
-        return Err(AppError::FileValidation(
-            format!("Test media path is not a file: {}", media_path.display())
-        ));
+        return Err(AppError::FileValidation(format!(
+            "Test media path is not a file: {}",
+            media_path.display()
+        )));
     }
     Ok(media_path)
 }
@@ -79,32 +82,46 @@ mod integration_tests {
         let files = vec![media_path.to_string_lossy().to_string()];
         let validation_result = validate_files(files.clone());
         assert!(validation_result.is_ok(), "File validation should succeed");
-        assert!(validation_result.expect("validation ok").contains("Successfully validated 1 files"));
+        assert!(validation_result
+            .expect("validation ok")
+            .contains("Successfully validated 1 files"));
 
         // Step 2: Analyze the audio file
         let analysis_result = analyze_audio_files(files);
         assert!(analysis_result.is_ok(), "File analysis should succeed");
-        
+
         let file_info = analysis_result.expect("analysis ok");
         assert_eq!(file_info.files.len(), 1, "Should analyze exactly 1 file");
         assert_eq!(file_info.valid_count, 1, "Should have 1 valid file");
         assert_eq!(file_info.invalid_count, 0, "Should have 0 invalid files");
-        
+
         let audio_file = &file_info.files[0];
         assert!(audio_file.is_valid, "Test media file should be valid");
-        assert!(audio_file.duration.is_some(), "Should have duration information");
+        assert!(
+            audio_file.duration.is_some(),
+            "Should have duration information"
+        );
         assert!(audio_file.size.is_some(), "Should have size information");
-        assert!(audio_file.format.is_some(), "Should have format information");
+        assert!(
+            audio_file.format.is_some(),
+            "Should have format information"
+        );
 
         // Step 3: Validate processing settings
         let settings_validation = validate_audio_settings(settings.clone());
-        assert!(settings_validation.is_ok(), "Settings validation should succeed");
-        assert_eq!(settings_validation.expect("settings ok"), "Settings are valid");
+        assert!(
+            settings_validation.is_ok(),
+            "Settings validation should succeed"
+        );
+        assert_eq!(
+            settings_validation.expect("settings ok"),
+            "Settings are valid"
+        );
 
         // Step 4: Read metadata from input file
         let metadata_result = read_audio_metadata(media_path.to_string_lossy().to_string());
         assert!(metadata_result.is_ok(), "Should be able to read metadata");
-        
+
         let input_metadata = metadata_result.expect("metadata ok");
         // Document current metadata structure (don't assert specific values)
         eprintln!("Current metadata structure:");
@@ -120,8 +137,8 @@ mod integration_tests {
     /// Documents how progress tracking currently works
     #[test]
     fn test_progress_reporting_accuracy() {
-        use crate::audio::ProgressReporter;
         use crate::audio::ProcessingStage;
+        use crate::audio::ProgressReporter;
 
         // Test current progress reporting implementation
         let mut reporter = ProgressReporter::new(3); // 3 files
@@ -173,10 +190,13 @@ mod integration_tests {
 
         // Read current metadata
         let metadata_result = read_audio_metadata(media_path.to_string_lossy().to_string());
-        assert!(metadata_result.is_ok(), "Should be able to read metadata from test file");
+        assert!(
+            metadata_result.is_ok(),
+            "Should be able to read metadata from test file"
+        );
 
         let original_metadata = metadata_result.expect("metadata ok");
-        
+
         // Document current metadata structure and behavior
         eprintln!("Original metadata behavior:");
         eprintln!("  Title: {:?}", original_metadata.title);
@@ -190,9 +210,18 @@ mod integration_tests {
 
         // Test metadata creation and modification
         let mut new_metadata = AudiobookMetadata::new();
-        assert!(new_metadata.title.is_none(), "New metadata should have no title");
-        assert!(new_metadata.artist.is_none(), "New metadata should have no author");
-        assert!(new_metadata.cover_art.is_none(), "New metadata should have no cover art");
+        assert!(
+            new_metadata.title.is_none(),
+            "New metadata should have no title"
+        );
+        assert!(
+            new_metadata.artist.is_none(),
+            "New metadata should have no author"
+        );
+        assert!(
+            new_metadata.cover_art.is_none(),
+            "New metadata should have no cover art"
+        );
 
         // Test metadata field assignment
         new_metadata.title = Some("Test Title".to_string());
@@ -206,45 +235,77 @@ mod integration_tests {
     #[test]
     fn test_error_handling() {
         // Test file validation errors
-        let nonexistent_files = vec!["nonexistent1.mp3".to_string(), "nonexistent2.mp3".to_string()];
+        let nonexistent_files = vec![
+            "nonexistent1.mp3".to_string(),
+            "nonexistent2.mp3".to_string(),
+        ];
         let validation_result = validate_files(nonexistent_files);
-        assert!(validation_result.is_err(), "Should fail for nonexistent files");
-        
-        let error_msg = validation_result.expect_err("expected validation error").to_string();
-        assert!(error_msg.contains("No such file or directory"), "Should report file not found");
+        assert!(
+            validation_result.is_err(),
+            "Should fail for nonexistent files"
+        );
+
+        let error_msg = validation_result
+            .expect_err("expected validation error")
+            .to_string();
+        assert!(
+            error_msg.contains("No such file or directory"),
+            "Should report file not found"
+        );
 
         // Test analysis of invalid files
         let invalid_files = vec!["nonexistent.mp3".to_string()];
         let analysis_result = analyze_audio_files(invalid_files);
-        assert!(analysis_result.is_ok(), "Analysis should succeed but mark files as invalid");
-        
+        assert!(
+            analysis_result.is_ok(),
+            "Analysis should succeed but mark files as invalid"
+        );
+
         let file_info = analysis_result.expect("analysis ok");
         assert_eq!(file_info.valid_count, 0, "Should have 0 valid files");
         assert_eq!(file_info.invalid_count, 1, "Should have 1 invalid file");
-        assert!(!file_info.files[0].is_valid, "File should be marked as invalid");
-        assert!(file_info.files[0].error.is_some(), "Should have error message");
+        assert!(
+            !file_info.files[0].is_valid,
+            "File should be marked as invalid"
+        );
+        assert!(
+            file_info.files[0].error.is_some(),
+            "Should have error message"
+        );
 
         // Test settings validation errors
         let temp_dir = TempDir::new().expect("create temp dir");
         let mut invalid_settings = create_test_settings(temp_dir.path().join("test.m4b"));
-        
+
         // Invalid bitrate
         invalid_settings.bitrate = 256; // Too high
         let settings_result = validate_audio_settings(invalid_settings.clone());
         assert!(settings_result.is_err(), "Should fail for invalid bitrate");
-        assert!(settings_result.expect_err("expected bitrate error").to_string().contains("Bitrate must be"));
+        assert!(settings_result
+            .expect_err("expected bitrate error")
+            .to_string()
+            .contains("Bitrate must be"));
 
         // Invalid output extension
         invalid_settings.bitrate = 64; // Fix bitrate
         invalid_settings.output_path = temp_dir.path().join("test.mp3"); // Wrong extension
         let settings_result = validate_audio_settings(invalid_settings);
-        assert!(settings_result.is_err(), "Should fail for wrong file extension");
-        assert!(settings_result.expect_err("expected extension error").to_string().contains(".m4b"));
+        assert!(
+            settings_result.is_err(),
+            "Should fail for wrong file extension"
+        );
+        assert!(settings_result
+            .expect_err("expected extension error")
+            .to_string()
+            .contains(".m4b"));
 
         // Test metadata reading from invalid file
         let metadata_result = read_audio_metadata("nonexistent.mp3".to_string());
         assert!(metadata_result.is_err(), "Should fail for nonexistent file");
-        assert!(metadata_result.expect_err("expected file not found").to_string().contains("File not found"));
+        assert!(metadata_result
+            .expect_err("expected file not found")
+            .to_string()
+            .contains("File not found"));
     }
 
     /// Test that captures current file validation logic
@@ -255,21 +316,27 @@ mod integration_tests {
         if let Ok(media_path) = verify_test_media_exists() {
             let files = vec![media_path.to_string_lossy().to_string()];
             let validation_result = validate_files(files.clone());
-            assert!(validation_result.is_ok(), "Valid file should pass validation");
+            assert!(
+                validation_result.is_ok(),
+                "Valid file should pass validation"
+            );
 
             let analysis_result = analyze_audio_files(files);
             assert!(analysis_result.is_ok(), "Valid file should be analyzable");
-            
+
             let file_info = analysis_result.expect("analysis ok");
             let audio_file = &file_info.files[0];
-            
+
             // Document current validation criteria
             assert!(audio_file.is_valid, "Test media should be valid");
-            assert!(audio_file.error.is_none(), "Valid file should have no error");
+            assert!(
+                audio_file.error.is_none(),
+                "Valid file should have no error"
+            );
             assert!(audio_file.size.is_some(), "Should determine file size");
             assert!(audio_file.duration.is_some(), "Should determine duration");
             assert!(audio_file.format.is_some(), "Should determine format");
-            
+
             eprintln!("Valid file properties:");
             eprintln!("  Size: {:?} bytes", audio_file.size);
             eprintln!("  Duration: {:?} seconds", audio_file.duration);
@@ -281,24 +348,36 @@ mod integration_tests {
 
         // Test invalid file scenarios
         let temp_dir = TempDir::new().expect("create temp dir");
-        
+
         // Create fake audio file with invalid content
         let fake_audio = temp_dir.path().join("fake.mp3");
         std::fs::write(&fake_audio, b"not audio content").expect("write fake audio");
-        
+
         let files = vec![fake_audio.to_string_lossy().to_string()];
         let analysis_result = analyze_audio_files(files);
-        assert!(analysis_result.is_ok(), "Analysis should succeed even for invalid files");
-        
+        assert!(
+            analysis_result.is_ok(),
+            "Analysis should succeed even for invalid files"
+        );
+
         let file_info = analysis_result.expect("analysis ok");
         let audio_file = &file_info.files[0];
-        
+
         // Document current behavior for invalid files
         assert!(!audio_file.is_valid, "Fake audio file should be invalid");
-        assert!(audio_file.error.is_some(), "Invalid file should have error message");
-        assert!(audio_file.size.is_some(), "Should still determine file size");
-        assert!(audio_file.duration.is_none(), "Invalid file should have no duration");
-        
+        assert!(
+            audio_file.error.is_some(),
+            "Invalid file should have error message"
+        );
+        assert!(
+            audio_file.size.is_some(),
+            "Should still determine file size"
+        );
+        assert!(
+            audio_file.duration.is_none(),
+            "Invalid file should have no duration"
+        );
+
         eprintln!("Invalid file properties:");
         eprintln!("  Error: {:?}", audio_file.error);
         eprintln!("  Size: {:?} bytes", audio_file.size);
@@ -306,15 +385,24 @@ mod integration_tests {
         // Test empty file list
         let empty_result = analyze_audio_files(vec![]);
         assert!(empty_result.is_err(), "Empty file list should fail");
-        assert!(empty_result.expect_err("expected empty list error").to_string().contains("No files provided"));
+        assert!(empty_result
+            .expect_err("expected empty list error")
+            .to_string()
+            .contains("No files provided"));
 
         // Test nonexistent file
         let nonexistent_files = vec!["totally_nonexistent.mp3".to_string()];
         let nonexistent_result = analyze_audio_files(nonexistent_files);
-        assert!(nonexistent_result.is_ok(), "Analysis should succeed for nonexistent files");
-        
+        assert!(
+            nonexistent_result.is_ok(),
+            "Analysis should succeed for nonexistent files"
+        );
+
         let file_info = nonexistent_result.expect("analysis ok");
-        assert_eq!(file_info.valid_count, 0, "Nonexistent file should be invalid");
+        assert_eq!(
+            file_info.valid_count, 0,
+            "Nonexistent file should be invalid"
+        );
         assert_eq!(file_info.invalid_count, 1, "Should count as invalid");
         assert!(!file_info.files[0].is_valid, "Should be marked invalid");
     }
@@ -328,31 +416,41 @@ mod integration_tests {
         // Test empty input
         let empty_result = detect_input_sample_rate(&[]);
         assert!(empty_result.is_err(), "Empty input should fail");
-        assert!(empty_result.expect_err("expected no input files error").to_string().contains("no input files provided"));
+        assert!(empty_result
+            .expect_err("expected no input files error")
+            .to_string()
+            .contains("no input files provided"));
 
         // Test nonexistent files
         let nonexistent = vec![PathBuf::from("nonexistent.mp3")];
         let nonexistent_result = detect_input_sample_rate(&nonexistent);
         assert!(nonexistent_result.is_err(), "Nonexistent files should fail");
-        assert!(nonexistent_result.expect_err("expected no valid audio files error").to_string().contains("no valid audio files found"));
+        assert!(nonexistent_result
+            .expect_err("expected no valid audio files error")
+            .to_string()
+            .contains("no valid audio files found"));
 
         // Test with actual media file if available
         if let Ok(media_path) = verify_test_media_exists() {
             let files = vec![media_path];
             let sample_rate_result = detect_input_sample_rate(&files);
-            
+
             if sample_rate_result.is_ok() {
                 let sample_rate = sample_rate_result.expect("sample rate ok");
                 eprintln!("Detected sample rate: {sample_rate} Hz");
                 assert!(sample_rate > 0, "Sample rate should be positive");
-                
+
                 // Document typical sample rates
                 let common_rates = [22050, 32000, 44100, 48000];
-                eprintln!("Sample rate {sample_rate} is common: {}", 
-                         common_rates.contains(&sample_rate));
+                eprintln!(
+                    "Sample rate {sample_rate} is common: {}",
+                    common_rates.contains(&sample_rate)
+                );
             } else {
-                eprintln!("Could not detect sample rate from test media: {}", 
-                         sample_rate_result.expect_err("expected sample rate error"));
+                eprintln!(
+                    "Could not detect sample rate from test media: {}",
+                    sample_rate_result.expect_err("expected sample rate error")
+                );
             }
         }
     }
@@ -364,14 +462,17 @@ mod integration_tests {
         // Note: build_merge_command is private, so we test the behavior indirectly
         // by testing the public API that uses it
         eprintln!("FFmpeg command construction is tested indirectly through processor module");
-        
+
         // Test the public sample rate detection function instead
         use crate::audio::processor::detect_input_sample_rate;
-        
+
         let empty_result = detect_input_sample_rate(&[]);
         assert!(empty_result.is_err());
-        assert!(empty_result.expect_err("expected no input files").to_string().contains("no input files provided"));
-        
+        assert!(empty_result
+            .expect_err("expected no input files")
+            .to_string()
+            .contains("no input files provided"));
+
         eprintln!("FFmpeg command building behavior is captured by end-to-end tests");
     }
 
@@ -381,17 +482,19 @@ mod integration_tests {
     fn test_temporary_file_handling() {
         // Note: create_temp_directory and create_concat_file are private functions
         // We test the temporary file behavior indirectly through the public API
-        
+
         use tempfile::TempDir;
-        
+
         // Test that we can create temporary directories manually
         let temp_dir = TempDir::new().expect("create temp dir");
         assert!(temp_dir.path().exists(), "Temp directory should exist");
         assert!(temp_dir.path().is_dir(), "Should be a directory");
-        
+
         eprintln!("Temp directory created at: {}", temp_dir.path().display());
-        
+
         // Legacy CLI concat file behavior intentionally removed in ffmpeg-next engine
-        eprintln!("Temporary directory handling verified; no concat file behavior in ffmpeg-next engine");
+        eprintln!(
+            "Temporary directory handling verified; no concat file behavior in ffmpeg-next engine"
+        );
     }
 }

--- a/src-tauri/src/tests_metadata_integration.rs
+++ b/src-tauri/src/tests_metadata_integration.rs
@@ -3,8 +3,8 @@
 
 #[cfg(test)]
 mod metadata_integration_tests {
-    use crate::metadata::AudiobookMetadata;
     use crate::metadata::ffmpeg_bridge;
+    use crate::metadata::AudiobookMetadata;
 
     #[test]
     fn test_metadata_to_ffmpeg_conversion() {
@@ -27,7 +27,10 @@ mod metadata_integration_tests {
         let dict = dict_result.unwrap();
         assert!(dict.get("title").is_some(), "Title should be present");
         assert!(dict.get("artist").is_some(), "Artist should be present");
-        assert!(dict.get("media_type").is_some(), "Media type should be set for audiobooks");
+        assert!(
+            dict.get("media_type").is_some(),
+            "Media type should be set for audiobooks"
+        );
     }
 
     #[test]
@@ -40,14 +43,17 @@ mod metadata_integration_tests {
         };
 
         let warnings = ffmpeg_bridge::validate_metadata_compatibility(&metadata);
-        assert!(warnings.len() >= 2, "Should warn about track and cover art size");
+        assert!(
+            warnings.len() >= 2,
+            "Should warn about track and cover art size"
+        );
     }
 
-    #[test] 
+    #[test]
     fn test_cover_art_embedding_placeholder() {
         // Test that cover art embedding doesn't fail (even though it's not fully implemented yet)
         let cover_data = vec![0xFF, 0xD8, 0xFF, 0xE0]; // JPEG header
-        
+
         // This will be a no-op until we complete the ffmpeg-next cover art implementation
         // But it should not fail
         // Note: We can't easily test the actual embedding without a real output context
@@ -61,7 +67,9 @@ mod metadata_integration_tests {
         // Test that twoloop enhancement is mentioned in logs
         // This is primarily a documentation/tracking test
         // The actual twoloop implementation test would require ffmpeg-next context
-        println!("Twoloop enhancement: Improves AAC quality through better psychoacoustic analysis");
+        println!(
+            "Twoloop enhancement: Improves AAC quality through better psychoacoustic analysis"
+        );
         println!("Implementation: Set aac_coder=twoloop on encoder context");
         assert!(true); // This test mainly documents the twoloop feature
     }

--- a/src-tauri/tests/comprehensive_cover_art_test.rs
+++ b/src-tauri/tests/comprehensive_cover_art_test.rs
@@ -2,14 +2,12 @@
 //! Tests all aspects of the native cover art embedding feature
 
 use audiobook_boss_lib::AudiobookMetadata;
-use audiobook_boss_lib::{
-    ffmpeg_detect_cover_art_format, 
-    ffmpeg_validate_metadata_compatibility,
-};
+use audiobook_boss_lib::{ffmpeg_detect_cover_art_format, ffmpeg_validate_metadata_compatibility};
 use std::path::PathBuf;
 
 // Test data - minimal valid JPEG and PNG images
-const MINIMAL_JPEG: &[u8] = b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
+const MINIMAL_JPEG: &[u8] =
+    b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
 const MINIMAL_PNG: &[u8] = b"\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xDE\x00\x00\x00\x0CIDAT\x08\x99c```\x00\x00\x00\x04\x00\x01]\xCC\x18[\x00\x00\x00\x00IEND\xAEB`\x82";
 
 #[test]
@@ -29,23 +27,35 @@ fn test_cover_art_format_detection_comprehensive() {
     // Test unsupported formats
     let gif_data = b"GIF89a\x01\x00\x01\x00\x00\x00\x00!";
     let gif_result = ffmpeg_detect_cover_art_format(gif_data);
-    assert!(gif_result.is_none(), "Should not detect unsupported GIF format");
+    assert!(
+        gif_result.is_none(),
+        "Should not detect unsupported GIF format"
+    );
     println!("✓ Unsupported format (GIF) correctly rejected");
 
     let webp_data = b"RIFF\x00\x00\x00\x00WEBP";
     let webp_result = ffmpeg_detect_cover_art_format(webp_data);
-    assert!(webp_result.is_none(), "Should not detect unsupported WebP format");
+    assert!(
+        webp_result.is_none(),
+        "Should not detect unsupported WebP format"
+    );
     println!("✓ Unsupported format (WebP) correctly rejected");
 
     // Test empty data
     let empty_result = ffmpeg_detect_cover_art_format(&[]);
-    assert!(empty_result.is_none(), "Should not detect format for empty data");
+    assert!(
+        empty_result.is_none(),
+        "Should not detect format for empty data"
+    );
     println!("✓ Empty data correctly handled");
 
     // Test insufficient data
     let short_data = b"\xFF\xD8"; // Too short for full JPEG signature
     let short_result = ffmpeg_detect_cover_art_format(short_data);
-    assert!(short_result.is_none(), "Should not detect format for insufficient data");
+    assert!(
+        short_result.is_none(),
+        "Should not detect format for insufficient data"
+    );
     println!("✓ Insufficient data correctly handled");
 
     println!("All format detection tests passed!");
@@ -59,14 +69,20 @@ fn test_metadata_compatibility_validation_comprehensive() {
     let problematic_metadata = AudiobookMetadata {
         title: Some("Test Book".to_string()),
         track: Some((1, Some(12))), // Should generate warning
-        disk: Some((1, Some(1))), // Should generate warning
+        disk: Some((1, Some(1))),   // Should generate warning
         cover_art: Some(vec![0u8; 15 * 1024 * 1024]), // 15MB - too large, should warn
         ..Default::default()
     };
 
     let warnings = ffmpeg_validate_metadata_compatibility(&problematic_metadata);
-    assert!(warnings.len() >= 3, "Should generate at least 3 warnings (track, disk, cover art size)");
-    println!("✓ Problematic metadata generated {} warnings", warnings.len());
+    assert!(
+        warnings.len() >= 3,
+        "Should generate at least 3 warnings (track, disk, cover art size)"
+    );
+    println!(
+        "✓ Problematic metadata generated {} warnings",
+        warnings.len()
+    );
     for warning in &warnings {
         println!("  Warning: {}", warning);
     }
@@ -83,7 +99,11 @@ fn test_metadata_compatibility_validation_comprehensive() {
     };
 
     let warnings = ffmpeg_validate_metadata_compatibility(&normal_metadata);
-    assert!(warnings.is_empty(), "Normal metadata should not generate warnings, got: {:?}", warnings);
+    assert!(
+        warnings.is_empty(),
+        "Normal metadata should not generate warnings, got: {:?}",
+        warnings
+    );
     println!("✓ Normal metadata passed validation without warnings");
 
     // Test edge case - exactly at size limit
@@ -94,7 +114,10 @@ fn test_metadata_compatibility_validation_comprehensive() {
     };
 
     let warnings = ffmpeg_validate_metadata_compatibility(&limit_metadata);
-    assert!(warnings.is_empty(), "10MB cover art should not generate warnings");
+    assert!(
+        warnings.is_empty(),
+        "10MB cover art should not generate warnings"
+    );
     println!("✓ 10MB cover art (at limit) passed validation");
 
     println!("All metadata validation tests passed!");
@@ -105,23 +128,25 @@ fn test_real_media_file_cover_art_detection() {
     println!("Testing cover art detection on real media file...");
 
     let media_file = PathBuf::from("../media/01 - Introduction.mp3");
-    
+
     if !media_file.exists() {
         println!("Test media file not available, skipping real file test");
         return;
     }
 
     // Test reading metadata from real file
-    match audiobook_boss_lib::commands::read_audio_metadata(media_file.to_string_lossy().to_string()) {
+    match audiobook_boss_lib::commands::read_audio_metadata(
+        media_file.to_string_lossy().to_string(),
+    ) {
         Ok(metadata) => {
             println!("✓ Successfully read metadata from real MP3 file");
             if let Some(ref cover_art) = metadata.cover_art {
                 println!("✓ Cover art found ({} bytes)", cover_art.len());
-                
+
                 // Test format detection on real cover art
                 let format = ffmpeg_detect_cover_art_format(cover_art);
                 println!("✓ Cover art format detected: {:?}", format);
-                
+
                 // Test validation on real cover art
                 let warnings = ffmpeg_validate_metadata_compatibility(&metadata);
                 println!("✓ Validation warnings: {}", warnings.len());
@@ -131,7 +156,7 @@ fn test_real_media_file_cover_art_detection() {
             } else {
                 println!("Real MP3 file has no cover art to test");
             }
-        },
+        }
         Err(e) => {
             println!("Failed to read real MP3 metadata: {}", e);
             // This might be expected if the file format isn't supported
@@ -159,7 +184,10 @@ fn test_ffmpeg_bridge_functions_directly() {
     // Test that the bridge functions are accessible and working
     println!("Testing metadata validation...");
     let warnings = ffmpeg_validate_metadata_compatibility(&metadata);
-    println!("✓ Metadata validation completed with {} warnings", warnings.len());
+    println!(
+        "✓ Metadata validation completed with {} warnings",
+        warnings.len()
+    );
 
     // Test cover art format detection
     println!("Testing cover art format detection...");
@@ -184,7 +212,7 @@ fn test_unsupported_format_detection() {
     let bmp_data = b"BM\x36\x00\x00\x00\x00\x00\x00\x00\x36\x00\x00\x00";
     let tiff_data = b"II*\x00";
     let unknown_data = b"UNKNOWN_FORMAT";
-    
+
     let test_cases = vec![
         ("GIF", gif_data.as_slice()),
         ("WebP", webp_data.as_slice()),
@@ -207,7 +235,7 @@ fn test_unsupported_format_detection() {
     };
 
     let warnings = ffmpeg_validate_metadata_compatibility(&unsupported_metadata);
-    // Note: The validation function currently doesn't warn about format, 
+    // Note: The validation function currently doesn't warn about format,
     // but the format detection itself handles this
     println!("✓ Metadata validation completed for unsupported format");
 
@@ -220,12 +248,12 @@ fn test_large_cover_art_validation() {
 
     // Test size limits and warnings
     let size_test_cases = vec![
-        (1024, "1KB", false),                    // Small - should pass
-        (1024 * 1024, "1MB", false),           // Medium - should pass
-        (5 * 1024 * 1024, "5MB", false),       // Large but acceptable - should pass
-        (10 * 1024 * 1024, "10MB", false),     // At limit - should pass
-        (15 * 1024 * 1024, "15MB", true),      // Over limit - should warn
-        (50 * 1024 * 1024, "50MB", true),      // Very large - should warn
+        (1024, "1KB", false),              // Small - should pass
+        (1024 * 1024, "1MB", false),       // Medium - should pass
+        (5 * 1024 * 1024, "5MB", false),   // Large but acceptable - should pass
+        (10 * 1024 * 1024, "10MB", false), // At limit - should pass
+        (15 * 1024 * 1024, "15MB", true),  // Over limit - should warn
+        (50 * 1024 * 1024, "50MB", true),  // Very large - should warn
     ];
 
     for (size_bytes, size_desc, should_warn) in size_test_cases {
@@ -245,11 +273,22 @@ fn test_large_cover_art_validation() {
         let has_size_warning = warnings.iter().any(|w| w.contains("size limit"));
 
         if should_warn {
-            assert!(has_size_warning, "Cover art of {} should generate size warning", size_desc);
+            assert!(
+                has_size_warning,
+                "Cover art of {} should generate size warning",
+                size_desc
+            );
             println!("✓ {} cover art correctly generated size warning", size_desc);
         } else {
-            assert!(!has_size_warning, "Cover art of {} should not generate size warning", size_desc);
-            println!("✓ {} cover art passed validation without size warning", size_desc);
+            assert!(
+                !has_size_warning,
+                "Cover art of {} should not generate size warning",
+                size_desc
+            );
+            println!(
+                "✓ {} cover art passed validation without size warning",
+                size_desc
+            );
         }
     }
 
@@ -270,17 +309,26 @@ fn test_no_cover_art_validation() {
 
     // Test that metadata without cover art validates properly
     let warnings = ffmpeg_validate_metadata_compatibility(&metadata_no_cover);
-    println!("✓ Metadata without cover art validated with {} warnings", warnings.len());
+    println!(
+        "✓ Metadata without cover art validated with {} warnings",
+        warnings.len()
+    );
 
     // Should not have cover art related warnings
     let has_cover_warnings = warnings.iter().any(|w| w.to_lowercase().contains("cover"));
-    assert!(!has_cover_warnings, "Should not have cover art warnings when no cover art provided");
+    assert!(
+        !has_cover_warnings,
+        "Should not have cover art warnings when no cover art provided"
+    );
     println!("✓ No cover art related warnings generated");
 
     // Test format detection on None
     // (This would be called with empty data in practice)
     let empty_format = ffmpeg_detect_cover_art_format(&[]);
-    assert!(empty_format.is_none(), "Empty data should not detect format");
+    assert!(
+        empty_format.is_none(),
+        "Empty data should not detect format"
+    );
     println!("✓ Empty cover art data handled correctly");
 
     println!("No cover art validation test passed!");
@@ -318,7 +366,10 @@ fn test_twoloop_environment_variable() {
     let disable = std::env::var("ABB_DISABLE_TWOOLOOP")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    assert!(disable, "Should detect 'TRUE' as disabled (case insensitive)");
+    assert!(
+        disable,
+        "Should detect 'TRUE' as disabled (case insensitive)"
+    );
     println!("✓ ABB_DISABLE_TWOOLOOP=TRUE correctly detected as disabled");
 
     // Test invalid values (should default to enabled)

--- a/src-tauri/tests/cover_art_embedding_integration.rs
+++ b/src-tauri/tests/cover_art_embedding_integration.rs
@@ -1,15 +1,13 @@
 //! Integration tests for cover art embedding reliability
-//! 
+//!
 //! These tests verify that both native FFmpeg embedding and Lofty fallback
 //! work correctly, and that the system gracefully handles failures.
 
 use audiobook_boss_lib::{
-    AudiobookMetadata, 
     ffmpeg_add_cover_art_stream_pre_header as add_cover_art_stream_pre_header,
-    ffmpeg_write_cover_art_packet_post_header as write_cover_art_packet_post_header,
-    FfmpegCoverFormat as CoverFormat,
     ffmpeg_validate_metadata_compatibility as validate_metadata_compatibility,
-    lofty_write_cover_art,
+    ffmpeg_write_cover_art_packet_post_header as write_cover_art_packet_post_header,
+    lofty_write_cover_art, AudiobookMetadata, FfmpegCoverFormat as CoverFormat,
 };
 use ffmpeg_next as ff;
 use lofty::prelude::*;
@@ -22,11 +20,11 @@ fn create_test_jpeg() -> Vec<u8> {
     vec![
         0xFF, 0xD8, // SOI (Start of Image)
         0xFF, 0xE0, 0x00, 0x10, // APP0 marker with length
-        b'J', b'F', b'I', b'F', 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
-        0xFF, 0xC0, 0x00, 0x11, 0x08, // SOF0 marker
+        b'J', b'F', b'I', b'F', 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF,
+        0xC0, 0x00, 0x11, 0x08, // SOF0 marker
         0x00, 0x10, 0x00, 0x10, // Height=16, Width=16
-        0x01, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01,
-        0xFF, 0xD9, // EOI (End of Image)
+        0x01, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01, 0xFF,
+        0xD9, // EOI (End of Image)
     ]
 }
 
@@ -49,98 +47,111 @@ fn create_test_png() -> Vec<u8> {
 #[test]
 fn test_native_cover_art_embedding_success() {
     ff::init().expect("FFmpeg initialization should succeed");
-    
+
     let temp_dir = TempDir::new().expect("Should create temp directory");
     let output_path = temp_dir.path().join("test_native.m4b");
-    
+
     // Create output context
     let mut octx = ff::format::output(&output_path).expect("Should create output context");
-    
+
     // Test with JPEG cover art
     let jpeg_data = create_test_jpeg();
     let result = add_cover_art_stream_pre_header(&mut octx, &jpeg_data);
-    
+
     // Should successfully add the stream
-    assert!(result.is_some(), "Native JPEG cover art stream should be added successfully");
-    
+    assert!(
+        result.is_some(),
+        "Native JPEG cover art stream should be added successfully"
+    );
+
     if let Some((stream_index, format)) = result {
         assert_eq!(format, CoverFormat::Jpeg);
         assert_eq!(stream_index, 0); // First stream should be index 0
-        
+
         // Write header to finalize stream setup
-        octx.write_header().expect("Should write header successfully");
-        
+        octx.write_header()
+            .expect("Should write header successfully");
+
         // Write cover art packet
         write_cover_art_packet_post_header(&mut octx, stream_index, &jpeg_data, format);
-        
+
         // Finalize the file
-        octx.write_trailer().expect("Should write trailer successfully");
+        octx.write_trailer()
+            .expect("Should write trailer successfully");
     }
 }
 
 #[test]
 fn test_native_cover_art_embedding_with_png() {
     ff::init().expect("FFmpeg initialization should succeed");
-    
+
     let temp_dir = TempDir::new().expect("Should create temp directory");
     let output_path = temp_dir.path().join("test_native_png.m4b");
-    
+
     // Create output context
     let mut octx = ff::format::output(&output_path).expect("Should create output context");
-    
+
     // Test with PNG cover art
     let png_data = create_test_png();
     let result = add_cover_art_stream_pre_header(&mut octx, &png_data);
-    
+
     // Should successfully add the stream
-    assert!(result.is_some(), "Native PNG cover art stream should be added successfully");
-    
+    assert!(
+        result.is_some(),
+        "Native PNG cover art stream should be added successfully"
+    );
+
     if let Some((stream_index, format)) = result {
         assert_eq!(format, CoverFormat::Png);
-        
+
         // Write header to finalize stream setup
-        octx.write_header().expect("Should write header successfully");
-        
+        octx.write_header()
+            .expect("Should write header successfully");
+
         // Write cover art packet
         write_cover_art_packet_post_header(&mut octx, stream_index, &png_data, format);
-        
+
         // Finalize the file
-        octx.write_trailer().expect("Should write trailer successfully");
+        octx.write_trailer()
+            .expect("Should write trailer successfully");
     }
 }
 
 #[test]
 fn test_unsupported_format_fallback() {
     ff::init().expect("FFmpeg initialization should succeed");
-    
+
     let temp_dir = TempDir::new().expect("Should create temp directory");
     let output_path = temp_dir.path().join("test_fallback.m4b");
-    
+
     // Create output context
     let mut octx = ff::format::output(&output_path).expect("Should create output context");
-    
+
     // Test with unsupported GIF format
     let gif_data = b"GIF89a\x01\x00\x01\x00\x00\x00\x00!".to_vec();
     let result = add_cover_art_stream_pre_header(&mut octx, &gif_data);
-    
+
     // Should return None for unsupported format
-    assert!(result.is_none(), "Unsupported format should return None for native embedding");
+    assert!(
+        result.is_none(),
+        "Unsupported format should return None for native embedding"
+    );
 }
 
 #[test]
 fn test_lofty_fallback_embedding() {
     // This test verifies that Lofty fallback works when given a proper M4B file
     // In practice, this would be called after FFmpeg has created the audio file
-    
+
     let temp_dir = TempDir::new().expect("Should create temp directory");
     let test_file = temp_dir.path().join("test_lofty.m4b");
-    
+
     // Create a proper M4B file using FFmpeg first
     ff::init().expect("FFmpeg initialization should succeed");
-    
+
     // Create a minimal but valid M4B file with FFmpeg
     let mut octx = ff::format::output(&test_file).expect("Should create output context");
-    
+
     // Add a minimal audio stream
     if let Some(audio_codec) = ff::encoder::find(ff::codec::Id::AAC) {
         if let Ok(mut audio_stream) = octx.add_stream(audio_codec) {
@@ -153,29 +164,38 @@ fn test_lofty_fallback_embedding() {
             ctx.set_channel_layout(ff::channel_layout::ChannelLayout::MONO);
             ctx.set_format(ff::format::Sample::F32(ff::format::sample::Type::Planar));
             ctx.set_time_base(ff::Rational(1, 44100));
-            
+
             if let Ok(encoder) = ctx.open_as(audio_codec) {
                 audio_stream.set_parameters(&encoder);
-                
+
                 // Write header and trailer to create a valid file
                 octx.write_header().expect("Should write header");
                 octx.write_trailer().expect("Should write trailer");
-                
+
                 // Now test Lofty cover art embedding on the valid file
                 let jpeg_data = create_test_jpeg();
                 let result = lofty_write_cover_art(&test_file, &jpeg_data);
-                
+
                 // Should succeed on a properly formatted M4B file
                 if result.is_ok() {
                     // Verify the cover art was embedded
                     if let Ok(tagged_file) = lofty::read_from_path(&test_file) {
-                        let has_cover = tagged_file.tags().iter().any(|tag| !tag.pictures().is_empty());
-                        assert!(has_cover, "File should contain cover art after Lofty embedding");
+                        let has_cover = tagged_file
+                            .tags()
+                            .iter()
+                            .any(|tag| !tag.pictures().is_empty());
+                        assert!(
+                            has_cover,
+                            "File should contain cover art after Lofty embedding"
+                        );
                     }
                 } else {
                     // If Lofty fails, it might be due to the minimal file structure
                     // This is acceptable as long as we can detect the failure gracefully
-                    println!("Lofty embedding failed as expected with minimal file: {:?}", result.err());
+                    println!(
+                        "Lofty embedding failed as expected with minimal file: {:?}",
+                        result.err()
+                    );
                 }
             }
         }
@@ -185,7 +205,7 @@ fn test_lofty_fallback_embedding() {
 #[test]
 fn test_cover_art_validation_comprehensive() {
     // validate_metadata_compatibility is already imported at the top
-    
+
     // Test with valid JPEG
     let valid_jpeg = create_test_jpeg();
     let metadata_jpeg = AudiobookMetadata {
@@ -193,11 +213,11 @@ fn test_cover_art_validation_comprehensive() {
         cover_art: Some(valid_jpeg),
         ..Default::default()
     };
-    
+
     let warnings = validate_metadata_compatibility(&metadata_jpeg);
     // Should not have format warnings for valid JPEG
     assert!(!warnings.iter().any(|w| w.contains("format not supported")));
-    
+
     // Test with valid PNG
     let valid_png = create_test_png();
     let metadata_png = AudiobookMetadata {
@@ -205,11 +225,11 @@ fn test_cover_art_validation_comprehensive() {
         cover_art: Some(valid_png),
         ..Default::default()
     };
-    
+
     let warnings = validate_metadata_compatibility(&metadata_png);
     // Should not have format warnings for valid PNG
     assert!(!warnings.iter().any(|w| w.contains("format not supported")));
-    
+
     // Test with invalid format
     let invalid_data = b"INVALID_IMAGE_DATA".to_vec();
     let metadata_invalid = AudiobookMetadata {
@@ -217,22 +237,22 @@ fn test_cover_art_validation_comprehensive() {
         cover_art: Some(invalid_data),
         ..Default::default()
     };
-    
+
     let warnings = validate_metadata_compatibility(&metadata_invalid);
     // Should warn about unsupported format
     assert!(warnings.iter().any(|w| w.contains("format not supported")));
-    
+
     // Test with empty cover art
     let metadata_empty = AudiobookMetadata {
         title: Some("Test Book".to_string()),
         cover_art: Some(vec![]),
         ..Default::default()
     };
-    
+
     let warnings = validate_metadata_compatibility(&metadata_empty);
     // Should warn about empty data
     assert!(warnings.iter().any(|w| w.contains("empty")));
-    
+
     // Test with oversized cover art
     let oversized_data = vec![0xFF; 15 * 1024 * 1024]; // 15MB
     let metadata_oversized = AudiobookMetadata {
@@ -240,7 +260,7 @@ fn test_cover_art_validation_comprehensive() {
         cover_art: Some(oversized_data),
         ..Default::default()
     };
-    
+
     let warnings = validate_metadata_compatibility(&metadata_oversized);
     // Should warn about size
     assert!(warnings.iter().any(|w| w.contains("size limit")));
@@ -252,7 +272,7 @@ fn create_minimal_m4b_file() -> Vec<u8> {
     // Create a proper minimal MP4 structure that Lofty can parse
     // This includes ftyp, moov, and mdat atoms
     let mut data = Vec::new();
-    
+
     // ftyp atom (file type)
     data.extend_from_slice(&[
         0x00, 0x00, 0x00, 0x20, // size (32 bytes)
@@ -263,12 +283,11 @@ fn create_minimal_m4b_file() -> Vec<u8> {
         b'i', b's', b'o', b'm', // compatible brand 2
         b'm', b'p', b'4', b'1', // compatible brand 3
     ]);
-    
+
     // moov atom (movie metadata) - minimal structure
     data.extend_from_slice(&[
         0x00, 0x00, 0x00, 0x6C, // size (108 bytes)
         b'm', b'o', b'o', b'v', // type
-        
         // mvhd atom (movie header)
         0x00, 0x00, 0x00, 0x64, // size (100 bytes)
         b'm', b'v', b'h', b'd', // type
@@ -281,54 +300,68 @@ fn create_minimal_m4b_file() -> Vec<u8> {
         0x01, 0x00, 0x00, 0x00, // preferred volume (1.0)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved
         // transformation matrix (identity)
-        0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // next track ID
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x02, // next track ID
     ]);
-    
+
     // mdat atom (media data) - empty for this test
     data.extend_from_slice(&[
         0x00, 0x00, 0x00, 0x08, // size (8 bytes)
         b'm', b'd', b'a', b't', // type
     ]);
-    
+
     data
 }
 
 #[cfg(test)]
 mod integration_helpers {
     use super::*;
-    
+
     /// Helper to create a complete test scenario with both native and fallback paths
-    pub fn test_complete_embedding_workflow(cover_data: Vec<u8>, expected_format: Option<CoverFormat>) {
+    pub fn test_complete_embedding_workflow(
+        cover_data: Vec<u8>,
+        expected_format: Option<CoverFormat>,
+    ) {
         ff::init().expect("FFmpeg initialization should succeed");
-        
+
         let temp_dir = TempDir::new().expect("Should create temp directory");
         let output_path = temp_dir.path().join("test_complete.m4b");
-        
+
         // Step 1: Try native embedding
         let mut octx = ff::format::output(&output_path).expect("Should create output context");
         let native_result = add_cover_art_stream_pre_header(&mut octx, &cover_data);
-        
+
         match expected_format {
             Some(expected) => {
                 // Should succeed for supported formats
-                assert!(native_result.is_some(), "Native embedding should succeed for supported format");
+                assert!(
+                    native_result.is_some(),
+                    "Native embedding should succeed for supported format"
+                );
                 if let Some((stream_index, format)) = native_result {
                     assert_eq!(format, expected);
-                    
+
                     // Complete the native embedding
                     octx.write_header().expect("Should write header");
-                    write_cover_art_packet_post_header(&mut octx, stream_index, &cover_data, format);
+                    write_cover_art_packet_post_header(
+                        &mut octx,
+                        stream_index,
+                        &cover_data,
+                        format,
+                    );
                     octx.write_trailer().expect("Should write trailer");
                 }
             }
             None => {
                 // Should fail for unsupported formats
-                assert!(native_result.is_none(), "Native embedding should fail for unsupported format");
-                
+                assert!(
+                    native_result.is_none(),
+                    "Native embedding should fail for unsupported format"
+                );
+
                 // We need to add at least one stream for FFmpeg to create a valid file
                 // Add a dummy audio stream
                 if let Some(audio_codec) = ff::encoder::find(ff::codec::Id::AAC) {
@@ -343,21 +376,22 @@ mod integration_helpers {
                         ctx.set_channel_layout(ff::channel_layout::ChannelLayout::MONO);
                         ctx.set_format(ff::format::Sample::F32(ff::format::sample::Type::Planar));
                         ctx.set_time_base(ff::Rational(1, 44100));
-                        
+
                         if let Ok(encoder) = ctx.open_as(audio_codec) {
                             audio_stream.set_parameters(&encoder);
                         }
                     }
                 }
-                
+
                 // Complete file creation without cover art
                 octx.write_header().expect("Should write header");
                 octx.write_trailer().expect("Should write trailer");
-                
+
                 // Step 2: Try Lofty fallback
                 // Replace with minimal M4B content for Lofty to work with
-                std::fs::write(&output_path, create_minimal_m4b_file()).expect("Should write minimal M4B");
-                
+                std::fs::write(&output_path, create_minimal_m4b_file())
+                    .expect("Should write minimal M4B");
+
                 let fallback_result = lofty_write_cover_art(&output_path, &cover_data);
                 // Lofty might still fail for truly invalid formats, but should handle more cases
                 println!("Lofty fallback result: {:?}", fallback_result);
@@ -368,12 +402,18 @@ mod integration_helpers {
 
 #[test]
 fn test_complete_workflow_jpeg() {
-    integration_helpers::test_complete_embedding_workflow(create_test_jpeg(), Some(CoverFormat::Jpeg));
+    integration_helpers::test_complete_embedding_workflow(
+        create_test_jpeg(),
+        Some(CoverFormat::Jpeg),
+    );
 }
 
 #[test]
 fn test_complete_workflow_png() {
-    integration_helpers::test_complete_embedding_workflow(create_test_png(), Some(CoverFormat::Png));
+    integration_helpers::test_complete_embedding_workflow(
+        create_test_png(),
+        Some(CoverFormat::Png),
+    );
 }
 
 #[test]

--- a/src-tauri/tests/cover_art_native_embedding.rs
+++ b/src-tauri/tests/cover_art_native_embedding.rs
@@ -6,21 +6,24 @@ use audiobook_boss_lib::AudiobookMetadata;
 #[test]
 fn test_cover_art_format_detection() {
     // Test the cover art format detection function
-    
+
     // Test JPEG detection
     let jpeg_data = b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
     let jpeg_format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(jpeg_data);
     assert!(jpeg_format.is_some(), "Should detect JPEG format");
-    
-    // Test PNG detection  
+
+    // Test PNG detection
     let png_data = b"\x89PNG\r\n\x1A\nrest";
     let png_format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(png_data);
     assert!(png_format.is_some(), "Should detect PNG format");
-    
+
     // Test unsupported format
     let gif_data = b"GIF89a";
     let gif_format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(gif_data);
-    assert!(gif_format.is_none(), "Should not detect unsupported formats");
+    assert!(
+        gif_format.is_none(),
+        "Should not detect unsupported formats"
+    );
 }
 
 #[test]
@@ -32,10 +35,13 @@ fn test_metadata_compatibility_validation() {
         cover_art: Some(vec![0u8; 15 * 1024 * 1024]), // 15MB - too large, should warn
         ..Default::default()
     };
-    
+
     let warnings = audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&metadata);
-    assert!(warnings.len() >= 2, "Should generate at least 2 warnings for track and cover art size");
-    
+    assert!(
+        warnings.len() >= 2,
+        "Should generate at least 2 warnings for track and cover art size"
+    );
+
     // Test that normal metadata doesn't generate warnings
     let normal_metadata = AudiobookMetadata {
         title: Some("Normal Book".to_string()),
@@ -43,30 +49,39 @@ fn test_metadata_compatibility_validation() {
         cover_art: Some(vec![0u8; 1024]), // 1KB - reasonable size
         ..Default::default()
     };
-    
+
     let warnings = audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&normal_metadata);
-    assert!(warnings.is_empty(), "Normal metadata should not generate warnings");
+    assert!(
+        warnings.is_empty(),
+        "Normal metadata should not generate warnings"
+    );
 }
 
 #[test]
 fn test_twoloop_environment_variable_handling() {
     // Test that environment variable parsing works correctly
-    
+
     // Test disabled
     std::env::set_var("ABB_DISABLE_TWOOLOOP", "1");
-    let disable = std::env::var("ABB_DISABLE_TWOOLOOP").map(|v| v == "1" || v.eq_ignore_ascii_case("true")).unwrap_or(false);
+    let disable = std::env::var("ABB_DISABLE_TWOOLOOP")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     assert!(disable, "Should detect environment variable as disabled");
-    
+
     // Test enabled (no env var)
     std::env::remove_var("ABB_DISABLE_TWOOLOOP");
-    let disable = std::env::var("ABB_DISABLE_TWOOLOOP").map(|v| v == "1" || v.eq_ignore_ascii_case("true")).unwrap_or(false);
+    let disable = std::env::var("ABB_DISABLE_TWOOLOOP")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     assert!(!disable, "Should default to enabled when env var not set");
-    
+
     // Test alternative true values
     std::env::set_var("ABB_DISABLE_TWOOLOOP", "true");
-    let disable = std::env::var("ABB_DISABLE_TWOOLOOP").map(|v| v == "1" || v.eq_ignore_ascii_case("true")).unwrap_or(false);
+    let disable = std::env::var("ABB_DISABLE_TWOOLOOP")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     assert!(disable, "Should detect 'true' as disabled");
-    
+
     // Clean up
     std::env::remove_var("ABB_DISABLE_TWOOLOOP");
 }

--- a/src-tauri/tests/ffmpegnext_integration.rs
+++ b/src-tauri/tests/ffmpegnext_integration.rs
@@ -1,18 +1,21 @@
-
 //! FFmpeg-next integration tests
-//! 
+//!
 //! This test file ensures FFmpeg-next functionality is properly tested.
 
 use std::path::PathBuf;
 
-use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
 use audiobook_boss_lib::audio::context::ProgressContextBuilder;
+use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
 
 const TEST_MEDIA_FILE: &str = "../media/01 - Introduction.mp3";
 
 fn ensure_media() -> Option<PathBuf> {
     let p = PathBuf::from(TEST_MEDIA_FILE);
-    if p.exists() && p.is_file() { Some(p) } else { None }
+    if p.exists() && p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
 }
 
 #[test]
@@ -47,7 +50,7 @@ fn test_audio_settings_creation() {
         sample_rate: SampleRateConfig::Auto,
         output_path: PathBuf::from("/tmp/test.m4b"),
     };
-    
+
     assert_eq!(settings.bitrate, 64);
     assert_eq!(settings.channels, ChannelConfig::Mono);
     assert_eq!(settings.sample_rate, SampleRateConfig::Auto);
@@ -64,19 +67,22 @@ fn test_progress_context_builder_usage() {
         .build();
     assert_eq!(ctx.progress, 5.0);
     assert_eq!(ctx.message.as_ref().unwrap(), "testing");
-    assert_eq!(ctx.stage, audiobook_boss_lib::audio::ProcessingStage::Analyzing);
+    assert_eq!(
+        ctx.stage,
+        audiobook_boss_lib::audio::ProcessingStage::Analyzing
+    );
 }
 
 #[test]
 fn test_ffmpeg_next_dependency_available() {
     // Test that ffmpeg-next types are available
     // This verifies the dependency is properly configured
-    
+
     // Simple test to ensure the ffmpeg-next crate is accessible
     // We don't initialize ffmpeg here to avoid global state issues in tests
     let version_info = format!("ffmpeg-next crate available for testing");
     println!("✓ {}", version_info);
-    
+
     // This test passing means the dependency is properly linked
     assert!(!version_info.is_empty());
 }

--- a/src-tauri/tests/integration_cover_art_test.rs
+++ b/src-tauri/tests/integration_cover_art_test.rs
@@ -8,10 +8,10 @@ const TEST_MEDIA_FILE: &str = "../media/01 - Introduction.mp3";
 
 fn ensure_media() -> Option<PathBuf> {
     let p = PathBuf::from(TEST_MEDIA_FILE);
-    if p.exists() && p.is_file() { 
-        Some(p) 
-    } else { 
-        None 
+    if p.exists() && p.is_file() {
+        Some(p)
+    } else {
+        None
     }
 }
 
@@ -30,50 +30,62 @@ fn test_real_mp3_cover_art_integration() {
     println!("Using media file: {}", media_file.display());
 
     // Test reading metadata with cover art
-    match audiobook_boss_lib::commands::read_audio_metadata(media_file.to_string_lossy().to_string()) {
+    match audiobook_boss_lib::commands::read_audio_metadata(
+        media_file.to_string_lossy().to_string(),
+    ) {
         Ok(metadata) => {
             println!("✓ Successfully read metadata from MP3");
-            
+
             // Validate metadata structure
             assert!(metadata.title.is_some(), "MP3 should have title metadata");
             assert!(metadata.artist.is_some(), "MP3 should have artist metadata");
-            
+
             println!("Metadata:");
             println!("  Title: {:?}", metadata.title);
             println!("  Artist: {:?}", metadata.artist);
             println!("  Album: {:?}", metadata.album);
             println!("  Genre: {:?}", metadata.genre);
-            
+
             if let Some(ref cover_art) = metadata.cover_art {
                 println!("✓ Cover art present ({} bytes)", cover_art.len());
-                
+
                 // Test format detection
                 let format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(cover_art);
                 println!("✓ Cover art format: {:?}", format);
-                assert!(format.is_some(), "Real cover art should have detectable format");
-                
+                assert!(
+                    format.is_some(),
+                    "Real cover art should have detectable format"
+                );
+
                 // Test validation
-                let warnings = audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&metadata);
+                let warnings =
+                    audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&metadata);
                 println!("✓ Validation completed with {} warnings", warnings.len());
                 for warning in &warnings {
                     println!("  Warning: {}", warning);
                 }
-                
+
                 // Test that cover art is reasonable size
-                assert!(cover_art.len() > 1000, "Cover art should be substantial size");
-                assert!(cover_art.len() < 10 * 1024 * 1024, "Cover art should be under 10MB");
-                
+                assert!(
+                    cover_art.len() > 1000,
+                    "Cover art should be substantial size"
+                );
+                assert!(
+                    cover_art.len() < 10 * 1024 * 1024,
+                    "Cover art should be under 10MB"
+                );
+
                 // Test round-trip: write and read back
                 test_cover_art_round_trip(&metadata, &media_file);
-                
             } else {
                 println!("Real MP3 file has no cover art - testing metadata-only flow");
-                
+
                 // Even without cover art, metadata should validate
-                let warnings = audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&metadata);
+                let warnings =
+                    audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&metadata);
                 println!("✓ Metadata-only validation: {} warnings", warnings.len());
             }
-        },
+        }
         Err(e) => {
             println!("Failed to read MP3 metadata: {}", e);
             panic!("Should be able to read metadata from real MP3 file");
@@ -85,16 +97,16 @@ fn test_real_mp3_cover_art_integration() {
 
 fn test_cover_art_round_trip(original_metadata: &AudiobookMetadata, source_file: &PathBuf) {
     println!("Testing cover art round-trip (write then read)...");
-    
+
     use tempfile::NamedTempFile;
-    
+
     // Create temporary file for testing
     let temp_file = NamedTempFile::new().expect("Failed to create temp file");
     let temp_path = temp_file.path();
-    
+
     // Copy original file to temp location for testing
     std::fs::copy(source_file, temp_path).expect("Failed to copy test file");
-    
+
     // Test writing cover art to the temp file
     if let Some(ref cover_data) = original_metadata.cover_art {
         match audiobook_boss_lib::commands::write_cover_art(
@@ -103,43 +115,57 @@ fn test_cover_art_round_trip(original_metadata: &AudiobookMetadata, source_file:
         ) {
             Ok(_) => {
                 println!("✓ Cover art written successfully");
-                
+
                 // Read back and verify
-                match audiobook_boss_lib::commands::read_audio_metadata(temp_path.to_string_lossy().to_string()) {
+                match audiobook_boss_lib::commands::read_audio_metadata(
+                    temp_path.to_string_lossy().to_string(),
+                ) {
                     Ok(read_back_metadata) => {
                         println!("✓ Successfully read back metadata");
-                        
+
                         if let Some(ref read_back_cover) = read_back_metadata.cover_art {
-                            println!("✓ Cover art present in read-back ({} bytes)", read_back_cover.len());
-                            
+                            println!(
+                                "✓ Cover art present in read-back ({} bytes)",
+                                read_back_cover.len()
+                            );
+
                             // Verify cover art is substantial and format is preserved
-                            assert!(read_back_cover.len() > 1000, "Read-back cover art should be substantial");
-                            
-                            let original_format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(cover_data);
-                            let readback_format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(read_back_cover);
-                            
+                            assert!(
+                                read_back_cover.len() > 1000,
+                                "Read-back cover art should be substantial"
+                            );
+
+                            let original_format =
+                                audiobook_boss_lib::ffmpeg_detect_cover_art_format(cover_data);
+                            let readback_format =
+                                audiobook_boss_lib::ffmpeg_detect_cover_art_format(read_back_cover);
+
                             println!("  Original format: {:?}", original_format);
                             println!("  Read-back format: {:?}", readback_format);
-                            
+
                             // Note: formats might differ due to transcoding, but both should be valid
-                            assert!(readback_format.is_some(), "Read-back cover art should have valid format");
-                            
+                            assert!(
+                                readback_format.is_some(),
+                                "Read-back cover art should have valid format"
+                            );
                         } else {
-                            println!("⚠ Cover art not found in read-back - may indicate embedding issue");
+                            println!(
+                                "⚠ Cover art not found in read-back - may indicate embedding issue"
+                            );
                         }
-                    },
+                    }
                     Err(e) => {
                         println!("Failed to read back metadata: {}", e);
                     }
                 }
-            },
+            }
             Err(e) => {
                 println!("Failed to write cover art: {}", e);
                 // This might be expected for some file formats
             }
         }
     }
-    
+
     println!("✓ Round-trip test completed");
 }
 
@@ -148,11 +174,12 @@ fn test_cover_art_commands_error_handling() {
     println!("Testing cover art command error handling...");
 
     // Test reading from non-existent file
-    let result = audiobook_boss_lib::commands::read_audio_metadata("non_existent_file.mp3".to_string());
+    let result =
+        audiobook_boss_lib::commands::read_audio_metadata("non_existent_file.mp3".to_string());
     assert!(result.is_err(), "Should fail to read non-existent file");
     println!("✓ Non-existent file correctly returns error");
 
-    // Test writing to non-existent file  
+    // Test writing to non-existent file
     let result = audiobook_boss_lib::commands::write_cover_art(
         "non_existent_file.mp3".to_string(),
         vec![0xFF, 0xD8, 0xFF, 0xD9], // minimal JPEG
@@ -161,78 +188,106 @@ fn test_cover_art_commands_error_handling() {
     println!("✓ Writing to non-existent file correctly returns error");
 
     // Test loading non-existent cover file (async function)
-    let result = futures::executor::block_on(audiobook_boss_lib::commands::load_cover_art_file("non_existent_image.jpg".to_string()));
-    assert!(result.is_err(), "Should fail to load non-existent cover file");
+    let result = futures::executor::block_on(audiobook_boss_lib::commands::load_cover_art_file(
+        "non_existent_image.jpg".to_string(),
+    ));
+    assert!(
+        result.is_err(),
+        "Should fail to load non-existent cover file"
+    );
     println!("✓ Loading non-existent cover file correctly returns error");
 
     println!("Cover art command error handling tests passed!");
 }
 
-#[test] 
+#[test]
 fn test_cover_art_size_limits() {
     println!("Testing cover art size limits and performance...");
 
     if let Some(media_file) = ensure_media() {
         // Read original metadata
-        if let Ok(metadata) = audiobook_boss_lib::commands::read_audio_metadata(media_file.to_string_lossy().to_string()) {
+        if let Ok(metadata) = audiobook_boss_lib::commands::read_audio_metadata(
+            media_file.to_string_lossy().to_string(),
+        ) {
             if let Some(ref original_cover) = metadata.cover_art {
                 println!("Original cover art size: {} bytes", original_cover.len());
-                
+
                 // Test validation for various sizes
                 let test_sizes = vec![
                     (original_cover.len(), "original"),
                     (1024, "1KB"),
-                    (100 * 1024, "100KB"), 
+                    (100 * 1024, "100KB"),
                     (1024 * 1024, "1MB"),
                     (5 * 1024 * 1024, "5MB"),
                 ];
-                
+
                 for (size, description) in test_sizes {
                     // Create test cover art of specified size
-                    let mut test_cover = original_cover[..std::cmp::min(size, original_cover.len())].to_vec();
+                    let mut test_cover =
+                        original_cover[..std::cmp::min(size, original_cover.len())].to_vec();
                     if size > original_cover.len() {
                         test_cover.extend(vec![0u8; size - original_cover.len()]);
                     }
-                    
+
                     let test_metadata = AudiobookMetadata {
                         title: Some(format!("Test {}", description)),
                         cover_art: Some(test_cover.clone()),
                         ..Default::default()
                     };
-                    
+
                     // Test format detection performance
                     let start = std::time::Instant::now();
                     let format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(&test_cover);
                     let detection_time = start.elapsed();
-                    
-                    println!("✓ {} cover art: format={:?}, detection_time={:?}", 
-                             description, format, detection_time);
-                    
-                    // Test validation performance  
+
+                    println!(
+                        "✓ {} cover art: format={:?}, detection_time={:?}",
+                        description, format, detection_time
+                    );
+
+                    // Test validation performance
                     let start = std::time::Instant::now();
-                    let warnings = audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&test_metadata);
+                    let warnings =
+                        audiobook_boss_lib::ffmpeg_validate_metadata_compatibility(&test_metadata);
                     let validation_time = start.elapsed();
-                    
-                    println!("  Validation: {} warnings, time={:?}", warnings.len(), validation_time);
-                    
+
+                    println!(
+                        "  Validation: {} warnings, time={:?}",
+                        warnings.len(),
+                        validation_time
+                    );
+
                     // Performance should be reasonable (under 100ms for most operations)
-                    assert!(detection_time.as_millis() < 100, "Format detection should be fast");
-                    assert!(validation_time.as_millis() < 100, "Validation should be fast");
+                    assert!(
+                        detection_time.as_millis() < 100,
+                        "Format detection should be fast"
+                    );
+                    assert!(
+                        validation_time.as_millis() < 100,
+                        "Validation should be fast"
+                    );
                 }
             }
         }
     } else {
         println!("No test media available - testing with synthetic data");
-        
+
         // Test with minimal JPEG
-        let minimal_jpeg = b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
+        let minimal_jpeg =
+            b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9";
         let start = std::time::Instant::now();
         let format = audiobook_boss_lib::ffmpeg_detect_cover_art_format(minimal_jpeg);
         let detection_time = start.elapsed();
-        
+
         assert!(format.is_some(), "Should detect JPEG format");
-        assert!(detection_time.as_millis() < 10, "Format detection should be very fast for small data");
-        println!("✓ Minimal JPEG detection: {:?} in {:?}", format, detection_time);
+        assert!(
+            detection_time.as_millis() < 10,
+            "Format detection should be very fast for small data"
+        );
+        println!(
+            "✓ Minimal JPEG detection: {:?} in {:?}",
+            format, detection_time
+        );
     }
 
     println!("Cover art size and performance tests passed!");

--- a/src-tauri/tests/p41_core_pipeline_tests.rs
+++ b/src-tauri/tests/p41_core_pipeline_tests.rs
@@ -3,12 +3,10 @@
 //! Tests the complete ffmpeg-next audio processing pipeline to verify
 //! P4.1 success criteria are met.
 
-
+use audiobook_boss_lib::audio::media_pipeline::{FfmpegNextProcessor, MediaProcessingPlan};
 use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
-use audiobook_boss_lib::audio::media_pipeline::{MediaProcessingPlan, FfmpegNextProcessor};
 use std::path::PathBuf;
 use tempfile::TempDir;
-
 
 /// Test that MediaProcessingPlan::execute_with_context works (no placeholder)
 #[test]
@@ -16,27 +14,26 @@ fn test_media_processing_plan_execute_method_exists() {
     // This test verifies that the placeholder has been removed and the method compiles
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("plan_output.m4b");
-    
+
     let settings = AudioSettings {
         bitrate: 64,
         sample_rate: SampleRateConfig::Explicit(44100),
         channels: ChannelConfig::Stereo,
         output_path: output_path.clone(),
     };
-    
+
     let plan = MediaProcessingPlan::new(
         output_path.clone(),
         settings,
         vec![PathBuf::from("dummy.mp3")],
         60.0,
     );
-    
+
     // We're just testing that the method exists and is callable
     // (execution would require a proper ProcessingContext which needs Tauri)
     assert_eq!(plan.total_duration, 60.0);
     assert_eq!(plan.output_path, output_path);
 }
-
 
 /// Test that FfmpegNextProcessor can be instantiated
 #[test]
@@ -50,7 +47,7 @@ fn test_ffmpeg_next_processor_instantiation() {
 fn test_media_processing_plan_creation() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("test.m4b");
-    
+
     // Test various audio settings combinations
     let test_cases = vec![
         AudioSettings {
@@ -66,7 +63,7 @@ fn test_media_processing_plan_creation() {
             output_path: output_path.clone(),
         },
     ];
-    
+
     for (i, settings) in test_cases.into_iter().enumerate() {
         let plan = MediaProcessingPlan::new(
             output_path.clone(),
@@ -74,7 +71,7 @@ fn test_media_processing_plan_creation() {
             vec![PathBuf::from(&format!("test{}.mp3", i))],
             30.0 * (i as f64 + 1.0),
         );
-        
+
         assert_eq!(plan.settings.bitrate, settings.bitrate);
         assert_eq!(plan.settings.channels, settings.channels);
         assert_eq!(plan.total_duration, 30.0 * (i as f64 + 1.0));
@@ -85,7 +82,7 @@ fn test_media_processing_plan_creation() {
 #[test]
 fn test_duration_calculation() {
     use audiobook_boss_lib::audio::AudioFile;
-    
+
     let files = vec![
         AudioFile {
             path: PathBuf::from("file1.mp3"),
@@ -121,7 +118,7 @@ fn test_duration_calculation() {
             error: None,
         },
     ];
-    
+
     let total = MediaProcessingPlan::calculate_total_duration(&files);
     assert_eq!(total, 75.5, "Should sum only non-None durations");
 }

--- a/src-tauri/tests/path_validation_integration.rs
+++ b/src-tauri/tests/path_validation_integration.rs
@@ -1,31 +1,40 @@
 // Integration tests for path validation implementation across all entry points
 // These tests verify that invalid inputs are rejected at all API boundaries
 
-use audiobook_boss_lib::commands::{validate_files, analyze_audio_files};
 use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
-use tempfile::TempDir;
+use audiobook_boss_lib::commands::{analyze_audio_files, validate_files};
 use std::fs::File;
+use tempfile::TempDir;
 
 /// Test that validate_files command rejects invalid paths
 #[test]
 fn test_validate_files_rejects_invalid_inputs() {
     // Test nonexistent files
-    let nonexistent_files = vec!["nonexistent1.mp3".to_string(), "nonexistent2.mp3".to_string()];
+    let nonexistent_files = vec![
+        "nonexistent1.mp3".to_string(),
+        "nonexistent2.mp3".to_string(),
+    ];
     let result = validate_files(nonexistent_files);
     assert!(result.is_err(), "Should reject nonexistent files");
     let error_msg = result.expect_err("expected error").to_string();
-    assert!(error_msg.contains("Cannot read file metadata"), 
-            "Expected file validation error, got: {}", error_msg);
-    
+    assert!(
+        error_msg.contains("Cannot read file metadata"),
+        "Expected file validation error, got: {}",
+        error_msg
+    );
+
     // Test directory instead of file
     let temp_dir = TempDir::new().expect("create temp dir");
     let dir_files = vec![temp_dir.path().to_string_lossy().to_string()];
     let result = validate_files(dir_files);
     assert!(result.is_err(), "Should reject directories");
     let error_msg = result.expect_err("expected error").to_string();
-    assert!(error_msg.contains("not a regular file"),
-            "Expected directory validation error, got: {}", error_msg);
-    
+    assert!(
+        error_msg.contains("not a regular file"),
+        "Expected directory validation error, got: {}",
+        error_msg
+    );
+
     // Test unsupported file type
     let unsupported_file = temp_dir.path().join("document.txt");
     File::create(&unsupported_file).expect("create test file");
@@ -33,41 +42,58 @@ fn test_validate_files_rejects_invalid_inputs() {
     let result = validate_files(unsupported_files);
     assert!(result.is_err(), "Should reject unsupported file types");
     let error_msg = result.expect_err("expected error").to_string();
-    assert!(error_msg.contains("Unsupported audio format"),
-            "Expected format validation error, got: {}", error_msg);
+    assert!(
+        error_msg.contains("Unsupported audio format"),
+        "Expected format validation error, got: {}",
+        error_msg
+    );
 }
 
 /// Test that analyze_audio_files command properly validates inputs
 #[test]
 fn test_analyze_audio_files_validates_inputs() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Test with mix of valid and invalid files
     let valid_file = temp_dir.path().join("valid.mp3");
     File::create(&valid_file).expect("create valid file");
-    
+
     let files = vec![
         "nonexistent.mp3".to_string(),
         valid_file.to_string_lossy().to_string(),
         temp_dir.path().to_string_lossy().to_string(), // directory
     ];
-    
+
     let result = analyze_audio_files(files);
-    assert!(result.is_ok(), "Analysis should succeed but mark invalid files");
-    
+    assert!(
+        result.is_ok(),
+        "Analysis should succeed but mark invalid files"
+    );
+
     let file_info = result.expect("analysis ok");
-    assert_eq!(file_info.files.len(), 3, "Should analyze all provided paths");
-    
+    assert_eq!(
+        file_info.files.len(),
+        3,
+        "Should analyze all provided paths"
+    );
+
     // Check that invalid files are properly marked
     let invalid_count = file_info.files.iter().filter(|f| !f.is_valid).count();
     eprintln!("Invalid file count: {} (expected 2 or 3)", invalid_count);
     for (i, file) in file_info.files.iter().enumerate() {
-        eprintln!("File {}: valid={}, error={:?}", i, file.is_valid, file.error);
+        eprintln!(
+            "File {}: valid={}, error={:?}",
+            i, file.is_valid, file.error
+        );
     }
-    
+
     // Expecting at least 2 invalid files (nonexistent + directory), valid.mp3 may also be invalid due to content
-    assert!(invalid_count >= 2, "At least two files should be marked invalid, got {}", invalid_count);
-    
+    assert!(
+        invalid_count >= 2,
+        "At least two files should be marked invalid, got {}",
+        invalid_count
+    );
+
     // Verify error messages contain path validation failures
     for file in &file_info.files {
         if !file.is_valid {
@@ -78,19 +104,20 @@ fn test_analyze_audio_files_validates_inputs() {
                 error.contains("Unsupported audio format") ||
                 error.contains("Audio metadata error") || // Lofty metadata errors are also acceptable for invalid content
                 error.contains("failed to fill whole buffer"), // Specific lofty error for empty/invalid files
-                "Error should indicate validation failure: {}", error
+                "Error should indicate validation failure: {}",
+                error
             );
         }
     }
 }
 
 /// Test that audio settings validation works correctly
-#[test] 
+#[test]
 fn test_audio_settings_validation() {
     use audiobook_boss_lib::commands::validate_audio_settings;
-    
+
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Test valid settings
     let valid_settings = AudioSettings {
         bitrate: 64,
@@ -100,7 +127,7 @@ fn test_audio_settings_validation() {
     };
     let result = validate_audio_settings(valid_settings);
     assert!(result.is_ok(), "Valid settings should pass validation");
-    
+
     // Test invalid output directory (nonexistent parent)
     let invalid_settings = AudioSettings {
         bitrate: 64,
@@ -109,15 +136,21 @@ fn test_audio_settings_validation() {
         output_path: "/nonexistent/directory/output.m4b".into(),
     };
     let result = validate_audio_settings(invalid_settings);
-    assert!(result.is_err(), "Should reject nonexistent output directory");
-    assert!(result.expect_err("expected error").to_string().contains("does not exist"));
+    assert!(
+        result.is_err(),
+        "Should reject nonexistent output directory"
+    );
+    assert!(result
+        .expect_err("expected error")
+        .to_string()
+        .contains("does not exist"));
 }
 
 /// Test that path validation handles special characters correctly
 #[test]
 fn test_path_validation_special_characters() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Test unicode filename (should be accepted)
     let unicode_file = temp_dir.path().join("测试文件.mp3");
     File::create(&unicode_file).expect("create unicode file");
@@ -128,32 +161,38 @@ fn test_path_validation_special_characters() {
     // The file will be marked invalid due to content, but not due to path validation
     let file = &file_info.files[0];
     if let Some(error) = &file.error {
-        assert!(!error.contains("invalid characters"), "Should not fail on unicode characters");
+        assert!(
+            !error.contains("invalid characters"),
+            "Should not fail on unicode characters"
+        );
     }
 }
 
 /// Test symlink handling with integration
-#[test] 
+#[test]
 #[cfg(unix)] // Symlinks are Unix-specific
 fn test_symlink_integration() {
     use std::os::unix::fs::symlink;
-    
+
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Create target file and symlink
     let target = temp_dir.path().join("target.mp3");
     File::create(&target).expect("create target file");
     let link = temp_dir.path().join("link.mp3");
     symlink(&target, &link).expect("create symlink");
-    
+
     let files = vec![link.to_string_lossy().to_string()];
     let result = analyze_audio_files(files);
     assert!(result.is_ok(), "Symlinks should be accepted");
-    
+
     let file_info = result.expect("analysis ok");
     assert_eq!(file_info.files.len(), 1, "Should process symlink");
-    
+
     // Check that the symlink was resolved to canonical path
     let file = &file_info.files[0];
-    assert!(file.path.is_absolute(), "Should use canonical absolute path");
+    assert!(
+        file.path.is_absolute(),
+        "Should use canonical absolute path"
+    );
 }

--- a/src-tauri/tests/path_validation_p013.rs
+++ b/src-tauri/tests/path_validation_p013.rs
@@ -1,24 +1,24 @@
 // Integration test for P0.1.3 - symlink policy and output directory validation
 // Tests symlink handling and write permission probing
 
-use audiobook_boss_lib::commands::validate_audio_settings;
 use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
-use tempfile::TempDir;
+use audiobook_boss_lib::commands::validate_audio_settings;
 use std::fs::Permissions;
+use tempfile::TempDir;
 
 #[cfg(unix)]
 #[test]
 fn test_read_only_output_directory_integration() {
     use std::os::unix::fs::PermissionsExt;
-    
+
     let temp_dir = TempDir::new().expect("create temp dir");
     let readonly_dir = temp_dir.path().join("readonly");
     std::fs::create_dir(&readonly_dir).expect("create readonly dir");
-    
+
     // Make directory read-only
     let readonly_perms = Permissions::from_mode(0o444);
     std::fs::set_permissions(&readonly_dir, readonly_perms).expect("set readonly permissions");
-    
+
     // Test settings validation with read-only output directory
     let settings = AudioSettings {
         bitrate: 64,
@@ -26,11 +26,14 @@ fn test_read_only_output_directory_integration() {
         sample_rate: SampleRateConfig::Auto,
         output_path: readonly_dir.join("output.m4b"),
     };
-    
+
     let result = validate_audio_settings(settings);
     assert!(result.is_err(), "Should reject read-only output directory");
-    assert!(result.expect_err("expected write permission error").to_string().contains("not writable"));
-    
+    assert!(result
+        .expect_err("expected write permission error")
+        .to_string()
+        .contains("not writable"));
+
     // Restore permissions for cleanup
     let normal_perms = Permissions::from_mode(0o755);
     std::fs::set_permissions(&readonly_dir, normal_perms).expect("restore permissions");
@@ -39,7 +42,7 @@ fn test_read_only_output_directory_integration() {
 #[test]
 fn test_output_path_validation_integration() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Test valid output path
     let valid_settings = AudioSettings {
         bitrate: 64,
@@ -49,7 +52,7 @@ fn test_output_path_validation_integration() {
     };
     let result = validate_audio_settings(valid_settings);
     assert!(result.is_ok(), "Valid settings should pass validation");
-    
+
     // Test invalid extension
     let invalid_ext_settings = AudioSettings {
         bitrate: 64,
@@ -59,8 +62,11 @@ fn test_output_path_validation_integration() {
     };
     let result = validate_audio_settings(invalid_ext_settings);
     assert!(result.is_err(), "Should reject non-.m4b extension");
-    assert!(result.expect_err("expected extension error").to_string().contains(".m4b"));
-    
+    assert!(result
+        .expect_err("expected extension error")
+        .to_string()
+        .contains(".m4b"));
+
     // Test nonexistent parent directory
     let nonexistent_dir_settings = AudioSettings {
         bitrate: 64,
@@ -69,6 +75,12 @@ fn test_output_path_validation_integration() {
         output_path: "/nonexistent/directory/output.m4b".into(),
     };
     let result = validate_audio_settings(nonexistent_dir_settings);
-    assert!(result.is_err(), "Should reject nonexistent parent directory");
-    assert!(result.expect_err("expected directory error").to_string().contains("does not exist"));
+    assert!(
+        result.is_err(),
+        "Should reject nonexistent parent directory"
+    );
+    assert!(result
+        .expect_err("expected directory error")
+        .to_string()
+        .contains("does not exist"));
 }

--- a/src-tauri/tests/preview_30s_integration.rs
+++ b/src-tauri/tests/preview_30s_integration.rs
@@ -30,5 +30,3 @@ fn preview_path_derivation_does_not_panic() {
     assert!(expected.parent().unwrap().exists());
     drop(settings); // avoid unused warnings
 }
-
-

--- a/src-tauri/tests/settings_validation_integration.rs
+++ b/src-tauri/tests/settings_validation_integration.rs
@@ -3,43 +3,40 @@
 //! These tests ensure that audio settings (bitrate, channels, sample rate) are
 //! correctly applied and result in output files with matching properties.
 
-use audiobook_boss_lib::audio::{
-    AudioSettings, ChannelConfig, SampleRateConfig,
-    validate_audio_settings,
-};
 use audiobook_boss_lib::audio::media_pipeline::MediaProcessingPlan;
 use audiobook_boss_lib::audio::processor::detect_input_sample_rate;
+use audiobook_boss_lib::audio::{
+    validate_audio_settings, AudioSettings, ChannelConfig, SampleRateConfig,
+};
 use std::path::PathBuf;
 use tempfile::TempDir;
 
 /// Creates a minimal valid audio file for testing
 fn create_test_audio_file(temp_dir: &TempDir, filename: &str) -> std::io::Result<PathBuf> {
     let test_file_path = temp_dir.path().join(filename);
-    
+
     // Create a minimal WAV file (44 bytes header + some audio data)
     // This is a valid 1-second mono 8kHz 8-bit WAV file
     let wav_data = [
         // RIFF header
-        0x52, 0x49, 0x46, 0x46,  // "RIFF"
-        0x24, 0x00, 0x00, 0x00,  // File size - 8 (36 bytes)
-        0x57, 0x41, 0x56, 0x45,  // "WAVE"
-        
+        0x52, 0x49, 0x46, 0x46, // "RIFF"
+        0x24, 0x00, 0x00, 0x00, // File size - 8 (36 bytes)
+        0x57, 0x41, 0x56, 0x45, // "WAVE"
         // fmt chunk
-        0x66, 0x6d, 0x74, 0x20,  // "fmt "
-        0x10, 0x00, 0x00, 0x00,  // Chunk size (16)
-        0x01, 0x00,              // Audio format (1 = PCM)
-        0x01, 0x00,              // Number of channels (1 = mono)
-        0x40, 0x1f, 0x00, 0x00,  // Sample rate (8000)
-        0x40, 0x1f, 0x00, 0x00,  // Byte rate (8000)
-        0x01, 0x00,              // Block align (1)
-        0x08, 0x00,              // Bits per sample (8)
-        
+        0x66, 0x6d, 0x74, 0x20, // "fmt "
+        0x10, 0x00, 0x00, 0x00, // Chunk size (16)
+        0x01, 0x00, // Audio format (1 = PCM)
+        0x01, 0x00, // Number of channels (1 = mono)
+        0x40, 0x1f, 0x00, 0x00, // Sample rate (8000)
+        0x40, 0x1f, 0x00, 0x00, // Byte rate (8000)
+        0x01, 0x00, // Block align (1)
+        0x08, 0x00, // Bits per sample (8)
         // data chunk
-        0x64, 0x61, 0x74, 0x61,  // "data"
-        0x04, 0x00, 0x00, 0x00,  // Data size (4 bytes)
-        0x80, 0x80, 0x80, 0x80,  // Audio data (silence)
+        0x64, 0x61, 0x74, 0x61, // "data"
+        0x04, 0x00, 0x00, 0x00, // Data size (4 bytes)
+        0x80, 0x80, 0x80, 0x80, // Audio data (silence)
     ];
-    
+
     std::fs::write(&test_file_path, &wav_data)?;
     Ok(test_file_path)
 }
@@ -48,14 +45,14 @@ fn create_test_audio_file(temp_dir: &TempDir, filename: &str) -> std::io::Result
 fn test_validate_audio_settings_all_valid() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("output.m4b");
-    
+
     let settings = AudioSettings {
         bitrate: 64,
         channels: ChannelConfig::Mono,
         sample_rate: SampleRateConfig::Explicit(22050),
         output_path,
     };
-    
+
     let result = validate_audio_settings(&settings);
     assert!(result.is_ok(), "Valid settings should pass validation");
 }
@@ -65,15 +62,18 @@ fn test_validate_bitrate_edge_cases() {
     // Test minimum valid bitrate
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("output.m4b");
-    
+
     let settings_min = AudioSettings {
         bitrate: 32,
         channels: ChannelConfig::Mono,
         sample_rate: SampleRateConfig::Auto,
         output_path: output_path.clone(),
     };
-    assert!(validate_audio_settings(&settings_min).is_ok(), "Minimum bitrate should be valid");
-    
+    assert!(
+        validate_audio_settings(&settings_min).is_ok(),
+        "Minimum bitrate should be valid"
+    );
+
     // Test maximum valid bitrate
     let settings_max = AudioSettings {
         bitrate: 128,
@@ -81,8 +81,11 @@ fn test_validate_bitrate_edge_cases() {
         sample_rate: SampleRateConfig::Auto,
         output_path: output_path.clone(),
     };
-    assert!(validate_audio_settings(&settings_max).is_ok(), "Maximum bitrate should be valid");
-    
+    assert!(
+        validate_audio_settings(&settings_max).is_ok(),
+        "Maximum bitrate should be valid"
+    );
+
     // Test invalid low bitrate
     let settings_low = AudioSettings {
         bitrate: 16,
@@ -91,9 +94,15 @@ fn test_validate_bitrate_edge_cases() {
         output_path: output_path.clone(),
     };
     let result_low = validate_audio_settings(&settings_low);
-    assert!(result_low.is_err(), "Too low bitrate should fail validation");
-    assert!(result_low.expect_err("expected error").to_string().contains("32-128"));
-    
+    assert!(
+        result_low.is_err(),
+        "Too low bitrate should fail validation"
+    );
+    assert!(result_low
+        .expect_err("expected error")
+        .to_string()
+        .contains("32-128"));
+
     // Test invalid high bitrate
     let settings_high = AudioSettings {
         bitrate: 256,
@@ -102,15 +111,21 @@ fn test_validate_bitrate_edge_cases() {
         output_path,
     };
     let result_high = validate_audio_settings(&settings_high);
-    assert!(result_high.is_err(), "Too high bitrate should fail validation");
-    assert!(result_high.expect_err("expected error").to_string().contains("32-128"));
+    assert!(
+        result_high.is_err(),
+        "Too high bitrate should fail validation"
+    );
+    assert!(result_high
+        .expect_err("expected error")
+        .to_string()
+        .contains("32-128"));
 }
 
 #[test]
 fn test_validate_sample_rate_configurations() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("output.m4b");
-    
+
     // Test all valid explicit sample rates
     let valid_rates = [22050, 32000, 44100, 48000];
     for rate in valid_rates {
@@ -120,10 +135,12 @@ fn test_validate_sample_rate_configurations() {
             sample_rate: SampleRateConfig::Explicit(rate),
             output_path: output_path.clone(),
         };
-        assert!(validate_audio_settings(&settings).is_ok(),
-                "Valid sample rate {rate} should pass validation");
+        assert!(
+            validate_audio_settings(&settings).is_ok(),
+            "Valid sample rate {rate} should pass validation"
+        );
     }
-    
+
     // Test invalid sample rate
     let settings_invalid = AudioSettings {
         bitrate: 64,
@@ -132,9 +149,15 @@ fn test_validate_sample_rate_configurations() {
         output_path,
     };
     let result = validate_audio_settings(&settings_invalid);
-    assert!(result.is_err(), "Invalid sample rate should fail validation");
+    assert!(
+        result.is_err(),
+        "Invalid sample rate should fail validation"
+    );
     let error_msg = result.expect_err("expected error").to_string();
-    assert!(error_msg.contains("12345"), "Error should mention the invalid rate");
+    assert!(
+        error_msg.contains("12345"),
+        "Error should mention the invalid rate"
+    );
     assert!(error_msg.contains("22050"), "Error should list valid rates");
 }
 
@@ -143,7 +166,7 @@ fn test_channel_config_properties() {
     // Test channel count mapping
     assert_eq!(ChannelConfig::Mono.channel_count(), 1);
     assert_eq!(ChannelConfig::Stereo.channel_count(), 2);
-    
+
     // Channel layout strings helper removed; verify counts only
 }
 
@@ -154,31 +177,31 @@ fn test_audio_settings_presets() {
     assert_eq!(audiobook.bitrate, 64);
     assert!(matches!(audiobook.channels, ChannelConfig::Mono));
     assert!(matches!(audiobook.sample_rate, SampleRateConfig::Auto));
-    
+
     // Test high quality preset
     let hq = AudioSettings::high_quality_preset();
     assert_eq!(hq.bitrate, 128);
     assert!(matches!(hq.channels, ChannelConfig::Stereo));
     assert!(matches!(hq.sample_rate, SampleRateConfig::Explicit(44100)));
-    
+
     // Test low bandwidth preset
     let low = AudioSettings::low_bandwidth_preset();
     assert_eq!(low.bitrate, 32);
     assert!(matches!(low.channels, ChannelConfig::Mono));
     assert!(matches!(low.sample_rate, SampleRateConfig::Explicit(22050)));
-    
+
     // Validate all presets are valid
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("test.m4b");
-    
+
     let mut audiobook_with_path = audiobook;
     audiobook_with_path.output_path = output_path.clone();
     assert!(validate_audio_settings(&audiobook_with_path).is_ok());
-    
+
     let mut hq_with_path = hq;
     hq_with_path.output_path = output_path.clone();
     assert!(validate_audio_settings(&hq_with_path).is_ok());
-    
+
     let mut low_with_path = low;
     low_with_path.output_path = output_path;
     assert!(validate_audio_settings(&low_with_path).is_ok());
@@ -187,18 +210,21 @@ fn test_audio_settings_presets() {
 #[test]
 fn test_sample_rate_detection_from_files() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Create test files with different sample rates (simulated via AudioFile metadata)
     let file1_path = create_test_audio_file(&temp_dir, "file1.wav").expect("create test file 1");
     let file2_path = create_test_audio_file(&temp_dir, "file2.wav").expect("create test file 2");
     let file3_path = create_test_audio_file(&temp_dir, "file3.wav").expect("create test file 3");
-    
+
     let file_paths = vec![file1_path, file2_path, file3_path];
-    
+
     // Test detection with actual files
     // Note: Our test WAV files all have 8000 Hz, so that should be detected
     let detected = detect_input_sample_rate(&file_paths).expect("detect sample rate");
-    assert_eq!(detected, 8000, "Should detect sample rate from test WAV files");
+    assert_eq!(
+        detected, 8000,
+        "Should detect sample rate from test WAV files"
+    );
 }
 
 #[test]
@@ -208,7 +234,7 @@ fn test_sample_rate_detection_error_cases() {
     assert!(result.is_err());
     let error = result.expect_err("expected error");
     assert!(error.to_string().contains("no input files"));
-    
+
     // Test with nonexistent files
     let nonexistent_files = vec![
         PathBuf::from("/nonexistent/file1.mp3"),
@@ -225,36 +251,49 @@ fn test_media_processing_plan_construction() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let input_file = create_test_audio_file(&temp_dir, "input.wav").expect("create test file");
     let output_file = temp_dir.path().join("output.m4b");
-    
+
     // Concat no longer required in single-engine path
-    
+
     let settings = AudioSettings {
         bitrate: 64,
         channels: ChannelConfig::Mono,
         sample_rate: SampleRateConfig::Explicit(22050),
         output_path: output_file.clone(),
     };
-    
+
     let plan = MediaProcessingPlan::new(
         output_file,
         settings,
         vec![input_file],
         1.0, // 1 second duration
     );
-    
+
     // Test plan creation and validation
     // Note: build_ffmpeg_command removed in Phase 11 cleanup - behavior now validated via end-to-end processing
-    
+
     // Verify the plan contains our settings
-    assert_eq!(plan.settings.bitrate, 64, "Plan should contain correct bitrate setting");
-    
-    // Check for sample rate setting  
-    assert!(matches!(plan.settings.sample_rate, audiobook_boss_lib::audio::SampleRateConfig::Explicit(22050)),
-            "Plan should contain sample rate setting");
-    
+    assert_eq!(
+        plan.settings.bitrate, 64,
+        "Plan should contain correct bitrate setting"
+    );
+
+    // Check for sample rate setting
+    assert!(
+        matches!(
+            plan.settings.sample_rate,
+            audiobook_boss_lib::audio::SampleRateConfig::Explicit(22050)
+        ),
+        "Plan should contain sample rate setting"
+    );
+
     // Check for channel setting
-    assert!(matches!(plan.settings.channels, audiobook_boss_lib::audio::ChannelConfig::Mono),
-            "Plan should contain channel setting");
+    assert!(
+        matches!(
+            plan.settings.channels,
+            audiobook_boss_lib::audio::ChannelConfig::Mono
+        ),
+        "Plan should contain channel setting"
+    );
 }
 
 /// Integration test that verifies settings are applied correctly by the processor
@@ -265,7 +304,7 @@ fn test_settings_application_integration() {
     let input_file = create_test_audio_file(&temp_dir, "input.wav").expect("create test file");
     let _output_file = temp_dir.path().join("output.m4b");
     // Concat file not needed in single-engine path
-    
+
     // Test different settings configurations
     let test_cases = vec![
         // Low quality mono
@@ -290,12 +329,14 @@ fn test_settings_application_integration() {
             output_path: temp_dir.path().join("output_auto.m4b"),
         },
     ];
-    
+
     for (i, settings) in test_cases.into_iter().enumerate() {
         // Validate settings are valid
-        assert!(validate_audio_settings(&settings).is_ok(),
-                "Test case {i} settings should be valid");
-        
+        assert!(
+            validate_audio_settings(&settings).is_ok(),
+            "Test case {i} settings should be valid"
+        );
+
         // Create processing plan
         let plan = MediaProcessingPlan::new(
             settings.output_path.clone(),
@@ -303,11 +344,14 @@ fn test_settings_application_integration() {
             vec![input_file.clone()],
             1.0,
         );
-        
+
         // Verify plan can be created
         // Note: build_ffmpeg_command removed in Phase 11 cleanup
-        assert!(plan.settings.bitrate > 0, "Test case {i} should have valid bitrate");
-        
+        assert!(
+            plan.settings.bitrate > 0,
+            "Test case {i} should have valid bitrate"
+        );
+
         // In a full integration test, we would:
         // 1. Create mock ProcessingContext
         // 2. Execute the plan using available processor implementation
@@ -321,7 +365,7 @@ fn test_settings_validation_comprehensive() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let valid_output = temp_dir.path().join("valid.m4b");
     let invalid_output = temp_dir.path().join("invalid.mp3");
-    
+
     // Valid settings should pass
     let valid_settings = AudioSettings {
         bitrate: 64,
@@ -330,7 +374,7 @@ fn test_settings_validation_comprehensive() {
         output_path: valid_output,
     };
     assert!(validate_audio_settings(&valid_settings).is_ok());
-    
+
     // Invalid bitrate
     let invalid_bitrate = AudioSettings {
         bitrate: 200,
@@ -339,7 +383,7 @@ fn test_settings_validation_comprehensive() {
         output_path: temp_dir.path().join("test.m4b"),
     };
     assert!(validate_audio_settings(&invalid_bitrate).is_err());
-    
+
     // Invalid sample rate
     let invalid_sample_rate = AudioSettings {
         bitrate: 64,
@@ -348,7 +392,7 @@ fn test_settings_validation_comprehensive() {
         output_path: temp_dir.path().join("test.m4b"),
     };
     assert!(validate_audio_settings(&invalid_sample_rate).is_err());
-    
+
     // Invalid output extension
     let invalid_extension = AudioSettings {
         bitrate: 64,
@@ -359,7 +403,10 @@ fn test_settings_validation_comprehensive() {
     let result = validate_audio_settings(&invalid_extension);
     assert!(result.is_err());
     let error_msg = result.expect_err("expected error").to_string();
-    assert!(error_msg.contains(".m4b"), "Error should mention required extension");
+    assert!(
+        error_msg.contains(".m4b"),
+        "Error should mention required extension"
+    );
 }
 
 #[test]
@@ -367,16 +414,16 @@ fn test_channel_config_edge_cases() {
     // Test that channel count is correct for all variants
     let mono = ChannelConfig::Mono;
     let stereo = ChannelConfig::Stereo;
-    
+
     assert_eq!(mono.channel_count(), 1);
     assert_eq!(stereo.channel_count(), 2);
-    
+
     // Channel layout helper removed
-    
+
     // Test that these values work in settings validation
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_path = temp_dir.path().join("test.m4b");
-    
+
     let mono_settings = AudioSettings {
         bitrate: 64,
         channels: mono,
@@ -384,7 +431,7 @@ fn test_channel_config_edge_cases() {
         output_path: output_path.clone(),
     };
     assert!(validate_audio_settings(&mono_settings).is_ok());
-    
+
     let stereo_settings = AudioSettings {
         bitrate: 64,
         channels: stereo,
@@ -395,30 +442,33 @@ fn test_channel_config_edge_cases() {
 }
 
 /// Test that validates the settings are correctly applied in MediaProcessingPlan
-#[test] 
+#[test]
 fn test_media_processing_plan_settings_preservation() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let output_file = temp_dir.path().join("output.m4b");
     let input_file = temp_dir.path().join("input.wav");
-    
+
     let original_settings = AudioSettings {
         bitrate: 96,
         channels: ChannelConfig::Stereo,
         sample_rate: SampleRateConfig::Explicit(48000),
         output_path: output_file.clone(),
     };
-    
+
     let plan = MediaProcessingPlan::new(
         output_file.clone(),
         original_settings.clone(),
         vec![input_file],
         2.5,
     );
-    
+
     // Verify plan preserves all settings
     assert_eq!(plan.settings.bitrate, original_settings.bitrate);
     assert!(matches!(plan.settings.channels, ChannelConfig::Stereo));
-    assert!(matches!(plan.settings.sample_rate, SampleRateConfig::Explicit(48000)));
+    assert!(matches!(
+        plan.settings.sample_rate,
+        SampleRateConfig::Explicit(48000)
+    ));
     assert_eq!(plan.settings.output_path, original_settings.output_path);
     assert_eq!(plan.total_duration, 2.5);
 }
@@ -427,7 +477,7 @@ fn test_media_processing_plan_settings_preservation() {
 #[test]
 fn test_settings_validation_matrix() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    
+
     // Test matrix of valid combinations
     let bitrates = [32, 64, 96, 128];
     let channels = [ChannelConfig::Mono, ChannelConfig::Stereo];
@@ -437,7 +487,7 @@ fn test_settings_validation_matrix() {
         SampleRateConfig::Explicit(44100),
         SampleRateConfig::Explicit(48000),
     ];
-    
+
     let mut test_count = 0;
     for bitrate in bitrates {
         for channel in &channels {
@@ -449,16 +499,16 @@ fn test_settings_validation_matrix() {
                     sample_rate: sample_rate.clone(),
                     output_path,
                 };
-                
+
                 let result = validate_audio_settings(&settings);
-                assert!(result.is_ok(), 
-                        "Settings combination {test_count} should be valid: bitrate={bitrate}, channels={:?}, sample_rate={:?}", 
+                assert!(result.is_ok(),
+                        "Settings combination {test_count} should be valid: bitrate={bitrate}, channels={:?}, sample_rate={:?}",
                         channel, sample_rate);
-                
+
                 test_count += 1;
             }
         }
     }
-    
+
     println!("Validated {test_count} valid settings combinations");
 }


### PR DESCRIPTION
This PR:

- Replaces AGENTS.md with a unified, spec-aligned agent guide (includes Event contracts and pre-submit checks: cargo fmt --all -- --check, tsc --noEmit)
- Adds a README ‘For AI agents’ callout linking to AGENTS.md and spec
- Runs cargo fmt across src-tauri (no behavior changes)

Notes:
- TypeScript and formatting checks pass locally; clippy/tests depend on local FFmpeg dev headers (homebrew ffmpeg + pkg-config). No code behavior changes intended.

Please review the large fmt-only diffs at your convenience.
