### PR TITLE
refactor: move output destination into dedicated config

### DIFF
--- a/src-tauri/src/audio/context.rs
+++ b/src-tauri/src/audio/context.rs
@@ -10,6 +10,7 @@ use super::AudioSettings;
 use crate::audio::ProcessingStage;
 use crate::errors::Result;
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::Window;
 
@@ -18,6 +19,32 @@ use tauri::Window;
 pub struct PreviewConfig {
     /// Number of seconds to encode before early-stop
     pub seconds: f64,
+}
+
+/// Output configuration derived from user input
+#[derive(Debug, Clone)]
+pub struct OutputConfig {
+    /// Final destination for the processed audiobook
+    final_path: PathBuf,
+}
+
+impl OutputConfig {
+    /// Creates a new output configuration
+    pub fn new<P: Into<PathBuf>>(final_path: P) -> Self {
+        Self {
+            final_path: final_path.into(),
+        }
+    }
+
+    /// Returns a reference to the final output path
+    pub fn final_path(&self) -> &Path {
+        &self.final_path
+    }
+
+    /// Consumes the config and returns the final path
+    pub fn into_final_path(self) -> PathBuf {
+        self.final_path
+    }
 }
 
 /// Groups core processing dependencies together
@@ -32,19 +59,27 @@ pub struct ProcessingContext {
     pub session: Arc<ProcessingSession>,
     /// Audio processing settings
     pub settings: AudioSettings,
+    /// Output configuration
+    pub output: OutputConfig,
     /// Optional advanced encoder settings (v2) carried through the pipeline
     pub encoder_settings_v2: Option<EncoderSettings>,
-    /// Optional preview configuration (when present, processing should early‑stop)
+    /// Optional preview configuration (when present, processing should early-stop)
     pub preview: Option<PreviewConfig>,
 }
 
 impl ProcessingContext {
     /// Creates a new ProcessingContext with the given components
-    pub fn new(window: Window, session: Arc<ProcessingSession>, settings: AudioSettings) -> Self {
+    pub fn new(
+        window: Window,
+        session: Arc<ProcessingSession>,
+        settings: AudioSettings,
+        output: OutputConfig,
+    ) -> Self {
         Self {
             window,
             session,
             settings,
+            output,
             encoder_settings_v2: None,
             preview: None,
         }
@@ -114,6 +149,7 @@ pub struct ProcessingContextBuilder {
     window: Option<Window>,
     session: Option<Arc<ProcessingSession>>,
     settings: Option<AudioSettings>,
+    output: Option<OutputConfig>,
 }
 
 impl ProcessingContextBuilder {
@@ -123,6 +159,7 @@ impl ProcessingContextBuilder {
             window: None,
             session: None,
             settings: None,
+            output: None,
         }
     }
 
@@ -144,6 +181,12 @@ impl ProcessingContextBuilder {
         self
     }
 
+    /// Sets the output configuration
+    pub fn output(mut self, output: OutputConfig) -> Self {
+        self.output = Some(output);
+        self
+    }
+
     /// Builds the ProcessingContext
     ///
     /// # Errors
@@ -155,16 +198,26 @@ impl ProcessingContextBuilder {
                     .to_string(),
             )
         })?;
-        let session = self.session
-            .ok_or_else(|| crate::errors::AppError::InvalidInput(
-                "Failed to build ProcessingContext: Processing session is required for state management".to_string()
-            ))?;
-        let settings = self.settings
-            .ok_or_else(|| crate::errors::AppError::InvalidInput(
-                "Failed to build ProcessingContext: Audio settings are required for processing configuration".to_string()
-            ))?;
+        let session = self.session.ok_or_else(|| {
+            crate::errors::AppError::InvalidInput(
+                "Failed to build ProcessingContext: Processing session is required for state management"
+                    .to_string(),
+            )
+        })?;
+        let settings = self.settings.ok_or_else(|| {
+            crate::errors::AppError::InvalidInput(
+                "Failed to build ProcessingContext: Audio settings are required for processing configuration"
+                    .to_string(),
+            )
+        })?;
+        let output = self.output.ok_or_else(|| {
+            crate::errors::AppError::InvalidInput(
+                "Failed to build ProcessingContext: Output configuration is required for finalization"
+                    .to_string(),
+            )
+        })?;
 
-        Ok(ProcessingContext::new(window, session, settings))
+        Ok(ProcessingContext::new(window, session, settings, output))
     }
 }
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -156,7 +156,9 @@ pub use processor::{detect_input_sample_rate, process_audiobook_with_context};
 pub use context::ProcessingContext;
 
 // Builders and progress context always available after cleanup
-pub use context::{ProcessingContextBuilder, ProgressContext, ProgressContextBuilder};
+pub use context::{
+    OutputConfig, ProcessingContextBuilder, ProgressContext, ProgressContextBuilder,
+};
 
 // Cleanup infrastructure - CleanupGuard used, ProcessGuard feature-gated
 pub use cleanup::CleanupGuard;

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -257,14 +257,14 @@ pub(crate) fn complete_processing(
     log::info!("Temporary file: {}", merged_output.display());
     log::info!(
         "Final output path: {}",
-        context.settings.output_path.display()
+        context.output.final_path().display()
     );
 
     let ui = crate::audio::progress::ProgressEmitter::new(context.window.clone());
     ui.emit_cleanup("Cleaning up...");
 
     log::info!("Moving temporary file to final location...");
-    let final_output = move_to_final_location(merged_output, &context.settings.output_path)?;
+    let final_output = move_to_final_location(merged_output, context.output.final_path())?;
     log::info!("✓ File moved successfully to: {}", final_output.display());
 
     if context.is_cancelled() {
@@ -298,7 +298,7 @@ pub(crate) async fn finalize_processing(
 
     // If preview mode is enabled, move to preview-named path with overwrite policy
     if let Some(preview_cfg) = context.preview.as_ref() {
-        let preview_path = derive_preview_output_path(&context.settings.output_path);
+        let preview_path = derive_preview_output_path(context.output.final_path());
         log::info!(
             "Preview finalize: seconds={:.3} dest={}",
             preview_cfg.seconds,

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -156,9 +156,14 @@ pub async fn process_audiobook_files_v2(
     // Process the audiobook with progress events
     let (message, preview_path_opt, preview_seconds_used) = {
         let session = audio::session::ProcessingSession::new();
-        let settings_for_path = settings_v1.clone();
-        let mut context =
-            audio::ProcessingContext::new(window, std::sync::Arc::new(session), settings_v1);
+        let final_output_path = settings_v1.output_path.clone();
+        let output_config = audio::OutputConfig::new(final_output_path.clone());
+        let mut context = audio::ProcessingContext::new(
+            window,
+            std::sync::Arc::new(session),
+            settings_v1,
+            output_config,
+        );
         // Attach v2 encoder settings to context for downstream mapping
         context.encoder_settings_v2 = Some(payload.settings.clone());
 
@@ -180,7 +185,7 @@ pub async fn process_audiobook_files_v2(
             audio::processor::process_audiobook_with_context(context, file_info.files, metadata)
                 .await?;
         let preview_path = if is_preview {
-            let final_output = &settings_for_path.output_path;
+            let final_output = &final_output_path;
             let parent = final_output
                 .parent()
                 .unwrap_or_else(|| std::path::Path::new("."));
@@ -253,10 +258,14 @@ pub async fn process_audiobook_files(
     let (message, preview_path_opt, preview_seconds_used) = {
         // Single engine path: ffmpeg-next context based processing
         let session = audio::session::ProcessingSession::new();
-        // Clone settings for deriving preview path later (original moved into context)
-        let settings_for_path = settings.clone();
-        let mut context =
-            audio::ProcessingContext::new(window, std::sync::Arc::new(session), settings);
+        let final_output_path = settings.output_path.clone();
+        let output_config = audio::OutputConfig::new(final_output_path.clone());
+        let mut context = audio::ProcessingContext::new(
+            window,
+            std::sync::Arc::new(session),
+            settings,
+            output_config,
+        );
         // Resolve preview seconds from payload or environment fallback
         let mut preview_seconds_resolved: Option<f64> = None;
         if let Some(sec) = preview_seconds.or_else(|| {
@@ -276,7 +285,7 @@ pub async fn process_audiobook_files(
                 .await?;
         let preview_path = if is_preview {
             // Derive preview path deterministically based on output settings
-            let final_output = &settings_for_path.output_path;
+            let final_output = &final_output_path;
             let parent = final_output
                 .parent()
                 .unwrap_or_else(|| std::path::Path::new("."));

--- a/src-tauri/tests/unit/metadata/cover_art_native_embedding.rs
+++ b/src-tauri/tests/unit/metadata/cover_art_native_embedding.rs
@@ -1,11 +1,20 @@
 //! Tests native ffmpeg-next cover art embedding
 //! Ensures that when cover art is provided, a stream is added pre-header and packet written.
 
-use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig, media_pipeline::MediaProcessingPlan};
-use audiobook_boss_lib::audio::context::ProcessingContextBuilder;
+use audiobook_boss_lib::audio::{
+    AudioSettings,
+    ChannelConfig,
+    OutputConfig,
+    SampleRateConfig,
+    context::ProcessingContext,
+    media_pipeline::MediaProcessingPlan,
+    session::ProcessingSession,
+};
 use audiobook_boss_lib::metadata::AudiobookMetadata;
 use tempfile::TempDir;
 use std::path::PathBuf;
+use std::sync::Arc;
+use tauri::{test::mock_app, WebviewUrl, WebviewWindowBuilder};
 
 // Minimal 1x1 JPEG (JFIF) header (valid tiny image) - using a common minimal pattern.
 const MINIMAL_JPEG: &[u8] = b"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xFF\xD9"; // SOI + APP0 + EOI
@@ -42,13 +51,24 @@ fn test_native_cover_art_embedding_end_to_end() {
 
     let plan = MediaProcessingPlan::new(
         output.clone(),
-        settings,
+        settings.clone(),
         vec![input.clone()],
         1.0,
     );
 
-    // Build a minimal processing context (window and session mocks handled by builder default semantics)
-    let ctx = ProcessingContextBuilder::new().build();
+    // Build a minimal processing context backed by a mock window/session
+    let app = mock_app();
+    let webview = WebviewWindowBuilder::new(
+        &app,
+        "cover-art-test",
+        WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("create mock webview window");
+    let window = webview.as_ref().window();
+    let session = Arc::new(ProcessingSession::new());
+    let output_config = OutputConfig::new(settings.output_path.clone());
+    let ctx = ProcessingContext::new(window, session, settings, output_config);
 
     // Execute with context (async). We use a minimal executor via futures::executor.
     futures::executor::block_on(async {
@@ -92,12 +112,23 @@ fn test_cover_art_unsupported_format_fallback() {
 
     let plan = MediaProcessingPlan::new(
         output.clone(),
-        settings,
+        settings.clone(),
         vec![input.clone()],
         1.0,
     );
 
-    let ctx = ProcessingContextBuilder::new().build();
+    let app = mock_app();
+    let webview = WebviewWindowBuilder::new(
+        &app,
+        "cover-art-fallback",
+        WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("create mock webview window");
+    let window = webview.as_ref().window();
+    let session = Arc::new(ProcessingSession::new());
+    let output_config = OutputConfig::new(settings.output_path.clone());
+    let ctx = ProcessingContext::new(window, session, settings, output_config);
     futures::executor::block_on(async {
         plan.execute_with_context(&ctx, Some(&metadata))
             .await


### PR DESCRIPTION
## Summary
- introduce `OutputConfig` in the processing context so the final destination is decoupled from legacy `AudioSettings`
- thread the new config through both v1/v2 command handlers and the finalize stage
- update cover-art unit tests to build contexts with mock windows instead of relying on the deprecated builder defaults

## Testing
- cargo check
- cargo test --tests --no-run

@codex Please focus on:
1. ensuring the new `OutputConfig` struct is wired cleanly without altering runtime behaviour
2. verifying command handlers still derive preview paths correctly after the refactor
3. checking the updated cover-art unit tests continue to exercise the expected pipeline
