### PR TITLE
refactor: route encoder through v2 settings

### DIFF
--- a/src-tauri/src/audio/context.rs
+++ b/src-tauri/src/audio/context.rs
@@ -142,6 +142,22 @@ impl ProcessingContext {
             self.session.id()
         ))
     }
+
+    /// Returns the effective bitrate in kbps (v2-aware)
+    pub fn effective_bitrate_kbps(&self) -> u32 {
+        self.encoder_settings_v2
+            .as_ref()
+            .map(|enc| enc.bitrate_kbps as u32)
+            .unwrap_or(self.settings.bitrate)
+    }
+
+    /// Returns the effective channel count (v2-aware)
+    pub fn effective_channel_count(&self) -> u8 {
+        self.encoder_settings_v2
+            .as_ref()
+            .map(|enc| enc.channels)
+            .unwrap_or_else(|| self.settings.channels.channel_count())
+    }
 }
 
 /// Builder pattern for ProcessingContext

--- a/src-tauri/src/audio/processor/encoder.rs
+++ b/src-tauri/src/audio/processor/encoder.rs
@@ -104,10 +104,14 @@ fn resolve_target_audio_params(
     use crate::audio::SampleRateConfig;
     use crate::errors::AppError;
 
+    let channel_count = plan
+        .encoder_settings_v2
+        .as_ref()
+        .map(|enc| enc.channels as i32)
+        .unwrap_or_else(|| plan.settings.channels.channel_count() as i32);
+
     match &plan.settings.sample_rate {
-        SampleRateConfig::Explicit(rate) => {
-            Ok((*rate, plan.settings.channels.channel_count() as i32))
-        }
+        SampleRateConfig::Explicit(rate) => Ok((*rate, channel_count)),
         SampleRateConfig::Auto => {
             let first = plan
                 .input_file_paths
@@ -125,10 +129,7 @@ fn resolve_target_audio_params(
                 .audio()
                 .map_err(|e| AppError::General(format!("Open audio decoder failed: {e}")))?;
             // Pass through sample rate; channels always come from UI settings
-            Ok((
-                decoder.rate(),
-                plan.settings.channels.channel_count() as i32,
-            ))
+            Ok((decoder.rate(), channel_count))
         }
     }
 }
@@ -174,7 +175,13 @@ pub(crate) fn create_audio_encoder(
         .audio()
         .map_err(|e| AppError::General(format!("Open encoder failed: {e}")))?;
     // Bitrate/rate/channels
-    opened.set_bit_rate(((plan.settings.bitrate as i64) * 1000) as usize);
+    let effective_bitrate_kbps = plan
+        .encoder_settings_v2
+        .as_ref()
+        .map(|enc| enc.bitrate_kbps as usize)
+        .unwrap_or(plan.settings.bitrate as usize);
+    let target_bit_rate = effective_bitrate_kbps * 1000;
+    opened.set_bit_rate(target_bit_rate);
     opened.set_rate(target_sample_rate as i32);
     opened.set_channel_layout(channel_layout);
     opened.set_format(sample_format);
@@ -410,14 +417,20 @@ pub(crate) fn setup_encoder(
         }
     }
 
+    let logged_bitrate = plan
+        .encoder_settings_v2
+        .as_ref()
+        .map(|enc| enc.bitrate_kbps as u32)
+        .unwrap_or(plan.settings.bitrate);
+
     log::info!(
-        "encoder_setup resolved: rate={}Hz channels={} fmt={:?} frame_size={} bitrate={}k settings={:?}",
+        "encoder_setup resolved: rate={}Hz channels={} fmt={:?} frame_size={} bitrate={}k encoder_settings_v2={:?}",
         target_sample_rate,
         target_channels,
         enc_ctx.format(),
         enc_ctx.frame_size(),
-        plan.settings.bitrate,
-        plan.settings
+        logged_bitrate,
+        plan.encoder_settings_v2
     );
 
     Ok((octx, enc_ctx, ost_index, ost_time_base, target_sample_rate))

--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -50,7 +50,7 @@ pub(crate) async fn execute_processing(
     log::info!(
         "Starting FFmpeg merge - Total duration: {:.2}s, Bitrate: {}k",
         workflow.total_duration(),
-        context.settings.bitrate
+        context.effective_bitrate_kbps()
     );
 
     let merged_output = merge_audio_files_with_context(

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -99,7 +99,8 @@ pub async fn process_audiobook_with_context(
     for file in &files {
         if file.is_valid {
             if let Some(duration) = file.duration {
-                let estimated_bytes = (duration * context.settings.bitrate as f64 * 125.0) as usize;
+                let estimated_bytes =
+                    (duration * context.effective_bitrate_kbps() as f64 * 125.0) as usize;
                 metrics.update_file_processed(Duration::from_secs_f64(duration), estimated_bytes);
             }
         }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,7 +1,7 @@
 use crate::audio::file_list::FileListInfo;
 use crate::audio::settings_encoder::{validate_encoder_settings, EncoderSettings};
+use crate::audio::ChannelConfig;
 use crate::audio::{self, AudioSettings};
-use crate::audio::{ChannelConfig, SampleRateConfig};
 use crate::errors::{AppError, Result};
 use std::path::{Path, PathBuf};
 // removed duplicate PathBuf import
@@ -70,46 +70,6 @@ pub struct ProcessV2Payload {
     pub settings: EncoderSettings,
 }
 
-fn derive_v1_settings_from_v2(payload: &ProcessV2Payload) -> Result<AudioSettings> {
-    // Map EncoderSettings -> current v1 AudioSettings (Phase 2: plumbing only)
-    let channels = match payload.settings.channels {
-        1 => ChannelConfig::Mono,
-        2 => ChannelConfig::Stereo,
-        other => {
-            return Err(AppError::InvalidInput(format!(
-                "Unsupported channel count: {} (allowed: 1 or 2)",
-                other
-            )))
-        }
-    };
-
-    let output_dir = Path::new(&payload.output_dir);
-    if !output_dir.exists() {
-        return Err(AppError::FileValidation(format!(
-            "Output directory does not exist: {}",
-            output_dir.display()
-        )));
-    }
-    if !output_dir.is_dir() {
-        return Err(AppError::FileValidation(format!(
-            "Output path is not a directory: {}",
-            output_dir.display()
-        )));
-    }
-    // Temporary deterministic filename; UI can override in Phase 4
-    let output_path: PathBuf = output_dir.join("audiobook.m4b");
-
-    let v1 = AudioSettings {
-        bitrate: payload.settings.bitrate_kbps as u32,
-        channels,
-        sample_rate: SampleRateConfig::Auto,
-        output_path,
-    };
-    // Reuse existing v1 validation
-    audio::validate_audio_settings(&v1)?;
-    Ok(v1)
-}
-
 /// Processes files using v2 payload (EncoderSettings + v2 shape). For now, routes
 /// through the same pipeline by mapping to v1 AudioSettings. No behavior change.
 #[tauri::command]
@@ -132,8 +92,26 @@ pub async fn process_audiobook_files_v2(
         payload.settings.threads
     );
 
-    // Map to v1 settings for current pipeline
-    let settings_v1 = derive_v1_settings_from_v2(&payload)?;
+    // Validate output directory and construct final path
+    let output_path = validate_and_resolve_output_path(&payload.output_dir)?;
+
+    // Minimal AudioSettings kept for legacy validation paths (bitrate/channel/sample rate)
+    let mut settings_v1 = audio::AudioSettings::audiobook_preset();
+    settings_v1.bitrate = payload.settings.bitrate_kbps as u32;
+    settings_v1.channels = match payload.settings.channels {
+        1 => ChannelConfig::Mono,
+        2 => ChannelConfig::Stereo,
+        other => {
+            return Err(AppError::InvalidInput(format!(
+                "Unsupported channel count: {} (allowed: 1 or 2)",
+                other
+            )))
+        }
+    };
+    settings_v1.output_path = output_path.clone();
+
+    // Reuse existing validation to ensure path/bitrate configuration is acceptable
+    audio::validate_audio_settings(&settings_v1)?;
 
     // Set processing state
     {
@@ -156,7 +134,7 @@ pub async fn process_audiobook_files_v2(
     // Process the audiobook with progress events
     let (message, preview_path_opt, preview_seconds_used) = {
         let session = audio::session::ProcessingSession::new();
-        let final_output_path = settings_v1.output_path.clone();
+        let final_output_path = output_path.clone();
         let output_config = audio::OutputConfig::new(final_output_path.clone());
         let mut context = audio::ProcessingContext::new(
             window,
@@ -225,6 +203,24 @@ pub struct ProcessCommandResult {
     pub message: String,
     pub preview_file_path: Option<String>,
     pub preview_actual_seconds: Option<f64>,
+}
+
+fn validate_and_resolve_output_path(output_dir: &str) -> Result<PathBuf> {
+    let dir = Path::new(output_dir);
+    if !dir.exists() {
+        return Err(AppError::FileValidation(format!(
+            "Output directory does not exist: {}",
+            dir.display()
+        )));
+    }
+    if !dir.is_dir() {
+        return Err(AppError::FileValidation(format!(
+            "Output path is not a directory: {}",
+            dir.display()
+        )));
+    }
+
+    Ok(dir.join("audiobook.m4b"))
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- remove the v2→v1 mapping helper and validate the output target directly in the v2 command handler
- carry `EncoderSettings` through the processing context and prefer those values when configuring bitrate/channels
- add context helpers so downstream modules can log/estimate with the v2 bitrate, and update the cover-art tests to build contexts with explicit windows/sessions

## Testing
- cargo check
- cargo test --tests --no-run

@codex Please focus on:
1. verifying the pipeline now uses `EncoderSettings` for bitrate/channel decisions without regressing v1 flows
2. checking the new output-path validation in the v2 command preserves earlier guarantees
3. ensuring the updated cover-art context construction remains representative of runtime behaviour
