### PR TITLE
chore: drop v1 audio commands and harness entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ You are a senior software engineer who audits and develops code using engineerin
 
 ### Critical Flows
 - **Import**: UI drag/drop → `analyze_audio_files` → `audio::file_list::get_file_list_info`
-- **Processing**: `process_audiobook_files` (v2) → `MediaProcessor::execute` → progress events
+- **Processing**: `process_audiobook_files_v2` → `MediaProcessor::execute` → progress events
 - **Metadata**: Lofty read → custom model → Lofty write (with native cover art)
 
 ### Integration Touchpoints
@@ -55,7 +55,7 @@ You are a senior software engineer who audits and develops code using engineerin
 - Primary target: macOS (Apple Silicon) only; ffmpeg-next links system libraries
 
 ### Boundary & Migration (processing v1 vs v2)
-- v1 (legacy boundary): Types `AudioSettings`; commands `process_audiobook_files`, `validate_audio_settings`.
+- v1 (legacy boundary): Types `AudioSettings`; legacy commands have been removed from the IPC surface.
 - v2 (current boundary): Types `EncoderSettings`; commands `process_audiobook_files_v2`, `validate_encoder_settings_cmd`.
 - Today: v2 maps into the legacy v1 pipeline for stability; the new encoder will consume v2 directly.
 - Policy:

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ If you are an AI coding agent, start with the project’s agent guide in `AGENTS
 
 ## Critical Data Flows
 1. File Import: UI drag/drop → `analyze_audio_files` → `audio::file_list::get_file_list_info`
-2. Processing Pipeline: `process_audiobook_files` (or v2) → `MediaProcessor::execute` → progress events via Tauri window
+2. Processing Pipeline: `process_audiobook_files_v2` → `MediaProcessor::execute` → progress events via Tauri window
 3. Metadata Flow: Lofty read → custom `AudiobookMetadata` → Lofty write (and native embedding when available)
 
 ## Commands & Integration Points
 - Tauri Commands module: `src-tauri/src/commands/`
-  - `validate_files`, `analyze_audio_files`, `validate_audio_settings`, `process_audiobook_files`, `process_audiobook_files_v2`, `cancel_processing`, plus metadata read/write commands
+- `validate_files`, `analyze_audio_files`, `process_audiobook_files_v2`, `validate_encoder_settings_cmd`, `cancel_processing`, plus metadata read/write commands
 - Processing Runtime
   - Engine selection is trivial: `FfmpegNextProcessor` only (see `audio/processor/selection.rs`)
   - ffmpeg-next initialized once per process (`ff::init()`)
@@ -124,4 +124,3 @@ cargo test path_validation
   - 'main' (https://github.com/Allmight97/audiobook-boss.git) is the current stable branch.
   - 'feat/new_encoder' (https://github.com/Allmight97/audiobook-boss.git) is the current work-in-progress audio processing pipeline update that will support Apple AAC (aac_at) and HE-AAC v1/v2 and libfdk_aac (external call to local FDK binary only) encoders. And expose new 'advanced' settings panel for the user to configure more encoder and profile options.
 - Primary development target: macOS (Apple Silicon). Out of scope: Intel Macs, Linux, Windows.
-

--- a/docs/external-apis/tauri-commands.md
+++ b/docs/external-apis/tauri-commands.md
@@ -9,9 +9,7 @@ This guide expands on the lightweight index by summarizing the public Tauri IPC 
 | `ping`, `echo` | `src-tauri/src/commands/system.rs` | Console smoke tests via `window.testCommands` |
 | `validate_files` | `src-tauri/src/commands/audio.rs` → `audio::path_validation` | Integration tests and console harness |
 | `analyze_audio_files` | `src-tauri/src/commands/audio.rs` → `audio::file_list` | Drag/drop and picker flows in `src/ui/fileImport` |
-| `validate_audio_settings` | `src-tauri/src/commands/audio.rs` → `audio::validate_audio_settings` | Diagnostics through `window.testCommands`; UI does inline validation |
 | `validate_encoder_settings_cmd` | `src-tauri/src/commands/audio.rs` → `audio::settings_encoder` | Reserved for advanced encoder UI; no current UI caller |
-| `process_audiobook_files` | `src-tauri/src/commands/audio.rs` → `audio::processor::process_audiobook_with_context` | Legacy console fallback; superseded by v2 payload |
 | `process_audiobook_files_v2` | `src-tauri/src/commands/audio.rs` (async) | `StatusPanel` start/preview flows, providing EncoderSettings v2 |
 | `cancel_processing` | `src-tauri/src/commands/audio.rs` → shared `ProcessingState` | StatusPanel cancel button |
 | `read_audio_metadata` | `src-tauri/src/commands/metadata.rs` → `metadata::reader` | File list metadata pane, cover-art thumbnail refresh |
@@ -64,7 +62,7 @@ This guide expands on the lightweight index by summarizing the public Tauri IPC 
 
 ### Frontend harness for QA
 
-- `window.testCommands` in `src/main.ts` mirrors each command for manual QA and automated console testing; production UI flows depend on the modules listed above rather than the harness itself.
+- `window.testCommands` in `src/main.ts` exposes select commands for manual QA (ping/echo/validation/metadata); production UI flows depend on the modules listed above rather than the harness itself.
 
 ### Notes on scope
 

--- a/docs/planning/encoder-enhancement-plan.md
+++ b/docs/planning/encoder-enhancement-plan.md
@@ -13,7 +13,7 @@
 
 ## Boundary & Migration (v1 → v2)
 Dev note: Goal is to remove v1 and v2 mapping completely and have v2 be the only boundary.
-- v1 (legacy): `AudioSettings`; commands: `process_audiobook_files`, `validate_audio_settings`.
+- v1 (legacy): `AudioSettings`; legacy commands have been removed from the IPC surface.
 - v2 (current): `EncoderSettings`; commands: `process_audiobook_files_v2`, `validate_encoder_settings_cmd`.
 - Current bridge: v2 maps into legacy v1 pipeline for stability; the new encoder will consume v2 directly.
 - Policy: all new encoder features (FDK detection, `aac_at`, `aac_coder`, afterburner, threads) are v2-only; UI should invoke v2 only; deprecate v1 and remove after one release.
@@ -174,5 +174,4 @@ if request.skip_optimized && should_skip_optimized(file, plan.settings.channels.
 - Encoder/progress patterns: `docs/external-apis/ffmpeg-next.md`
 - Tauri command/event surfaces: `docs/external-apis/tauri-commands.md`, `docs/external-apis/tauri-patterns.md`, `docs/external-apis/tauri-ts-boundaries.md`
 - v1→v2 migration context: `AGENTS.md` and `docs/reports/api_recs.md`
-
 

--- a/docs/reports/api_recs.md
+++ b/docs/reports/api_recs.md
@@ -46,8 +46,10 @@ This report provides a comprehensive comparison between documented APIs and the 
 
 | v1 Endpoint | Status | v2 Equivalent | Complexity Gap |
 |------------|--------|---------------|-----------------|
-| `process_audiobook_files` | Active but superseded | `process_audiobook_files_v2` | Minimal mapping layer |
-| `validate_audio_settings` | Active but limited | `validate_encoder_settings_cmd` | Significant feature mismatch |
+| `process_audiobook_files` | Removed (Nov 2025) | `process_audiobook_files_v2` | N/A |
+| `validate_audio_settings` | Removed (Nov 2025) | `validate_encoder_settings_cmd` | N/A |
+
+Legacy findings below are retained for historical context prior to removal.
 
 **Key Issues with v1 Legacy:**
 1. **Limited Encoder Control**: v1 only supports basic bitrate and channel config
@@ -222,14 +224,14 @@ const PROGRESS_COMPLETE: f32 = 100.0;
 
 ### Immediate Actions
 
-1. **Tag Legacy Code**
+1. **Tag Legacy Code** *(Completed Nov 2025: command removed)*
 ```rust
 // Add to src-tauri/src/commands/audio.rs
 #[deprecated(note = "Use process_audiobook_files_v2 instead")]
 pub async fn process_audiobook_files(...) -> Result<ProcessCommandResult>
 ```
 
-2. **Update Frontend Warnings**
+2. **Update Frontend Warnings** *(Completed Nov 2025: legacy harness entries removed)*
 ```typescript
 // Add to src/ui/statusPanel/logic.ts
 console.warn("Using legacy v1 API - migrate to process_audiobook_files_v2");
@@ -237,7 +239,7 @@ console.warn("Using legacy v1 API - migrate to process_audiobook_files_v2");
 
 ### Medium-term Cleanup
 
-1. ** consolidate v1/v2 mapping**
+1. ** consolidate v1/v2 mapping** *(Completed Nov 2025)*
 ```rust
 // Remove function and inline its logic into process_audiobook_files_v2
 fn derive_v1_settings_from_v2(payload: &ProcessV2Payload) -> Result<AudioSettings>

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,7 +1,6 @@
 use crate::audio::file_list::FileListInfo;
 use crate::audio::settings_encoder::{validate_encoder_settings, EncoderSettings};
-use crate::audio::ChannelConfig;
-use crate::audio::{self, AudioSettings};
+use crate::audio::{self, ChannelConfig};
 use crate::errors::{AppError, Result};
 use std::path::{Path, PathBuf};
 // removed duplicate PathBuf import
@@ -45,14 +44,6 @@ pub fn validate_files(file_paths: Vec<String>) -> Result<String> {
 pub fn analyze_audio_files(file_paths: Vec<String>) -> Result<FileListInfo> {
     let paths: Vec<PathBuf> = file_paths.iter().map(PathBuf::from).collect();
     audio::get_file_list_info(&paths)
-}
-
-/// Validates audio processing settings
-/// Checks bitrate, sample rate, and output path validity
-#[tauri::command]
-pub fn validate_audio_settings(settings: AudioSettings) -> Result<String> {
-    audio::validate_audio_settings(&settings)?;
-    Ok("Settings are valid".to_string())
 }
 
 /// Validates advanced encoder v2 settings (no side effects)
@@ -221,96 +212,6 @@ fn validate_and_resolve_output_path(output_dir: &str) -> Result<PathBuf> {
     }
 
     Ok(dir.join("audiobook.m4b"))
-}
-
-#[tauri::command]
-pub async fn process_audiobook_files(
-    window: tauri::Window,
-    state: tauri::State<'_, crate::ProcessingState>,
-    file_paths: Vec<String>,
-    settings: AudioSettings,
-    metadata: Option<crate::metadata::AudiobookMetadata>,
-    preview_seconds: Option<f64>,
-) -> Result<ProcessCommandResult> {
-    // Set processing state
-    {
-        let mut is_processing = state
-            .is_processing
-            .lock()
-            .map_err(|_| AppError::InvalidInput("Failed to acquire processing lock".to_string()))?;
-        *is_processing = true;
-
-        let mut is_cancelled = state.is_cancelled.lock().map_err(|_| {
-            AppError::InvalidInput("Failed to acquire cancellation lock".to_string())
-        })?;
-        *is_cancelled = false;
-    }
-
-    // Validate and get file information
-    let paths: Vec<PathBuf> = file_paths.iter().map(PathBuf::from).collect();
-    let file_info = audio::get_file_list_info(&paths)?;
-
-    // Process the audiobook with progress events
-    let (message, preview_path_opt, preview_seconds_used) = {
-        // Single engine path: ffmpeg-next context based processing
-        let session = audio::session::ProcessingSession::new();
-        let final_output_path = settings.output_path.clone();
-        let output_config = audio::OutputConfig::new(final_output_path.clone());
-        let mut context = audio::ProcessingContext::new(
-            window,
-            std::sync::Arc::new(session),
-            settings,
-            output_config,
-        );
-        // Resolve preview seconds from payload or environment fallback
-        let mut preview_seconds_resolved: Option<f64> = None;
-        if let Some(sec) = preview_seconds.or_else(|| {
-            std::env::var("ABB_PREVIEW_SECONDS")
-                .ok()
-                .and_then(|s| s.parse::<f64>().ok())
-        }) {
-            if sec.is_finite() && sec > 0.0 {
-                context.preview = Some(crate::audio::context::PreviewConfig { seconds: sec });
-                log::info!("Preview requested: seconds={:.3}", sec);
-                preview_seconds_resolved = Some(sec);
-            }
-        }
-        let is_preview = context.preview.is_some();
-        let msg =
-            audio::processor::process_audiobook_with_context(context, file_info.files, metadata)
-                .await?;
-        let preview_path = if is_preview {
-            // Derive preview path deterministically based on output settings
-            let final_output = &final_output_path;
-            let parent = final_output
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new("."));
-            let stem = final_output
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("output");
-            let p = parent.join(format!("{}.preview.m4b", stem));
-            Some(p.display().to_string())
-        } else {
-            None
-        };
-        (msg, preview_path, preview_seconds_resolved)
-    };
-
-    // Reset processing state
-    {
-        let mut is_processing = state
-            .is_processing
-            .lock()
-            .map_err(|_| AppError::InvalidInput("Failed to acquire processing lock".to_string()))?;
-        *is_processing = false;
-    }
-
-    Ok(ProcessCommandResult {
-        message,
-        preview_file_path: preview_path_opt,
-        preview_actual_seconds: preview_seconds_used,
-    })
 }
 
 /// Cancels the current audio processing operation

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,9 +59,7 @@ pub fn run() {
             commands::write_cover_art,
             commands::load_cover_art_file,
             commands::analyze_audio_files,
-            commands::validate_audio_settings,
             commands::validate_encoder_settings_cmd,
-            commands::process_audiobook_files,
             commands::process_audiobook_files_v2,
             commands::cancel_processing
         ])

--- a/src-tauri/src/tests_integration.rs
+++ b/src-tauri/src/tests_integration.rs
@@ -6,10 +6,8 @@
 //! DO NOT MODIFY THESE TESTS - they document how the system works now.
 //! Any changes should only be made if the current behavior is incorrect.
 
-use crate::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
-use crate::commands::{
-    analyze_audio_files, read_audio_metadata, validate_audio_settings, validate_files,
-};
+use crate::audio::{self, AudioSettings, ChannelConfig, SampleRateConfig};
+use crate::commands::{analyze_audio_files, read_audio_metadata, validate_files};
 use crate::errors::{AppError, Result};
 use crate::metadata::AudiobookMetadata;
 use std::path::PathBuf;
@@ -108,14 +106,10 @@ mod integration_tests {
         );
 
         // Step 3: Validate processing settings
-        let settings_validation = validate_audio_settings(settings.clone());
+        let settings_validation = audio::validate_audio_settings(&settings);
         assert!(
             settings_validation.is_ok(),
             "Settings validation should succeed"
-        );
-        assert_eq!(
-            settings_validation.expect("settings ok"),
-            "Settings are valid"
         );
 
         // Step 4: Read metadata from input file
@@ -279,7 +273,7 @@ mod integration_tests {
 
         // Invalid bitrate
         invalid_settings.bitrate = 256; // Too high
-        let settings_result = validate_audio_settings(invalid_settings.clone());
+        let settings_result = audio::validate_audio_settings(&invalid_settings);
         assert!(settings_result.is_err(), "Should fail for invalid bitrate");
         assert!(settings_result
             .expect_err("expected bitrate error")
@@ -289,7 +283,7 @@ mod integration_tests {
         // Invalid output extension
         invalid_settings.bitrate = 64; // Fix bitrate
         invalid_settings.output_path = temp_dir.path().join("test.mp3"); // Wrong extension
-        let settings_result = validate_audio_settings(invalid_settings);
+        let settings_result = audio::validate_audio_settings(&invalid_settings);
         assert!(
             settings_result.is_err(),
             "Should fail for wrong file extension"

--- a/src-tauri/tests/integration/path_validation_integration.rs
+++ b/src-tauri/tests/integration/path_validation_integration.rs
@@ -1,8 +1,8 @@
 // Integration tests for path validation implementation across all entry points
 // These tests verify that invalid inputs are rejected at all API boundaries
 
-use audiobook_boss_lib::commands::{validate_files, analyze_audio_files};
-use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
+use audiobook_boss_lib::audio::{self, AudioSettings, ChannelConfig, SampleRateConfig};
+use audiobook_boss_lib::commands::{analyze_audio_files, validate_files};
 use tempfile::TempDir;
 use std::fs::File;
 
@@ -73,8 +73,6 @@ fn test_analyze_audio_files_validates_inputs() {
 /// Test that audio settings validation works correctly
 #[test] 
 fn test_audio_settings_validation() {
-    use audiobook_boss_lib::commands::validate_audio_settings;
-    
     let temp_dir = TempDir::new().expect("create temp dir");
     
     // Test valid settings
@@ -84,7 +82,7 @@ fn test_audio_settings_validation() {
         sample_rate: SampleRateConfig::Auto,
         output_path: temp_dir.path().join("output.m4b"),
     };
-    let result = validate_audio_settings(valid_settings);
+    let result = audio::validate_audio_settings(&valid_settings);
     assert!(result.is_ok(), "Valid settings should pass validation");
     
     // Test invalid output directory (nonexistent parent)
@@ -94,7 +92,7 @@ fn test_audio_settings_validation() {
         sample_rate: SampleRateConfig::Auto,
         output_path: "/nonexistent/directory/output.m4b".into(),
     };
-    let result = validate_audio_settings(invalid_settings);
+    let result = audio::validate_audio_settings(&invalid_settings);
     assert!(result.is_err(), "Should reject nonexistent output directory");
     assert!(result.expect_err("expected error").to_string().contains("does not exist"));
 }

--- a/src-tauri/tests/path_validation_integration.rs
+++ b/src-tauri/tests/path_validation_integration.rs
@@ -1,7 +1,7 @@
 // Integration tests for path validation implementation across all entry points
 // These tests verify that invalid inputs are rejected at all API boundaries
 
-use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
+use audiobook_boss_lib::audio::{self, AudioSettings, ChannelConfig, SampleRateConfig};
 use audiobook_boss_lib::commands::{analyze_audio_files, validate_files};
 use std::fs::File;
 use tempfile::TempDir;
@@ -114,8 +114,6 @@ fn test_analyze_audio_files_validates_inputs() {
 /// Test that audio settings validation works correctly
 #[test]
 fn test_audio_settings_validation() {
-    use audiobook_boss_lib::commands::validate_audio_settings;
-
     let temp_dir = TempDir::new().expect("create temp dir");
 
     // Test valid settings
@@ -125,7 +123,7 @@ fn test_audio_settings_validation() {
         sample_rate: SampleRateConfig::Auto,
         output_path: temp_dir.path().join("output.m4b"),
     };
-    let result = validate_audio_settings(valid_settings);
+    let result = audio::validate_audio_settings(&valid_settings);
     assert!(result.is_ok(), "Valid settings should pass validation");
 
     // Test invalid output directory (nonexistent parent)
@@ -135,7 +133,7 @@ fn test_audio_settings_validation() {
         sample_rate: SampleRateConfig::Auto,
         output_path: "/nonexistent/directory/output.m4b".into(),
     };
-    let result = validate_audio_settings(invalid_settings);
+    let result = audio::validate_audio_settings(&invalid_settings);
     assert!(
         result.is_err(),
         "Should reject nonexistent output directory"

--- a/src-tauri/tests/path_validation_p013.rs
+++ b/src-tauri/tests/path_validation_p013.rs
@@ -1,8 +1,7 @@
 // Integration test for P0.1.3 - symlink policy and output directory validation
 // Tests symlink handling and write permission probing
 
-use audiobook_boss_lib::audio::{AudioSettings, ChannelConfig, SampleRateConfig};
-use audiobook_boss_lib::commands::validate_audio_settings;
+use audiobook_boss_lib::audio::{self, AudioSettings, ChannelConfig, SampleRateConfig};
 use std::fs::Permissions;
 use tempfile::TempDir;
 
@@ -27,7 +26,7 @@ fn test_read_only_output_directory_integration() {
         output_path: readonly_dir.join("output.m4b"),
     };
 
-    let result = validate_audio_settings(settings);
+    let result = audio::validate_audio_settings(&settings);
     assert!(result.is_err(), "Should reject read-only output directory");
     assert!(result
         .expect_err("expected write permission error")
@@ -50,7 +49,7 @@ fn test_output_path_validation_integration() {
         sample_rate: SampleRateConfig::Auto,
         output_path: temp_dir.path().join("valid_output.m4b"),
     };
-    let result = validate_audio_settings(valid_settings);
+    let result = audio::validate_audio_settings(&valid_settings);
     assert!(result.is_ok(), "Valid settings should pass validation");
 
     // Test invalid extension
@@ -60,7 +59,7 @@ fn test_output_path_validation_integration() {
         sample_rate: SampleRateConfig::Auto,
         output_path: temp_dir.path().join("invalid_output.mp3"),
     };
-    let result = validate_audio_settings(invalid_ext_settings);
+    let result = audio::validate_audio_settings(&invalid_ext_settings);
     assert!(result.is_err(), "Should reject non-.m4b extension");
     assert!(result
         .expect_err("expected extension error")
@@ -74,7 +73,7 @@ fn test_output_path_validation_integration() {
         sample_rate: SampleRateConfig::Auto,
         output_path: "/nonexistent/directory/output.m4b".into(),
     };
-    let result = validate_audio_settings(nonexistent_dir_settings);
+    let result = audio::validate_audio_settings(&nonexistent_dir_settings);
     assert!(
         result.is_err(),
         "Should reject nonexistent parent directory"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { AudiobookMetadata } from "./types/metadata";
-import type { FileListInfo, AudioSettings } from "./types/audio";
+import type { FileListInfo } from "./types/audio";
 import { initFileImport } from "./ui/fileImport";
 import { displayFileList, currentFileList, clearAllFiles, toggleFileSort } from "./ui/fileList";
 import { initOutputPanel, getCurrentAudioSettings, onFileListChange, onMetadataChange } from "./ui/outputPanel";
@@ -25,10 +25,6 @@ import { initCoverArt, getCurrentCoverArt, setCoverArt, clearCoverArt } from "./
   
   // Audio processing commands
   analyzeAudioFiles: (filePaths: string[]) => invoke<FileListInfo>('analyze_audio_files', { filePaths: filePaths }),
-  validateAudioSettings: (settings: AudioSettings) => invoke('validate_audio_settings', { settings }),
-  processAudiobook: (filePaths: string[], settings: AudioSettings, metadata?: AudiobookMetadata) => 
-    invoke('process_audiobook_files', { filePaths: filePaths, settings, metadata }),
-
   // UI test functions
   testDisplayList: (fileListInfo: FileListInfo) => displayFileList(fileListInfo),
   getCurrentFileList: () => currentFileList,
@@ -81,8 +77,6 @@ console.log('  window.testCommands.readMetadata(filePath)');
 console.log('  window.testCommands.writeMetadata(filePath, metadata)');
 console.log('  window.testCommands.writeCoverArt(filePath, coverData)');
 console.log('  window.testCommands.analyzeAudioFiles(filePaths)');
-console.log('  window.testCommands.validateAudioSettings(settings)');
-console.log('  window.testCommands.processAudiobook(filePaths, settings, metadata?)');
 console.log('  window.testCommands.testDisplayList(fileListInfo)');
 console.log('  window.testCommands.getCurrentFileList()');
 console.log('  window.testCommands.clearFiles()');


### PR DESCRIPTION
## Summary
- remove the legacy `validate_audio_settings` and `process_audiobook_files` Tauri commands and stop registering them with the invoke handler
- update TypeScript harnesses/docs to reference only the v2 command surface and trim the corresponding test-command helpers
- rewrite integration/path-validation tests to call `audio::validate_audio_settings` directly and refresh docs to note that the v1 commands are gone

## Testing
- scripts/quick-checks.sh (fmt, clippy, ensure-contract, tsc)

@codex Please focus on:
1. verifying no remaining callers reference the removed commands (TS harness, docs, tests)
2. ensuring the updated tests still cover audio settings validation via the Rust API
3. double-checking documentation reflects the v2-only boundary without dangling v1 references
