### PR TITLE
feat: unify frontend encoder settings bridge

### DIFF
--- a/src/types/encoder.ts
+++ b/src/types/encoder.ts
@@ -11,6 +11,9 @@
 // FEATURE_TOGGLE:VBR  VBR_DISABLED_MARKER
 // FEATURE_TOGGLE:FDK  FDK_PLACEHOLDER
 
+import type { EncoderSettings, EncoderType, ThreadSetting } from './audio';
+import { defaultEncoderSettings } from './audio';
+
 export type EncoderFlavor = 'auto' | 'aac_at' | 'external_fdk' | 'native_aac';
 export type AacProfile = 'lc' | 'he' | 'he_v2';
 
@@ -40,3 +43,145 @@ export const defaultEncoderSettingsV2 = (isMac: boolean): EncoderSettingsV2 => (
   optimizeLcLowBitrate: true,
 });
 
+const VALID_ENCODER_BITRATES: ReadonlyArray<EncoderSettings['bitrateKbps']> = [
+  56,
+  64,
+  72,
+  80,
+  88,
+  96,
+];
+
+export type EncoderSettingsLike = Partial<EncoderSettingsV2> | EncoderSettings | null | undefined;
+
+const isBoundaryEncoderSettings = (value: unknown): value is EncoderSettings => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.encoderType === 'string' &&
+    typeof candidate.bitrateKbps === 'number' &&
+    typeof candidate.channels === 'number'
+  );
+};
+
+const sanitizeBitrate = (
+  value: unknown,
+  fallback: EncoderSettings['bitrateKbps'],
+): EncoderSettings['bitrateKbps'] => {
+  if (typeof value === 'number' && VALID_ENCODER_BITRATES.includes(value as EncoderSettings['bitrateKbps'])) {
+    return value as EncoderSettings['bitrateKbps'];
+  }
+  return fallback;
+};
+
+const sanitizeChannels = (
+  encoderType: EncoderType,
+  value: unknown,
+  fallback: EncoderSettings['channels'],
+): EncoderSettings['channels'] => {
+  if (encoderType === 'he_aac_v2') {
+    return 2;
+  }
+  if (value === 1 || value === 2) {
+    return value;
+  }
+  return fallback;
+};
+
+const sanitizeThreads = (value: ThreadSetting | undefined, fallback: ThreadSetting): ThreadSetting => {
+  if (!value) {
+    return fallback;
+  }
+  switch (value.mode) {
+    case 'auto':
+    case 'off':
+      return value;
+    case 'fixed': {
+      const numeric = Number(value.value);
+      if (!Number.isFinite(numeric)) {
+        return fallback;
+      }
+      const clamped = Math.max(1, Math.min(1024, Math.round(numeric)));
+      return { mode: 'fixed', value: clamped };
+    }
+    default:
+      return fallback;
+  }
+};
+
+const resolveEncoderType = (
+  flavor: EncoderFlavor | undefined,
+  profile: AacProfile | undefined,
+  fallback: EncoderType,
+): EncoderType => {
+  switch (flavor) {
+    case 'aac_at':
+      return 'aac_at';
+    case 'external_fdk':
+    case 'native_aac':
+      if (profile === 'he_v2') {
+        return 'he_aac_v2';
+      }
+      return 'he_aac_v1';
+    case 'auto':
+    default:
+      if (profile === 'he_v2') {
+        return 'he_aac_v2';
+      }
+      if (profile === 'he') {
+        return fallback === 'aac_at' ? 'he_aac_v1' : fallback;
+      }
+      return fallback;
+  }
+};
+
+const normalizeBoundary = (
+  candidate: EncoderSettings,
+  base: EncoderSettings,
+): EncoderSettings => {
+  const encoderType = candidate.encoderType;
+  const bitrateKbps = sanitizeBitrate(candidate.bitrateKbps, base.bitrateKbps);
+  const channels = sanitizeChannels(encoderType, candidate.channels, base.channels);
+  const threads = sanitizeThreads(candidate.threads, base.threads);
+  const aacCoder = encoderType === 'aac_at' ? undefined : candidate.aacCoder ?? base.aacCoder;
+  const afterburner = encoderType === 'aac_at' ? undefined : candidate.afterburner ?? base.afterburner;
+
+  return {
+    encoderType,
+    bitrateKbps,
+    channels,
+    aacCoder,
+    afterburner,
+    threads,
+  };
+};
+
+export const toBoundaryEncoderSettings = (
+  source: EncoderSettingsLike,
+  defaults: EncoderSettings = defaultEncoderSettings(),
+): EncoderSettings => {
+  const base = normalizeBoundary(defaults, defaultEncoderSettings());
+
+  if (isBoundaryEncoderSettings(source)) {
+    return normalizeBoundary(source, base);
+  }
+
+  const ui = (source ?? {}) as Partial<EncoderSettingsV2>;
+  const encoderType = resolveEncoderType(ui.flavor, ui.profile, base.encoderType);
+  const bitrateKbps = sanitizeBitrate(ui.bitrateKbps, base.bitrateKbps);
+  const channels = sanitizeChannels(encoderType, ui.channels, base.channels);
+  const threads = sanitizeThreads(base.threads, base.threads);
+  const aacCoder = encoderType === 'aac_at' ? undefined : base.aacCoder;
+  const afterburner = encoderType === 'aac_at' ? undefined : ui.fdkAfterburner ?? base.afterburner;
+
+  return {
+    encoderType,
+    bitrateKbps,
+    channels,
+    aacCoder,
+    afterburner,
+    threads,
+  };
+};

--- a/src/ui/statusPanel/logic.ts
+++ b/src/ui/statusPanel/logic.ts
@@ -11,6 +11,10 @@ import { openPath as openExternal } from '@tauri-apps/plugin-opener';
 import { ProcessingProgressEvent, EVENTS, STAGES } from '../../types/events';
 import { currentFileList } from '../fileList';
 import { getCurrentAudioSettings } from '../outputPanel';
+import type { EncoderSettings } from '../../types/audio';
+import { defaultEncoderSettings } from '../../types/audio';
+import { toBoundaryEncoderSettings } from '../../types/encoder';
+import type { EncoderSettingsLike } from '../../types/encoder';
 import { AudiobookMetadata } from '../../types/metadata';
 import * as dom from './dom';
 import { getCurrentCoverArt } from '../coverArt';
@@ -22,6 +26,12 @@ interface ProcessingStatus {
     currentFile?: string;
     etaSeconds?: number;
 }
+
+type WindowWithEncoderProvider = Window & {
+    EncoderSettingsProvider?: () => EncoderSettingsLike;
+};
+
+const SUPPORTED_ENCODER_BITRATES = new Set([56, 64, 72, 80, 88, 96]);
 
 export class StatusPanel {
     private cancelUnlisten?: () => void;
@@ -138,34 +148,54 @@ export class StatusPanel {
             const metadata = this.getCurrentMetadata();
 
             // Call backend processing command (v2 payload)
-            const v2Payload = {
-                inputFiles: filePaths,
-                outputDir: (document.getElementById('output-dir-text') as HTMLInputElement)?.value || '',
-                settings: (window as any).EncoderSettingsProvider?.() ?? ({} as any)
-            };
-            // Fallback: if provider not set, derive minimal v2 settings from UI
-            if (!v2Payload.settings || !v2Payload.settings.encoderType) {
-                const { defaultEncoderSettings } = await import('../../types/audio');
-                const def = defaultEncoderSettings();
-                v2Payload.settings = {
-                    encoderType: def.encoderType,
-                    bitrateKbps: ([56, 64, 72, 80, 88, 96] as number[]).includes(settings.bitrate) ? settings.bitrate as 56|64|72|80|88|96 : 64,
-                    channels: settings.channels === 'Mono' ? 1 : 2,
-                    threads: { mode: 'auto' as const }
-                } as any;
-            }
+            const fallbackEncoderDefaults = (() => {
+                const defaults = defaultEncoderSettings();
+                const bitrate = SUPPORTED_ENCODER_BITRATES.has(settings.bitrate)
+                    ? (settings.bitrate as EncoderSettings['bitrateKbps'])
+                    : defaults.bitrateKbps;
+                const channels: EncoderSettings['channels'] = settings.channels === 'Stereo' ? 2 : 1;
+                return {
+                    ...defaults,
+                    bitrateKbps: bitrate,
+                    channels,
+                } satisfies EncoderSettings;
+            })();
+
+            const windowWithProvider = window as WindowWithEncoderProvider;
+            const providerResult: EncoderSettingsLike = typeof windowWithProvider.EncoderSettingsProvider === 'function'
+                ? windowWithProvider.EncoderSettingsProvider()
+                : undefined;
+
+            let boundaryEncoderSettings = toBoundaryEncoderSettings(providerResult, fallbackEncoderDefaults);
 
             // Enforce HE-AAC v2 stereo-only: coerce to stereo and update UI control when applicable
-            if (v2Payload.settings && v2Payload.settings.encoderType === 'he_aac_v2' && v2Payload.settings.channels !== 2) {
-                v2Payload.settings.channels = 2;
+            if (boundaryEncoderSettings.encoderType === 'he_aac_v2') {
+                const coercedChannels = boundaryEncoderSettings.channels !== 2;
+                let updatedUi = false;
+                if (coercedChannels) {
+                    boundaryEncoderSettings = {
+                        ...boundaryEncoderSettings,
+                        channels: 2,
+                    };
+                    updatedUi = true;
+                }
                 const chSelect = document.getElementById('output-channels') as HTMLSelectElement | null;
-                if (chSelect) {
+                if (chSelect && (settings.channels !== 'Stereo' || coercedChannels)) {
                     const monoOption = Array.from(chSelect.options).find(o => o.value.toLowerCase() === 'mono');
                     if (monoOption) monoOption.disabled = true;
                     chSelect.value = 'stereo';
+                    updatedUi = true;
                 }
-                console.info('HE-AAC v2 requires stereo; channels coerced to 2');
+                if (updatedUi) {
+                    console.info('HE-AAC v2 requires stereo; channels coerced to 2');
+                }
             }
+
+            const v2Payload = {
+                inputFiles: filePaths,
+                outputDir: (document.getElementById('output-dir-text') as HTMLInputElement)?.value || '',
+                settings: boundaryEncoderSettings,
+            };
 
             const result = await invoke<{ message: string; previewFilePath?: string; previewActualSeconds?: number }>('process_audiobook_files_v2', {
                 payload: v2Payload,


### PR DESCRIPTION
## Summary
- add adapter mapping UI encoder state into the EncoderSettings boundary
- switch StatusPanel to consume the adapter and enforce HE-AAC v2 stereo updates

## Testing
- scripts/quick-checks.sh

@codex Please review and spool up a dev environment (e.g., `npm run tauri dev`) to run the Step 1 manual exercise validating encoder payload assembly and stereo coercion.