### PR TITLE
fix(audio): resolve processing blocker and add sample rate passthrough (P1-A, P1-C)

### DIFF
--- a/docs/planning/p1-settings-contract-fix.md
+++ b/docs/planning/p1-settings-contract-fix.md
@@ -1,0 +1,270 @@
+# P1 Fix Plan: Settings Contract Alignment
+
+## Executive Summary
+
+Three interconnected issues prevent audio processing and cause settings to be silently ignored:
+
+| ID | Issue | Severity | Impact |
+|----|-------|----------|--------|
+| P1-A | Output path contract mismatch | **Blocker** | Processing fails silently |
+| P1-B | Bitrate range mismatch | High | User's 128k → 64k silently |
+| P1-C | Sample rate not passed | High | UI setting ignored entirely |
+
+## Root Cause Analysis
+
+### P1-A: Output Path Contract Mismatch (Processing Fails)
+
+**Frontend sends full file path:**
+```
+/Users/jstar/Audiobooks/Author/2024-Title/Title (2024).m4b
+```
+
+**Backend expects directory and constructs filename:**
+```rust
+fn validate_and_resolve_output_path(output_dir: &str) -> Result<PathBuf> {
+    let dir = Path::new(output_dir);
+    if !dir.is_dir() { return Err(...) }  // FAILS HERE
+    Ok(dir.join("audiobook.m4b"))         // Never reached
+}
+```
+
+**Evidence:**
+- `outputPanel.ts:202-211` - `calculateOutputPath()` returns full path with `.m4b`
+- `logic.ts:194` - Reads from `output-dir-text` input (which contains full path)
+- `audio.rs:199-215` - Validates as directory, then appends own filename
+
+### P1-B: Bitrate Range Mismatch
+
+| Location | Allowed Values |
+|----------|----------------|
+| UI Dropdown (HTML) | 32, 48, 56, **64**, 96, 128 |
+| `logic.ts:32` | 56, 64, 72, 80, 88, 96 |
+| `encoder.ts:46` | 56, 64, 72, 80, 88, 96 |
+| `settings_encoder.rs:60` | 56, 64, 72, 80, 88, 96 |
+| `EncoderSettings` type | `56 \| 64 \| 72 \| 80 \| 88 \| 96` |
+
+**Result:** User selects 128 → sanitized to 64 in frontend → backend never sees 128
+
+### P1-C: Sample Rate Not Passed
+
+- `EncoderSettings` (both TS and Rust) has **no sample rate field**
+- `audio.rs:90` creates `settings_v1` from `audiobook_preset()` → `SampleRateConfig::Auto`
+- User's explicit 44100 is collected but **never reaches backend**
+
+---
+
+## Proposed Fix Strategy
+
+### Decision Point: Output Path Contract
+
+**Option A: Frontend sends directory only, backend constructs full path**
+- Pros: Backend has full control over filename; easier validation
+- Cons: Requires frontend to communicate filename pattern to backend
+- Change scope: Medium (both sides)
+
+**Option B: Frontend sends full file path, backend uses it directly**
+- Pros: Frontend controls filename pattern; simpler mental model
+- Cons: Backend must create parent directories; less validation control
+- Change scope: Medium (backend only)
+
+**Recommendation:** Option B - Frontend already computes the desired full path. Backend should accept it and create directories as needed. This respects user's filename pattern choices.
+
+### Decision Point: Bitrate Range
+
+**Proposed canonical range:** 48, 56, 64, 72, 80, 88, 96, 112, 128 kbps
+
+Rationale:
+- 48k: Low bandwidth/storage for speech
+- 56-96: Current supported range (8k steps)
+- 112, 128: Higher quality options users expect
+
+**Single source of truth:** Define in Rust `settings_encoder.rs`, expose via command, consume in TypeScript
+
+### Decision Point: Sample Rate
+
+**Option A: Add sample_rate to EncoderSettings**
+- Full parity between UI and backend
+- Requires type changes on both sides
+
+**Option B: Keep sample_rate in AudioSettings (v1), ensure it's passed**
+- Minimal change; v1 already has it
+- Requires fixing the mapping in `process_audiobook_files_v2`
+
+**Recommendation:** Option B for now (minimal change), with note that v2 should eventually absorb it.
+
+---
+
+## Implementation Plan
+
+### PR Strategy
+
+Two PRs to minimize risk and enable incremental verification:
+
+| PR | Scope | Files Changed | Risk |
+|----|-------|---------------|------|
+| **PR1** | P1-A + P1-C | `audio.rs` only | Low - backend only, self-contained |
+| **PR2** | P1-B | 5+ files (Rust, TS, HTML) | Medium - contract change |
+
+---
+
+## PR1: Fix Processing Blocker + Sample Rate
+
+**Branch:** `fix/p1-processing-and-samplerate`
+
+### P1-A: Fix Output Path Contract
+
+**File:** `src-tauri/src/commands/audio.rs`
+
+**Changes:**
+1. Rename `validate_and_resolve_output_path` to `validate_and_prepare_output_path`
+2. Accept full file path (not directory)
+3. Validate parent directory exists OR create it
+4. Return the provided path directly (don't append filename)
+
+**Code sketch:**
+```rust
+fn validate_and_prepare_output_path(output_path: &str) -> Result<PathBuf> {
+    let path = Path::new(output_path);
+
+    // Validate extension
+    if path.extension().and_then(|e| e.to_str()) != Some("m4b") {
+        return Err(AppError::InvalidInput("Output must be .m4b file".into()));
+    }
+
+    // Get parent directory
+    let parent = path.parent().ok_or_else(||
+        AppError::InvalidInput("Invalid output path".into()))?;
+
+    // Create parent directories if needed
+    if !parent.exists() {
+        std::fs::create_dir_all(parent).map_err(|e|
+            AppError::FileValidation(format!("Cannot create directory: {}", e)))?;
+    }
+
+    Ok(path.to_path_buf())
+}
+```
+
+### P1-C: Fix Sample Rate Passthrough
+
+**File:** `src-tauri/src/commands/audio.rs`
+
+**Changes:**
+In `process_audiobook_files_v2`, map sample rate from payload:
+
+```rust
+// Current (broken):
+let mut settings_v1 = audio::AudioSettings::audiobook_preset();
+
+// Fixed:
+let mut settings_v1 = audio::AudioSettings::audiobook_preset();
+// TODO: Accept sample_rate in ProcessV2Payload or parse from AudioSettings
+// For now, keep Auto behavior but document the gap
+```
+
+**Note:** Full fix requires adding `sample_rate` to `ProcessV2Payload`. Interim fix: document limitation.
+
+### PR1 Verification Checklist
+
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] Manual test: Load files, select output dir, click Process → processing starts
+- [ ] Manual test: Output file created in correct subdirectory path
+- [ ] Manual test: Error shown if output path invalid
+
+---
+
+## PR2: Expand Bitrate Range (P1-B)
+
+**Branch:** `fix/p1-bitrate-range`
+
+**Prerequisite:** PR1 merged and verified
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/audio/settings_encoder.rs` | `VALID_ENCODER_BITRATES = [48, 56, 64, 72, 80, 88, 96, 112, 128]` |
+| `src/types/audio.ts` | Update `bitrateKbps` type union |
+| `src/types/encoder.ts` | Update `VALID_ENCODER_BITRATES` array |
+| `src/ui/statusPanel/logic.ts` | Update `SUPPORTED_ENCODER_BITRATES` set |
+| `index.html` | Update `<select id="output-bitrate">` options |
+
+### New Valid Bitrates
+
+```
+[48, 56, 64, 72, 80, 88, 96, 112, 128]
+```
+
+### PR2 Verification Checklist
+
+- [ ] `scripts/quick-checks.sh` passes
+- [ ] `npm run build` succeeds
+- [ ] Manual test: Select 48k → output at 48k (verify with ffprobe)
+- [ ] Manual test: Select 128k → output at 128k
+- [ ] Manual test: Default 64k still works
+
+---
+
+## Future: Contract Tests (Post-PR2)
+
+**New test files:**
+- `src-tauri/tests/contract_settings.rs`
+
+**Test cases:**
+1. Valid bitrates serialize/deserialize correctly
+2. Invalid bitrates produce actionable errors
+3. Full path output validation works
+4. Directory creation works
+
+---
+
+## Future: Diagnostic Commands (Post-PR2)
+
+Add to `window.testCommands`:
+```typescript
+testProcessingPipeline: async () => {
+  // Returns what would be sent to backend without actually processing
+  // Useful for debugging settings flow
+}
+```
+
+---
+
+## Testing Matrix
+
+| Scenario | Expected Before Fix | Expected After Fix |
+|----------|--------------------|--------------------|
+| Process with 128k bitrate | Silent fallback to 64k | Output at 128k |
+| Process with 48k bitrate | Silent fallback to 64k | Output at 48k |
+| Process with 44100 sample rate | Uses input file rate | Output at 44100 |
+| Process with subdirectory pattern | Fails silently | Creates directories, succeeds |
+| Invalid bitrate in request | May crash or silent fallback | Clear error message |
+
+---
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking existing functionality | Run full test suite before/after |
+| Directory creation security | Validate path doesn't escape output root |
+| Type changes break serialization | Contract tests catch mismatches |
+
+---
+
+## Questions for Owner (Resolved)
+
+1. **Bitrate range:** Is 48-128 kbps acceptable? Any values to add/remove?
+   - **Decision:** 48, 56, 64, 72, 80, 88, 96, 112, 128 kbps ✓
+
+2. **Directory creation:** Should backend auto-create directories, or error if missing?
+   - **Decision:** Auto-create directories (user expects subdirectory pattern to work) ✓
+
+3. **Sample rate:** Should it eventually move to `EncoderSettings` (v2 type)?
+   - **Decision:** Quick fix in PR1 (document gap), full fix deferred to future v2 work ✓
+
+4. **PR Strategy:** Bundle or separate?
+   - **Decision:** Two PRs - PR1 (P1-A + P1-C), PR2 (P1-B) ✓
+

--- a/docs/planning/progress_bug_tracker.md
+++ b/docs/planning/progress_bug_tracker.md
@@ -2,10 +2,26 @@
 
 ## ACTIVE PRIORITIES (Start Here)
 
-- [ ] **BUG (P1): Output settings not honored.**
+- [ ] **BUG (P1-A): Processing fails silently - output path contract mismatch** [BLOCKER]
 
-  - Context: User reports settings (bitrate, etc.) are ignored. Code review shows plumbing is in place (`commands/audio.rs` -> `execute.rs` -> `encoder.rs`), but runtime behavior fails.
-  - Action: Verify via `RUST_LOG=debug` to see if `encoder_settings_v2` is dropped or overwritten.
+  - Context: Frontend sends full file path (e.g., `/path/Author/Title.m4b`), but backend expects directory and constructs own filename. Validation fails because `.m4b` path isn't a directory.
+  - Root cause: `outputPanel.ts:202-211` returns full path; `audio.rs:199-215` expects directory.
+  - Action: Backend should accept full file path and create parent directories as needed.
+  - See: `docs/planning/p1-settings-contract-fix.md`
+
+- [ ] **BUG (P1-B): Bitrate range mismatch - settings silently ignored**
+
+  - Context: UI offers 32, 48, 128 kbps but type system and validation only accepts 56-96 kbps.
+  - Root cause: `SUPPORTED_ENCODER_BITRATES` in `logic.ts:32`, `encoder.ts:46`, `settings_encoder.rs:60` all use `[56, 64, 72, 80, 88, 96]`. Frontend sanitizes invalid values to 64k before backend ever sees them.
+  - Action: Expand range to 48-128 kbps across all locations. Single source of truth in Rust.
+  - See: `docs/planning/p1-settings-contract-fix.md`
+
+- [ ] **BUG (P1-C): Sample rate not passed to backend**
+
+  - Context: UI collects explicit sample rate (e.g., 44100) but it never reaches encoder.
+  - Root cause: `audio.rs:90` uses `AudioSettings::audiobook_preset()` which defaults to `SampleRateConfig::Auto`. Frontend's sample rate setting is discarded.
+  - Action: Parse and map sample rate from frontend payload in `process_audiobook_files_v2`.
+  - See: `docs/planning/p1-settings-contract-fix.md`
 
 - [ ] **Fast Path Optimization (P2)**
   - Context: Currently disabled (`ABB_DISABLE_FASTPATH=1`) due to AAC errors.

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -59,6 +59,8 @@ pub struct ProcessV2Payload {
     pub input_files: Vec<String>,
     pub output_dir: String,
     pub settings: EncoderSettings,
+    /// Sample rate from frontend (optional, defaults to Auto)
+    pub sample_rate: Option<audio::SampleRateConfig>,
 }
 
 /// Processes files using v2 payload (EncoderSettings + v2 shape). For now, routes
@@ -74,17 +76,19 @@ pub async fn process_audiobook_files_v2(
     // Validate encoder settings (v2)
     validate_encoder_settings(&payload.settings)?;
     log::info!(
-        "encoder_v2 summary: encoder={:?} bitrate={}k channels={} aac_coder={:?} afterburner={:?} threads={:?}",
+        "encoder_v2 summary: encoder={:?} bitrate={}k channels={} sample_rate={:?} aac_coder={:?} afterburner={:?} threads={:?}",
         payload.settings.encoder_type,
         payload.settings.bitrate_kbps,
         payload.settings.channels,
+        payload.sample_rate,
         payload.settings.aac_coder,
         payload.settings.afterburner,
         payload.settings.threads
     );
 
-    // Validate output directory and construct final path
-    let output_path = validate_and_resolve_output_path(&payload.output_dir)?;
+    // Validate output path and create parent directories if needed
+    // Note: Frontend sends full file path in output_dir field (legacy naming)
+    let output_path = validate_and_prepare_output_path(&payload.output_dir)?;
 
     // Minimal AudioSettings kept for legacy validation paths (bitrate/channel/sample rate)
     let mut settings_v1 = audio::AudioSettings::audiobook_preset();
@@ -99,6 +103,10 @@ pub async fn process_audiobook_files_v2(
             )))
         }
     };
+    // Map sample rate from frontend payload (defaults to Auto if not provided)
+    if let Some(sample_rate) = payload.sample_rate {
+        settings_v1.sample_rate = sample_rate;
+    }
     settings_v1.output_path = output_path.clone();
 
     // Reuse existing validation to ensure path/bitrate configuration is acceptable
@@ -196,22 +204,55 @@ pub struct ProcessCommandResult {
     pub preview_actual_seconds: Option<f64>,
 }
 
-fn validate_and_resolve_output_path(output_dir: &str) -> Result<PathBuf> {
-    let dir = Path::new(output_dir);
-    if !dir.exists() {
-        return Err(AppError::FileValidation(format!(
-            "Output directory does not exist: {}",
-            dir.display()
-        )));
-    }
-    if !dir.is_dir() {
-        return Err(AppError::FileValidation(format!(
-            "Output path is not a directory: {}",
-            dir.display()
-        )));
+/// Validates and prepares the output path for the audiobook file.
+///
+/// Accepts a full file path (e.g., `/path/to/Author/2024-Title/Book.m4b`).
+/// Creates parent directories if they don't exist.
+///
+/// # Contract
+/// - Frontend sends the complete output file path (including filename)
+/// - Backend validates extension and creates parent directories as needed
+fn validate_and_prepare_output_path(output_path: &str) -> Result<PathBuf> {
+    let path = Path::new(output_path);
+
+    // Validate the path has a filename
+    if path.file_name().is_none() {
+        return Err(AppError::InvalidInput(
+            "Output path must include a filename".to_string(),
+        ));
     }
 
-    Ok(dir.join("audiobook.m4b"))
+    // Validate extension is .m4b
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("m4b") => {}
+        Some(ext) => {
+            return Err(AppError::InvalidInput(format!(
+                "Output file must have .m4b extension, got: .{}",
+                ext
+            )));
+        }
+        None => {
+            return Err(AppError::InvalidInput(
+                "Output file must have .m4b extension".to_string(),
+            ));
+        }
+    }
+
+    // Get parent directory and create if needed
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            log::info!("Creating output directory: {}", parent.display());
+            std::fs::create_dir_all(parent).map_err(|e| {
+                AppError::FileValidation(format!(
+                    "Failed to create output directory '{}': {}",
+                    parent.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+
+    Ok(path.to_path_buf())
 }
 
 /// Cancels the current audio processing operation

--- a/src/ui/statusPanel/logic.ts
+++ b/src/ui/statusPanel/logic.ts
@@ -193,6 +193,7 @@ export class StatusPanel {
                 inputFiles: filePaths,
                 outputDir: (document.getElementById('output-dir-text') as HTMLInputElement)?.value || '',
                 settings: boundaryEncoderSettings,
+                sampleRate: settings.sampleRate,
             };
 
             const result = await bridge.invoke<{ message: string; previewFilePath?: string; previewActualSeconds?: number }>('process_audiobook_files_v2', {


### PR DESCRIPTION
## Summary

- **P1-A**: Fix output path contract mismatch - backend now accepts full file path from frontend and auto-creates parent directories
- **P1-C**: Add sample rate passthrough from frontend to backend encoder settings

## Changes

### P1-A: Output Path Contract Fix
- Frontend sends full file path (e.g., `/path/to/Author/2024-Title/Book.m4b`)
- `validate_and_prepare_output_path` now accepts full file path instead of expecting directory
- Auto-creates parent directories if they don't exist
- Validates `.m4b` extension

### P1-C: Sample Rate Passthrough
- Added `sample_rate: Option<SampleRateConfig>` to `ProcessV2Payload` struct
- Maps frontend sample rate to `settings_v1.sample_rate`
- Logs sample rate in encoder summary for debugging
- Frontend now includes `sampleRate` in v2Payload

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (119 tests)
- [ ] Manual test: Load files, select output dir, click Process → processing starts
- [ ] Manual test: Output file created in correct subdirectory path
- [ ] Manual test: Error shown if output path invalid
- [ ] Manual test: Verify sample rate honored in output (via ffprobe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)