### PR TITLE
fix: update drag-drop to Tauri v2 event API

### DIFF
--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -225,12 +225,18 @@ export function isProcessingProgressEvent(
 /**
  * Type guard for file drop events
  */
-export function isFileDropEvent(event: unknown): event is { paths: string[], position: { x: number, y: number } } {
-    const e = event as { paths?: unknown };
+type DragDropPayload = TauriFileDropEvents['tauri://drag-drop'];
+
+export function isFileDropEvent(event: unknown): event is DragDropPayload {
+    const e = event as Partial<DragDropPayload>;
     return (
         typeof e === 'object' &&
         e !== null &&
         Array.isArray(e.paths) &&
-        e.paths.every(item => typeof item === 'string')
+        e.paths.every(item => typeof item === 'string') &&
+        typeof e.position === 'object' &&
+        e.position !== null &&
+        typeof e.position.x === 'number' &&
+        typeof e.position.y === 'number'
     );
 }

--- a/src/ui/fileImport.ts
+++ b/src/ui/fileImport.ts
@@ -1,5 +1,6 @@
 import { bridge } from '../lib/bridge';
 import { FileListInfo } from '../types/audio';
+import { EventPayload, isFileDropEvent } from '../types/events';
 import { displayFileList } from './fileList';
 
 let dragDropArea: HTMLElement | null = null;
@@ -17,9 +18,9 @@ function setupDragDropHandlers(): void {
 
     // Listen for the Tauri file drop event
     // Payload is now { paths: string[], position: { x, y } }
-    bridge.listen<{ paths: string[] }>('tauri://drag-drop', async (event) => {
+    bridge.listen<EventPayload<'tauri://drag-drop'>>('tauri://drag-drop', async (event) => {
         dragDropArea?.classList.remove('drag-over');
-        if (event.payload && Array.isArray(event.payload.paths)) {
+        if (isFileDropEvent(event.payload)) {
             await handleFileDrop(event.payload.paths);
         }
     });


### PR DESCRIPTION
## Summary
- Migrates file drop handling from deprecated Tauri v1 events to v2 API
- Updates event listeners and type definitions for new payload structure

## Changes
- `src-tauri/capabilities/default.json`: Enable drag-drop interactions, remove unused permissions
- `src/types/events.ts`: Update event types to match Tauri v2 drag-drop API
- `src/ui/fileImport.ts`: Update event listeners for new event names and payload structure

## Event Migration
| Old (v1) | New (v2) |
|----------|----------|
| `tauri://file-drop` | `tauri://drag-drop` |
| `tauri://file-drop-hover` | `tauri://drag-enter` |
| `tauri://file-drop-cancelled` | `tauri://drag-leave` |

## Test plan
- [x] Drag files over drop zone → visual feedback appears
- [x] Drop files → files are processed correctly
- [x] Drag files away without dropping → visual feedback clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)