### PR TITLE
Refactor: split status panel logic

### DIFF
--- a/src/ui/statusPanel/README.md
+++ b/src/ui/statusPanel/README.md
@@ -11,14 +11,42 @@ Public API aggregator that re-exports the main interfaces:
 - `getStatusPanel()` function
 
 ### `/logic.ts`
-Core business logic and state management:
-- Event handling for processing progress
-- State coordination and status updates
+Core business logic and orchestration:
+- Delegates event wiring, state derivation, and UI rendering
 - Backend communication (invoke calls)
 - Cover art processing and metadata extraction
 - Public API implementation
 
-### `/dom.ts` 
+### `/processing.ts`
+Processing workflow helpers:
+- Backend invocation payload assembly
+- Metadata preparation for merge/batch
+- Processing lifecycle coordination
+
+### `/state.ts`
+In-memory state helpers and types:
+- Processing status and per-job progress types
+- Aggregate progress calculations
+- Stage derivation
+
+### `/events.ts`
+Event wiring and listeners:
+- DOM event registration (buttons, dropdowns, toggles)
+- Progress event subscription
+
+### `/formatting.ts`
+Message and data formatting:
+- Status and aggregate message formatting
+- Cover art data URL conversion
+- Progress label parsing helpers
+
+### `/render.ts`
+UI update coordination:
+- Status and progress rendering
+- Concurrency indicator rendering
+- Job list rendering
+
+### `/dom.ts`
 DOM manipulation and UI update helpers:
 - Element caching and lookup
 - Progress bar and text updates

--- a/src/ui/statusPanel/events.ts
+++ b/src/ui/statusPanel/events.ts
@@ -1,0 +1,98 @@
+import { bridge } from "../../lib/bridge";
+import { EVENTS } from "../../types/events";
+import type { ProcessingProgressEvent } from "../../types/events";
+import * as dom from "./dom";
+
+interface StatusPanelEventHandlers {
+  onProcess: () => Promise<void>;
+  onCancelAll: () => Promise<void>;
+  onPreview: (duration: number) => Promise<void>;
+  getPreviewDuration: () => number;
+  setPreviewDuration: (duration: number) => void;
+  onUpdateConcurrencyIndicator: () => void;
+}
+
+export function bindStatusPanelDomEvents(
+  handlers: StatusPanelEventHandlers
+): void {
+  const processButton = dom.getProcessButton();
+  const previewButton = document.getElementById(
+    "preview-button"
+  ) as HTMLButtonElement | null;
+  const previewDropdownToggle = document.getElementById(
+    "preview-dropdown-toggle"
+  ) as HTMLButtonElement | null;
+  const previewDropdown = document.getElementById(
+    "preview-dropdown"
+  ) as HTMLDivElement | null;
+  const advancedToggle = document.getElementById(
+    "advanced-settings-toggle"
+  ) as HTMLButtonElement | null;
+
+  if (processButton) {
+    processButton.addEventListener("click", () => {
+      void handlers.onProcess();
+    });
+  }
+
+  const cancelAllButton = dom.getCancelAllButton();
+  if (cancelAllButton) {
+    cancelAllButton.addEventListener("click", () => {
+      void handlers.onCancelAll();
+    });
+  }
+
+  if (previewButton) {
+    previewButton.addEventListener("click", () => {
+      void handlers.onPreview(handlers.getPreviewDuration());
+    });
+  }
+
+  if (previewDropdownToggle && previewDropdown) {
+    previewDropdownToggle.addEventListener("click", (event) => {
+      event.stopPropagation();
+      previewDropdown.style.display =
+        previewDropdown.style.display === "none" ? "block" : "none";
+    });
+
+    previewDropdown.querySelectorAll(".split-option").forEach((opt) => {
+      opt.addEventListener("click", () => {
+        const duration = parseInt(
+          (opt as HTMLElement).dataset.duration || "30",
+          10
+        );
+        handlers.setPreviewDuration(duration);
+        previewDropdown.style.display = "none";
+        void handlers.onPreview(duration);
+      });
+    });
+
+    document.addEventListener("click", () => {
+      previewDropdown.style.display = "none";
+    });
+  }
+
+  if (advancedToggle) {
+    advancedToggle.addEventListener("click", () => {
+      const panel = document.getElementById("advanced-settings-panel");
+      const icon = document.getElementById("advanced-toggle-icon");
+      if (panel) {
+        panel.classList.toggle("open");
+        if (icon)
+          icon.textContent = panel.classList.contains("open") ? "▼" : "▶";
+      }
+    });
+  }
+
+  document.addEventListener("abb:max-concurrent-updated", () => {
+    handlers.onUpdateConcurrencyIndicator();
+  });
+}
+
+export async function listenForProgressEvents(
+  onProgress: (event: ProcessingProgressEvent) => void
+): Promise<() => void> {
+  return bridge.listen(EVENTS.PROGRESS, (event) => {
+    onProgress(event.payload as ProcessingProgressEvent);
+  });
+}

--- a/src/ui/statusPanel/formatting.ts
+++ b/src/ui/statusPanel/formatting.ts
@@ -1,0 +1,95 @@
+import type { AggregateProgress, JobProgress, ProcessingStatus } from "./state";
+
+export function formatStatusDisplayText(
+  stage: ProcessingStatus["stage"]
+): string {
+  switch (stage) {
+    case "idle":
+      return "Idle";
+    case "analyzing":
+      return "Analyzing";
+    case "converting":
+      return "Converting";
+    case "writing":
+      return "Writing Metadata";
+    case "completed":
+      return "Completed";
+    case "cancelled":
+      return "Cancelled";
+    case "failed":
+      return "Failed";
+    default:
+      return "Processing";
+  }
+}
+
+export function formatAggregateMessage(
+  jobProgress: Map<string, JobProgress>,
+  aggregate: AggregateProgress
+): string {
+  if (aggregate.activeJobs > 1) {
+    return `Processing ${aggregate.activeJobs} files (${aggregate.completedJobs} completed)`;
+  }
+  if (aggregate.activeJobs === 1) {
+    const activeJob = Array.from(jobProgress.values()).find(
+      (job) =>
+        job.stage !== "completed" &&
+        job.stage !== "failed" &&
+        job.stage !== "cancelled"
+    );
+    return activeJob?.message ?? "Processing...";
+  }
+  return "Ready to process audiobook";
+}
+
+export function convertBytesToDataUrl(bytes: number[]): string {
+  const uint8Array = new Uint8Array(bytes);
+
+  let mimeType = "image/jpeg"; // default fallback
+  if (uint8Array.length >= 4) {
+    // PNG: 89 50 4E 47
+    if (
+      uint8Array[0] === 0x89 &&
+      uint8Array[1] === 0x50 &&
+      uint8Array[2] === 0x4e &&
+      uint8Array[3] === 0x47
+    ) {
+      mimeType = "image/png";
+    }
+    // JPEG: FF D8 FF
+    else if (
+      uint8Array[0] === 0xff &&
+      uint8Array[1] === 0xd8 &&
+      uint8Array[2] === 0xff
+    ) {
+      mimeType = "image/jpeg";
+    }
+    // WebP: 52 49 46 46 ... 57 45 42 50
+    else if (
+      uint8Array[0] === 0x52 &&
+      uint8Array[1] === 0x49 &&
+      uint8Array[2] === 0x46 &&
+      uint8Array[3] === 0x46
+    ) {
+      mimeType = "image/webp";
+    }
+  }
+
+  let binary = "";
+  uint8Array.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  const base64 = btoa(binary);
+
+  return `data:${mimeType};base64,${base64}`;
+}
+
+export function extractFilenameFromProgress(label: string): string | null {
+  const trimmed = label.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(.*?) \(\d+\/\d+\)$/);
+  if (match && match[1]) {
+    return match[1].trim();
+  }
+  return trimmed;
+}

--- a/src/ui/statusPanel/logic.ts
+++ b/src/ui/statusPanel/logic.ts
@@ -1,4 +1,3 @@
-// REFACTOR: Module exceeds 400 LOC (569). Consider splitting before adding new code.
 /**
  * StatusPanel business logic and state management
  *
@@ -7,72 +6,28 @@
  */
 
 import { bridge } from "../../lib/bridge";
-import { ProcessingProgressEvent, EVENTS, STAGES } from "../../types/events";
-import {
-  currentFileList,
-  selectedFileIndex,
-  setFileOrderLocked,
-} from "../fileList";
-import { getCurrentOutputConfig } from "../outputPanel";
-import type { EncoderSettings, OutputConfig } from "../../types/audio";
-import {
-  defaultEncoderSettings,
-  VALID_ENCODER_BITRATES,
-} from "../../types/audio";
-import { toBoundaryEncoderSettings } from "../../types/encoder";
-import type { EncoderSettingsLike } from "../../types/encoder";
+import { STAGES } from "../../types/events";
+import type { ProcessingProgressEvent } from "../../types/events";
+import { currentFileList, setFileOrderLocked } from "../fileList";
 import { AudiobookMetadata } from "../../types/metadata";
 import * as dom from "./dom";
+import { setJobControlsEnabled } from "../jobControls";
+import { bindStatusPanelDomEvents, listenForProgressEvents } from "./events";
 import {
-  getJobType,
-  getMaxConcurrentStatus,
-  setJobControlsEnabled,
-} from "../jobControls";
-import { readMetadataForm } from "../metadataForm";
+  convertBytesToDataUrl,
+  extractFilenameFromProgress,
+  formatAggregateMessage,
+} from "./formatting";
+import { startProcessing as startProcessingAction } from "./processing";
+import { renderConcurrencyStatus, renderJobList, renderStatus } from "./render";
 import {
-  getAllMetadata,
-  getMetadataForFile,
-  setMetadataForFile,
-} from "../metadataState";
-
-interface ProcessingStatus {
-  stage:
-  | "idle"
-  | "analyzing"
-  | "converting"
-  | "writing"
-  | "completed"
-  | "cancelled"
-  | "failed";
-  percentage: number;
-  message: string;
-  currentFile?: string;
-  etaSeconds?: number;
-}
-
-/** Per-job progress tracking for parallel batch processing */
-interface JobProgress {
-  jobId: string;
-  stage: ProcessingStatus["stage"];
-  percentage: number;
-  message: string;
-  lastUpdate: number;
-}
-
-/** Aggregate progress across all active jobs */
-interface AggregateProgress {
-  activeJobs: number;
-  completedJobs: number;
-  overallPercentage: number;
-}
-
-type WindowWithEncoderProvider = Window & {
-  EncoderSettingsProvider?: () => EncoderSettingsLike;
-};
-
-// Derived from centralized VALID_ENCODER_BITRATES (audio.ts)
-// Typed as Set<number> to allow membership check with any numeric bitrate
-const SUPPORTED_ENCODER_BITRATES: Set<number> = new Set(VALID_ENCODER_BITRATES);
+  calculateAggregateProgress as calculateAggregateProgressState,
+  createInitialStatus,
+  deriveAggregateStage as deriveAggregateStageState,
+  type AggregateProgress,
+  type JobProgress,
+  type ProcessingStatus,
+} from "./state";
 
 export class StatusPanel {
   private cancelUnlisten?: () => void;
@@ -86,11 +41,7 @@ export class StatusPanel {
   private lastCoverArtPath: string | null = null;
 
   constructor() {
-    this.currentStatus = {
-      stage: "idle",
-      percentage: 0,
-      message: "Ready to process audiobook",
-    };
+    this.currentStatus = createInitialStatus();
 
     this.initializeElements();
     this.setupEventHandlers();
@@ -121,78 +72,16 @@ export class StatusPanel {
   }
 
   private setupEventHandlers(): void {
-    const processButton = dom.getProcessButton();
-    const previewButton = document.getElementById(
-      "preview-button"
-    ) as HTMLButtonElement | null;
-    const previewDropdownToggle = document.getElementById(
-      "preview-dropdown-toggle"
-    ) as HTMLButtonElement | null;
-    const previewDropdown = document.getElementById(
-      "preview-dropdown"
-    ) as HTMLDivElement | null;
-    const advancedToggle = document.getElementById(
-      "advanced-settings-toggle"
-    ) as HTMLButtonElement | null;
-
-    if (processButton) {
-      processButton.addEventListener("click", () => this.startProcessing());
-    }
-
-    const cancelAllButton = dom.getCancelAllButton();
-    if (cancelAllButton) {
-      cancelAllButton.addEventListener("click", () => this.handleCancelAll());
-    }
-
-    if (previewButton) {
-      previewButton.addEventListener("click", async () => {
-        await this.startProcessing({ previewSeconds: this.previewDuration });
-      });
-    }
-
-    // Preview duration dropdown
-    if (previewDropdownToggle && previewDropdown) {
-      previewDropdownToggle.addEventListener("click", (e) => {
-        e.stopPropagation();
-        previewDropdown.style.display =
-          previewDropdown.style.display === "none" ? "block" : "none";
-      });
-
-      // Handle duration options
-      previewDropdown.querySelectorAll(".split-option").forEach((opt) => {
-        opt.addEventListener("click", () => {
-          const duration = parseInt(
-            (opt as HTMLElement).dataset.duration || "30",
-            10
-          );
-          this.previewDuration = duration;
-          previewDropdown.style.display = "none";
-          // Optionally trigger preview with new duration
-          this.startProcessing({ previewSeconds: duration });
-        });
-      });
-
-      // Close dropdown on outside click
-      document.addEventListener("click", () => {
-        previewDropdown.style.display = "none";
-      });
-    }
-
-    // Advanced settings accordion
-    if (advancedToggle) {
-      advancedToggle.addEventListener("click", () => {
-        const panel = document.getElementById("advanced-settings-panel");
-        const icon = document.getElementById("advanced-toggle-icon");
-        if (panel) {
-          panel.classList.toggle("open");
-          if (icon)
-            icon.textContent = panel.classList.contains("open") ? "▼" : "▶";
-        }
-      });
-    }
-
-    document.addEventListener("abb:max-concurrent-updated", () => {
-      this.updateConcurrencyIndicator();
+    bindStatusPanelDomEvents({
+      onProcess: () => this.startProcessing(),
+      onCancelAll: () => this.handleCancelAll(),
+      onPreview: (duration) =>
+        this.startProcessing({ previewSeconds: duration }),
+      getPreviewDuration: () => this.previewDuration,
+      setPreviewDuration: (duration) => {
+        this.previewDuration = duration;
+      },
+      onUpdateConcurrencyIndicator: () => this.updateConcurrencyIndicator(),
     });
   }
 
@@ -201,202 +90,21 @@ export class StatusPanel {
   public async startProcessing(options?: {
     previewSeconds?: number;
   }): Promise<void> {
-    try {
-      console.log("StatusPanel: Starting processing...");
-      console.log("Current file list:", currentFileList);
-
-      // Validate inputs
-      if (
-        !currentFileList ||
-        !currentFileList.files ||
-        currentFileList.files.length === 0
-      ) {
-        console.log("StatusPanel: No files found");
-        dom.showError("No audio files selected. Please add files to process.");
-        return;
-      }
-
-      if (currentFileList.validCount === 0) {
-        console.log("StatusPanel: No valid files found");
-        dom.showError(
-          "No valid audio files found. Please check your files and try again."
-        );
-        return;
-      }
-
-      console.log(
-        "StatusPanel: Files validated, getting output configuration..."
-      );
-
-      // Get output configuration
-      let outputConfig: OutputConfig;
-      try {
-        outputConfig = getCurrentOutputConfig();
-        console.log("StatusPanel: Output configuration retrieved:", outputConfig);
-      } catch (error) {
-        console.log("StatusPanel: Settings validation failed:", error);
-        dom.showError(`Settings validation failed: ${error}`);
-        return;
-      }
-
-      // Update UI to processing state
-      this.isProcessing = true;
-      this.updateStatus({
-        stage: "analyzing",
-        percentage: 0,
-        message: "Starting processing...",
-      });
-
-      // Disable job controls
-      setJobControlsEnabled(false);
-      setFileOrderLocked(true);
-
-      // Update art thumbnail with current file's cover art
-      await this.updateArtThumbnail();
-
-      // Start listening for progress events
-      await this.startProgressListener();
-
-      // Get file paths for processing
-      const filePaths = currentFileList.files
-        .filter((file) => file.isValid)
-        .map((file) => file.path);
-
-      const currentMetadata = readMetadataForm();
-      const activeFile =
-        selectedFileIndex >= 0
-          ? currentFileList.files[selectedFileIndex]
-          : currentFileList.files.find((file) => file.isValid);
-      if (activeFile?.isValid) {
-        setMetadataForFile(activeFile.path, currentMetadata);
-      }
-
-      // Call backend processing command
-      const fallbackEncoderDefaults = (() => {
-        const defaults = defaultEncoderSettings();
-        const selected = outputConfig.encoderSettings;
-        const bitrate = SUPPORTED_ENCODER_BITRATES.has(selected.bitrateKbps)
-          ? selected.bitrateKbps
-          : defaults.bitrateKbps;
-        const channels = selected.channels ?? defaults.channels;
-        return {
-          ...defaults,
-          ...selected,
-          bitrateKbps: bitrate,
-          channels,
-        } satisfies EncoderSettings;
-      })();
-
-      const windowWithProvider = window as WindowWithEncoderProvider;
-      const providerResult: EncoderSettingsLike =
-        typeof windowWithProvider.EncoderSettingsProvider === "function"
-          ? windowWithProvider.EncoderSettingsProvider()
-          : undefined;
-
-      let boundaryEncoderSettings = toBoundaryEncoderSettings(
-        providerResult,
-        fallbackEncoderDefaults
-      );
-
-      const jobType = getJobType();
-      this.currentJobType = jobType;
-
-      const v2Payload = {
-        inputFiles: filePaths,
-        outputDir: outputConfig.outputPath,
-        settings: boundaryEncoderSettings,
-        sampleRate: outputConfig.sampleRate,
-        jobType,
-        useSubdirPattern: outputConfig.useSubdirPattern,
-        filenamePattern: outputConfig.filenamePattern,
-      };
-
-      if (v2Payload.jobType === "batch") {
-        const missingMetadata = filePaths.filter(
-          (filePath) => !getMetadataForFile(filePath)
-        );
-        if (missingMetadata.length > 0) {
-          await Promise.all(
-            missingMetadata.map(async (filePath) => {
-              try {
-                const metadata = await bridge.invoke<AudiobookMetadata>(
-                  "read_audio_metadata",
-                  { filePath }
-                );
-                setMetadataForFile(filePath, metadata);
-              } catch (error) {
-                console.warn(
-                  "Failed to load metadata for batch file:",
-                  filePath,
-                  error
-                );
-              }
-            })
-          );
-        }
-      }
-
-      let metadataPayload: Record<string, Partial<AudiobookMetadata>> | null =
-        null;
-      if (v2Payload.jobType === "merge") {
-        if (
-          v2Payload.inputFiles.length > 0 &&
-          Object.keys(currentMetadata).length > 0
-        ) {
-          metadataPayload = {
-            [v2Payload.inputFiles[0]]: currentMetadata,
-          };
-        }
-      } else {
-        const storedMetadata = getAllMetadata();
-        const filteredMetadata = Object.fromEntries(
-          Object.entries(storedMetadata).filter(
-            ([, value]) => Object.keys(value).length > 0
-          )
-        );
-        metadataPayload =
-          Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null;
-      }
-
-      const result = await bridge.invoke<{
-        message: string;
-        previewFilePath?: string;
-        previewActualSeconds?: number;
-        jobId?: string;
-      }>("process_audiobook_files_v2", {
-        payload: v2Payload,
-        metadata: metadataPayload,
-        previewSeconds: options?.previewSeconds,
-      });
-
-      console.log("Processing completed successfully:", result);
-      if (result && result.previewFilePath) {
-        const seconds =
-          typeof result.previewActualSeconds === "number"
-            ? result.previewActualSeconds.toFixed(3)
-            : "≈30";
-        console.log(
-          `Preview file created at: ${result.previewFilePath} (${seconds}s)`
-        );
-        try {
-          await bridge.openExternal(result.previewFilePath);
-        } catch (e) {
-          console.warn("Failed to open preview file automatically:", e);
-        }
-      }
-      if (options?.previewSeconds) {
-        // Optionally handle showing/opening preview file via result once backend returns a path shape
-        // Placeholder: UI messaging handled by progress events for now
-      }
-    } catch (error) {
-      const msg = String((error as any)?.message ?? error ?? "");
-      if (msg.toLowerCase().includes("cancelled")) {
-        return;
-      }
-      console.error("Processing failed:", error);
-      dom.showError(`Processing failed: ${msg}`);
-      this.resetToIdle();
-    }
+    return startProcessingAction(
+      {
+        updateStatus: (status) => this.updateStatus(status),
+        setProcessingState: (isProcessing) => {
+          this.isProcessing = isProcessing;
+        },
+        updateArtThumbnail: () => this.updateArtThumbnail(),
+        startProgressListener: () => this.startProgressListener(),
+        setCurrentJobType: (jobType) => {
+          this.currentJobType = jobType;
+        },
+        resetToIdle: () => this.resetToIdle(),
+      },
+      options
+    );
   }
 
   private async startProgressListener(): Promise<void> {
@@ -404,8 +112,7 @@ export class StatusPanel {
       this.cancelUnlisten();
     }
 
-    this.cancelUnlisten = await bridge.listen(EVENTS.PROGRESS, (event) => {
-      const progress = event.payload as ProcessingProgressEvent;
+    this.cancelUnlisten = await listenForProgressEvents((progress) => {
       this.updateProgress(progress);
     });
   }
@@ -433,7 +140,7 @@ export class StatusPanel {
       lastUpdate: now,
     });
 
-    this.syncJobListUI();
+    renderJobList(this.jobProgress, (id) => this.cancelJob(id));
 
     // Handle terminal states for this job
     if (
@@ -457,7 +164,7 @@ export class StatusPanel {
         }
 
         this.updateAggregateUI();
-        this.syncJobListUI();
+        renderJobList(this.jobProgress, (id) => this.cancelJob(id));
       }, 2000);
     }
 
@@ -471,7 +178,7 @@ export class StatusPanel {
     const status: ProcessingStatus = {
       stage: this.deriveAggregateStage(),
       percentage: aggregate.overallPercentage,
-      message: this.deriveAggregateMessage(aggregate),
+      message: formatAggregateMessage(this.jobProgress, aggregate),
       currentFile: event.current_file,
       etaSeconds: event.eta_seconds,
     };
@@ -486,7 +193,7 @@ export class StatusPanel {
       if (indexedPath) {
         void this.updateArtThumbnailForFile(indexedPath);
       } else if (event.current_file) {
-        const filename = this.extractFilenameFromProgress(event.current_file);
+        const filename = extractFilenameFromProgress(event.current_file);
         if (filename) {
           const filePath = this.findFilePathByName(filename);
           if (filePath) {
@@ -495,84 +202,16 @@ export class StatusPanel {
         }
       }
     }
-
   }
 
   /** Calculate aggregate progress across all active jobs */
   private calculateAggregateProgress(): AggregateProgress {
-    let activeJobs = 0;
-    let completedJobs = 0;
-    let totalPercentage = 0;
-
-    for (const job of this.jobProgress.values()) {
-      if (job.stage === "completed") {
-        completedJobs++;
-        totalPercentage += 100;
-      } else if (job.stage === "failed" || job.stage === "cancelled") {
-        // Don't count failed/cancelled in active or completed
-      } else {
-        activeJobs++;
-        totalPercentage += job.percentage;
-      }
-    }
-
-    const totalJobs = activeJobs + completedJobs;
-    // Simple average across active + completed jobs. This keeps the aggregate legible
-    // without over-weighting long-running jobs; consider a weighted strategy if we
-    // need time/progress proportionality later.
-    const overallPercentage = totalJobs > 0 ? totalPercentage / totalJobs : 0;
-
-    return {
-      activeJobs,
-      completedJobs,
-      overallPercentage: Math.round(overallPercentage * 10) / 10,
-    };
-  }
-
-  /** Render the job list with per-job cancel controls */
-  private syncJobListUI(): void {
-    const jobs = Array.from(this.jobProgress.values())
-      .sort((a, b) => b.lastUpdate - a.lastUpdate)
-      .map((job) => ({
-        id: job.jobId,
-        label: `${job.jobId.slice(0, 8)} • ${job.message}`,
-        stage: job.stage,
-        percentage: job.percentage,
-        onCancel: job.jobId === "default" ? undefined : (id: string) => this.cancelJob(id),
-      }));
-
-    dom.renderJobList(jobs);
+    return calculateAggregateProgressState(this.jobProgress);
   }
 
   /** Derive aggregate stage from active jobs */
   private deriveAggregateStage(): ProcessingStatus["stage"] {
-    const stages = Array.from(this.jobProgress.values()).map((j) => j.stage);
-
-    // Priority: failed > cancelled > converting > analyzing > writing > completed > idle
-    if (stages.includes("failed")) return "failed";
-    if (stages.includes("cancelled")) return "cancelled";
-    if (stages.includes("converting")) return "converting";
-    if (stages.includes("analyzing")) return "analyzing";
-    if (stages.includes("writing")) return "writing";
-    if (stages.includes("completed")) return "completed";
-    return "idle";
-  }
-
-  /** Derive message for aggregate display */
-  private deriveAggregateMessage(aggregate: AggregateProgress): string {
-    if (aggregate.activeJobs > 1) {
-      return `Processing ${aggregate.activeJobs} files (${aggregate.completedJobs} completed)`;
-    } else if (aggregate.activeJobs === 1) {
-      // Return the single job's message
-      const activeJob = Array.from(this.jobProgress.values()).find(
-        (j) =>
-          j.stage !== "completed" &&
-          j.stage !== "failed" &&
-          j.stage !== "cancelled"
-      );
-      return activeJob?.message ?? "Processing...";
-    }
-    return "Ready to process audiobook";
+    return deriveAggregateStageState(this.jobProgress);
   }
 
   /** Update UI with aggregate progress (called after job removal) */
@@ -585,31 +224,14 @@ export class StatusPanel {
     const status: ProcessingStatus = {
       stage: this.deriveAggregateStage(),
       percentage: aggregate.overallPercentage,
-      message: this.deriveAggregateMessage(aggregate),
+      message: formatAggregateMessage(this.jobProgress, aggregate),
     };
     this.updateStatus(status);
     this.updateConcurrencyIndicator(aggregate);
   }
 
   private updateConcurrencyIndicator(aggregate?: AggregateProgress): void {
-    const { effective, selection } = getMaxConcurrentStatus();
-    const suffix = selection === "auto" ? " (Auto)" : "";
-
-    if (effective === null) {
-      dom.updateConcurrencyStatus("Max jobs: —");
-      return;
-    }
-
-    if (aggregate && (aggregate.activeJobs > 0 || aggregate.completedJobs > 0)) {
-      const completedSuffix =
-        aggregate.completedJobs > 0 ? ` • Completed ${aggregate.completedJobs}` : "";
-      dom.updateConcurrencyStatus(
-        `Running ${aggregate.activeJobs} / Max ${effective}${suffix}${completedSuffix}`
-      );
-      return;
-    }
-
-    dom.updateConcurrencyStatus(`Max jobs: ${effective}${suffix}`);
+    renderConcurrencyStatus(aggregate);
   }
 
   private updateStatus(status: ProcessingStatus): void {
@@ -618,40 +240,7 @@ export class StatusPanel {
   }
 
   private updateUI(): void {
-    // Update progress bar and percentage
-    dom.updateProgressBar(this.currentStatus.percentage);
-    dom.updatePercentageText(this.currentStatus.percentage);
-
-    // Update status text
-    const statusDisplay = this.getStatusDisplayText();
-    dom.updateStatusText(statusDisplay);
-
-    // Update step text
-    dom.updateStepText(`Current Step: ${this.currentStatus.message}`);
-
-    // Update process button
-    dom.updateProcessButton(this.isProcessing);
-  }
-
-  private getStatusDisplayText(): string {
-    switch (this.currentStatus.stage) {
-      case "idle":
-        return "Idle";
-      case "analyzing":
-        return "Analyzing";
-      case "converting":
-        return "Converting";
-      case "writing":
-        return "Writing Metadata";
-      case "completed":
-        return "Completed";
-      case "cancelled":
-        return "Cancelled";
-      case "failed":
-        return "Failed";
-      default:
-        return "Processing";
-    }
+    renderStatus(this.currentStatus, this.isProcessing);
   }
 
   private async handleCancelAll(): Promise<void> {
@@ -690,13 +279,9 @@ export class StatusPanel {
 
     // Clear all job progress tracking
     this.jobProgress.clear();
-    dom.renderJobList([]);
+    renderJobList(this.jobProgress, (id) => this.cancelJob(id));
 
-    this.updateStatus({
-      stage: "idle",
-      percentage: 0,
-      message: "Ready to process audiobook",
-    });
+    this.updateStatus(createInitialStatus());
     this.updateConcurrencyIndicator();
 
     // Re-enable controls
@@ -707,51 +292,6 @@ export class StatusPanel {
     dom.resetArtThumbnail();
   }
 
-  private convertBytesToDataUrl(bytes: number[]): string {
-    // Convert number array to Uint8Array
-    const uint8Array = new Uint8Array(bytes);
-
-    // Detect image format from magic bytes
-    let mimeType = "image/jpeg"; // default fallback
-    if (uint8Array.length >= 4) {
-      // PNG: 89 50 4E 47
-      if (
-        uint8Array[0] === 0x89 &&
-        uint8Array[1] === 0x50 &&
-        uint8Array[2] === 0x4e &&
-        uint8Array[3] === 0x47
-      ) {
-        mimeType = "image/png";
-      }
-      // JPEG: FF D8 FF
-      else if (
-        uint8Array[0] === 0xff &&
-        uint8Array[1] === 0xd8 &&
-        uint8Array[2] === 0xff
-      ) {
-        mimeType = "image/jpeg";
-      }
-      // WebP: 52 49 46 46 ... 57 45 42 50
-      else if (
-        uint8Array[0] === 0x52 &&
-        uint8Array[1] === 0x49 &&
-        uint8Array[2] === 0x46 &&
-        uint8Array[3] === 0x46
-      ) {
-        mimeType = "image/webp";
-      }
-    }
-
-    // Convert to base64
-    let binary = "";
-    uint8Array.forEach((byte) => {
-      binary += String.fromCharCode(byte);
-    });
-    const base64 = btoa(binary);
-
-    return `data:${mimeType};base64,${base64}`;
-  }
-
   private async updateArtThumbnail(): Promise<void> {
     if (!currentFileList || !currentFileList.files.length) {
       dom.resetArtThumbnail();
@@ -759,7 +299,7 @@ export class StatusPanel {
     }
 
     // Get the first valid file for cover art
-    const firstValidFile = currentFileList.files.find((f) => f.isValid);
+    const firstValidFile = currentFileList.files.find((file) => file.isValid);
     if (!firstValidFile) {
       dom.resetArtThumbnail();
       return;
@@ -783,7 +323,7 @@ export class StatusPanel {
       );
 
       if (metadata.cover_art && metadata.cover_art.length > 0) {
-        const dataUrl = this.convertBytesToDataUrl(metadata.cover_art);
+        const dataUrl = convertBytesToDataUrl(metadata.cover_art);
         dom.displayCoverArt(dataUrl);
       } else {
         dom.resetArtThumbnail();
@@ -792,16 +332,6 @@ export class StatusPanel {
       console.warn("Failed to load cover art for thumbnail:", error);
       dom.resetArtThumbnail();
     }
-  }
-
-  private extractFilenameFromProgress(label: string): string | null {
-    const trimmed = label.trim();
-    if (!trimmed) return null;
-    const match = trimmed.match(/^(.*?) \(\d+\/\d+\)$/);
-    if (match && match[1]) {
-      return match[1].trim();
-    }
-    return trimmed;
   }
 
   private findFilePathByName(filename: string): string | null {

--- a/src/ui/statusPanel/processing.ts
+++ b/src/ui/statusPanel/processing.ts
@@ -1,0 +1,245 @@
+import { bridge } from "../../lib/bridge";
+import type { EncoderSettings, OutputConfig } from "../../types/audio";
+import {
+  defaultEncoderSettings,
+  VALID_ENCODER_BITRATES,
+} from "../../types/audio";
+import { toBoundaryEncoderSettings } from "../../types/encoder";
+import type { EncoderSettingsLike } from "../../types/encoder";
+import type { AudiobookMetadata } from "../../types/metadata";
+import {
+  currentFileList,
+  selectedFileIndex,
+  setFileOrderLocked,
+} from "../fileList";
+import { getCurrentOutputConfig } from "../outputPanel";
+import { getJobType, setJobControlsEnabled } from "../jobControls";
+import { readMetadataForm } from "../metadataForm";
+import {
+  getAllMetadata,
+  getMetadataForFile,
+  setMetadataForFile,
+} from "../metadataState";
+import * as dom from "./dom";
+import type { ProcessingStatus } from "./state";
+
+interface WindowWithEncoderProvider extends Window {
+  EncoderSettingsProvider?: () => EncoderSettingsLike;
+}
+
+interface StartProcessingContext {
+  updateStatus: (status: ProcessingStatus) => void;
+  setProcessingState: (isProcessing: boolean) => void;
+  updateArtThumbnail: () => Promise<void>;
+  startProgressListener: () => Promise<void>;
+  setCurrentJobType: (jobType: "merge" | "batch") => void;
+  resetToIdle: () => void;
+}
+
+// Derived from centralized VALID_ENCODER_BITRATES (audio.ts)
+// Typed as Set<number> to allow membership check with any numeric bitrate
+const SUPPORTED_ENCODER_BITRATES: Set<number> = new Set(VALID_ENCODER_BITRATES);
+
+export async function startProcessing(
+  context: StartProcessingContext,
+  options?: {
+    previewSeconds?: number;
+  }
+): Promise<void> {
+  try {
+    console.log("StatusPanel: Starting processing...");
+    console.log("Current file list:", currentFileList);
+
+    // Validate inputs
+    if (
+      !currentFileList ||
+      !currentFileList.files ||
+      currentFileList.files.length === 0
+    ) {
+      console.log("StatusPanel: No files found");
+      dom.showError("No audio files selected. Please add files to process.");
+      return;
+    }
+
+    if (currentFileList.validCount === 0) {
+      console.log("StatusPanel: No valid files found");
+      dom.showError(
+        "No valid audio files found. Please check your files and try again."
+      );
+      return;
+    }
+
+    console.log(
+      "StatusPanel: Files validated, getting output configuration..."
+    );
+
+    // Get output configuration
+    let outputConfig: OutputConfig;
+    try {
+      outputConfig = getCurrentOutputConfig();
+      console.log("StatusPanel: Output configuration retrieved:", outputConfig);
+    } catch (error) {
+      console.log("StatusPanel: Settings validation failed:", error);
+      dom.showError(`Settings validation failed: ${error}`);
+      return;
+    }
+
+    // Update UI to processing state
+    context.setProcessingState(true);
+    context.updateStatus({
+      stage: "analyzing",
+      percentage: 0,
+      message: "Starting processing...",
+    });
+
+    // Disable job controls
+    setJobControlsEnabled(false);
+    setFileOrderLocked(true);
+
+    // Update art thumbnail with current file's cover art
+    await context.updateArtThumbnail();
+
+    // Start listening for progress events
+    await context.startProgressListener();
+
+    // Get file paths for processing
+    const filePaths = currentFileList.files
+      .filter((file) => file.isValid)
+      .map((file) => file.path);
+
+    const currentMetadata = readMetadataForm();
+    const activeFile =
+      selectedFileIndex >= 0
+        ? currentFileList.files[selectedFileIndex]
+        : currentFileList.files.find((file) => file.isValid);
+    if (activeFile?.isValid) {
+      setMetadataForFile(activeFile.path, currentMetadata);
+    }
+
+    // Call backend processing command
+    const fallbackEncoderDefaults = (() => {
+      const defaults = defaultEncoderSettings();
+      const selected = outputConfig.encoderSettings;
+      const bitrate = SUPPORTED_ENCODER_BITRATES.has(selected.bitrateKbps)
+        ? selected.bitrateKbps
+        : defaults.bitrateKbps;
+      const channels = selected.channels ?? defaults.channels;
+      return {
+        ...defaults,
+        ...selected,
+        bitrateKbps: bitrate,
+        channels,
+      } satisfies EncoderSettings;
+    })();
+
+    const windowWithProvider = window as WindowWithEncoderProvider;
+    const providerResult: EncoderSettingsLike =
+      typeof windowWithProvider.EncoderSettingsProvider === "function"
+        ? windowWithProvider.EncoderSettingsProvider()
+        : undefined;
+
+    const boundaryEncoderSettings = toBoundaryEncoderSettings(
+      providerResult,
+      fallbackEncoderDefaults
+    );
+
+    const jobType = getJobType();
+    context.setCurrentJobType(jobType);
+
+    const v2Payload = {
+      inputFiles: filePaths,
+      outputDir: outputConfig.outputPath,
+      settings: boundaryEncoderSettings,
+      sampleRate: outputConfig.sampleRate,
+      jobType,
+      useSubdirPattern: outputConfig.useSubdirPattern,
+      filenamePattern: outputConfig.filenamePattern,
+    };
+
+    if (v2Payload.jobType === "batch") {
+      const missingMetadata = filePaths.filter(
+        (filePath) => !getMetadataForFile(filePath)
+      );
+      if (missingMetadata.length > 0) {
+        await Promise.all(
+          missingMetadata.map(async (filePath) => {
+            try {
+              const metadata = await bridge.invoke<AudiobookMetadata>(
+                "read_audio_metadata",
+                { filePath }
+              );
+              setMetadataForFile(filePath, metadata);
+            } catch (error) {
+              console.warn(
+                "Failed to load metadata for batch file:",
+                filePath,
+                error
+              );
+            }
+          })
+        );
+      }
+    }
+
+    let metadataPayload: Record<string, Partial<AudiobookMetadata>> | null =
+      null;
+    if (v2Payload.jobType === "merge") {
+      if (
+        v2Payload.inputFiles.length > 0 &&
+        Object.keys(currentMetadata).length > 0
+      ) {
+        metadataPayload = {
+          [v2Payload.inputFiles[0]]: currentMetadata,
+        };
+      }
+    } else {
+      const storedMetadata = getAllMetadata();
+      const filteredMetadata = Object.fromEntries(
+        Object.entries(storedMetadata).filter(
+          ([, value]) => Object.keys(value).length > 0
+        )
+      );
+      metadataPayload =
+        Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null;
+    }
+
+    const result = await bridge.invoke<{
+      message: string;
+      previewFilePath?: string;
+      previewActualSeconds?: number;
+      jobId?: string;
+    }>("process_audiobook_files_v2", {
+      payload: v2Payload,
+      metadata: metadataPayload,
+      previewSeconds: options?.previewSeconds,
+    });
+
+    console.log("Processing completed successfully:", result);
+    if (result && result.previewFilePath) {
+      const seconds =
+        typeof result.previewActualSeconds === "number"
+          ? result.previewActualSeconds.toFixed(3)
+          : "≈30";
+      console.log(
+        `Preview file created at: ${result.previewFilePath} (${seconds}s)`
+      );
+      try {
+        await bridge.openExternal(result.previewFilePath);
+      } catch (error) {
+        console.warn("Failed to open preview file automatically:", error);
+      }
+    }
+    if (options?.previewSeconds) {
+      // Optionally handle showing/opening preview file via result once backend returns a path shape
+      // Placeholder: UI messaging handled by progress events for now
+    }
+  } catch (error) {
+    const msg = String((error as any)?.message ?? error ?? "");
+    if (msg.toLowerCase().includes("cancelled")) {
+      return;
+    }
+    console.error("Processing failed:", error);
+    dom.showError(`Processing failed: ${msg}`);
+    context.resetToIdle();
+  }
+}

--- a/src/ui/statusPanel/render.ts
+++ b/src/ui/statusPanel/render.ts
@@ -1,0 +1,55 @@
+import { getMaxConcurrentStatus } from "../jobControls";
+import * as dom from "./dom";
+import { formatStatusDisplayText } from "./formatting";
+import type { AggregateProgress, JobProgress, ProcessingStatus } from "./state";
+
+export function renderStatus(
+  status: ProcessingStatus,
+  isProcessing: boolean
+): void {
+  dom.updateProgressBar(status.percentage);
+  dom.updatePercentageText(status.percentage);
+  dom.updateStatusText(formatStatusDisplayText(status.stage));
+  dom.updateStepText(`Current Step: ${status.message}`);
+  dom.updateProcessButton(isProcessing);
+}
+
+export function renderConcurrencyStatus(aggregate?: AggregateProgress): void {
+  const { effective, selection } = getMaxConcurrentStatus();
+  const suffix = selection === "auto" ? " (Auto)" : "";
+
+  if (effective === null) {
+    dom.updateConcurrencyStatus("Max jobs: —");
+    return;
+  }
+
+  if (aggregate && (aggregate.activeJobs > 0 || aggregate.completedJobs > 0)) {
+    const completedSuffix =
+      aggregate.completedJobs > 0
+        ? ` • Completed ${aggregate.completedJobs}`
+        : "";
+    dom.updateConcurrencyStatus(
+      `Running ${aggregate.activeJobs} / Max ${effective}${suffix}${completedSuffix}`
+    );
+    return;
+  }
+
+  dom.updateConcurrencyStatus(`Max jobs: ${effective}${suffix}`);
+}
+
+export function renderJobList(
+  jobProgress: Map<string, JobProgress>,
+  onCancel: (id: string) => void
+): void {
+  const jobs = Array.from(jobProgress.values())
+    .sort((a, b) => b.lastUpdate - a.lastUpdate)
+    .map((job) => ({
+      id: job.jobId,
+      label: `${job.jobId.slice(0, 8)} • ${job.message}`,
+      stage: job.stage,
+      percentage: job.percentage,
+      onCancel: job.jobId === "default" ? undefined : onCancel,
+    }));
+
+  dom.renderJobList(jobs);
+}

--- a/src/ui/statusPanel/state.ts
+++ b/src/ui/statusPanel/state.ts
@@ -1,0 +1,87 @@
+export interface ProcessingStatus {
+  stage:
+  | "idle"
+  | "analyzing"
+  | "converting"
+  | "writing"
+  | "completed"
+  | "cancelled"
+  | "failed";
+  percentage: number;
+  message: string;
+  currentFile?: string;
+  etaSeconds?: number;
+}
+
+/** Per-job progress tracking for parallel batch processing */
+export interface JobProgress {
+  jobId: string;
+  stage: ProcessingStatus["stage"];
+  percentage: number;
+  message: string;
+  lastUpdate: number;
+}
+
+/** Aggregate progress across all active jobs */
+export interface AggregateProgress {
+  activeJobs: number;
+  completedJobs: number;
+  overallPercentage: number;
+}
+
+export function createInitialStatus(): ProcessingStatus {
+  return {
+    stage: "idle",
+    percentage: 0,
+    message: "Ready to process audiobook",
+  };
+}
+
+/** Calculate aggregate progress across all active jobs */
+export function calculateAggregateProgress(
+  jobProgress: Map<string, JobProgress>
+): AggregateProgress {
+  let activeJobs = 0;
+  let completedJobs = 0;
+  let totalPercentage = 0;
+
+  for (const job of jobProgress.values()) {
+    if (job.stage === "completed") {
+      completedJobs++;
+      totalPercentage += 100;
+    } else if (job.stage === "failed" || job.stage === "cancelled") {
+      // Don't count failed/cancelled in active or completed
+    } else {
+      activeJobs++;
+      totalPercentage += job.percentage;
+    }
+  }
+
+  const totalJobs = activeJobs + completedJobs;
+  // Simple average across active + completed jobs. This keeps the aggregate legible
+  // without over-weighting long-running jobs; consider a weighted strategy if we
+  // need time/progress proportionality later.
+  const overallPercentage = totalJobs > 0 ? totalPercentage / totalJobs : 0;
+
+  return {
+    activeJobs,
+    completedJobs,
+    overallPercentage: Math.round(overallPercentage * 10) / 10,
+  };
+}
+
+/** Derive aggregate stage from active jobs */
+export function deriveAggregateStage(
+  jobProgress: Map<string, JobProgress>
+): ProcessingStatus["stage"] {
+  const stages = Array.from(jobProgress.values()).map((job) => job.stage);
+
+  // Priority: failed > cancelled > converting > analyzing > writing > completed > idle
+  if (stages.includes("failed")) return "failed";
+  if (stages.includes("cancelled")) return "cancelled";
+  if (stages.includes("converting")) return "converting";
+  if (stages.includes("analyzing")) return "analyzing";
+  if (stages.includes("writing")) return "writing";
+  if (stages.includes("completed")) return "completed";
+  return "idle";
+}


### PR DESCRIPTION
## Summary
- split status panel logic into state/events/formatting/render/processing modules
- keep logic.ts as the entry point with no behavior changes
- document the updated module layout

## Testing
- not run (manual smoke test needed: run a processing job and verify status/progress updates)

Closes #119