### PR TITLE
feat: Implement Multi-Select and Bulk Metadata Editing (Issue #109)

### DIFF
--- a/docs/reports/pr-134-audit.md
+++ b/docs/reports/pr-134-audit.md
@@ -1,0 +1,67 @@
+**Findings**
+- Critical — Cmd+S bulk/single saves ignore edits because dirty tracking never activates (no `initMetadataFormEvents` call + selector targets missing `#metadata-form`), so `readMetadataForm({ onlyDirty: true })` yields `{}`; likely the reported “Save Failure.” `src/main.ts:134`, `src/main.ts:221`, `src/ui/metadataForm.ts:6`, `index.html:214`
+- High — Selection state can drift: deselecting the anchor leaves `selectedFileIndex` invalid and list mutations don’t update `selectedFileIndices`, so bulk apply can target the wrong files. `src/ui/fileList/selection.ts:58`, `src/ui/fileList/actions.ts:140`, `src/ui/fileList/events.ts:193`, `src/main.ts:195`
+- High — Cover art edits are dropped in Cmd+S because dirty-mode skips cover art entirely, so even single-file cover art changes never persist. `src/main.ts:221`, `src/ui/metadataForm.ts:102`
+- Medium — `metadataState` is no longer refreshed on selection change or after bulk save; batch processing can emit stale tags even after a successful save. `src/ui/fileList/actions.ts:61`, `src/main.ts:239`, `src/ui/statusPanel/processing.ts:159`
+- Medium — Dirty mode can’t clear numeric fields and several Issue #109 UX items are missing (Cmd+A/Escape, Apply to Selected button, selection count/placeholder), leaving bulk editing incomplete. `src/ui/metadataForm.ts:69`, `src/ui/fileList/selection.ts:94`, `src/ui/fileList/events.ts:97`, `index.html:214`
+- Low — `src/ui/fileList/actions.ts` remains 518 LOC (over the 400 guideline), so the refactor doesn’t meet the maintainability target. `src/ui/fileList/actions.ts:1`
+
+Tri-order impact: 1st‑order, edits appear saved but aren’t (and bulk apply can hit wrong files); 2nd‑order, users may unknowingly overwrite metadata and processing outputs can carry stale tags; 3rd‑order, trust erosion and higher cost for future bulk‑edit features.
+
+**User Clarifications (current session)**
+- Bulk cover art is out of scope for multi-select (no bulk cover art apply).
+- Multi-select intent: apply common metadata (author/series/narrator/etc) across selected files via Cmd+S; blank fields stay blank unless edited.
+- Mixed-value display desired: when multiple files selected, identical values show, blank stays blank, and mixed values expose a third-state control (e.g., "<keep>" / "<blank>") while still allowing edits (mp3tag-inspired).
+- Mixed-value UI should use explicit per-field dropdowns (keep/blank) plus normal editable inputs; dropdown choice defines what happens on Cmd+S or encoding.
+- If the year field is empty, it should be treated as empty on save/encode.
+- Selection change behavior: preserve cached edits in single-select; reset pending edits for multi-select when the selection set changes.
+- Multi-select Cmd+S with no dirty fields should be a no-op (single-select keeps current behavior).
+- Mixed-value display should read metadata for all selected files (use cache where available; async fetch for missing).
+
+**Engineering Decisions (locked)**
+- Cmd+S writes to disk and updates `metadataState` for selected files; Apply to Selected updates `metadataState` only (no disk writes).
+- Multi-select uses explicit per-field dropdowns for Keep/Blank plus normal editable inputs; dropdown choice defines apply behavior.
+- Multi-select Cmd+S is a no-op if no dirty fields; single-select keeps current behavior.
+- Mixed-value display reads metadata for all selected files (use cache when available; async fetch for missing).
+- Single-select preserves cached edits on selection change; multi-select resets pending edits when selection set changes.
+- Cover art is single-select only; multi-select ignores cover art changes.
+
+**Scope (Minimum Viable for this PR)**
+- Fix dirty-field tracking (initialize events + ensure selectors exist).
+- Selection integrity fixes (anchor updates, selection set updates on remove/reorder/sort/clear).
+- Cmd+A selects all; Escape clears selection.
+- Mixed-value computation for selected files (same/blank/mixed) with Keep/Blank dropdowns + editable inputs.
+- Apply to Selected button (metadataState only) + Cmd+S (disk + metadataState).
+- Selection count label in UI near metadata context header.
+- Backend support for clearing year (mp4ameta remove_year + ffmpeg dict removal path).
+
+**UI Placement (locked)**
+- Apply to Selected lives in the metadata section directly under the Description field, right-aligned, matching the Output “Browse” button style and color.
+
+**Implementation Status (post-fix)**
+- Metadata form now supports multi-select mode with Keep/Blank dropdowns, mixed-value placeholders, and a selection count label.
+- Added Apply to Selected (metadataState-only) and Cmd+S persists to disk + metadataState (single file or multi-select).
+- Selection logic refreshed (anchor handling, reorder/remove reindex, select-all/Cmd+A, Escape clear) and metadata panel split for clarity.
+- Multi-select reads metadata for all selected files (cache-first, async fetch for missing), cover art remains single-select.
+- Year clearing implemented in backend (mp4ameta `remove_year` + ffmpeg dict removal for `date`/`year`).
+
+**Open Questions (remaining)**
+- None.
+
+**Applied Changes**
+- Wired dirty tracking (`#metadata-form`, `initMetadataFormEvents`, reset after save/apply).
+- Kept selection state consistent across remove/reorder/sort/clear and maintained anchor.
+- Added mixed-value display with Keep/Blank controls plus editable inputs for multi-select.
+- Preserved cover art as single-select only; multi-select ignores cover art.
+- Implemented numeric clearing (year = 0) with mp4ameta + ffmpeg dict removal, synced `metadataState` after apply/save.
+- Added UX affordances and tests (Cmd+A/Escape, Apply button, selection count, selection unit tests).
+
+**Quality Rating**
+- Original PR: Design 2/5 · Practice 2/5 · Code & Solution Quality 2/5 — core flows were incomplete, state drifted, and tests/guardrails were missing.
+- Post-fix: Design 4/5 · Practice 4/5 · Code & Solution Quality 4/5 — core flows implemented with tests; remaining gaps are minor polish.
+
+**Tests & Checks**
+- `scripts/quick-checks.sh` (cargo fmt/clippy, ensure-contract, tsc)
+- `bun run test`
+- `cargo test` (from `src-tauri/`)
+  - Note: ffmpeg/codec warnings observed in test logs; tests still passed.

--- a/index.html
+++ b/index.html
@@ -161,6 +161,12 @@
             <div class="section-header">
               <h3>Metadata Manager</h3>
             </div>
+            <div
+              id="metadata-selection-count"
+              class="text-xs muted-text mb-2"
+              hidden
+            ></div>
+            <div id="metadata-form" data-multi-select="false">
             <div class="grid grid-cols-4 gap-3 mb-3">
               <!-- Cover art - aligned with metadata grid -->
               <div class="col-span-1 flex flex-col items-center">
@@ -215,7 +221,17 @@
               <div class="col-span-3">
                 <div class="grid grid-cols-4 gap-x-3 gap-y-1.5">
                   <div class="col-span-3">
-                    <label for="meta-title">Book Title</label>
+                    <div class="meta-field-header">
+                      <label for="meta-title">Book Title</label>
+                      <select
+                        id="meta-title-action"
+                        class="meta-apply-select"
+                        data-testid="meta-title-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input
                       type="text"
                       id="meta-title"
@@ -223,11 +239,31 @@
                     />
                   </div>
                   <div class="col-span-1">
-                    <label for="meta-year">Year</label>
+                    <div class="meta-field-header">
+                      <label for="meta-year">Year</label>
+                      <select
+                        id="meta-year-action"
+                        class="meta-apply-select"
+                        data-testid="meta-year-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input type="text" id="meta-year" placeholder="2007" />
                   </div>
                   <div class="col-span-2">
-                    <label for="meta-author">Author</label>
+                    <div class="meta-field-header">
+                      <label for="meta-author">Author</label>
+                      <select
+                        id="meta-author-action"
+                        class="meta-apply-select"
+                        data-testid="meta-author-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input
                       type="text"
                       id="meta-author"
@@ -235,7 +271,17 @@
                     />
                   </div>
                   <div class="col-span-2">
-                    <label for="meta-narrator">Narrator</label>
+                    <div class="meta-field-header">
+                      <label for="meta-narrator">Narrator</label>
+                      <select
+                        id="meta-narrator-action"
+                        class="meta-apply-select"
+                        data-testid="meta-narrator-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input
                       type="text"
                       id="meta-narrator"
@@ -243,7 +289,17 @@
                     />
                   </div>
                   <div class="col-span-2">
-                    <label for="meta-series">Series</label>
+                    <div class="meta-field-header">
+                      <label for="meta-series">Series</label>
+                      <select
+                        id="meta-series-action"
+                        class="meta-apply-select"
+                        data-testid="meta-series-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input
                       type="text"
                       id="meta-series"
@@ -251,15 +307,45 @@
                     />
                   </div>
                   <div class="col-span-1">
-                    <label for="meta-series-part">Book #</label>
+                    <div class="meta-field-header">
+                      <label for="meta-series-part">Book #</label>
+                      <select
+                        id="meta-series-part-action"
+                        class="meta-apply-select"
+                        data-testid="meta-series-part-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input type="text" id="meta-series-part" placeholder="1" />
                   </div>
                   <div class="col-span-1">
-                    <label for="meta-genre">Genre</label>
+                    <div class="meta-field-header">
+                      <label for="meta-genre">Genre</label>
+                      <select
+                        id="meta-genre-action"
+                        class="meta-apply-select"
+                        data-testid="meta-genre-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <input type="text" id="meta-genre" placeholder="Fantasy" />
                   </div>
                   <div class="col-span-4">
-                    <label for="meta-description">Description</label>
+                    <div class="meta-field-header">
+                      <label for="meta-description">Description</label>
+                      <select
+                        id="meta-description-action"
+                        class="meta-apply-select"
+                        data-testid="meta-description-action"
+                      >
+                        <option value="keep">Keep</option>
+                        <option value="blank">Blank</option>
+                      </select>
+                    </div>
                     <textarea
                       id="meta-description"
                       rows="2"
@@ -267,7 +353,17 @@
                     ></textarea>
                   </div>
                 </div>
+                <div class="metadata-apply-row">
+                  <button
+                    id="metadata-apply-btn"
+                    class="btn-pill btn-pill-primary-soft"
+                    data-testid="metadata-apply-btn"
+                  >
+                    Apply to Selected
+                  </button>
+                </div>
               </div>
+            </div>
             </div>
 
             <!-- AUDIO ENCODER SETTINGS SECTION -->

--- a/src-tauri/src/metadata/ffmpeg_dict.rs
+++ b/src-tauri/src/metadata/ffmpeg_dict.rs
@@ -46,8 +46,10 @@ pub fn metadata_to_ffmpeg_dict(metadata: &AudiobookMetadata) -> Result<ff::Dicti
     }
 
     if let Some(date) = metadata.date {
-        dict.set("date", &date.to_string());
-        dict.set("year", &date.to_string()); // Some containers prefer year
+        if date > 0 {
+            dict.set("date", &date.to_string());
+            dict.set("year", &date.to_string()); // Some containers prefer year
+        }
     }
 
     if let Some(ref comment) = metadata.comment {
@@ -157,6 +159,10 @@ fn should_remove_key(metadata: &AudiobookMetadata, key: &str) -> bool {
         .map(|value| value.trim().is_empty())
         .unwrap_or(false);
     if description_clear && key == "description" {
+        return true;
+    }
+
+    if metadata.date == Some(0) && matches!(key, "date" | "year") {
         return true;
     }
 

--- a/src-tauri/src/metadata/mp4ameta_bridge.rs
+++ b/src-tauri/src/metadata/mp4ameta_bridge.rs
@@ -78,7 +78,11 @@ fn apply_metadata(tag: &mut Tag, metadata: &AudiobookMetadata) -> Result<()> {
     }
 
     if let Some(date) = metadata.date {
-        tag.set_year(date.to_string());
+        if date == 0 {
+            tag.remove_year();
+        } else {
+            tag.set_year(date.to_string());
+        }
     }
 
     if let Some(ref comment) = metadata.comment {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { bridge } from "./lib/bridge";
 import type { AudiobookMetadata } from "./types/metadata";
-import type { FileListInfo, EncoderSettings } from "./types/audio";
+import type { FileListInfo, EncoderSettings, AudioFile } from "./types/audio";
 import { initFileImport } from "./ui/fileImport";
 import {
   displayFileList,
@@ -11,6 +11,7 @@ import {
   moveFileUp,
   moveFileDown,
 } from "./ui/fileList";
+import { getSelectedFileIndices } from "./ui/fileList/state";
 import {
   initOutputPanel,
   getCurrentOutputConfig,
@@ -24,10 +25,11 @@ import {
   getCurrentCoverArt,
   setCoverArt,
   clearCoverArt,
-  isCoverArtRemovalRequested,
 } from "./ui/coverArt";
+import { readMetadataForm, initMetadataFormEvents, resetDirtyState } from "./ui/metadataForm";
 import { initTagPreview, updateTagPreview } from "./ui/tagPreview";
 import { initJobControls } from "./ui/jobControls";
+import { setMetadataForFile } from "./ui/metadataState";
 
 // Expose test functions for console access
 (window as any).testCommands = {
@@ -137,6 +139,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initOutputPanel();
   initStatusPanel();
   initCoverArt();
+  initMetadataFormEvents();
   // Initialize Advanced Encoder panel (no-op if panel not present)
   initEncoderPanel();
   // Initialize tag preview grid
@@ -157,9 +160,9 @@ document.addEventListener("DOMContentLoaded", () => {
  * Initializes the Cmd+S / Ctrl+S keyboard handler for metadata-only saving
  *
  * When triggered:
- * 1. Collects metadata from the form
- * 2. Computes TSOA on the backend
- * 3. Saves metadata to the loaded file(s) without audio processing
+ * 1. Collects DIRTY metadata changes from the form
+ * 2. Applies changes to ALL selected files (Read-Merge-Write pattern)
+ * 3. Saves each file
  */
 function initMetadataSaveHandler(): void {
   document.addEventListener("keydown", async (event) => {
@@ -180,48 +183,93 @@ function initMetadataSaveHandler(): void {
         return;
       }
 
-      // Get the file to save metadata to. Prioritize the selected file.
-      let fileToSave = null;
-      if (
-        selectedFileIndex > -1 &&
-        currentFileList.files[selectedFileIndex]?.isValid
-      ) {
-        fileToSave = currentFileList.files[selectedFileIndex];
+      // Determine target files
+      const selectedIndices = getSelectedFileIndices();
+      let targetFiles: AudioFile[] = [];
+
+      if (selectedIndices.size > 0) {
+        targetFiles = Array.from(selectedIndices)
+          .map((i) => currentFileList!.files[i])
+          .filter((f) => f && f.isValid);
       } else {
-        fileToSave = currentFileList.files.find((f) => f.isValid);
+        if (
+          selectedFileIndex > -1 &&
+          currentFileList.files[selectedFileIndex]?.isValid
+        ) {
+          targetFiles = [currentFileList.files[selectedFileIndex]];
+        } else {
+          const first = currentFileList.files.find((f) => f.isValid);
+          if (first) targetFiles = [first];
+        }
       }
 
-      if (!fileToSave) {
+      if (targetFiles.length === 0) {
         console.log("No valid files to save metadata to");
         return;
       }
 
-      // Collect metadata from the form
-      const metadata = collectMetadataFromForm();
+      const isMultiSelect = selectedIndices.size > 1;
+      const metadataPayload = isMultiSelect
+        ? readMetadataForm({ mode: "multi", onlyDirty: true })
+        : readMetadataForm({ mode: "single" });
+
+      const hasChanges = Object.keys(metadataPayload).length > 0;
+      if (!hasChanges && isMultiSelect) {
+        console.log("No metadata changes detected (multi-select).");
+        return;
+      }
 
       try {
-        console.log("Saving metadata to:", fileToSave.path);
-        await bridge.invoke("save_metadata_to_file", {
-          filePath: fileToSave.path,
-          metadata: metadata,
-        });
-        console.log("Metadata saved successfully");
+        let successCount = 0;
 
-        // Update status text briefly to indicate success
+        if (isMultiSelect) {
+          for (const file of targetFiles) {
+            console.log(`Processing save for ${file.path}...`);
+
+            const currentMeta = await bridge.invoke<AudiobookMetadata>(
+              "read_audio_metadata",
+              { filePath: file.path }
+            );
+
+            const merged = { ...currentMeta, ...metadataPayload };
+
+            await bridge.invoke("save_metadata_to_file", {
+              filePath: file.path,
+              metadata: merged,
+            });
+
+            setMetadataForFile(file.path, merged);
+            successCount++;
+          }
+        } else {
+          const file = targetFiles[0];
+          await bridge.invoke("save_metadata_to_file", {
+            filePath: file.path,
+            metadata: metadataPayload,
+          });
+          setMetadataForFile(file.path, metadataPayload);
+          successCount = 1;
+        }
+
+        resetDirtyState();
+        console.log(`Metadata saved successfully for ${successCount} files`);
+
         const statusText = document.getElementById("status-text");
         if (statusText) {
           const originalText = statusText.textContent;
-          statusText.textContent = "Metadata saved!";
-          // Fix race condition: only restore if still showing "Metadata saved!"
+          const msg =
+            targetFiles.length > 1
+              ? `Metadata saved (${successCount} files)!`
+              : "Metadata saved!";
+          statusText.textContent = msg;
           setTimeout(() => {
-            if (statusText.textContent === "Metadata saved!") {
+            if (statusText.textContent === msg) {
               statusText.textContent = originalText;
             }
           }, 2000);
         }
       } catch (error) {
         console.error("Failed to save metadata:", error);
-        // Show error to user
         const statusText = document.getElementById("status-text");
         if (statusText) {
           statusText.textContent = "Save failed - see console";
@@ -229,53 +277,4 @@ function initMetadataSaveHandler(): void {
       }
     }
   });
-}
-
-/**
- * Collects metadata from the form fields and returns an AudiobookMetadata object
- */
-export function collectMetadataFromForm(): AudiobookMetadata {
-  const getElementValue = (id: string): string => {
-    const element = document.getElementById(id) as
-      | HTMLInputElement
-      | HTMLTextAreaElement;
-    return element?.value?.trim() || "";
-  };
-
-  const title = getElementValue("meta-title");
-  const author = getElementValue("meta-author");
-  const narrator = getElementValue("meta-narrator");
-  const year = getElementValue("meta-year");
-  const genre = getElementValue("meta-genre");
-  const series = getElementValue("meta-series");
-  const seriesPart = getElementValue("meta-series-part");
-  const description = getElementValue("meta-description");
-
-  const metadata: AudiobookMetadata = {};
-
-  // Map form fields to Rust struct field names
-  if (title) {
-    metadata.title = title;
-    metadata.album = title; // Album = Title for audiobooks
-  }
-  if (author) metadata.artist = author; // artist = Author
-  if (narrator) metadata.composer = narrator; // composer = Narrator
-  if (year) {
-    const yearNum = parseInt(year);
-    if (!isNaN(yearNum)) metadata.date = yearNum; // date = Year
-  }
-  if (genre) metadata.genre = genre;
-  metadata.series = series;
-  metadata.series_part = seriesPart;
-  metadata.description = description;
-
-  // Include cover art if present
-  const coverBytes = getCurrentCoverArt();
-  if (isCoverArtRemovalRequested()) {
-    metadata.cover_art = [];
-  } else if (coverBytes && coverBytes.length > 0) {
-    metadata.cover_art = coverBytes;
-  }
-
-  return metadata;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -617,6 +617,40 @@ textarea:hover:not(:focus) {
   background-color: var(--bg-hover);
 }
 
+/* Metadata bulk apply controls */
+.meta-field-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.meta-field-header label {
+  margin-bottom: 0;
+}
+
+.meta-apply-select {
+  width: auto;
+  padding: 0.2rem 0.55rem;
+  border-radius: 9999px;
+  border-style: solid;
+  border-width: 1px;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  box-shadow: none;
+}
+
+#metadata-form[data-multi-select="false"] .meta-apply-select,
+#metadata-form[data-multi-select="false"] .metadata-apply-row {
+  display: none;
+}
+
+.metadata-apply-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
 /* Property labels/values */
 .property-label {
   font-weight: 500;

--- a/src/ui/__tests__/fileList-selection.test.ts
+++ b/src/ui/__tests__/fileList-selection.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  handleSelection,
+  selectAllFiles,
+  clearSelection,
+  reindexSelectionAfterRemoval,
+  reindexSelectionAfterMove,
+  swapSelectionIndices,
+} from "../fileList/selection";
+import {
+  currentFileList,
+  selectedFileIndex,
+  setCurrentFileList,
+  setSelectedIndex,
+  setSelectedFileIndices,
+  clearSelectedIndices,
+  getSelectedFileIndices,
+} from "../fileList/state";
+import type { AudioFile, FileListInfo } from "../../types/audio";
+
+const makeFileList = (count: number): FileListInfo => {
+  const files: AudioFile[] = Array.from({ length: count }, (_, index) => ({
+    path: `/tmp/file-${index}.m4b`,
+    isValid: true,
+  }));
+
+  return {
+    files,
+    totalDuration: 0,
+    totalSize: 0,
+    validCount: count,
+    invalidCount: 0,
+  };
+};
+
+const selectedIndices = (): number[] =>
+  Array.from(getSelectedFileIndices()).sort((a, b) => a - b);
+
+describe("file list selection", () => {
+  beforeEach(() => {
+    setCurrentFileList(makeFileList(5));
+    clearSelectedIndices();
+    setSelectedIndex(-1);
+  });
+
+  it("selects a single item and updates anchor", () => {
+    const result = handleSelection(2, { multi: false, range: false });
+
+    expect(result.changed).toBe(true);
+    expect(selectedIndices()).toEqual([2]);
+    expect(selectedFileIndex).toBe(2);
+  });
+
+  it("toggles multi-select and maintains anchor", () => {
+    handleSelection(1, { multi: false, range: false });
+    handleSelection(3, { multi: true, range: false });
+
+    expect(selectedIndices()).toEqual([1, 3]);
+    expect(selectedFileIndex).toBe(3);
+
+    handleSelection(3, { multi: true, range: false });
+
+    expect(selectedIndices()).toEqual([1]);
+    expect(selectedFileIndex).toBe(1);
+  });
+
+  it("selects a range from the anchor", () => {
+    handleSelection(1, { multi: false, range: false });
+    handleSelection(3, { multi: false, range: true });
+
+    expect(selectedIndices()).toEqual([1, 2, 3]);
+    expect(selectedFileIndex).toBe(3);
+  });
+
+  it("selects all files", () => {
+    const changed = selectAllFiles();
+
+    expect(changed).toBe(true);
+    expect(selectedIndices()).toEqual([0, 1, 2, 3, 4]);
+    expect(selectedFileIndex).toBe(0);
+  });
+
+  it("clears selection", () => {
+    handleSelection(2, { multi: false, range: false });
+
+    const changed = clearSelection();
+
+    expect(changed).toBe(true);
+    expect(selectedIndices()).toEqual([]);
+    expect(selectedFileIndex).toBe(-1);
+  });
+
+  it("reindexes selection after removal", () => {
+    setSelectedFileIndices([1, 3, 4]);
+    setSelectedIndex(4);
+
+    reindexSelectionAfterRemoval(2);
+
+    expect(selectedIndices()).toEqual([1, 2, 3]);
+    expect(selectedFileIndex).toBe(3);
+  });
+
+  it("reindexes selection after move", () => {
+    setSelectedFileIndices([1, 4]);
+    setSelectedIndex(4);
+
+    reindexSelectionAfterMove(1, 3);
+
+    expect(selectedIndices()).toEqual([3, 4]);
+    expect(selectedFileIndex).toBe(4);
+  });
+
+  it("swaps selection indices and anchor", () => {
+    setSelectedFileIndices([1, 3]);
+    setSelectedIndex(1);
+
+    swapSelectionIndices(1, 2);
+
+    expect(selectedIndices()).toEqual([2, 3]);
+    expect(selectedFileIndex).toBe(2);
+  });
+
+  it("ignores out-of-bounds selections", () => {
+    const result = handleSelection(9, { multi: false, range: false });
+
+    expect(result.changed).toBe(false);
+    expect(currentFileList?.files.length).toBe(5);
+    expect(selectedIndices()).toEqual([]);
+  });
+});

--- a/src/ui/__tests__/metadata-save.test.ts
+++ b/src/ui/__tests__/metadata-save.test.ts
@@ -3,29 +3,41 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 let coverArtBytes: number[] | null = null;
 let coverRemoval = false;
 
-vi.mock('../../ui/coverArt', () => ({
+vi.mock('../coverArt', () => ({
   getCurrentCoverArt: () => coverArtBytes,
+  getHasCustomCoverArt: () => false,
   isCoverArtRemovalRequested: () => coverRemoval,
+  setCoverArt: () => {},
 }));
 
-import { collectMetadataFromForm } from '../../main';
+import { readMetadataForm } from '../metadataForm';
 
 const setField = (id: string, value: string) => {
   const el = document.getElementById(id) as HTMLInputElement | HTMLTextAreaElement | null;
   if (el) el.value = value;
 };
 
-describe('collectMetadataFromForm', () => {
+describe('readMetadataForm (single mode)', () => {
   beforeEach(() => {
     document.body.innerHTML = `
-      <input id="meta-title" />
-      <input id="meta-author" />
-      <input id="meta-narrator" />
-      <input id="meta-year" />
-      <input id="meta-genre" />
-      <input id="meta-series" />
-      <input id="meta-series-part" />
-      <textarea id="meta-description"></textarea>
+      <div id="metadata-form">
+        <input id="meta-title" />
+        <select id="meta-title-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-author" />
+        <select id="meta-author-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-narrator" />
+        <select id="meta-narrator-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-year" />
+        <select id="meta-year-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-genre" />
+        <select id="meta-genre-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-series" />
+        <select id="meta-series-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-series-part" />
+        <select id="meta-series-part-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <textarea id="meta-description"></textarea>
+        <select id="meta-description-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+      </div>
     `;
     coverArtBytes = null;
     coverRemoval = false;
@@ -42,7 +54,7 @@ describe('collectMetadataFromForm', () => {
     setField('meta-description', 'Desc');
     coverArtBytes = [1, 2, 3];
 
-    const metadata = collectMetadataFromForm();
+    const metadata = readMetadataForm({ mode: 'single' });
 
     expect(metadata).toMatchObject({
       title: 'Title',
@@ -61,16 +73,63 @@ describe('collectMetadataFromForm', () => {
   it('emits empty cover_art array when removal requested', () => {
     coverRemoval = true;
 
-    const metadata = collectMetadataFromForm();
+    const metadata = readMetadataForm({ mode: 'single' });
 
     expect(metadata.cover_art).toEqual([]);
   });
 
   it('includes empty strings for clearable metadata fields', () => {
-    const metadata = collectMetadataFromForm();
+    const metadata = readMetadataForm({ mode: 'single' });
 
     expect(metadata.series).toBe('');
     expect(metadata.series_part).toBe('');
     expect(metadata.description).toBe('');
+  });
+});
+
+describe('readMetadataForm (multi mode)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="metadata-form" data-multi-select="true">
+        <input id="meta-title" />
+        <select id="meta-title-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-author" />
+        <select id="meta-author-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-narrator" />
+        <select id="meta-narrator-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-year" />
+        <select id="meta-year-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-genre" />
+        <select id="meta-genre-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-series" />
+        <select id="meta-series-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <input id="meta-series-part" />
+        <select id="meta-series-part-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+        <textarea id="meta-description"></textarea>
+        <select id="meta-description-action"><option value="keep">Keep</option><option value="blank">Blank</option></select>
+      </div>
+    `;
+  });
+
+  it('uses bulk blank actions for multi-select', () => {
+    const yearAction = document.getElementById('meta-year-action') as HTMLSelectElement;
+    yearAction.value = 'blank';
+
+    const metadata = readMetadataForm({ mode: 'multi', onlyDirty: true });
+
+    expect(metadata.date).toBe(0);
+  });
+
+  it('applies edited values in multi-select mode', () => {
+    const titleInput = document.getElementById('meta-title') as HTMLInputElement;
+    titleInput.value = 'New Title';
+    titleInput.dataset.dirty = 'true';
+
+    const metadata = readMetadataForm({ mode: 'multi', onlyDirty: true });
+
+    expect(metadata).toMatchObject({
+      title: 'New Title',
+      album: 'New Title',
+    });
   });
 });

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -1,16 +1,18 @@
-import { AudioFile, FileListInfo, formatFileSize } from "../../types/audio";
-import { bridge } from "../../lib/bridge";
-import { onFileListChange, onMetadataChange } from "../outputPanel";
-import { setCoverArt, getHasCustomCoverArt, clearCoverArt } from "../coverArt";
-import type { AudiobookMetadata } from "../../types/metadata";
-import { readMetadataForm } from "../metadataForm";
+import type { AudioFile, FileListInfo } from "../../types/audio";
+import {
+  onFileListChange,
+  onMetadataChange,
+} from "../outputPanel";
 import {
   clearMetadataState,
   getMetadataForFile,
   removeMetadataForFile,
   setMetadataForFile,
 } from "../metadataState";
-import { updateTagPreview } from "../tagPreview";
+import {
+  readMetadataForm,
+  resetDirtyState,
+} from "../metadataForm";
 import {
   currentFileList,
   selectedFileIndex,
@@ -31,56 +33,177 @@ import {
   setOrderLockNotice,
 } from "./dom";
 import { initFileListEvents, setupDragStartHandlers } from "./events";
+import {
+  clearSelection,
+  handleSelection,
+  reindexSelectionAfterMove,
+  reindexSelectionAfterRemoval,
+  selectAllFiles,
+  swapSelectionIndices,
+} from "./selection";
+import {
+  autoUpdateCoverArtFromFirstValidFile,
+  clearSelectionPanels,
+  ensureMetadataForFiles,
+  getSelectedFiles,
+  showMultiSelection,
+  showSingleSelection,
+} from "./metadataPanel";
 
 export function displayFileList(fileListInfo: FileListInfo): void {
   clearMetadataState();
   setCurrentFileList(fileListInfo);
 
-  // Update DOM (includes drop zone state update)
   updateFileListDOM();
-
-  // Initialize events (includes drag handlers)
   initFileListEvents();
 
-  // Update stats and buttons
   updateTotalStats();
   updateButtonVisibility();
   updateSortButtonText(getSortAscending());
 
-  // Notify other components
   onFileListChange();
 
-  // Auto-load cover art from the first valid file unless the user has
-  // already provided custom cover art
   void autoUpdateCoverArtFromFirstValidFile();
 }
 
-export function selectFile(index: number): void {
-  if (!currentFileList || index < 0 || index >= currentFileList.files.length)
-    return;
+function persistSingleSelectionMetadata(file: AudioFile | null): void {
+  if (!file?.isValid) return;
 
+  const metadata = readMetadataForm({ mode: "single" });
+  setMetadataForFile(file.path, metadata);
+}
+
+export function selectFile(
+  index: number,
+  modifiers?: { multi: boolean; range: boolean }
+): void {
+  if (!currentFileList || index < 0 || index >= currentFileList.files.length) {
+    return;
+  }
+
+  const previousSelectionCount = getSelectedFiles().length;
+  const previousIndex = selectedFileIndex;
   const previousFile =
-    selectedFileIndex >= 0 ? currentFileList.files[selectedFileIndex] : null;
-  if (previousFile?.isValid) {
-    setMetadataForFile(previousFile.path, readMetadataForm());
+    previousSelectionCount === 1 && currentFileList
+      ? currentFileList.files[previousIndex] ?? null
+      : null;
+
+  const selectionResult = handleSelection(index, modifiers || { multi: false, range: false });
+  if (!selectionResult.changed) return;
+
+  if (previousSelectionCount === 1 && previousIndex >= 0) {
+    persistSingleSelectionMetadata(previousFile);
   }
 
-  setSelectedIndex(index);
   updateSelection();
-  const nextFile = currentFileList.files[index];
-  const storedMetadata = getMetadataForFile(nextFile.path);
-  if (storedMetadata) {
-    updateFileProperties(nextFile, { skipMetadataLoad: true });
-    populateMetadataForm(storedMetadata);
+
+  const selectedFiles = getSelectedFiles();
+  const count = selectedFiles.length;
+
+  if (count === 0) {
+    setSelectedIndex(-1);
+    clearSelectionPanels();
     return;
   }
-  updateFileProperties(nextFile);
+
+  if (count === 1) {
+    void showSingleSelection(selectedFiles[0]);
+    return;
+  }
+
+  void showMultiSelection(selectedFiles);
+}
+
+export function selectAll(): void {
+  if (!currentFileList) return;
+  const previousFile =
+    getSelectedFiles().length === 1 && selectedFileIndex >= 0
+      ? currentFileList.files[selectedFileIndex] ?? null
+      : null;
+  persistSingleSelectionMetadata(previousFile);
+
+  const changed = selectAllFiles();
+  if (!changed) return;
+
+  updateSelection();
+  const selectedFiles = getSelectedFiles();
+  if (selectedFiles.length > 1) {
+    void showMultiSelection(selectedFiles);
+  } else if (selectedFiles.length === 1) {
+    void showSingleSelection(selectedFiles[0]);
+  }
+}
+
+export function clearSelectionAction(): void {
+  const fileList = currentFileList;
+  const previousFile =
+    fileList && getSelectedFiles().length === 1 && selectedFileIndex >= 0
+      ? fileList.files[selectedFileIndex] ?? null
+      : null;
+  persistSingleSelectionMetadata(previousFile);
+
+  const changed = clearSelection();
+  if (!changed) return;
+
+  updateSelection();
+  clearSelectionPanels();
+}
+
+async function applyMetadataToSelection(): Promise<void> {
+  if (!currentFileList) return;
+
+  const selectedFiles = getSelectedFiles().filter((file) => file.isValid);
+  if (selectedFiles.length === 0) return;
+
+  const changes = readMetadataForm({ mode: "multi", onlyDirty: true });
+  if (Object.keys(changes).length === 0) {
+    const statusText = document.getElementById("status-text");
+    if (statusText) {
+      statusText.textContent = "No metadata changes to apply";
+    }
+    return;
+  }
+
+  await ensureMetadataForFiles(selectedFiles);
+
+  selectedFiles.forEach((file) => {
+    const existing = getMetadataForFile(file.path) ?? {};
+    const merged = { ...existing, ...changes };
+    setMetadataForFile(file.path, merged);
+  });
+
+  resetDirtyState();
+  onMetadataChange();
+
+  const statusText = document.getElementById("status-text");
+  if (statusText) {
+    const originalText = statusText.textContent;
+    const msg = `Applied to ${selectedFiles.length} files`;
+    statusText.textContent = msg;
+    setTimeout(() => {
+      if (statusText.textContent === msg) {
+        statusText.textContent = originalText;
+      }
+    }, 2000);
+  }
+}
+
+export function initMetadataApplyHandler(): void {
+  const applyButton = document.getElementById(
+    "metadata-apply-btn"
+  ) as HTMLButtonElement | null;
+  if (!applyButton) return;
+
+  applyButton.addEventListener("click", () => {
+    void applyMetadataToSelection();
+  });
 }
 
 export function removeFile(index: number): void {
   if (isOrderLocked()) return;
-  if (!currentFileList || index < 0 || index >= currentFileList.files.length)
+  if (!currentFileList || index < 0 || index >= currentFileList.files.length) {
     return;
+  }
 
   const removedFile = currentFileList.files[index];
   removeMetadataForFile(removedFile.path);
@@ -95,11 +218,16 @@ export function removeFile(index: number): void {
   recalculateTotals();
   updateFileListDOM();
 
-  if (selectedFileIndex === index) {
-    setSelectedIndex(-1);
-    clearFileProperties();
-  } else if (selectedFileIndex > index) {
-    setSelectedIndex(selectedFileIndex - 1);
+  reindexSelectionAfterRemoval(index);
+  updateSelection();
+
+  const remainingSelection = getSelectedFiles();
+  if (remainingSelection.length === 0) {
+    clearSelectionPanels();
+  } else if (remainingSelection.length === 1) {
+    void showSingleSelection(remainingSelection[0]);
+  } else {
+    void showMultiSelection(remainingSelection);
   }
 
   onFileListChange();
@@ -121,271 +249,52 @@ export function recalculateTotals(): void {
   );
 }
 
-export function updateFileProperties(
-  file: AudioFile,
-  options?: { skipMetadataLoad?: boolean }
-): void {
-  const bitrateEl = document.getElementById("prop-bitrate");
-  const sampleRateEl = document.getElementById("prop-samplerate");
-  const channelsEl = document.getElementById("prop-channels");
-  const fileSizeEl = document.getElementById("prop-filesize");
-
-  if (file.isValid) {
-    // Display technical audio properties
-    if (bitrateEl)
-      bitrateEl.textContent = file.bitrate ? `${file.bitrate} kb/s` : "N/A";
-    if (sampleRateEl)
-      sampleRateEl.textContent = file.sampleRate
-        ? `${file.sampleRate} Hz`
-        : "N/A";
-    if (channelsEl)
-      channelsEl.textContent = file.channels ? `${file.channels} ch` : "N/A";
-    if (fileSizeEl)
-      fileSizeEl.textContent = file.size ? formatFileSize(file.size) : "N/A";
-
-    if (!options?.skipMetadataLoad) {
-      // Still load metadata for the metadata form
-      loadFileMetadata(file.path);
-    }
-  } else {
-    // File is invalid, show dashes
-    if (bitrateEl) bitrateEl.textContent = "---";
-    if (sampleRateEl) sampleRateEl.textContent = "---";
-    if (channelsEl) channelsEl.textContent = "---";
-    if (fileSizeEl) fileSizeEl.textContent = "---";
-  }
-
-  // Update context header
-  updatePropertiesContext(file, selectedFileIndex);
-}
-
-function updatePropertiesContext(file: AudioFile, index: number): void {
-  const contextEl = document.getElementById("prop-selected-context");
-  if (!contextEl) return;
-
-  // Clear existing content using replaceChildren() for better DX (structural change only)
-  contextEl.replaceChildren();
-
-  if (!currentFileList || index < 0 || index >= currentFileList.files.length) {
-    // Empty state
-    const emptySpan = document.createElement("span");
-    emptySpan.className = "context-empty";
-    emptySpan.textContent = "No file selected";
-    contextEl.appendChild(emptySpan);
-    return;
-  }
-
-  // File selected state - build structured display
-  const fileName = file.path.split(/[\\\/]/).pop() || file.path;
-  const totalFiles = currentFileList.files.length;
-
-  // Filename span with truncation
-  const filenameSpan = document.createElement("span");
-  filenameSpan.className = "context-filename";
-  filenameSpan.title = fileName; // Full name on hover
-  filenameSpan.textContent = fileName;
-
-  // Position badge
-  const posSpan = document.createElement("span");
-  posSpan.className = "context-position";
-  posSpan.textContent = `${index + 1} of ${totalFiles}`;
-
-  contextEl.appendChild(filenameSpan);
-  contextEl.appendChild(posSpan);
-}
-
-async function loadFileMetadata(filePath: string): Promise<void> {
-  try {
-    const metadata = await bridge.invoke<AudiobookMetadata>(
-      "read_audio_metadata",
-      { filePath: filePath }
-    );
-    setMetadataForFile(filePath, metadata);
-    populateMetadataForm(metadata);
-  } catch (error) {
-    console.warn("Failed to load metadata:", error);
-  }
-}
-
-/**
- * Populates the metadata form with values from the backend
- *
- * Field mapping from Rust AudiobookMetadata:
- * - artist → Author
- * - composer → Narrator
- * - date → Year
- * - series → Series
- * - series_part → Book #
- */
-function populateMetadataForm(metadata: Partial<AudiobookMetadata>): void {
-  const titleEl = document.getElementById("meta-title") as HTMLInputElement;
-  const authorEl = document.getElementById("meta-author") as HTMLInputElement;
-  const narratorEl = document.getElementById(
-    "meta-narrator"
-  ) as HTMLInputElement;
-  const yearEl = document.getElementById("meta-year") as HTMLInputElement;
-  const genreEl = document.getElementById("meta-genre") as HTMLInputElement;
-  const seriesEl = document.getElementById("meta-series") as HTMLInputElement;
-  const seriesPartEl = document.getElementById(
-    "meta-series-part"
-  ) as HTMLInputElement;
-  const descriptionEl = document.getElementById(
-    "meta-description"
-  ) as HTMLTextAreaElement;
-
-  // Clear existing values first to avoid stale data
-  if (titleEl) titleEl.value = "";
-  if (authorEl) authorEl.value = "";
-  if (narratorEl) narratorEl.value = "";
-  if (yearEl) yearEl.value = "";
-  if (genreEl) genreEl.value = "";
-  if (seriesEl) seriesEl.value = "";
-  if (seriesPartEl) seriesPartEl.value = "";
-  if (descriptionEl) descriptionEl.value = "";
-
-  // Populate with new values using correct Rust field names
-  if (titleEl && metadata.title) titleEl.value = metadata.title;
-  if (authorEl && metadata.artist) authorEl.value = metadata.artist; // artist = Author
-  if (narratorEl && metadata.composer) narratorEl.value = metadata.composer; // composer = Narrator
-  if (yearEl && metadata.date) yearEl.value = metadata.date.toString(); // date = Year
-  if (genreEl && metadata.genre) genreEl.value = metadata.genre;
-  if (seriesEl && metadata.series) seriesEl.value = metadata.series;
-  if (seriesPartEl && metadata.series_part)
-    seriesPartEl.value = metadata.series_part;
-  if (descriptionEl && metadata.description)
-    descriptionEl.value = metadata.description;
-
-  // Handle cover art display - preserve user-loaded custom art
-  if (!getHasCustomCoverArt()) {
-    setCoverArt(metadata.cover_art || null);
-  }
-
-  // Update the output path preview now that metadata has changed
-  onMetadataChange();
-  updateTagPreview();
-}
-
-async function autoUpdateCoverArtFromFirstValidFile(): Promise<void> {
-  try {
-    if (getHasCustomCoverArt()) return;
-    if (!currentFileList || !currentFileList.files.length) {
-      setCoverArt(null);
-      return;
-    }
-    const firstValid = currentFileList.files.find((f) => f.isValid);
-    if (!firstValid) {
-      setCoverArt(null);
-      return;
-    }
-    const metadata = await bridge.invoke<AudiobookMetadata>(
-      "read_audio_metadata",
-      { filePath: firstValid.path }
-    );
-    setCoverArt(metadata.cover_art || null);
-  } catch (error) {
-    // Non-fatal: just reset to placeholder if metadata cannot be read
-    setCoverArt(null);
-    console.warn("Failed to auto-load cover art:", error);
-  }
-}
-
-// Move file up in the list
 export function moveFileUp(index: number): void {
   if (isOrderLocked()) return;
-  if (!currentFileList || index <= 0 || index >= currentFileList.files.length)
+  if (!currentFileList || index <= 0 || index >= currentFileList.files.length) {
     return;
+  }
 
-  // Swap with previous file
   const temp = currentFileList.files[index];
   currentFileList.files[index] = currentFileList.files[index - 1];
   currentFileList.files[index - 1] = temp;
 
-  // Update selected index if needed
-  if (selectedFileIndex === index) {
-    setSelectedIndex(index - 1);
-  } else if (selectedFileIndex === index - 1) {
-    setSelectedIndex(index);
-  }
+  swapSelectionIndices(index, index - 1);
 
   updateFileListDOM();
   setupDragStartHandlers();
   onFileListChange();
+
+  const selectedFiles = getSelectedFiles();
+  if (selectedFiles.length === 1) {
+    void showSingleSelection(selectedFiles[0]);
+  }
 }
 
-// Move file down in the list
 export function moveFileDown(index: number): void {
   if (isOrderLocked()) return;
   if (
     !currentFileList ||
     index < 0 ||
     index >= currentFileList.files.length - 1
-  )
+  ) {
     return;
+  }
 
-  // Swap with next file
   const temp = currentFileList.files[index];
   currentFileList.files[index] = currentFileList.files[index + 1];
   currentFileList.files[index + 1] = temp;
 
-  // Update selected index if needed
-  if (selectedFileIndex === index) {
-    setSelectedIndex(index + 1);
-  } else if (selectedFileIndex === index + 1) {
-    setSelectedIndex(index);
-  }
+  swapSelectionIndices(index, index + 1);
 
   updateFileListDOM();
   setupDragStartHandlers();
   onFileListChange();
-}
 
-export function clearFileProperties(): void {
-  const bitrateEl = document.getElementById("prop-bitrate");
-  const sampleRateEl = document.getElementById("prop-samplerate");
-  const channelsEl = document.getElementById("prop-channels");
-  const fileSizeEl = document.getElementById("prop-filesize");
-
-  if (bitrateEl) bitrateEl.textContent = "---";
-  if (sampleRateEl) sampleRateEl.textContent = "---";
-  if (channelsEl) channelsEl.textContent = "---";
-  if (fileSizeEl) fileSizeEl.textContent = "---";
-
-  const contextEl = document.getElementById("prop-selected-context");
-  if (contextEl) {
-    contextEl.replaceChildren();
-    const emptySpan = document.createElement("span");
-    emptySpan.className = "context-empty";
-    emptySpan.textContent = "No file selected";
-    contextEl.appendChild(emptySpan);
+  const selectedFiles = getSelectedFiles();
+  if (selectedFiles.length === 1) {
+    void showSingleSelection(selectedFiles[0]);
   }
-
-  // Clear metadata form
-  const titleEl = document.getElementById("meta-title") as HTMLInputElement;
-  const authorEl = document.getElementById("meta-author") as HTMLInputElement;
-  const narratorEl = document.getElementById(
-    "meta-narrator"
-  ) as HTMLInputElement;
-  const yearEl = document.getElementById("meta-year") as HTMLInputElement;
-  const genreEl = document.getElementById("meta-genre") as HTMLInputElement;
-  const seriesEl = document.getElementById("meta-series") as HTMLInputElement;
-  const seriesPartEl = document.getElementById(
-    "meta-series-part"
-  ) as HTMLInputElement;
-  const descriptionEl = document.getElementById(
-    "meta-description"
-  ) as HTMLTextAreaElement;
-
-  if (titleEl) titleEl.value = "";
-  if (authorEl) authorEl.value = "";
-  if (narratorEl) narratorEl.value = "";
-  if (yearEl) yearEl.value = "";
-  if (genreEl) genreEl.value = "";
-  if (seriesEl) seriesEl.value = "";
-  if (seriesPartEl) seriesPartEl.value = "";
-  if (descriptionEl) descriptionEl.value = "";
-
-  // Clear cover art display and reset custom-art flag
-  clearCoverArt();
 }
 
 export function toggleFileSort(): void {
@@ -394,26 +303,21 @@ export function toggleFileSort(): void {
 
   setSortAscending(!getSortAscending());
 
-  // Sort files by name
   currentFileList.files.sort((a, b) => {
-    const nameA = a.path.split(/[\\\/]/).pop() || a.path;
-    const nameB = b.path.split(/[\\\/]/).pop() || b.path;
+    const nameA = a.path.split(/[\\/]/).pop() || a.path;
+    const nameB = b.path.split(/[\\/]/).pop() || b.path;
 
     if (getSortAscending()) {
       return nameA.localeCompare(nameB);
-    } else {
-      return nameB.localeCompare(nameA);
     }
+    return nameB.localeCompare(nameA);
   });
 
-  // Reset selected index as files have been reordered
+  clearSelection();
   setSelectedIndex(-1);
-  clearFileProperties();
+  clearSelectionPanels();
 
-  // Update the sort button text
   updateSortButtonText(getSortAscending());
-
-  // Ensure button visibility is updated after reordering
   updateButtonVisibility();
 
   updateFileListDOM();
@@ -434,8 +338,9 @@ export function clearAllFiles(): void {
 
   showEmptyState();
 
+  clearSelection();
   setSelectedIndex(-1);
-  clearFileProperties();
+  clearSelectionPanels();
   updateTotalStats();
   updateButtonVisibility();
   onFileListChange();
@@ -446,4 +351,28 @@ export function setFileOrderLocked(locked: boolean): void {
   setOrderLockNotice(locked);
   updateButtonVisibility();
   updateFileListDOM();
+}
+
+export function reorderFiles(fromIndex: number, toIndex: number): void {
+  if (isOrderLocked()) return;
+  if (!currentFileList) return;
+
+  const files = currentFileList.files;
+  const [moved] = files.splice(fromIndex, 1);
+  files.splice(toIndex, 0, moved);
+
+  reindexSelectionAfterMove(fromIndex, toIndex);
+
+  updateFileListDOM();
+  onFileListChange();
+  setupDragStartHandlers();
+
+  const selectedFiles = getSelectedFiles();
+  if (selectedFiles.length === 1) {
+    void showSingleSelection(selectedFiles[0]);
+  } else if (selectedFiles.length > 1) {
+    void showMultiSelection(selectedFiles);
+  } else {
+    clearSelectionPanels();
+  }
 }

--- a/src/ui/fileList/dom.ts
+++ b/src/ui/fileList/dom.ts
@@ -1,5 +1,5 @@
 import { AudioFile, formatDuration, formatFileSize } from "../../types/audio";
-import { currentFileList, selectedFileIndex, isOrderLocked } from "./state";
+import { currentFileList, isOrderLocked, getSelectedFileIndices } from "./state";
 import { updateDropZoneState } from "../fileImport";
 
 // Cached DOM elements (stable roots only)
@@ -46,24 +46,20 @@ export function createFileListItem(
             <div class="file-info">
                 <div class="file-name">${fileName}</div>
                 <div class="file-details">
-                    ${
-                      file.isValid && file.duration && file.size
-                        ? `${formatDuration(file.duration)} • ${formatFileSize(
-                            file.size
-                          )} • ${file.format}`
-                        : `Error: ${file.error || "Invalid file"}`
-                    }
+                    ${file.isValid && file.duration && file.size
+      ? `${formatDuration(file.duration)} • ${formatFileSize(
+        file.size
+      )} • ${file.format}`
+      : `Error: ${file.error || "Invalid file"}`
+    }
                 </div>
             </div>
-            <button class="move-up-btn" data-index="${index}" ${
-    isFirst || locked ? "disabled" : ""
-  }>▲</button>
-            <button class="move-down-btn" data-index="${index}" ${
-    isLast || locked ? "disabled" : ""
-  }>▼</button>
-            <button class="remove-file-btn" data-index="${index}" ${
-    locked ? "disabled" : ""
-  }>×</button>
+            <button class="move-up-btn" data-index="${index}" ${isFirst || locked ? "disabled" : ""
+    }>▲</button>
+            <button class="move-down-btn" data-index="${index}" ${isLast || locked ? "disabled" : ""
+    }>▼</button>
+            <button class="remove-file-btn" data-index="${index}" ${locked ? "disabled" : ""
+    }>×</button>
         </div>
     `;
 
@@ -97,24 +93,20 @@ export function updateFileListItem(
             <div class="file-info">
                 <div class="file-name">${fileName}</div>
                 <div class="file-details">
-                    ${
-                      file.isValid && file.duration && file.size
-                        ? `${formatDuration(file.duration)} • ${formatFileSize(
-                            file.size
-                          )} • ${file.format}`
-                        : `Error: ${file.error || "Invalid file"}`
-                    }
+                    ${file.isValid && file.duration && file.size
+      ? `${formatDuration(file.duration)} • ${formatFileSize(
+        file.size
+      )} • ${file.format}`
+      : `Error: ${file.error || "Invalid file"}`
+    }
                 </div>
             </div>
-            <button class="move-up-btn" data-index="${index}" ${
-    isFirst || locked ? "disabled" : ""
-  }>▲</button>
-            <button class="move-down-btn" data-index="${index}" ${
-    isLast || locked ? "disabled" : ""
-  }>▼</button>
-            <button class="remove-file-btn" data-index="${index}" ${
-    locked ? "disabled" : ""
-  }>×</button>
+            <button class="move-up-btn" data-index="${index}" ${isFirst || locked ? "disabled" : ""
+    }>▲</button>
+            <button class="move-down-btn" data-index="${index}" ${isLast || locked ? "disabled" : ""
+    }>▼</button>
+            <button class="remove-file-btn" data-index="${index}" ${locked ? "disabled" : ""
+    }>×</button>
         </div>
     `;
 }
@@ -191,10 +183,12 @@ export function updateTotalStats(): void {
     totalSizeEl.textContent = formatFileSize(currentFileList.totalSize);
 }
 
+
 export function updateSelection(): void {
+  const selectedIndices = getSelectedFileIndices();
   const items = document.querySelectorAll(".file-list-item");
   items.forEach((item, index) => {
-    item.classList.toggle("selected", index === selectedFileIndex);
+    item.classList.toggle("selected", selectedIndices.has(index));
   });
 }
 

--- a/src/ui/fileList/events.ts
+++ b/src/ui/fileList/events.ts
@@ -1,12 +1,16 @@
 import {
   currentFileList,
-  selectedFileIndex,
-  setSelectedIndex,
   isOrderLocked,
 } from "./state";
-import { selectFile, removeFile, moveFileUp, moveFileDown } from "./actions";
-import { updateFileListDOM } from "./dom";
-import { onFileListChange } from "../outputPanel";
+import {
+  selectFile,
+  removeFile,
+  moveFileUp,
+  moveFileDown,
+  reorderFiles,
+  selectAll,
+  clearSelectionAction,
+} from "./actions";
 
 let draggedIndex: number | null = null;
 
@@ -14,19 +18,19 @@ export function initFileListEvents(): void {
   const container = document.querySelector<HTMLElement>(".file-list-content");
   if (!container) return;
 
-  // Remove any existing event listeners to prevent duplicates
   container.removeEventListener("click", handleFileListClick);
   container.removeEventListener("dragover", handleDragOver);
   container.removeEventListener("drop", handleDrop);
   container.removeEventListener("dragend", handleDragEnd);
 
-  // Add event delegation handlers
   container.addEventListener("click", handleFileListClick);
   container.addEventListener("dragover", handleDragOver);
   container.addEventListener("drop", handleDrop);
   container.addEventListener("dragend", handleDragEnd);
 
-  // Add dragstart handlers to each file item
+  document.removeEventListener("keydown", handleFileListKeyDown);
+  document.addEventListener("keydown", handleFileListKeyDown);
+
   setupDragStartHandlers();
 }
 
@@ -36,13 +40,11 @@ export function setupDragStartHandlers(): void {
 
   const items = container.querySelectorAll<HTMLElement>(".file-list-item");
   items.forEach((item, index) => {
-    // Remove existing dragstart listeners by cloning (clean slate)
     const existingHandler = (item as any).__dragStartHandler;
     if (existingHandler) {
       item.removeEventListener("dragstart", existingHandler);
     }
 
-    // Create new handler and store reference
     const handler = (e: DragEvent) => handleDragStart(e, index);
     (item as any).__dragStartHandler = handler;
     item.addEventListener("dragstart", handler);
@@ -52,20 +54,17 @@ export function setupDragStartHandlers(): void {
 function handleFileListClick(e: Event): void {
   const target = e.target as HTMLElement;
 
-  // Handle remove button clicks
   if (target.classList.contains("remove-file-btn")) {
     e.stopPropagation();
     e.preventDefault();
     if (isOrderLocked()) return;
     const index = parseInt(target.dataset.index || "-1");
     if (index >= 0) {
-      console.log("Remove button clicked for index:", index);
       removeFile(index);
     }
     return;
   }
 
-  // Handle move up button clicks
   if (target.classList.contains("move-up-btn")) {
     e.stopPropagation();
     e.preventDefault();
@@ -77,28 +76,55 @@ function handleFileListClick(e: Event): void {
     return;
   }
 
-  // Handle move down button clicks
   if (target.classList.contains("move-down-btn")) {
     e.stopPropagation();
     e.preventDefault();
     if (isOrderLocked()) return;
     const index = parseInt(target.dataset.index || "-1");
-    if (
-      index >= 0 &&
-      currentFileList &&
-      index < currentFileList.files.length - 1
-    ) {
+    if (index >= 0 && currentFileList && index < currentFileList.files.length - 1) {
       moveFileDown(index);
     }
     return;
   }
 
-  // Handle file item selection
   const fileItem = target.closest(".file-list-item") as HTMLElement;
   if (fileItem) {
     const index = parseInt(fileItem.dataset.index || "-1");
-    if (index >= 0) selectFile(index);
+    if (index >= 0) {
+      const mouseEvent = e as MouseEvent;
+      const multi = mouseEvent.ctrlKey || mouseEvent.metaKey;
+      const range = mouseEvent.shiftKey;
+
+      if (range) {
+        window.getSelection()?.removeAllRanges();
+      }
+
+      selectFile(index, { multi, range });
+    }
   }
+}
+
+function handleFileListKeyDown(e: KeyboardEvent): void {
+  if (!currentFileList) return;
+  if (isTextInputTarget(e.target)) return;
+
+  const key = e.key.toLowerCase();
+  if ((e.metaKey || e.ctrlKey) && key === "a") {
+    e.preventDefault();
+    selectAll();
+    return;
+  }
+
+  if (key === "escape") {
+    e.preventDefault();
+    clearSelectionAction();
+  }
+}
+
+function isTextInputTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName.toLowerCase();
+  return tagName === "input" || tagName === "textarea";
 }
 
 function handleDragStart(e: DragEvent, index: number): void {
@@ -123,10 +149,8 @@ function handleDragOver(e: DragEvent): void {
   const container = e.currentTarget as HTMLElement;
   const items = Array.from(container.querySelectorAll(".file-list-item"));
 
-  // Remove all drag-over classes
   items.forEach((item) => item.classList.remove("drag-over"));
 
-  // Find item under cursor
   const target = e.target as HTMLElement;
   const fileItem = target.closest(".file-list-item") as HTMLElement;
   if (fileItem && !fileItem.classList.contains("dragging")) {
@@ -144,10 +168,8 @@ function handleDrop(e: DragEvent): void {
   const container = e.currentTarget as HTMLElement;
   const items = Array.from(container.querySelectorAll(".file-list-item"));
 
-  // Remove drag-over classes
   items.forEach((item) => item.classList.remove("drag-over"));
 
-  // Find drop target
   const target = e.target as HTMLElement;
   const dropTarget = target.closest(".file-list-item") as HTMLElement;
   if (!dropTarget) return;
@@ -155,55 +177,23 @@ function handleDrop(e: DragEvent): void {
   const dropIndex = parseInt(dropTarget.dataset.index || "-1");
   if (dropIndex < 0 || dropIndex === draggedIndex) return;
 
-  // Reorder files
   reorderFiles(draggedIndex, dropIndex);
 
   draggedIndex = null;
 }
 
 function handleDragEnd(e: DragEvent): void {
-  // Find the dragged item (it has the "dragging" class)
-  // e.currentTarget is the container, so we need to find the actual dragged item
   const container = e.currentTarget as HTMLElement;
   const draggedItem = container.querySelector(".file-list-item.dragging");
   if (draggedItem) {
     draggedItem.classList.remove("dragging");
   }
 
-  // Remove all drag-over classes
   container.querySelectorAll(".file-list-item").forEach((item) => {
     item.classList.remove("drag-over");
   });
 
   draggedIndex = null;
-}
-
-function reorderFiles(fromIndex: number, toIndex: number): void {
-  if (isOrderLocked()) return;
-  if (!currentFileList) return;
-
-  const files = currentFileList.files;
-  const [moved] = files.splice(fromIndex, 1);
-  files.splice(toIndex, 0, moved);
-
-  // Update selected index if needed
-  if (selectedFileIndex === fromIndex) {
-    setSelectedIndex(toIndex);
-  } else if (selectedFileIndex === toIndex && fromIndex < toIndex) {
-    setSelectedIndex(selectedFileIndex - 1);
-  } else if (selectedFileIndex === toIndex && fromIndex > toIndex) {
-    setSelectedIndex(selectedFileIndex + 1);
-  } else if (selectedFileIndex > fromIndex && selectedFileIndex <= toIndex) {
-    setSelectedIndex(selectedFileIndex - 1);
-  } else if (selectedFileIndex < fromIndex && selectedFileIndex >= toIndex) {
-    setSelectedIndex(selectedFileIndex + 1);
-  }
-
-  updateFileListDOM();
-  onFileListChange();
-
-  // Re-setup drag handlers for new order
-  setupDragStartHandlers();
 }
 
 // Initialize event handlers for sort and clear buttons on DOM load

--- a/src/ui/fileList/index.ts
+++ b/src/ui/fileList/index.ts
@@ -2,7 +2,7 @@
 // This preserves import paths during the split process
 
 import { initDOMCache } from './dom';
-import { toggleFileSort, clearAllFiles } from './actions';
+import { toggleFileSort, clearAllFiles, initMetadataApplyHandler } from './actions';
 
 export { 
     displayFileList, 
@@ -10,7 +10,8 @@ export {
     clearAllFiles,
     moveFileUp,
     moveFileDown,
-    setFileOrderLocked
+    setFileOrderLocked,
+    initMetadataApplyHandler
 } from './actions';
 
 // Re-export state from state module  
@@ -30,4 +31,5 @@ document.addEventListener('DOMContentLoaded', () => {
     if (clearBtn) {
         clearBtn.addEventListener('click', () => clearAllFiles());
     }
+    initMetadataApplyHandler();
 });

--- a/src/ui/fileList/metadataPanel.ts
+++ b/src/ui/fileList/metadataPanel.ts
@@ -1,0 +1,221 @@
+import { AudioFile, formatFileSize } from "../../types/audio";
+import { bridge } from "../../lib/bridge";
+import type { AudiobookMetadata } from "../../types/metadata";
+import { onMetadataChange } from "../outputPanel";
+import { updateTagPreview } from "../tagPreview";
+import {
+  clearCoverArt,
+  getHasCustomCoverArt,
+  setCoverArt,
+} from "../coverArt";
+import {
+  getMetadataForFile,
+  setMetadataForFile,
+} from "../metadataState";
+import {
+  populateMetadataFormMulti,
+  populateMetadataFormSingle,
+  resetDirtyState,
+} from "../metadataForm";
+import {
+  currentFileList,
+  getSelectedFileIndices,
+  selectedFileIndex,
+} from "./state";
+
+function setText(id: string, value: string): void {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+
+function updatePropertiesContextSingle(file: AudioFile, index: number): void {
+  const contextEl = document.getElementById("prop-selected-context");
+  if (!contextEl || !currentFileList) return;
+
+  contextEl.replaceChildren();
+
+  if (index < 0 || index >= currentFileList.files.length) {
+    const emptySpan = document.createElement("span");
+    emptySpan.className = "context-empty";
+    emptySpan.textContent = "No file selected";
+    contextEl.appendChild(emptySpan);
+    return;
+  }
+
+  const fileName = file.path.split(/[\\/]/).pop() || file.path;
+  const totalFiles = currentFileList.files.length;
+
+  const filenameSpan = document.createElement("span");
+  filenameSpan.className = "context-filename";
+  filenameSpan.title = fileName;
+  filenameSpan.textContent = fileName;
+
+  const posSpan = document.createElement("span");
+  posSpan.className = "context-position";
+  posSpan.textContent = `${index + 1} of ${totalFiles}`;
+
+  contextEl.appendChild(filenameSpan);
+  contextEl.appendChild(posSpan);
+}
+
+function updatePropertiesContextMulti(selectedCount: number): void {
+  const contextEl = document.getElementById("prop-selected-context");
+  if (!contextEl) return;
+
+  contextEl.replaceChildren();
+
+  const span = document.createElement("span");
+  span.className = "context-filename";
+  span.textContent = `${selectedCount} files selected`;
+  contextEl.appendChild(span);
+}
+
+function clearPropertiesContext(): void {
+  const contextEl = document.getElementById("prop-selected-context");
+  if (!contextEl) return;
+
+  contextEl.replaceChildren();
+  const emptySpan = document.createElement("span");
+  emptySpan.className = "context-empty";
+  emptySpan.textContent = "No file selected";
+  contextEl.appendChild(emptySpan);
+}
+
+function clearPropertyValues(): void {
+  setText("prop-bitrate", "---");
+  setText("prop-samplerate", "---");
+  setText("prop-channels", "---");
+  setText("prop-filesize", "---");
+}
+
+async function loadMetadataForFile(
+  file: AudioFile
+): Promise<Partial<AudiobookMetadata> | null> {
+  if (!file.isValid) return null;
+
+  const existing = getMetadataForFile(file.path);
+  if (existing) return existing;
+
+  try {
+    const metadata = await bridge.invoke<AudiobookMetadata>(
+      "read_audio_metadata",
+      { filePath: file.path }
+    );
+    setMetadataForFile(file.path, metadata);
+    return metadata;
+  } catch (error) {
+    console.warn("Failed to load metadata:", error);
+    return null;
+  }
+}
+
+export async function ensureMetadataForFiles(
+  files: AudioFile[]
+): Promise<void> {
+  const validFiles = files.filter((file) => file.isValid);
+  await Promise.all(validFiles.map((file) => loadMetadataForFile(file)));
+}
+
+export function updateFileProperties(
+  file: AudioFile,
+  options?: { skipMetadataLoad?: boolean }
+): void {
+  if (file.isValid) {
+    setText("prop-bitrate", file.bitrate ? `${file.bitrate} kb/s` : "N/A");
+    setText(
+      "prop-samplerate",
+      file.sampleRate ? `${file.sampleRate} Hz` : "N/A"
+    );
+    setText("prop-channels", file.channels ? `${file.channels} ch` : "N/A");
+    setText("prop-filesize", file.size ? formatFileSize(file.size) : "N/A");
+
+    if (!options?.skipMetadataLoad) {
+      void loadMetadataForFile(file).then((metadata) => {
+        if (metadata) {
+          populateMetadataFormSingle(metadata);
+          onMetadataChange();
+          updateTagPreview();
+        }
+      });
+    }
+  } else {
+    clearPropertyValues();
+  }
+
+  updatePropertiesContextSingle(file, selectedFileIndex);
+}
+
+export async function showSingleSelection(file: AudioFile): Promise<void> {
+  const stored = getMetadataForFile(file.path);
+  if (stored) {
+    updateFileProperties(file, { skipMetadataLoad: true });
+    populateMetadataFormSingle(stored);
+  } else {
+    updateFileProperties(file);
+  }
+
+  onMetadataChange();
+  updateTagPreview();
+}
+
+export async function showMultiSelection(
+  selectedFiles: AudioFile[]
+): Promise<void> {
+  const selectedCount = selectedFiles.length;
+
+  updatePropertiesContextMulti(selectedCount);
+  clearPropertyValues();
+
+  resetDirtyState();
+
+  const validFiles = selectedFiles.filter((file) => file.isValid);
+  const metadataList = await Promise.all(
+    validFiles.map(async (file) => {
+      const metadata = await loadMetadataForFile(file);
+      return metadata ?? {};
+    })
+  );
+
+  populateMetadataFormMulti(metadataList, selectedCount);
+  onMetadataChange();
+  updateTagPreview();
+}
+
+export function clearSelectionPanels(): void {
+  clearPropertyValues();
+  clearPropertiesContext();
+  populateMetadataFormSingle({});
+  clearCoverArt();
+}
+
+export async function autoUpdateCoverArtFromFirstValidFile(): Promise<void> {
+  try {
+    if (getHasCustomCoverArt()) return;
+    if (!currentFileList || !currentFileList.files.length) {
+      setCoverArt(null);
+      return;
+    }
+    const firstValid = currentFileList.files.find((f) => f.isValid);
+    if (!firstValid) {
+      setCoverArt(null);
+      return;
+    }
+    const metadata = await bridge.invoke<AudiobookMetadata>(
+      "read_audio_metadata",
+      { filePath: firstValid.path }
+    );
+    setCoverArt(metadata.cover_art || null);
+  } catch (error) {
+    setCoverArt(null);
+    console.warn("Failed to auto-load cover art:", error);
+  }
+}
+
+export function getSelectedFiles(): AudioFile[] {
+  const fileList = currentFileList;
+  if (!fileList) return [];
+  const selectedIndices = getSelectedFileIndices();
+  return Array.from(selectedIndices)
+    .map((index) => fileList.files[index])
+    .filter((file): file is AudioFile => Boolean(file));
+}

--- a/src/ui/fileList/selection.ts
+++ b/src/ui/fileList/selection.ts
@@ -1,0 +1,153 @@
+import {
+  currentFileList,
+  selectedFileIndex,
+  setSelectedIndex,
+  getSelectedFileIndices,
+  addToSelectedIndices,
+  clearSelectedIndices,
+  removeFromSelectedIndices,
+  setSelectedFileIndices,
+} from "./state";
+
+type SelectionModifiers = { multi: boolean; range: boolean };
+
+type SelectionResult = {
+  changed: boolean;
+};
+
+function getSortedSelectedIndices(): number[] {
+  return Array.from(getSelectedFileIndices()).sort((a, b) => a - b);
+}
+
+function ensureAnchor(): void {
+  const selected = getSelectedFileIndices();
+  if (selected.size === 0) {
+    setSelectedIndex(-1);
+    return;
+  }
+
+  if (selectedFileIndex >= 0 && selected.has(selectedFileIndex)) return;
+
+  const sorted = getSortedSelectedIndices();
+  const newAnchor = sorted[sorted.length - 1];
+  setSelectedIndex(newAnchor);
+}
+
+export function handleSelection(
+  index: number,
+  modifiers: SelectionModifiers
+): SelectionResult {
+  if (!currentFileList) return { changed: false };
+
+  const totalFiles = currentFileList.files.length;
+  if (index < 0 || index >= totalFiles) return { changed: false };
+
+  const { multi, range } = modifiers;
+
+  if (range && selectedFileIndex !== -1) {
+    const start = Math.min(selectedFileIndex, index);
+    const end = Math.max(selectedFileIndex, index);
+
+    clearSelectedIndices();
+    for (let i = start; i <= end; i += 1) {
+      addToSelectedIndices(i);
+    }
+    setSelectedIndex(index);
+    return { changed: true };
+  }
+
+  if (multi) {
+    const selected = getSelectedFileIndices();
+    if (selected.has(index)) {
+      removeFromSelectedIndices(index);
+    } else {
+      addToSelectedIndices(index);
+      setSelectedIndex(index);
+    }
+
+    ensureAnchor();
+    return { changed: true };
+  }
+
+  clearSelectedIndices();
+  addToSelectedIndices(index);
+  setSelectedIndex(index);
+  return { changed: true };
+}
+
+export function selectAllFiles(): boolean {
+  if (!currentFileList) return false;
+
+  clearSelectedIndices();
+  const count = currentFileList.files.length;
+  for (let i = 0; i < count; i += 1) {
+    addToSelectedIndices(i);
+  }
+  setSelectedIndex(count > 0 ? 0 : -1);
+  return count > 0;
+}
+
+export function clearSelection(): boolean {
+  if (getSelectedFileIndices().size === 0 && selectedFileIndex === -1) {
+    return false;
+  }
+  clearSelectedIndices();
+  setSelectedIndex(-1);
+  return true;
+}
+
+export function reindexSelectionAfterRemoval(removedIndex: number): void {
+  const updated = new Set<number>();
+  getSelectedFileIndices().forEach((index) => {
+    if (index === removedIndex) return;
+    updated.add(index > removedIndex ? index - 1 : index);
+  });
+
+  setSelectedFileIndices(updated);
+  ensureAnchor();
+}
+
+function mapIndexForMove(index: number, fromIndex: number, toIndex: number): number {
+  if (index === fromIndex) return toIndex;
+  if (fromIndex < toIndex && index > fromIndex && index <= toIndex) return index - 1;
+  if (fromIndex > toIndex && index >= toIndex && index < fromIndex) return index + 1;
+  return index;
+}
+
+export function reindexSelectionAfterMove(fromIndex: number, toIndex: number): void {
+  const updated = new Set<number>();
+  getSelectedFileIndices().forEach((index) => {
+    updated.add(mapIndexForMove(index, fromIndex, toIndex));
+  });
+
+  setSelectedFileIndices(updated);
+
+  if (selectedFileIndex !== -1) {
+    setSelectedIndex(mapIndexForMove(selectedFileIndex, fromIndex, toIndex));
+  }
+
+  ensureAnchor();
+}
+
+export function swapSelectionIndices(indexA: number, indexB: number): void {
+  const updated = new Set<number>();
+  getSelectedFileIndices().forEach((index) => {
+    if (index === indexA) {
+      updated.add(indexB);
+    } else if (index === indexB) {
+      updated.add(indexA);
+    } else {
+      updated.add(index);
+    }
+  });
+
+  setSelectedFileIndices(updated);
+
+  if (selectedFileIndex === indexA) {
+    setSelectedIndex(indexB);
+  } else if (selectedFileIndex === indexB) {
+    setSelectedIndex(indexA);
+  }
+
+  ensureAnchor();
+}

--- a/src/ui/fileList/state.ts
+++ b/src/ui/fileList/state.ts
@@ -3,6 +3,8 @@ import { FileListInfo } from '../../types/audio';
 // Core state variables - keep direct exports for backward compatibility
 export let currentFileList: FileListInfo | null = null;
 export let selectedFileIndex: number = -1;
+// New: Track multiple selections
+const selectedFileIndices = new Set<number>();
 
 // Internal state
 let sortAscending: boolean = true;
@@ -15,6 +17,29 @@ export function setCurrentFileList(fileList: FileListInfo | null): void {
 
 export function setSelectedIndex(index: number): void {
     selectedFileIndex = index;
+}
+
+// Multi-select accessors
+export function getSelectedFileIndices(): Set<number> {
+    return selectedFileIndices;
+}
+
+export function setSelectedFileIndices(indices: Set<number> | number[]): void {
+    selectedFileIndices.clear();
+    const arr = Array.isArray(indices) ? indices : Array.from(indices);
+    arr.forEach(i => selectedFileIndices.add(i));
+}
+
+export function addToSelectedIndices(index: number): void {
+    selectedFileIndices.add(index);
+}
+
+export function removeFromSelectedIndices(index: number): void {
+    selectedFileIndices.delete(index);
+}
+
+export function clearSelectedIndices(): void {
+    selectedFileIndices.clear();
 }
 
 export function getSortAscending(): boolean {

--- a/src/ui/metadataForm.ts
+++ b/src/ui/metadataForm.ts
@@ -1,41 +1,396 @@
 import type { AudiobookMetadata } from "../types/metadata";
-import { getCurrentCoverArt } from "./coverArt";
+import {
+  getCurrentCoverArt,
+  getHasCustomCoverArt,
+  isCoverArtRemovalRequested,
+  setCoverArt,
+} from "./coverArt";
 
-export function readMetadataForm(): Partial<AudiobookMetadata> {
-  const getElementValue = (id: string): string => {
-    const element = document.getElementById(id) as HTMLInputElement;
-    return element?.value?.trim() || "";
+export type MetadataFormMode = "single" | "multi";
+
+type FieldConfig = {
+  inputId: string;
+  actionId: string;
+  key: keyof AudiobookMetadata;
+  mapToAlbum?: boolean;
+  isNumber?: boolean;
+  unconditional?: boolean;
+};
+
+type FieldAction = "keep" | "blank";
+
+const FIELD_CONFIGS: FieldConfig[] = [
+  { inputId: "meta-title", actionId: "meta-title-action", key: "title", mapToAlbum: true },
+  { inputId: "meta-author", actionId: "meta-author-action", key: "artist" },
+  { inputId: "meta-narrator", actionId: "meta-narrator-action", key: "composer" },
+  { inputId: "meta-year", actionId: "meta-year-action", key: "date", isNumber: true },
+  { inputId: "meta-genre", actionId: "meta-genre-action", key: "genre" },
+  { inputId: "meta-series", actionId: "meta-series-action", key: "series", unconditional: true },
+  {
+    inputId: "meta-series-part",
+    actionId: "meta-series-part-action",
+    key: "series_part",
+    unconditional: true,
+  },
+  {
+    inputId: "meta-description",
+    actionId: "meta-description-action",
+    key: "description",
+    unconditional: true,
+  },
+];
+
+const MIXED_PLACEHOLDER = "Mixed values";
+
+function getMetadataForm(): HTMLElement | null {
+  return document.getElementById("metadata-form");
+}
+
+function getSelectionCountEl(): HTMLElement | null {
+  return document.getElementById("metadata-selection-count");
+}
+
+function getInputElement(
+  id: string
+): HTMLInputElement | HTMLTextAreaElement | null {
+  const el = document.getElementById(id);
+  if (!el) return null;
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return el;
+  }
+  return null;
+}
+
+function getActionElement(id: string): HTMLSelectElement | null {
+  const el = document.getElementById(id);
+  if (el instanceof HTMLSelectElement) {
+    return el;
+  }
+  return null;
+}
+
+function cacheDefaultPlaceholder(input: HTMLInputElement | HTMLTextAreaElement): void {
+  if (!input.dataset.defaultPlaceholder) {
+    input.dataset.defaultPlaceholder = input.placeholder || "";
+  }
+}
+
+function setMixedPlaceholder(
+  input: HTMLInputElement | HTMLTextAreaElement,
+  mixed: boolean
+): void {
+  cacheDefaultPlaceholder(input);
+  if (mixed) {
+    input.placeholder = MIXED_PLACEHOLDER;
+    input.dataset.mixed = "true";
+  } else {
+    input.placeholder = input.dataset.defaultPlaceholder || "";
+    delete input.dataset.mixed;
+  }
+}
+
+function markDirty(input: HTMLInputElement | HTMLTextAreaElement): void {
+  input.dataset.dirty = "true";
+  input.classList.add("dirty-field");
+}
+
+function isDirty(input: HTMLInputElement | HTMLTextAreaElement): boolean {
+  return input.dataset.dirty === "true";
+}
+
+function getFieldAction(actionId: string): FieldAction {
+  const action = getActionElement(actionId);
+  return (action?.value as FieldAction) || "keep";
+}
+
+function setFieldAction(actionId: string, value: FieldAction): void {
+  const action = getActionElement(actionId);
+  if (action) {
+    action.value = value;
+  }
+}
+
+function isMultiSelectMode(): boolean {
+  const form = getMetadataForm();
+  return form?.dataset.multiSelect === "true";
+}
+
+export function setMetadataFormMode(
+  mode: MetadataFormMode,
+  selectionCount?: number
+): void {
+  const form = getMetadataForm();
+  if (form) {
+    form.dataset.multiSelect = mode === "multi" ? "true" : "false";
+  }
+
+  const countEl = getSelectionCountEl();
+  if (!countEl) return;
+
+  if (mode === "multi" && selectionCount && selectionCount > 1) {
+    countEl.textContent = `${selectionCount} files selected`;
+    countEl.hidden = false;
+  } else {
+    countEl.textContent = "";
+    countEl.hidden = true;
+  }
+}
+
+export function initMetadataFormEvents(): void {
+  const form = getMetadataForm();
+  if (!form) return;
+
+  const inputs = form.querySelectorAll<
+    HTMLInputElement | HTMLTextAreaElement
+  >("input[id^='meta-'], textarea[id^='meta-']");
+
+  inputs.forEach((input) => {
+    const handleInput = () => {
+      markDirty(input);
+      if (!isMultiSelectMode()) return;
+
+      const config = FIELD_CONFIGS.find((field) => field.inputId === input.id);
+      if (!config) return;
+
+      const actionValue: FieldAction = input.value.trim() ? "keep" : "blank";
+      setFieldAction(config.actionId, actionValue);
+    };
+
+    input.addEventListener("input", handleInput);
+    input.addEventListener("change", handleInput);
+  });
+
+  const actionSelects = form.querySelectorAll<HTMLSelectElement>(
+    ".meta-apply-select"
+  );
+  actionSelects.forEach((select) => {
+    select.addEventListener("change", () => {
+      const config = FIELD_CONFIGS.find((field) => field.actionId === select.id);
+      if (!config) return;
+      const input = getInputElement(config.inputId);
+      if (!input) return;
+
+      if (select.value === "blank") {
+        input.value = "";
+        markDirty(input);
+      }
+    });
+  });
+}
+
+export function resetDirtyState(): void {
+  const form = getMetadataForm();
+  if (!form) return;
+
+  const inputs = form.querySelectorAll<
+    HTMLInputElement | HTMLTextAreaElement
+  >("input[id^='meta-'], textarea[id^='meta-']");
+  inputs.forEach((input) => {
+    delete input.dataset.dirty;
+    input.classList.remove("dirty-field");
+  });
+
+  const actionSelects = form.querySelectorAll<HTMLSelectElement>(
+    ".meta-apply-select"
+  );
+  actionSelects.forEach((select) => {
+    select.value = "keep";
+  });
+}
+
+export function populateMetadataFormSingle(
+  metadata: Partial<AudiobookMetadata>
+): void {
+  setMetadataFormMode("single");
+
+  FIELD_CONFIGS.forEach((field) => {
+    const input = getInputElement(field.inputId);
+    if (!input) return;
+
+    let value = "";
+    if (field.isNumber) {
+      const date = metadata.date;
+      if (typeof date === "number" && date > 0) {
+        value = date.toString();
+      }
+    } else {
+      const raw = metadata[field.key];
+      if (typeof raw === "string") {
+        value = raw;
+      }
+    }
+
+    input.value = value;
+    setMixedPlaceholder(input, false);
+  });
+
+  if (!getHasCustomCoverArt()) {
+    setCoverArt(metadata.cover_art || null);
+  }
+
+  resetDirtyState();
+}
+
+export function populateMetadataFormMulti(
+  metadataList: Partial<AudiobookMetadata>[],
+  selectionCount: number
+): void {
+  setMetadataFormMode("multi", selectionCount);
+
+  const hasMetadata = metadataList.length > 0;
+
+  FIELD_CONFIGS.forEach((field) => {
+    const input = getInputElement(field.inputId);
+    if (!input) return;
+
+    if (!hasMetadata) {
+      input.value = "";
+      setMixedPlaceholder(input, false);
+      return;
+    }
+
+    const values = metadataList.map((metadata) => {
+      if (field.isNumber) {
+        const date = metadata.date;
+        return typeof date === "number" && date > 0 ? date.toString() : "";
+      }
+      const raw = metadata[field.key];
+      return typeof raw === "string" ? raw.trim() : "";
+    });
+
+    const uniqueValues = new Set(values);
+    if (uniqueValues.size === 1) {
+      const value = values[0] ?? "";
+      input.value = value;
+      setMixedPlaceholder(input, false);
+    } else {
+      input.value = "";
+      setMixedPlaceholder(input, true);
+    }
+  });
+
+  if (!getHasCustomCoverArt()) {
+    setCoverArt(null);
+  }
+
+  resetDirtyState();
+}
+
+export function readMetadataForm(options?: {
+  mode?: MetadataFormMode;
+  onlyDirty?: boolean;
+}): Partial<AudiobookMetadata> {
+  const mode = options?.mode ?? "single";
+  const onlyDirty = options?.onlyDirty ?? false;
+  const metadata: Partial<AudiobookMetadata> = {};
+  const setMetadataValue = <K extends keyof AudiobookMetadata>(
+    key: K,
+    value: AudiobookMetadata[K]
+  ): void => {
+    metadata[key] = value;
   };
 
-  const metadata: Partial<AudiobookMetadata> = {};
+  FIELD_CONFIGS.forEach((field) => {
+    const input = getInputElement(field.inputId);
+    if (!input) return;
 
-  const title = getElementValue("meta-title");
-  const author = getElementValue("meta-author");
-  const narrator = getElementValue("meta-narrator");
-  const year = getElementValue("meta-year");
-  const genre = getElementValue("meta-genre");
-  const series = getElementValue("meta-series");
-  const seriesPart = getElementValue("meta-series-part");
-  const description = getElementValue("meta-description");
+    const raw = input.value.trim();
+    const dirty = isDirty(input);
 
-  if (title) {
-    metadata.title = title;
-    metadata.album = title; // Album derived from title
-  }
-  if (author) metadata.artist = author; // Map author -> artist for backend
-  if (narrator) metadata.composer = narrator; // Map narrator -> composer for backend
-  if (year) {
-    const yearNum = parseInt(year, 10);
-    if (!isNaN(yearNum)) metadata.date = yearNum; // Map year -> date for backend
-  }
-  if (genre) metadata.genre = genre;
-  if (series) metadata.series = series;
-  if (seriesPart) metadata.series_part = seriesPart;
-  if (description) metadata.description = description;
+    if (mode === "multi") {
+      const action = getFieldAction(field.actionId);
 
-  const coverBytes = getCurrentCoverArt();
-  if (coverBytes && coverBytes.length > 0) {
-    metadata.cover_art = coverBytes;
+      if (action === "blank") {
+        if (field.isNumber) {
+          setMetadataValue(
+            field.key,
+            0 as AudiobookMetadata[typeof field.key]
+          );
+        } else {
+          setMetadataValue(
+            field.key,
+            "" as AudiobookMetadata[typeof field.key]
+          );
+          if (field.mapToAlbum && field.key === "title") {
+            metadata.album = "";
+          }
+        }
+        return;
+      }
+
+      if (!dirty) return;
+
+      if (field.isNumber) {
+        if (!raw) {
+          setMetadataValue(
+            field.key,
+            0 as AudiobookMetadata[typeof field.key]
+          );
+          return;
+        }
+        const parsed = parseInt(raw, 10);
+        if (!Number.isNaN(parsed)) {
+          setMetadataValue(
+            field.key,
+            parsed as AudiobookMetadata[typeof field.key]
+          );
+        }
+        return;
+      }
+
+      setMetadataValue(
+        field.key,
+        raw as AudiobookMetadata[typeof field.key]
+      );
+      if (field.mapToAlbum && field.key === "title") {
+        metadata.album = raw;
+      }
+      return;
+    }
+
+    if (onlyDirty && !dirty) return;
+
+    if (field.isNumber) {
+      if (raw) {
+        const parsed = parseInt(raw, 10);
+        if (!Number.isNaN(parsed)) {
+          setMetadataValue(
+            field.key,
+            parsed as AudiobookMetadata[typeof field.key]
+          );
+        }
+      } else if (dirty) {
+        setMetadataValue(
+          field.key,
+          0 as AudiobookMetadata[typeof field.key]
+        );
+      }
+      return;
+    }
+
+    const shouldInclude =
+      raw || dirty || (field.unconditional && !onlyDirty);
+
+    if (!shouldInclude) return;
+
+    setMetadataValue(
+      field.key,
+      raw as AudiobookMetadata[typeof field.key]
+    );
+    if (field.mapToAlbum && field.key === "title") {
+      metadata.album = raw;
+    }
+  });
+
+  if (mode === "single") {
+    if (isCoverArtRemovalRequested()) {
+      metadata.cover_art = [];
+    } else {
+      const coverBytes = getCurrentCoverArt();
+      if (coverBytes && coverBytes.length > 0) {
+        metadata.cover_art = coverBytes;
+      }
+    }
   }
 
   return metadata;

--- a/src/ui/statusPanel/processing.ts
+++ b/src/ui/statusPanel/processing.ts
@@ -12,6 +12,7 @@ import {
   selectedFileIndex,
   setFileOrderLocked,
 } from "../fileList";
+import { getSelectedFileIndices } from "../fileList/state";
 import { getCurrentOutputConfig } from "../outputPanel";
 import { getJobType, setJobControlsEnabled } from "../jobControls";
 import { readMetadataForm } from "../metadataForm";
@@ -107,13 +108,17 @@ export async function startProcessing(
       .filter((file) => file.isValid)
       .map((file) => file.path);
 
-    const currentMetadata = readMetadataForm();
-    const activeFile =
-      selectedFileIndex >= 0
-        ? currentFileList.files[selectedFileIndex]
-        : currentFileList.files.find((file) => file.isValid);
-    if (activeFile?.isValid) {
-      setMetadataForFile(activeFile.path, currentMetadata);
+    const selectionCount = getSelectedFileIndices().size;
+    let currentMetadata: Partial<AudiobookMetadata> = {};
+    if (selectionCount <= 1) {
+      currentMetadata = readMetadataForm({ mode: "single" });
+      const activeFile =
+        selectedFileIndex >= 0
+          ? currentFileList.files[selectedFileIndex]
+          : currentFileList.files.find((file) => file.isValid);
+      if (activeFile?.isValid) {
+        setMetadataForFile(activeFile.path, currentMetadata);
+      }
     }
 
     // Call backend processing command


### PR DESCRIPTION
## Summary
Implements multi-select and bulk metadata editing functionality.

## Changes
- **Selection**: Added toggle (Cmd/Ctrl) and range (Shift) selection logic in `src/ui/fileList/selection.ts`.
- **Bulk Save**: Implemented 'Read-Merge-Write' pattern in `src/main.ts` to support safe bulk updates.
- **Dirty State Tracking**: Updated `src/ui/metadataForm.ts` to only save modified fields, preventing data loss in mixed-metadata scenarios.
- **UI**: Visual feedback for multi-selection in file list.

## User Feedback / Known Issues
The following issues were reported during manual testing and are pending resolution:
1. **Save Failure**: User reported that data was not persisted when bulk-saving 5 files (verified via external mp3tag tool).
2. **Metadata Visibility**: Metadata editor cleared all fields upon selecting multiple files.
3. **UI Polish**: Request for more details in the selection context panel.

## Verification
- Automated checks passed (`scripts/quick-checks.sh`).
- Unit tests updated and passing.