### PR TITLE
Prototype: Online metadata lookup (OpenLibrary + Apple Books)

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,13 @@
                 </div>
                 <div class="metadata-apply-row">
                   <button
+                    id="metadata-lookup-btn"
+                    class="btn-pill btn-pill-secondary"
+                    data-testid="metadata-lookup-btn"
+                  >
+                    Find Metadata
+                  </button>
+                  <button
                     id="metadata-apply-btn"
                     class="btn-pill btn-pill-primary-soft"
                     data-testid="metadata-apply-btn"
@@ -797,5 +804,83 @@
       <!-- End of right-column-wrapper -->
     </div>
     <!-- End of main-container -->
+    <div
+      id="metadata-lookup-modal"
+      class="metadata-lookup-modal"
+      data-testid="metadata-lookup-modal"
+      aria-hidden="true"
+    >
+      <div
+        class="metadata-lookup-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="metadata-lookup-title"
+      >
+        <div class="metadata-lookup-header">
+          <h3 id="metadata-lookup-title">Find Metadata Online</h3>
+          <button
+            id="metadata-lookup-close"
+            class="btn-pill btn-pill-secondary"
+            data-testid="metadata-lookup-close"
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+        <div class="metadata-lookup-body">
+          <div class="metadata-lookup-controls">
+            <div class="metadata-lookup-field">
+              <label for="metadata-lookup-query">Search</label>
+              <input
+                id="metadata-lookup-query"
+                type="text"
+                placeholder="Title, author, or narrator"
+                data-testid="metadata-lookup-query"
+              />
+            </div>
+            <div class="metadata-lookup-field">
+              <label for="metadata-lookup-source">Source</label>
+              <select
+                id="metadata-lookup-source"
+                data-testid="metadata-lookup-source"
+              >
+                <option value="all" selected>All sources</option>
+                <option value="open_library">Open Library</option>
+                <option value="itunes">Apple Books</option>
+              </select>
+            </div>
+            <div class="metadata-lookup-field">
+              <label for="metadata-lookup-apply-mode">Apply</label>
+              <select
+                id="metadata-lookup-apply-mode"
+                data-testid="metadata-lookup-apply-mode"
+              ></select>
+            </div>
+            <div class="metadata-lookup-field metadata-lookup-field-button">
+              <button
+                id="metadata-lookup-search-btn"
+                class="btn-pill btn-pill-primary"
+                data-testid="metadata-lookup-search-btn"
+                type="button"
+              >
+                Search
+              </button>
+            </div>
+          </div>
+          <div
+            id="metadata-lookup-context"
+            class="metadata-lookup-context text-xs muted-text"
+          ></div>
+          <div
+            id="metadata-lookup-status"
+            class="metadata-lookup-status text-xs"
+          ></div>
+          <div
+            id="metadata-lookup-results"
+            class="metadata-lookup-results"
+          ></div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/src-tauri/src/commands/metadata_lookup.rs
+++ b/src-tauri/src/commands/metadata_lookup.rs
@@ -1,0 +1,251 @@
+use crate::errors::{AppError, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataSource {
+    OpenLibrary,
+    Itunes,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnlineMetadataResult {
+    pub source: MetadataSource,
+    pub source_id: String,
+    pub title: String,
+    pub authors: Vec<String>,
+    pub narrators: Vec<String>,
+    pub series: Option<String>,
+    pub series_part: Option<String>,
+    pub description: Option<String>,
+    pub published_year: Option<i32>,
+    pub duration_seconds: Option<u32>,
+    pub cover_url: Option<String>,
+}
+
+#[tauri::command]
+pub async fn search_online_metadata(
+    query: String,
+    sources: Option<Vec<MetadataSource>>,
+    limit: Option<u8>,
+) -> Result<Vec<OnlineMetadataResult>> {
+    let trimmed = query.trim();
+    if trimmed.len() < 3 {
+        return Err(AppError::InvalidInput(
+            "Search query must be at least 3 characters.".to_string(),
+        ));
+    }
+
+    let limit = limit.unwrap_or(8).clamp(1, 20);
+    let sources =
+        sources.unwrap_or_else(|| vec![MetadataSource::OpenLibrary, MetadataSource::Itunes]);
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(12))
+        .user_agent("audiobook-boss/metadata-lookup")
+        .build()
+        .map_err(|e| {
+            log::error!("Failed to configure metadata lookup client: {}", e);
+            AppError::General("Failed to configure metadata lookup client".to_string())
+        })?;
+
+    let mut combined = Vec::new();
+    for source in sources {
+        let mut results = match source {
+            MetadataSource::OpenLibrary => fetch_open_library(&client, trimmed, limit).await?,
+            MetadataSource::Itunes => fetch_itunes(&client, trimmed, limit).await?,
+        };
+        combined.append(&mut results);
+    }
+
+    Ok(combined)
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenLibraryResponse {
+    docs: Vec<OpenLibraryDoc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenLibraryDoc {
+    key: Option<String>,
+    title: Option<String>,
+    subtitle: Option<String>,
+    author_name: Option<Vec<String>>,
+    first_publish_year: Option<i32>,
+    cover_i: Option<i64>,
+}
+
+async fn fetch_open_library(
+    client: &Client,
+    query: &str,
+    limit: u8,
+) -> Result<Vec<OnlineMetadataResult>> {
+    let mut url = reqwest::Url::parse("https://openlibrary.org/search.json")
+        .map_err(|_| AppError::General("Failed to build Open Library URL".to_string()))?;
+    url.query_pairs_mut()
+        .append_pair("q", query)
+        .append_pair("limit", &limit.to_string());
+
+    let response = client.get(url).send().await.map_err(|e| {
+        log::warn!("Open Library request failed: {}", e);
+        AppError::General("Open Library request failed".to_string())
+    })?;
+
+    if !response.status().is_success() {
+        return Err(AppError::General("Open Library request failed".to_string()));
+    }
+
+    let payload: OpenLibraryResponse = response.json().await.map_err(|e| {
+        log::warn!("Open Library response parse failed: {}", e);
+        AppError::General("Open Library response parse failed".to_string())
+    })?;
+
+    let results = payload
+        .docs
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, doc)| {
+            let title = doc.title?.trim().to_string();
+            if title.is_empty() {
+                return None;
+            }
+            let full_title = doc
+                .subtitle
+                .as_ref()
+                .map(|subtitle| format!("{}: {}", title, subtitle.trim()))
+                .unwrap_or(title);
+
+            let source_id = doc.key.unwrap_or_else(|| format!("openlibrary-{}", idx));
+            let authors = doc.author_name.unwrap_or_default();
+            let cover_url = doc
+                .cover_i
+                .map(|id| format!("https://covers.openlibrary.org/b/id/{}-L.jpg", id));
+
+            Some(OnlineMetadataResult {
+                source: MetadataSource::OpenLibrary,
+                source_id,
+                title: full_title,
+                authors,
+                narrators: Vec::new(),
+                series: None,
+                series_part: None,
+                description: None,
+                published_year: doc.first_publish_year,
+                duration_seconds: None,
+                cover_url,
+            })
+        })
+        .collect();
+
+    Ok(results)
+}
+
+#[derive(Debug, Deserialize)]
+struct ItunesResponse {
+    results: Vec<ItunesItem>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ItunesItem {
+    track_id: Option<u64>,
+    track_name: Option<String>,
+    collection_name: Option<String>,
+    artist_name: Option<String>,
+    description: Option<String>,
+    long_description: Option<String>,
+    release_date: Option<String>,
+    artwork_url_100: Option<String>,
+    artwork_url_600: Option<String>,
+    track_time_millis: Option<u64>,
+}
+
+async fn fetch_itunes(
+    client: &Client,
+    query: &str,
+    limit: u8,
+) -> Result<Vec<OnlineMetadataResult>> {
+    let mut url = reqwest::Url::parse("https://itunes.apple.com/search")
+        .map_err(|_| AppError::General("Failed to build Apple Books URL".to_string()))?;
+    url.query_pairs_mut()
+        .append_pair("media", "audiobook")
+        .append_pair("term", query)
+        .append_pair("limit", &limit.to_string());
+
+    let response = client.get(url).send().await.map_err(|e| {
+        log::warn!("Apple Books request failed: {}", e);
+        AppError::General("Apple Books request failed".to_string())
+    })?;
+
+    if !response.status().is_success() {
+        return Err(AppError::General("Apple Books request failed".to_string()));
+    }
+
+    let payload: ItunesResponse = response.json().await.map_err(|e| {
+        log::warn!("Apple Books response parse failed: {}", e);
+        AppError::General("Apple Books response parse failed".to_string())
+    })?;
+
+    let results = payload
+        .results
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, item)| {
+            let title = item.track_name.or(item.collection_name).unwrap_or_default();
+            let title = title.trim().to_string();
+            if title.is_empty() {
+                return None;
+            }
+
+            let source_id = item
+                .track_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| format!("itunes-{}", idx));
+            let authors = item.artist_name.map(|name| vec![name]).unwrap_or_default();
+            let description = item.long_description.or(item.description);
+            let published_year = parse_year(item.release_date.as_deref());
+            let duration_seconds = item.track_time_millis.map(|millis| (millis / 1000) as u32);
+
+            let cover_url = normalize_cover_url(item.artwork_url_600)
+                .or_else(|| normalize_cover_url(item.artwork_url_100));
+
+            Some(OnlineMetadataResult {
+                source: MetadataSource::Itunes,
+                source_id,
+                title,
+                authors,
+                narrators: Vec::new(),
+                series: None,
+                series_part: None,
+                description,
+                published_year,
+                duration_seconds,
+                cover_url,
+            })
+        })
+        .collect();
+
+    Ok(results)
+}
+
+fn parse_year(value: Option<&str>) -> Option<i32> {
+    let raw = value?.trim();
+    if raw.len() < 4 {
+        return None;
+    }
+
+    raw.get(0..4)?.parse().ok()
+}
+
+fn normalize_cover_url(raw: Option<String>) -> Option<String> {
+    let raw = raw?;
+    let parsed = reqwest::Url::parse(&raw).ok()?;
+    if parsed.scheme() != "https" {
+        return None;
+    }
+    Some(parsed.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,9 +2,11 @@ pub mod audio;
 mod audio_processing;
 mod audio_types;
 pub mod metadata;
+pub mod metadata_lookup;
 pub mod system;
 
 pub use audio::*;
 pub use audio_types::*;
 pub use metadata::*;
+pub use metadata_lookup::*;
 pub use system::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() {
             commands::load_cover_art_file,
             commands::load_cover_art_from_url,
             commands::save_metadata_to_file,
+            commands::search_online_metadata,
             commands::analyze_audio_files,
             commands::validate_encoder_settings_cmd,
             commands::list_available_encoders,

--- a/src/lib/mocks.ts
+++ b/src/lib/mocks.ts
@@ -1,5 +1,5 @@
 import { FileListInfo } from "../types/audio";
-import { AudiobookMetadata } from "../types/metadata";
+import { AudiobookMetadata, OnlineMetadataResult } from "../types/metadata";
 import {
   ProcessingProgressEvent,
   ProcessingQueueEvent,
@@ -47,6 +47,35 @@ const MOCK_METADATA: AudiobookMetadata = {
   series_part: "1",
   cover_art: undefined,
 };
+
+const MOCK_LOOKUP_RESULTS: OnlineMetadataResult[] = [
+  {
+    source: "open_library",
+    sourceId: "OL12345W",
+    title: "Mock Lookup Title",
+    authors: ["Mock Author"],
+    narrators: ["Mock Narrator"],
+    series: "Mock Series",
+    seriesPart: "1",
+    description: "Mock description from lookup source.",
+    publishedYear: 2021,
+    durationSeconds: 36000,
+    coverUrl: "https://covers.openlibrary.org/b/id/123456-L.jpg",
+  },
+  {
+    source: "itunes",
+    sourceId: "987654321",
+    title: "Mock Apple Books Result",
+    authors: ["Mock Author"],
+    narrators: [],
+    series: undefined,
+    seriesPart: undefined,
+    description: "Mock Apple Books description.",
+    publishedYear: 2020,
+    durationSeconds: 32400,
+    coverUrl: "https://is1-ssl.mzstatic.com/image/thumb/Audio123/v4/cover.jpg",
+  },
+];
 
 const MOCK_COVER_ART_BYTES = [
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
@@ -157,6 +186,9 @@ export async function mockInvoke<T>(cmd: string, args?: any): Promise<T> {
 
     case "load_cover_art_from_url":
       return MOCK_COVER_ART_BYTES as unknown as T;
+
+    case "search_online_metadata":
+      return MOCK_LOOKUP_RESULTS as unknown as T;
 
     default:
       console.warn(`[Bridge Mock] Unhandled command: ${cmd}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { readMetadataForm, initMetadataFormEvents, resetDirtyState } from "./ui/
 import { getSeriesPartValidationError } from "./ui/metadataValidation";
 import { initTagPreview } from "./ui/tagPreview";
 import { initJobControls } from "./ui/jobControls";
+import { initMetadataLookup } from "./ui/metadataLookup";
 import { setMetadataForFile, getMetadataForFile } from "./ui/metadataState";
 import { isMetadataSaveInProgress, setMetadataSaveInProgress } from "./ui/metadataSaveState";
 
@@ -25,6 +26,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initEncoderPanel();
   // Initialize tag preview grid
   initTagPreview();
+  initMetadataLookup();
   // Initialize Cmd+S metadata save handler
   initMetadataSaveHandler();
   // Initialize Job Controls (Job Type, Max Concurrent)

--- a/src/styles.css
+++ b/src/styles.css
@@ -666,6 +666,155 @@ textarea:hover:not(:focus) {
   text-align: right;
 }
 
+.metadata-lookup-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 60;
+}
+
+.metadata-lookup-modal.open {
+  display: flex;
+}
+
+.metadata-lookup-dialog {
+  width: min(720px, 90vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+}
+
+.metadata-lookup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.metadata-lookup-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem 1rem;
+  overflow: hidden;
+}
+
+.metadata-lookup-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.metadata-lookup-field label {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.metadata-lookup-field-button {
+  display: flex;
+  align-items: flex-end;
+}
+
+.metadata-lookup-context,
+.metadata-lookup-status {
+  min-height: 1rem;
+}
+
+.metadata-lookup-status.is-error {
+  color: var(--text-error, #ef4444);
+}
+
+.metadata-lookup-status.is-success {
+  color: var(--text-success, #10b981);
+}
+
+.metadata-lookup-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow: auto;
+  max-height: 50vh;
+  padding-right: 0.5rem;
+}
+
+.metadata-lookup-result {
+  display: grid;
+  grid-template-columns: 4rem minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem;
+  border: 1px solid var(--border-secondary);
+  border-radius: 0.375rem;
+  background: var(--bg-panel);
+}
+
+.metadata-lookup-cover {
+  width: 4rem;
+  height: 4rem;
+  border: 1px solid var(--border-secondary);
+  border-radius: 0.375rem;
+  background: var(--bg-drag-area);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  overflow: hidden;
+}
+
+.metadata-lookup-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.metadata-lookup-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.metadata-lookup-meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.metadata-lookup-source {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--border-secondary);
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.metadata-lookup-actions {
+  display: flex;
+  align-items: flex-start;
+}
+
+.metadata-lookup-empty {
+  padding: 0.75rem;
+  text-align: center;
+  border: 1px dashed var(--border-secondary);
+  border-radius: 0.375rem;
+  color: var(--text-muted);
+}
+
 /* Property labels/values */
 .property-label {
   font-weight: 500;

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -72,3 +72,19 @@ export interface WriteCoverArtParams {
   filePath: string;
   coverData: number[]; // byte array
 }
+
+export type MetadataSource = "open_library" | "itunes";
+
+export interface OnlineMetadataResult {
+  source: MetadataSource;
+  sourceId: string;
+  title: string;
+  authors: string[];
+  narrators: string[];
+  series?: string;
+  seriesPart?: string;
+  description?: string;
+  publishedYear?: number;
+  durationSeconds?: number;
+  coverUrl?: string;
+}

--- a/src/ui/coverArt.ts
+++ b/src/ui/coverArt.ts
@@ -409,6 +409,14 @@ export function setCoverArt(coverArtBytes: number[] | null): void {
     updateClearButtonVisibility();
 }
 
+export function setCustomCoverArt(coverArtBytes: number[] | null): void {
+    currentCoverArt = coverArtBytes;
+    hasCustomCoverArt = Boolean(coverArtBytes && coverArtBytes.length > 0);
+    coverArtRemovalRequested = false;
+    displayCoverArt(coverArtBytes);
+    updateClearButtonVisibility();
+}
+
 export function clearCoverArt(options?: { markRemoval?: boolean }): void {
     const markRemoval = options?.markRemoval ?? false;
     currentCoverArt = null;

--- a/src/ui/metadataForm.ts
+++ b/src/ui/metadataForm.ts
@@ -276,6 +276,39 @@ export function populateMetadataFormMulti(
   resetDirtyState();
 }
 
+export function applyMetadataToForm(
+  metadata: Partial<AudiobookMetadata>,
+  options?: { mode?: MetadataFormMode; markDirty?: boolean }
+): void {
+  const mode = options?.mode ?? "single";
+  const shouldMarkDirty = options?.markDirty ?? true;
+
+  FIELD_CONFIGS.forEach((field) => {
+    const input = getInputElement(field.inputId);
+    if (!input) return;
+
+    if (field.isNumber) {
+      const date = metadata.date;
+      if (typeof date !== "number") return;
+      input.value = date > 0 ? date.toString() : "";
+    } else {
+      const raw = metadata[field.key];
+      if (typeof raw !== "string") return;
+      input.value = raw;
+    }
+
+    setMixedPlaceholder(input, false);
+    if (shouldMarkDirty) {
+      markDirty(input);
+    }
+
+    if (mode === "multi") {
+      const actionValue: FieldAction = input.value.trim() ? "keep" : "blank";
+      setFieldAction(field.actionId, actionValue);
+    }
+  });
+}
+
 export function readMetadataForm(options?: {
   mode?: MetadataFormMode;
   onlyDirty?: boolean;
@@ -382,14 +415,12 @@ export function readMetadataForm(options?: {
     }
   });
 
-  if (mode === "single") {
-    if (isCoverArtRemovalRequested()) {
-      metadata.cover_art = [];
-    } else {
-      const coverBytes = getCurrentCoverArt();
-      if (coverBytes && coverBytes.length > 0) {
-        metadata.cover_art = coverBytes;
-      }
+  if (isCoverArtRemovalRequested()) {
+    metadata.cover_art = [];
+  } else if (mode === "single" || getHasCustomCoverArt()) {
+    const coverBytes = getCurrentCoverArt();
+    if (coverBytes && coverBytes.length > 0) {
+      metadata.cover_art = coverBytes;
     }
   }
 

--- a/src/ui/metadataLookup.ts
+++ b/src/ui/metadataLookup.ts
@@ -1,0 +1,441 @@
+import { bridge } from "../lib/bridge";
+import type { AudioFile } from "../types/audio";
+import type {
+  AudiobookMetadata,
+  MetadataSource,
+  OnlineMetadataResult,
+} from "../types/metadata";
+import { applyMetadataToForm } from "./metadataForm";
+import { onMetadataChange } from "./outputPanel";
+import { updateTagPreview } from "./tagPreview";
+import { setCustomCoverArt } from "./coverArt";
+import { getMetadataForFile } from "./metadataState";
+import { currentFileList } from "./fileList";
+import { stageMetadataToSelection, selectFile } from "./fileList/actions";
+import { getSelectedFileIndices } from "./fileList/state";
+
+const DEFAULT_SOURCES: MetadataSource[] = ["open_library", "itunes"];
+
+type ApplyMode = "current" | "all" | "queue";
+
+type LookupQueueItem = {
+  file: AudioFile;
+  index: number;
+};
+
+let lookupQueue: LookupQueueItem[] = [];
+let queueIndex = 0;
+let currentResults: OnlineMetadataResult[] = [];
+
+function getModal(): HTMLElement | null {
+  return document.getElementById("metadata-lookup-modal");
+}
+
+function getResultsContainer(): HTMLElement | null {
+  return document.getElementById("metadata-lookup-results");
+}
+
+function getSearchInput(): HTMLInputElement | null {
+  const el = document.getElementById("metadata-lookup-query");
+  return el instanceof HTMLInputElement ? el : null;
+}
+
+function getSourceSelect(): HTMLSelectElement | null {
+  const el = document.getElementById("metadata-lookup-source");
+  return el instanceof HTMLSelectElement ? el : null;
+}
+
+function getApplyModeSelect(): HTMLSelectElement | null {
+  const el = document.getElementById("metadata-lookup-apply-mode");
+  return el instanceof HTMLSelectElement ? el : null;
+}
+
+function getStatusEl(): HTMLElement | null {
+  return document.getElementById("metadata-lookup-status");
+}
+
+function getQueueContextEl(): HTMLElement | null {
+  return document.getElementById("metadata-lookup-context");
+}
+
+function setStatus(message: string, variant: "error" | "success" | "info" = "info"): void {
+  const statusEl = getStatusEl();
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.classList.toggle("is-error", variant === "error");
+  statusEl.classList.toggle("is-success", variant === "success");
+}
+
+function showModal(): void {
+  const modal = getModal();
+  if (!modal) return;
+  modal.classList.add("open");
+}
+
+function hideModal(): void {
+  const modal = getModal();
+  if (!modal) return;
+  modal.classList.remove("open");
+}
+
+function formatFileName(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path;
+}
+
+function deriveQueryFromFile(file: AudioFile): string {
+  const stored = getMetadataForFile(file.path) ?? {};
+  const parts: string[] = [];
+  if (stored.title) parts.push(stored.title);
+  if (stored.artist) parts.push(stored.artist);
+  if (stored.composer) parts.push(stored.composer);
+  if (parts.length > 0) return parts.join(" ");
+
+  const rawName = formatFileName(file.path).replace(/\.[^.]+$/, "");
+  return rawName.replace(/[._-]+/g, " ").trim();
+}
+
+function updateQueueContext(): void {
+  const contextEl = getQueueContextEl();
+  if (!contextEl) return;
+  if (lookupQueue.length === 0) {
+    contextEl.textContent = "No files selected.";
+    return;
+  }
+
+  const current = lookupQueue[queueIndex];
+  const label = `${queueIndex + 1} of ${lookupQueue.length}`;
+  contextEl.textContent = `${label} • ${formatFileName(current.file.path)}`;
+}
+
+function updateApplyModeOptions(): void {
+  const applySelect = getApplyModeSelect();
+  if (!applySelect) return;
+
+  const multi = lookupQueue.length > 1;
+  applySelect.innerHTML = "";
+
+  const currentOption = document.createElement("option");
+  currentOption.value = "current";
+  currentOption.textContent = multi ? "Apply to current file" : "Apply to file";
+  applySelect.appendChild(currentOption);
+
+  if (multi) {
+    const allOption = document.createElement("option");
+    allOption.value = "all";
+    allOption.textContent = "Apply to all selected";
+    applySelect.appendChild(allOption);
+
+    const queueOption = document.createElement("option");
+    queueOption.value = "queue";
+    queueOption.textContent = "Apply & next in queue";
+    applySelect.appendChild(queueOption);
+
+    applySelect.value = "all";
+  } else {
+    applySelect.value = "current";
+  }
+}
+
+function getApplyMode(): ApplyMode {
+  const select = getApplyModeSelect();
+  if (!select) return "current";
+  if (select.value === "all") return "all";
+  if (select.value === "queue") return "queue";
+  return "current";
+}
+
+function resetResults(): void {
+  currentResults = [];
+  const container = getResultsContainer();
+  if (container) {
+    container.replaceChildren();
+  }
+}
+
+function renderResults(results: OnlineMetadataResult[]): void {
+  const container = getResultsContainer();
+  if (!container) return;
+  container.replaceChildren();
+  currentResults = results;
+
+  if (results.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "metadata-lookup-empty muted-text";
+    empty.textContent = "No matches found. Try another search.";
+    container.appendChild(empty);
+    return;
+  }
+
+  results.forEach((result, index) => {
+    const row = document.createElement("div");
+    row.className = "metadata-lookup-result";
+
+    const cover = document.createElement("div");
+    cover.className = "metadata-lookup-cover";
+    if (result.coverUrl) {
+      const img = document.createElement("img");
+      img.src = result.coverUrl;
+      img.alt = `${result.title} cover art`;
+      img.loading = "lazy";
+      cover.appendChild(img);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.textContent = "No Art";
+      cover.appendChild(placeholder);
+    }
+
+    const details = document.createElement("div");
+    details.className = "metadata-lookup-details";
+
+    const title = document.createElement("div");
+    title.className = "metadata-lookup-title";
+    title.textContent = result.title;
+
+    const authors = document.createElement("div");
+    authors.className = "metadata-lookup-meta";
+    authors.textContent = result.authors.length
+      ? `Author: ${result.authors.join(", ")}`
+      : "Author: —";
+
+    const narrators = document.createElement("div");
+    narrators.className = "metadata-lookup-meta";
+    narrators.textContent = result.narrators.length
+      ? `Narrator: ${result.narrators.join(", ")}`
+      : "Narrator: —";
+
+    const extra = document.createElement("div");
+    extra.className = "metadata-lookup-meta";
+    const year = result.publishedYear ? result.publishedYear.toString() : "—";
+    const duration = result.durationSeconds
+      ? `${Math.round(result.durationSeconds / 3600)}h`
+      : "—";
+    extra.textContent = `Year: ${year} • Length: ${duration}`;
+
+    const source = document.createElement("span");
+    source.className = "metadata-lookup-source";
+    source.textContent = result.source === "itunes" ? "Apple Books" : "Open Library";
+
+    details.appendChild(title);
+    details.appendChild(authors);
+    details.appendChild(narrators);
+    details.appendChild(extra);
+    details.appendChild(source);
+
+    const applyButton = document.createElement("button");
+    applyButton.type = "button";
+    applyButton.className = "btn-pill btn-pill-secondary";
+    applyButton.textContent = "Use Metadata";
+    applyButton.dataset.index = index.toString();
+
+    const actions = document.createElement("div");
+    actions.className = "metadata-lookup-actions";
+    actions.appendChild(applyButton);
+
+    row.appendChild(cover);
+    row.appendChild(details);
+    row.appendChild(actions);
+
+    container.appendChild(row);
+  });
+}
+
+function mapResultToMetadata(result: OnlineMetadataResult): Partial<AudiobookMetadata> {
+  const metadata: Partial<AudiobookMetadata> = {
+    title: result.title,
+  };
+
+  if (result.authors.length > 0) {
+    metadata.artist = result.authors.join(", ");
+  }
+  if (result.narrators.length > 0) {
+    metadata.composer = result.narrators.join(", ");
+  }
+  if (result.series) {
+    metadata.series = result.series;
+  }
+  if (result.seriesPart) {
+    metadata.series_part = result.seriesPart;
+  }
+  if (result.description) {
+    metadata.description = result.description;
+  }
+  if (result.publishedYear) {
+    metadata.date = result.publishedYear;
+  }
+  if (result.title) {
+    metadata.album = result.title;
+  }
+
+  return metadata;
+}
+
+async function applyCoverArt(result: OnlineMetadataResult): Promise<void> {
+  if (!result.coverUrl) return;
+  try {
+    const coverBytes = await bridge.invoke<number[]>(
+      "load_cover_art_from_url",
+      { url: result.coverUrl }
+    );
+    setCustomCoverArt(coverBytes);
+  } catch (error) {
+    console.warn("Failed to load cover art from lookup:", error);
+    setStatus("Cover art failed to load from source.", "error");
+  }
+}
+
+async function applyResult(result: OnlineMetadataResult): Promise<void> {
+  if (lookupQueue.length === 0) {
+    setStatus("Select at least one file before applying metadata.", "error");
+    return;
+  }
+
+  const metadata = mapResultToMetadata(result);
+  const mode = getApplyMode();
+
+  if (mode === "all") {
+    applyMetadataToForm(metadata, { mode: "multi", markDirty: true });
+    await applyCoverArt(result);
+    await stageMetadataToSelection({ showStatus: true });
+    setStatus("Metadata staged for all selected files.", "success");
+    return;
+  }
+
+  const current = lookupQueue[queueIndex];
+  if (current) {
+    await selectFile(current.index, { multi: false, range: false });
+  }
+
+  applyMetadataToForm(metadata, { mode: "single", markDirty: true });
+  await applyCoverArt(result);
+  onMetadataChange();
+  updateTagPreview();
+  setStatus("Metadata applied to form.", "success");
+
+  if (mode === "queue" && queueIndex < lookupQueue.length - 1) {
+    queueIndex += 1;
+    updateQueueContext();
+    const nextItem = lookupQueue[queueIndex];
+    if (nextItem) {
+      await selectFile(nextItem.index, { multi: false, range: false });
+    }
+    const searchInput = getSearchInput();
+    if (searchInput) {
+      searchInput.value = deriveQueryFromFile(lookupQueue[queueIndex].file);
+    }
+    resetResults();
+  }
+}
+
+async function runSearch(): Promise<void> {
+  const queryInput = getSearchInput();
+  const sourceSelect = getSourceSelect();
+  if (!queryInput || !sourceSelect) return;
+
+  const query = queryInput.value.trim();
+  if (!query) {
+    setStatus("Enter a title or author to search.", "error");
+    return;
+  }
+
+  const selectedSource = sourceSelect.value as MetadataSource | "all";
+  const sources = selectedSource === "all" ? DEFAULT_SOURCES : [selectedSource];
+
+  setStatus("Searching metadata sources…", "info");
+
+  try {
+    const results = await bridge.invoke<OnlineMetadataResult[]>(
+      "search_online_metadata",
+      { query, sources, limit: 8 }
+    );
+    renderResults(results);
+    setStatus(`Found ${results.length} results.`, "success");
+  } catch (error) {
+    console.error("Metadata lookup failed:", error);
+    setStatus("Search failed. Check your query and try again.", "error");
+  }
+}
+
+function openLookup(): void {
+  const selectedIndices = Array.from(getSelectedFileIndices()).sort((a, b) => a - b);
+  lookupQueue = selectedIndices
+    .map((index) => {
+      const file = currentFileList?.files[index];
+      if (!file || !file.isValid) return null;
+      return { file, index };
+    })
+    .filter((item): item is LookupQueueItem => Boolean(item));
+  queueIndex = 0;
+
+  if (lookupQueue.length === 0) {
+    setStatus("Select a valid file to search metadata.", "error");
+  } else {
+    const queryInput = getSearchInput();
+    if (queryInput) {
+      queryInput.value = deriveQueryFromFile(lookupQueue[0].file);
+    }
+    setStatus("", "info");
+  }
+
+  updateQueueContext();
+  updateApplyModeOptions();
+  resetResults();
+  showModal();
+}
+
+export function initMetadataLookup(): void {
+  const openButton = document.getElementById(
+    "metadata-lookup-btn"
+  ) as HTMLButtonElement | null;
+  const closeButton = document.getElementById(
+    "metadata-lookup-close"
+  ) as HTMLButtonElement | null;
+  const searchButton = document.getElementById(
+    "metadata-lookup-search-btn"
+  ) as HTMLButtonElement | null;
+  const modal = getModal();
+
+  if (openButton) {
+    openButton.addEventListener("click", openLookup);
+  }
+
+  if (closeButton) {
+    closeButton.addEventListener("click", hideModal);
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal) {
+        hideModal();
+      }
+    });
+  }
+
+  if (searchButton) {
+    searchButton.addEventListener("click", () => {
+      void runSearch();
+    });
+  }
+
+  const searchInput = getSearchInput();
+  if (searchInput) {
+    searchInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void runSearch();
+      }
+    });
+  }
+
+  const results = getResultsContainer();
+  if (results) {
+    results.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      const button = target.closest<HTMLButtonElement>("button[data-index]");
+      if (!button) return;
+      const index = Number(button.dataset.index ?? "-1");
+      const result = currentResults[index];
+      if (!result) return;
+      void applyResult(result);
+    });
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a lightweight, prototype flow to search reputable online audiobook metadata sources and apply results into the existing metadata editor UI to support single and batch workflows.
- Keep the scope small and secure by limiting sources to two high-quality providers (`Open Library` and `Apple Books`/iTunes) and reusing existing backend cover-art fetching (which includes SSRF protections).
- Provide an agent- and developer-friendly integration that stages metadata changes (so users can review before writing) and fits existing multi-select and queue semantics.

### Description
- Backend: added a new Tauri command `search_online_metadata` implemented in `src-tauri/src/commands/metadata_lookup.rs` that queries Open Library and iTunes, normalizes results into `OnlineMetadataResult`, enforces simple input validation and client timeouts, and returns a combined result set.
- Types & mocks: added `OnlineMetadataResult` and `MetadataSource` to `src/types/metadata.ts` and included DEV mocks in `src/lib/mocks.ts` so the UI can be exercised without the native backend.
- Frontend UI: added a modal-based lookup UX (`index.html`, `src/styles.css`) and a controller `src/ui/metadataLookup.ts` that implements search, result rendering, per-result "Use Metadata" actions, apply modes (`current`, `all`, `queue`), per-file queue handling, and cover-art application via existing `load_cover_art_from_url` bridge.
- Integration points: registered the new command in `src-tauri/src/commands/mod.rs` and `src-tauri/src/lib.rs`, initialized the UI module in `src/main.ts`, and added small helpers in `src/ui/metadataForm.ts` and `src/ui/coverArt.ts` to support programmatic application of metadata and custom cover art.

### Testing
- Ran `scripts/quick-checks.sh` (which runs `cargo fmt`/`clippy` etc.); `cargo fmt` passed but the run failed during `cargo` build/clippy due to a missing system dependency (`glib-2.0` pkg-config) in the environment which prevented full verification.
- Started the frontend dev server (`bun run dev` / `vite`) and exercised the new modal via an automated browser script to confirm the dialog renders and the results UI appears (screenshot artifact captured during the run).
- Unit / integration tests were not added for the prototype per scope, and existing repo tests could not be fully executed because of the CI environment system dependency noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f37852640832ab226247c51a4d9b2)