### PR TITLE
Add Audible import prototype (AAX → M4B) with decrypt command and stabilize tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "ffmpeg-next",
  "futures",
  "image",
+ "libc",
  "log",
  "mp4ameta",
  "num_cpus",

--- a/docs/audible-import-prototype.md
+++ b/docs/audible-import-prototype.md
@@ -1,0 +1,21 @@
+# Audible Import Prototype Notes
+
+## Goal
+- Provide a minimal in-app path to decrypt Audible `.aax` downloads into `.m4b` files and load them into the existing Audiobook Boss workflow.
+
+## Minimal workflow
+- Select one or more `.aax` files.
+- Provide Audible activation bytes (16 hex characters / 8 bytes).
+- Decrypt to temporary `.m4b` files and load them into the file list for muxing/shrinking.
+- Remove original `.aax` downloads unless the user opts in to keeping them.
+
+## Metadata & security primitives
+- Preserve embedded metadata by stream-copying and retaining container/stream tags.
+- Require input path validation and activation byte sanity checks before decryption.
+
+## UX impact
+- Uses a dedicated modal to avoid interrupting the primary import workflow.
+- Keeps the main file list and processing pipeline unchanged by returning standard `FileListInfo`.
+
+## Libation reference
+- Direct repository inspection is pending; the environment returned a 403 when attempting to clone Libation.

--- a/docs/external-apis/tauri-commands.md
+++ b/docs/external-apis/tauri-commands.md
@@ -9,6 +9,7 @@ This guide expands on the lightweight index by summarizing the public Tauri IPC 
 | `ping`, `echo` | `src-tauri/src/commands/system.rs` | Console smoke tests via `window.testCommands` |
 | `validate_files` | `src-tauri/src/commands/audio.rs` → `audio::path_validation` | Integration tests and console harness |
 | `analyze_audio_files` | `src-tauri/src/commands/audio.rs` → `audio::file_list` | Drag/drop and picker flows in `src/ui/fileImport` |
+| `decrypt_audible_titles` | `src-tauri/src/commands/audio.rs` → `audio::audible_import` | Audible import modal (`src/ui/audibleImport`) |
 | `validate_encoder_settings_cmd` | `src-tauri/src/commands/audio.rs` → `audio::settings_encoder` | Reserved for advanced encoder UI; no current UI caller |
 | `process_audiobook_files_v2` | `src-tauri/src/commands/audio.rs` (async) | `StatusPanel` start/preview flows, providing EncoderSettings v2 |
 | `cancel_processing` | `src-tauri/src/commands/audio.rs` → `JobRegistry` | StatusPanel cancel-all and per-job cancel |
@@ -37,7 +38,14 @@ This guide expands on the lightweight index by summarizing the public Tauri IPC 
   - Notes:
     - `metadata` is keyed by input path; merge uses the first input path as the metadata key.
     - Threads mapping: `{mode:'auto'|'off'|'fixed'; value?}` → `threads=0|1|n`
-    - Emits `processing-progress` events with `job_id` and optional `input_index` (backward compatible)
+  - Emits `processing-progress` events with `job_id` and optional `input_index` (backward compatible)
+
+- `decrypt_audible_titles`
+  - Args: `{ filePaths: string[]; activationBytes: string; retainOriginal: boolean }`
+  - Returns: `FileListInfo` (`src/types/audio.ts:15`)
+  - Notes:
+    - Activation bytes must be 16 hex characters (8 bytes).
+    - Decrypted M4B files are returned to the main file list.
 
 - `cancel_processing`
   - Args: `{ job_id?: string }`
@@ -64,7 +72,7 @@ This guide expands on the lightweight index by summarizing the public Tauri IPC 
 
 ### Contract sources
 
-- Command and data types: `src/types/audio.ts`, `src/types/metadata.ts`
+- Command and data types: `src/types/audio.ts`, `src/types/audible.ts`, `src/types/metadata.ts`
 - Event contracts: `src/types/events.ts`
 
 ### Backend → frontend events

--- a/index.html
+++ b/index.html
@@ -84,6 +84,14 @@
               Sort: A-Z
             </button>
             <button
+              id="audible-import-open"
+              class="btn-pill btn-pill-secondary"
+              data-testid="audible-import-open"
+              type="button"
+            >
+              Audible Import
+            </button>
+            <button
               id="clear-files-btn"
               class="btn-pill btn-pill-secondary"
               style="display: none"
@@ -944,6 +952,95 @@
             id="metadata-lookup-results"
             class="metadata-lookup-results"
           ></div>
+        </div>
+      </div>
+    </div>
+    <div
+      id="audible-import-modal"
+      class="metadata-lookup-modal"
+      data-testid="audible-import-modal"
+      aria-hidden="true"
+    >
+      <div
+        class="metadata-lookup-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="audible-import-title"
+      >
+        <div class="metadata-lookup-header">
+          <h3 id="audible-import-title">Audible Import (Prototype)</h3>
+          <button
+            id="audible-import-close"
+            class="btn-pill btn-pill-secondary"
+            data-testid="audible-import-close"
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+        <div class="metadata-lookup-body">
+          <div class="audible-import-controls">
+            <div class="audible-import-field audible-import-files">
+              <label for="audible-import-files">Audible .aax files</label>
+              <div class="audible-import-file-row">
+                <input
+                  id="audible-import-files"
+                  data-testid="audible-import-files"
+                  type="text"
+                  placeholder="No files selected"
+                  readonly
+                />
+                <button
+                  id="audible-import-select"
+                  class="btn-pill btn-pill-secondary"
+                  data-testid="audible-import-select"
+                  type="button"
+                >
+                  Choose files
+                </button>
+              </div>
+            </div>
+            <div class="audible-import-field">
+              <label for="audible-import-activation">Activation bytes</label>
+              <input
+                id="audible-import-activation"
+                data-testid="audible-import-activation"
+                type="text"
+                placeholder="16 hex chars (e.g. 1A2B3C4D5E6F7890)"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
+            <div class="audible-import-field audible-import-field-toggle">
+              <label class="checkbox-label text-xs mb-0">
+                <input
+                  type="checkbox"
+                  id="audible-import-retain"
+                  data-testid="audible-import-retain"
+                />
+                <span class="option-label">Keep original .aax downloads</span>
+              </label>
+            </div>
+            <div class="audible-import-field audible-import-field-button">
+              <button
+                id="audible-import-start"
+                class="btn-pill btn-pill-primary"
+                data-testid="audible-import-start"
+                type="button"
+              >
+                Decrypt & Add to Queue
+              </button>
+            </div>
+          </div>
+          <div
+            id="audible-import-status"
+            class="metadata-lookup-status text-xs"
+          ></div>
+          <div class="audible-import-guidance text-xs muted-text">
+            Decrypted files are loaded into the main workflow for muxing and
+            shrinking. Original .aax downloads are removed unless you opt in to
+            keep them.
+          </div>
         </div>
       </div>
     </div>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,3 +49,4 @@ default = []
 tempfile = "3.24.0"
 tauri = { version = "2.9.5", features = ["test"] }
 futures = "0.3.31"
+libc = "0.2.177"

--- a/src-tauri/src/audio/audible_import.rs
+++ b/src-tauri/src/audio/audible_import.rs
@@ -1,0 +1,167 @@
+use crate::errors::{AppError, Result};
+use crate::metadata::set_stream_disposition_and_clear_codec_tag;
+use ffmpeg_next as ff;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ACTIVATION_BYTES_LENGTH: usize = 16;
+
+pub fn decrypt_audible_files(
+    file_paths: &[PathBuf],
+    activation_bytes: &str,
+    retain_original: bool,
+) -> Result<Vec<PathBuf>> {
+    if file_paths.is_empty() {
+        return Err(AppError::InvalidInput(
+            "No Audible files provided for decryption".to_string(),
+        ));
+    }
+
+    let normalized_bytes = normalize_activation_bytes(activation_bytes)?;
+    let output_dir = audible_temp_dir()?;
+
+    ff::init().map_err(AppError::Ffmpeg)?;
+
+    let mut decrypted_files = Vec::with_capacity(file_paths.len());
+    for path in file_paths {
+        let canonical = crate::audio::path_validation::validate_input_audio_path(path)?;
+        let output_path = decrypt_single_audible_file(&canonical, &output_dir, &normalized_bytes)?;
+        decrypted_files.push(output_path);
+
+        if !retain_original {
+            fs::remove_file(&canonical).map_err(|_| {
+                AppError::ResourceCleanup("Failed to remove original Audible download".to_string())
+            })?;
+        }
+    }
+
+    Ok(decrypted_files)
+}
+
+fn normalize_activation_bytes(raw: &str) -> Result<String> {
+    let trimmed: String = raw.chars().filter(|c| !c.is_whitespace()).collect();
+    let cleaned = trimmed.strip_prefix("0x").unwrap_or(&trimmed);
+    if cleaned.len() != ACTIVATION_BYTES_LENGTH {
+        return Err(AppError::InvalidInput(format!(
+            "Activation bytes must be {ACTIVATION_BYTES_LENGTH} hex characters"
+        )));
+    }
+
+    if !cleaned.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(AppError::InvalidInput(
+            "Activation bytes must be hex characters only".to_string(),
+        ));
+    }
+
+    Ok(cleaned.to_ascii_lowercase())
+}
+
+fn audible_temp_dir() -> Result<PathBuf> {
+    let dir = std::env::temp_dir()
+        .join(crate::audio::constants::TEMP_DIR_NAME)
+        .join("audible-import");
+    fs::create_dir_all(&dir).map_err(|_| {
+        AppError::TempDirectoryCreation(
+            "Failed to create temporary directory for Audible import".to_string(),
+        )
+    })?;
+    Ok(dir)
+}
+
+fn decrypt_single_audible_file(
+    input_path: &Path,
+    output_dir: &Path,
+    activation_bytes: &str,
+) -> Result<PathBuf> {
+    let mut opts = ff::Dictionary::new();
+    opts.set("activation_bytes", activation_bytes);
+
+    let mut ictx = ff::format::input_with_dictionary(input_path, opts).map_err(AppError::Ffmpeg)?;
+
+    let file_stem = input_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(sanitize_file_stem)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "audible".to_string());
+    let output_path = output_dir.join(format!("{}-{}.m4b", file_stem, uuid::Uuid::new_v4()));
+
+    if output_path.exists() {
+        fs::remove_file(&output_path).map_err(AppError::Io)?;
+    }
+
+    let mut octx = ff::format::output(&output_path).map_err(AppError::Ffmpeg)?;
+    let stream_len = ictx.streams().len();
+    let mut stream_mapping: Vec<isize> = vec![-1; stream_len];
+    let mut output_time_bases: Vec<Option<ff::Rational>> = vec![None; stream_len];
+
+    for (index, istream) in ictx.streams().enumerate() {
+        if istream.parameters().medium() == ff::media::Type::Data {
+            continue;
+        }
+
+        let codec_ctx = ff::codec::context::Context::from_parameters(istream.parameters())
+            .map_err(AppError::Ffmpeg)?;
+        let mut ostream = octx.add_stream_with(&codec_ctx).map_err(AppError::Ffmpeg)?;
+
+        ostream.set_time_base(istream.time_base());
+        ostream.set_metadata(istream.metadata().to_owned());
+        set_stream_disposition_and_clear_codec_tag(&mut ostream, istream.disposition());
+
+        stream_mapping[index] = ostream.index() as isize;
+        output_time_bases[ostream.index()] = Some(ostream.time_base());
+    }
+
+    if ictx.nb_chapters() > 0 {
+        for chapter in ictx.chapters() {
+            let title = chapter.metadata().get("title").map(|s| s.to_string());
+            if let Err(e) = octx.add_chapter(
+                chapter.id(),
+                chapter.time_base(),
+                chapter.start(),
+                chapter.end(),
+                title.as_deref().unwrap_or(""),
+            ) {
+                log::warn!("Failed to add chapter id {}: {}", chapter.id(), e);
+            }
+        }
+    }
+
+    octx.set_metadata(ictx.metadata().to_owned());
+    octx.write_header().map_err(AppError::Ffmpeg)?;
+
+    for (input_stream, mut packet) in ictx.packets() {
+        let in_index = input_stream.index();
+        let out_index = *stream_mapping.get(in_index).unwrap_or(&-1);
+        if out_index < 0 {
+            continue;
+        }
+
+        let out_tb = output_time_bases
+            .get(out_index as usize)
+            .and_then(|tb| *tb)
+            .unwrap_or(input_stream.time_base());
+
+        packet.set_stream(out_index as usize);
+        packet.rescale_ts(input_stream.time_base(), out_tb);
+        packet
+            .write_interleaved(&mut octx)
+            .map_err(AppError::Ffmpeg)?;
+    }
+
+    octx.write_trailer().map_err(AppError::Ffmpeg)?;
+
+    Ok(output_path)
+}
+
+fn sanitize_file_stem(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/src-tauri/src/audio/constants.rs
+++ b/src-tauri/src/audio/constants.rs
@@ -62,7 +62,7 @@ pub const DEFAULT_SAMPLE_RATE: u32 = 22050;
 pub const DEFAULT_OUTPUT_EXTENSION: &str = "m4b";
 
 /// Supported audio file extensions (lowercase)
-pub const ALLOWED_AUDIO_EXTENSIONS: &[&str] = &["mp3", "m4a", "m4b", "aac", "wav", "flac"];
+pub const ALLOWED_AUDIO_EXTENSIONS: &[&str] = &["mp3", "m4a", "m4b", "aac", "wav", "flac", "aax"];
 
 /// Temporary merged output filename
 pub const TEMP_MERGED_FILENAME: &str = "merged.m4b";

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub mod audible_import;
 pub mod buffer;
 pub mod cleanup;
 pub mod constants;

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -12,6 +12,14 @@ use crate::errors::{AppError, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudibleDecryptPayload {
+    pub file_paths: Vec<String>,
+    pub activation_bytes: String,
+    pub retain_original: bool,
+}
+
 /// Validates that all provided file paths exist and are files
 /// Accepts an array of file paths and checks file existence
 #[tauri::command]
@@ -51,6 +59,18 @@ pub fn validate_files(file_paths: Vec<String>) -> Result<String> {
 pub fn analyze_audio_files(file_paths: Vec<String>) -> Result<FileListInfo> {
     let paths: Vec<PathBuf> = file_paths.iter().map(PathBuf::from).collect();
     audio::get_file_list_info(&paths)
+}
+
+/// Decrypts Audible AAX files into M4B and returns file list info for the UI workflow.
+#[tauri::command]
+pub fn decrypt_audible_titles(payload: AudibleDecryptPayload) -> Result<FileListInfo> {
+    let paths: Vec<PathBuf> = payload.file_paths.iter().map(PathBuf::from).collect();
+    let decrypted_paths = audio::audible_import::decrypt_audible_files(
+        &paths,
+        &payload.activation_bytes,
+        payload.retain_original,
+    )?;
+    audio::get_file_list_info(&decrypted_paths)
 }
 
 /// Validates encoder settings (no side effects)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
             commands::save_metadata_to_file,
             commands::search_online_metadata,
             commands::analyze_audio_files,
+            commands::decrypt_audible_titles,
             commands::validate_encoder_settings_cmd,
             commands::list_available_encoders,
             commands::get_max_concurrent_jobs,

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -20,6 +20,8 @@ pub mod mp4ameta_bridge;
 // Passthrough helpers for chapter/cover preservation
 pub mod passthrough;
 
+pub(crate) use ffi::set_stream_disposition_and_clear_codec_tag;
+
 /// Represents audiobook metadata
 ///
 /// Field mapping for Plex/Audiobookshelf compatibility:

--- a/src-tauri/tests/integration_path_validation_tests.rs
+++ b/src-tauri/tests/integration_path_validation_tests.rs
@@ -196,6 +196,11 @@ fn test_output_path_validation_integration() {
 fn test_read_only_output_directory_integration() {
     use std::os::unix::fs::PermissionsExt;
 
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("Skipping read-only directory check when running as root.");
+        return;
+    }
+
     let temp_dir = TempDir::new().expect("create temp dir");
     let readonly_dir = temp_dir.path().join("readonly");
     std::fs::create_dir(&readonly_dir).expect("create readonly dir");

--- a/src-tauri/tests/integration_reqwest_resolver_tests.rs
+++ b/src-tauri/tests/integration_reqwest_resolver_tests.rs
@@ -17,6 +17,17 @@ impl Resolve for PortZeroResolver {
 
 #[tokio::test]
 async fn reqwest_replaces_port_zero_with_url_port() -> Result<(), Box<dyn std::error::Error>> {
+    for var in [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ] {
+        std::env::remove_var(var);
+    }
+
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 

--- a/src/lib/mocks.ts
+++ b/src/lib/mocks.ts
@@ -134,6 +134,9 @@ export async function mockInvoke<T>(cmd: string, args?: any): Promise<T> {
     case "analyze_audio_files":
       return MOCK_FILE_LIST as unknown as T;
 
+    case "decrypt_audible_titles":
+      return MOCK_FILE_LIST as unknown as T;
+
     case "read_audio_metadata":
       return MOCK_METADATA as unknown as T;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
 import { initTagPreview } from "./ui/tagPreview";
 import { initJobControls } from "./ui/jobControls";
 import { initMetadataLookup } from "./ui/metadataLookup";
+import { initAudibleImport } from "./ui/audibleImport";
 import { setMetadataForFile, getMetadataForFile } from "./ui/metadataState";
 import { isMetadataSaveInProgress, setMetadataSaveInProgress } from "./ui/metadataSaveState";
 
@@ -30,6 +31,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Initialize tag preview grid
   initTagPreview();
   initMetadataLookup();
+  initAudibleImport();
   // Initialize Cmd+S metadata save handler
   initMetadataSaveHandler();
   // Initialize Job Controls (Job Type, Max Concurrent)
@@ -40,6 +42,7 @@ document.addEventListener("DOMContentLoaded", () => {
   console.log("Cover art system initialized");
   console.log("Tag preview initialized");
   console.log("Metadata save handler initialized (Cmd+S / Ctrl+S)");
+  console.log("Audible import initialized");
 });
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -840,6 +840,47 @@ textarea:hover:not(:focus) {
   color: var(--text-muted);
 }
 
+.audible-import-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.audible-import-field label {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.audible-import-files {
+  grid-column: 1 / -1;
+}
+
+.audible-import-file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.audible-import-file-row input {
+  flex: 1;
+}
+
+.audible-import-field-toggle {
+  display: flex;
+  align-items: flex-end;
+}
+
+.audible-import-field-button {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.audible-import-guidance {
+  line-height: 1.4;
+}
+
 /* Property labels/values */
 .property-label {
   font-weight: 500;

--- a/src/types/audible.ts
+++ b/src/types/audible.ts
@@ -1,0 +1,5 @@
+export interface AudibleImportPayload {
+  filePaths: string[];
+  activationBytes: string;
+  retainOriginal: boolean;
+}

--- a/src/ui/audibleImport.ts
+++ b/src/ui/audibleImport.ts
@@ -1,0 +1,207 @@
+import { bridge } from "../lib/bridge";
+import type { FileListInfo } from "../types/audio";
+import type { AudibleImportPayload } from "../types/audible";
+import { displayFileList } from "./fileList";
+import { isOrderLocked } from "./fileList/state";
+
+type StatusVariant = "error" | "success" | "info";
+
+const AUDIBLE_EXTENSIONS = ["aax"];
+const DEFAULT_STATUS = "Select .aax files and provide activation bytes.";
+
+let selectedFiles: string[] = [];
+
+function getModal(): HTMLElement | null {
+  return document.getElementById("audible-import-modal");
+}
+
+function getOpenButton(): HTMLButtonElement | null {
+  const el = document.getElementById("audible-import-open");
+  return el instanceof HTMLButtonElement ? el : null;
+}
+
+function getCloseButton(): HTMLButtonElement | null {
+  const el = document.getElementById("audible-import-close");
+  return el instanceof HTMLButtonElement ? el : null;
+}
+
+function getSelectButton(): HTMLButtonElement | null {
+  const el = document.getElementById("audible-import-select");
+  return el instanceof HTMLButtonElement ? el : null;
+}
+
+function getStartButton(): HTMLButtonElement | null {
+  const el = document.getElementById("audible-import-start");
+  return el instanceof HTMLButtonElement ? el : null;
+}
+
+function getFilesInput(): HTMLInputElement | null {
+  const el = document.getElementById("audible-import-files");
+  return el instanceof HTMLInputElement ? el : null;
+}
+
+function getActivationInput(): HTMLInputElement | null {
+  const el = document.getElementById("audible-import-activation");
+  return el instanceof HTMLInputElement ? el : null;
+}
+
+function getRetainToggle(): HTMLInputElement | null {
+  const el = document.getElementById("audible-import-retain");
+  return el instanceof HTMLInputElement ? el : null;
+}
+
+function getStatusEl(): HTMLElement | null {
+  return document.getElementById("audible-import-status");
+}
+
+function setStatus(message: string, variant: StatusVariant = "info"): void {
+  const statusEl = getStatusEl();
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.classList.toggle("is-error", variant === "error");
+  statusEl.classList.toggle("is-success", variant === "success");
+}
+
+function showModal(): void {
+  const modal = getModal();
+  if (!modal) return;
+  modal.classList.add("open");
+  modal.setAttribute("aria-hidden", "false");
+  setStatus(DEFAULT_STATUS, "info");
+}
+
+function hideModal(): void {
+  const modal = getModal();
+  if (!modal) return;
+  modal.classList.remove("open");
+  modal.setAttribute("aria-hidden", "true");
+}
+
+function updateFilesSummary(): void {
+  const input = getFilesInput();
+  if (!input) return;
+  if (selectedFiles.length === 0) {
+    input.value = "";
+    input.placeholder = "No files selected";
+    return;
+  }
+  input.value = `${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"} selected`;
+}
+
+function normalizeActivationBytes(raw: string): string | null {
+  const trimmed = raw.trim().replace(/\s+/g, "");
+  const cleaned = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed;
+  if (!/^[0-9a-fA-F]+$/.test(cleaned)) return null;
+  if (cleaned.length !== 16) return null;
+  return cleaned.toLowerCase();
+}
+
+async function selectFiles(): Promise<void> {
+  try {
+    const selected = await bridge.open({
+      multiple: true,
+      directory: false,
+      filters: [
+        {
+          name: "Audible Downloads",
+          extensions: AUDIBLE_EXTENSIONS,
+        },
+      ],
+    });
+
+    if (Array.isArray(selected) && selected.length > 0) {
+      selectedFiles = selected;
+    } else if (typeof selected === "string") {
+      selectedFiles = [selected];
+    }
+
+    updateFilesSummary();
+    if (selectedFiles.length > 0) {
+      setStatus("Files ready. Provide activation bytes to continue.", "info");
+    } else {
+      setStatus(DEFAULT_STATUS, "info");
+    }
+  } catch (error) {
+    setStatus(`Failed to open file dialog: ${error}`, "error");
+  }
+}
+
+async function startImport(): Promise<void> {
+  if (isOrderLocked()) {
+    setStatus("Order locked while processing. Wait for completion.", "error");
+    return;
+  }
+
+  if (selectedFiles.length === 0) {
+    setStatus("Select at least one .aax file first.", "error");
+    return;
+  }
+
+  const activationInput = getActivationInput();
+  const activationRaw = activationInput?.value ?? "";
+  const activationBytes = normalizeActivationBytes(activationRaw);
+  if (!activationBytes) {
+    setStatus("Activation bytes must be 16 hex characters.", "error");
+    return;
+  }
+
+  const retain = getRetainToggle()?.checked ?? false;
+  const payload: AudibleImportPayload = {
+    filePaths: selectedFiles,
+    activationBytes,
+    retainOriginal: retain,
+  };
+
+  try {
+    setStatus("Decrypting Audible downloads...", "info");
+    const fileListInfo: FileListInfo = await bridge.invoke(
+      "decrypt_audible_titles",
+      payload
+    );
+    displayFileList(fileListInfo);
+    setStatus("Audible titles decrypted and loaded.", "success");
+    resetForm();
+    hideModal();
+  } catch (error) {
+    setStatus(`Audible import failed: ${error}`, "error");
+  }
+}
+
+function resetForm(): void {
+  selectedFiles = [];
+  updateFilesSummary();
+  const activationInput = getActivationInput();
+  if (activationInput) {
+    activationInput.value = "";
+  }
+  const retainToggle = getRetainToggle();
+  if (retainToggle) {
+    retainToggle.checked = false;
+  }
+}
+
+export function initAudibleImport(): void {
+  const openButton = getOpenButton();
+  const closeButton = getCloseButton();
+  const selectButton = getSelectButton();
+  const startButton = getStartButton();
+
+  if (!openButton || !closeButton || !selectButton || !startButton) return;
+
+  openButton.addEventListener("click", () => {
+    resetForm();
+    showModal();
+  });
+
+  closeButton.addEventListener("click", () => {
+    hideModal();
+  });
+
+  selectButton.addEventListener("click", () => {
+    void selectFiles();
+  });
+
+  startButton.addEventListener("click", () => {
+    void startImport();
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide an in-app prototype to decrypt user-owned Audible `.aax` downloads into `.m4b` and load them into the existing processing pipeline with minimal UX friction. 
- Keep the integration surface small by reusing existing file-list/metadata contracts and preserve metadata/chapters during stream-copy decryption. 
- Stabilize CI/test behavior that was intermittently failing in certain environments (root user, local HTTP proxy interference). 

### Description
- Add a frontend Audible Import modal and flow (`index.html`, `src/styles.css`, `src/ui/audibleImport.ts`) and a new payload type `src/types/audible.ts`. 
- Implement a backend decrypt-and-copy pipeline `src-tauri/src/audio/audible_import.rs` using `ffmpeg-next` that accepts `activation_bytes`, preserves metadata/chapters, writes temporary `.m4b` outputs, and optionally removes originals. 
- Expose a new Tauri command `decrypt_audible_titles` (handler in `src-tauri/src/commands/audio.rs`) and register it in the invoke handler; extend allowed audio extensions to include `aax` in `src-tauri/src/audio/constants.rs`. 
- Re-export a metadata helper in `src-tauri/src/metadata/mod.rs` and switch the Audible importer to use it; add a mock command in `src/lib/mocks.ts` and wire initialization in `src/main.ts`; document the command in `docs/external-apis/tauri-commands.md`. 
- Stabilize tests by skipping the read-only-directory assertion when running as root (adding a `libc` dev-dependency and UID check), and clearing common proxy env vars inside the reqwest resolver test to avoid local proxy interference (`src-tauri/tests/*`). 

### Testing
- Ran `scripts/standard-checks.sh` (which runs quick checks, `cargo test`, and the frontend build via `bun run build`) and the full standard checks passed. 
- `cargo test` executed unit and integration suites (including path/metadata/ffmpeg-related tests) and completed with all tests passing after the fixes. 
- Frontend build (`bun run build` / `vite build`) completed successfully during the standard checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982140af468832a899f0c93ee54dfd1)