### PR TITLE
perf: lane 185 bounded batch scheduler

### DIFF
--- a/src-tauri/src/audio/job_registry/mod.rs
+++ b/src-tauri/src/audio/job_registry/mod.rs
@@ -7,10 +7,12 @@ mod cancel;
 mod types;
 
 use crate::errors::{AppError, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::task::JoinSet;
 use uuid::Uuid;
 
 pub use cancel::CancellationChecker;
@@ -29,6 +31,91 @@ pub struct JobRegistry {
     max_concurrent: AtomicUsize,
     /// Global cancellation flag (cancels all jobs when set)
     global_cancel: Arc<AtomicBool>,
+}
+
+/// Internal batch scheduler facade backed by JobRegistry concurrency settings.
+pub struct BatchScheduler<'a> {
+    registry: &'a JobRegistry,
+}
+
+impl<'a> BatchScheduler<'a> {
+    fn new(registry: &'a JobRegistry) -> Self {
+        Self { registry }
+    }
+
+    /// Runs a batch of futures with bounded in-flight concurrency.
+    ///
+    /// If one task fails, no new tasks are scheduled. Existing in-flight tasks
+    /// are drained before returning the first encountered error.
+    pub async fn run_batch<R, Fut>(&self, futures: Vec<Fut>) -> Result<Vec<R>>
+    where
+        R: Send + 'static,
+        Fut: Future<Output = Result<R>> + Send + 'static,
+    {
+        if futures.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let max_in_flight = self.registry.max_concurrent().max(1);
+        let total_tasks = futures.len();
+        let mut pending: VecDeque<(usize, Fut)> = futures.into_iter().enumerate().collect();
+        let mut join_set: JoinSet<(usize, Result<R>)> = JoinSet::new();
+        let mut ordered_results: Vec<Option<R>> = Vec::with_capacity(total_tasks);
+        ordered_results.resize_with(total_tasks, || None);
+        let mut first_error: Option<AppError> = None;
+
+        for _ in 0..max_in_flight {
+            if let Some((index, future)) = pending.pop_front() {
+                join_set.spawn(async move { (index, future.await) });
+            } else {
+                break;
+            }
+        }
+
+        while let Some(joined) = join_set.join_next().await {
+            match joined {
+                Ok((index, Ok(value))) => {
+                    if first_error.is_none() {
+                        ordered_results[index] = Some(value);
+                    }
+                }
+                Ok((_, Err(error))) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+                Err(join_error) => {
+                    if first_error.is_none() {
+                        first_error = Some(AppError::General(format!(
+                            "Batch task join error: {join_error}"
+                        )));
+                    }
+                }
+            }
+
+            if first_error.is_none() {
+                if let Some((next_index, next_future)) = pending.pop_front() {
+                    join_set.spawn(async move { (next_index, next_future.await) });
+                }
+            }
+        }
+
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+
+        ordered_results
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value.ok_or_else(|| {
+                    AppError::General(format!(
+                        "Batch scheduler missing result for task index {index}"
+                    ))
+                })
+            })
+            .collect()
+    }
 }
 
 impl JobRegistry {
@@ -62,6 +149,11 @@ impl JobRegistry {
     pub fn default_max() -> usize {
         let cores = num_cpus::get();
         Self::normalize_max(cores / 2)
+    }
+
+    /// Returns a scheduler facade for bounded batch task orchestration.
+    pub fn scheduler(&self) -> BatchScheduler<'_> {
+        BatchScheduler::new(self)
     }
 
     /// Registers a new job and acquires a semaphore permit

--- a/src-tauri/src/commands/audio_processing.rs
+++ b/src-tauri/src/commands/audio_processing.rs
@@ -143,7 +143,7 @@ async fn dispatch_batch_jobs(
     };
     let _ = window.emit(crate::audio::constants::QUEUE_EVENT_NAME, &queue_event);
 
-    let mut tasks = Vec::new();
+    let mut scheduled_jobs = Vec::new();
     let mut claimed_paths: HashSet<PathBuf> = HashSet::new();
     for (index, input) in payload.input_files.iter().enumerate() {
         let path = PathBuf::from(input);
@@ -165,7 +165,7 @@ async fn dispatch_batch_jobs(
         let input_index = Some(index);
         let preview_cloned = inputs.preview_seconds;
 
-        tasks.push(tokio::spawn(async move {
+        scheduled_jobs.push(async move {
             let file_info = audio::get_file_list_info(std::slice::from_ref(&path))?;
             run_processing_job(
                 window_cloned,
@@ -179,23 +179,13 @@ async fn dispatch_batch_jobs(
                 preview_cloned,
             )
             .await
-        }));
+        });
     }
 
-    let mut last_ok: Option<ProcessCommandResult> = None;
-    for task in tasks {
-        match task.await {
-            Ok(Ok(res)) => last_ok = Some(res),
-            Ok(Err(e)) => return Err(e),
-            Err(join_err) => {
-                return Err(AppError::General(format!(
-                    "Batch task join error: {join_err}"
-                )))
-            }
-        }
-    }
+    let mut ordered_results = registry.scheduler().run_batch(scheduled_jobs).await?;
 
-    last_ok
+    ordered_results
+        .pop()
         .ok_or_else(|| AppError::InvalidInput("Batch processing produced no results".to_string()))
 }
 

--- a/src-tauri/tests/unit_audio_job_registry_tests.rs
+++ b/src-tauri/tests/unit_audio_job_registry_tests.rs
@@ -203,6 +203,112 @@ async fn test_stress_concurrent_registration_respects_limit() {
     assert_eq!(status.total_jobs, 0);
 }
 
+#[tokio::test]
+async fn test_scheduler_respects_max_in_flight() {
+    use std::sync::atomic::AtomicUsize;
+    use tokio::time::{sleep, Duration};
+
+    let registry = JobRegistry::new(2);
+    let active = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let mut futures = Vec::new();
+    for _ in 0..12 {
+        let active = Arc::clone(&active);
+        let peak = Arc::clone(&peak);
+        futures.push(async move {
+            let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+            let mut observed = peak.load(Ordering::SeqCst);
+            while current > observed {
+                match peak.compare_exchange(observed, current, Ordering::SeqCst, Ordering::SeqCst) {
+                    Ok(_) => break,
+                    Err(new_obs) => observed = new_obs,
+                }
+            }
+
+            sleep(Duration::from_millis(10)).await;
+            active.fetch_sub(1, Ordering::SeqCst);
+            Ok(1usize)
+        });
+    }
+
+    let results = registry
+        .scheduler()
+        .run_batch(futures)
+        .await
+        .expect("scheduler should complete all jobs");
+
+    assert_eq!(results.len(), 12);
+    assert!(
+        peak.load(Ordering::SeqCst) <= 2,
+        "scheduler should not exceed max_concurrent"
+    );
+}
+
+#[tokio::test]
+async fn test_scheduler_preserves_input_order() {
+    use tokio::time::{sleep, Duration};
+
+    let registry = JobRegistry::new(2);
+    let mut futures = Vec::new();
+
+    for index in 0..5usize {
+        futures.push(async move {
+            sleep(Duration::from_millis((4 - index as u64) * 5)).await;
+            Ok(index)
+        });
+    }
+
+    let results = registry
+        .scheduler()
+        .run_batch(futures)
+        .await
+        .expect("scheduler should complete");
+
+    assert_eq!(results, vec![0, 1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn test_scheduler_stops_scheduling_after_first_error() {
+    use std::sync::atomic::AtomicUsize;
+    use tokio::time::{sleep, Duration};
+
+    let registry = JobRegistry::new(2);
+    let started = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+    let mut futures = Vec::new();
+
+    for index in 0..6usize {
+        let started = Arc::clone(&started);
+        let completed = Arc::clone(&completed);
+        futures.push(async move {
+            started.fetch_add(1, Ordering::SeqCst);
+
+            if index == 1 {
+                sleep(Duration::from_millis(5)).await;
+                return JobId::parse("not-a-uuid").map(|_| index);
+            }
+
+            sleep(Duration::from_millis(30)).await;
+            completed.fetch_add(1, Ordering::SeqCst);
+            Ok(index)
+        });
+    }
+
+    let result = registry.scheduler().run_batch(futures).await;
+    assert!(result.is_err(), "scheduler should return first task error");
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        2,
+        "scheduler should not enqueue new work after first failure"
+    );
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        1,
+        "in-flight non-failing work should drain before returning"
+    );
+}
+
 #[test]
 fn aggregate_job_status_struct() {
     let status = AggregateJobStatus {


### PR DESCRIPTION
## Summary
- Add an internal `BatchScheduler` facade on `JobRegistry` for bounded, ordered batch orchestration.
- Route batch dispatch through scheduler instead of unbounded spawn fan-out.
- Add scheduler-focused unit tests for max in-flight enforcement, ordered results, and first-error stop scheduling semantics.

Closes #185

## Scope
- `src-tauri/src/audio/job_registry/mod.rs`
- `src-tauri/src/commands/audio_processing.rs`
- `src-tauri/tests/unit_audio_job_registry_tests.rs`

## Contract safety
- No Tauri command signature changes.
- No TS/Rust event payload schema changes.

## Validation
- `scripts/standard-checks.sh` ✅
- `cargo test -p audiobook-boss --test unit_audio_job_registry_tests --test unit_audio_progress_tests` ✅
- `bun run perf:all` executed once (non-zero exit due perf warn threshold); metrics captured below.

## Perf excerpt (`scripts/perf/results/latest.md`)
- `statuspanel-render-lookup` (real): `12.080 ms` (`WARN`, `+15.60%`)
- `audio-processing-throughput` (real): `180.293` realtime_factor (`IMPROVED`, `+844.98%`)
- Attribution (`real`):
  - `native_aac`: `rtf_cli 94.7x`, `rtf_app 65.4x`, `overhead_ratio 31.0%`
  - `aac_at`: `rtf_cli 246.7x`, `rtf_app 229.6x`, `overhead_ratio 6.9%`
  - `fdk_he_aac`: `rtf_cli 200.8x`, `rtf_app 189.9x`, `overhead_ratio 5.5%`

## Pre-merge gates (workflow)
- [ ] JStar manual QA in app (queue lifecycle/cancel/terminal UX)
- [ ] Resolve all PR comments
- [ ] After comments resolved: docs re-alignment pass (AGENTS/spec/perf docs)
- [ ] After all #182/#184/#185 are settled: final cross-PR perf metrics review together
