### PR TITLE
Refine execute-stage comments and audit non-evergreen comment debt

### DIFF
--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -1,28 +1,11 @@
 //! execute.rs
 //!
-//! Phase 2 implementation module for the processor split (see
-//! docs/planning/processor_split_plan.md).
+//! Execution stage for audio processing.
 //!
-//! Responsibilities:
-//!   - Execute merge / conversion stage using selected MediaProcessor implementation
-//!   - Manage stage transition to Converting
-//!   - Perform cancellation checks post-execution
-//!   - Provide context-based (window/session) execution path
-//!
-//! Engine Selection (Post-Nuclear Phase 11):
-//!   All feature flags and shell fallbacks were removed. The only implementation is
-//!   `FfmpegNextProcessor` accessed through `selection::create_default_processor()`.
-//!   Remaining abstraction is intentionally minimal for future enhancements.
-//!
-//! Function Size Compliance:
-//!   All functions <60 LOC. A logging helper can be introduced later if
-//!   additional logging expands bodies near the threshold.
-//!
-//! Public Surface:
-//!   Functions are `pub(crate)` and invoked by orchestrator in `finalize.rs`
-//!   (temporary placement) and later re-exported through `processor::mod.rs`.
-//!
-//! Phase: 2 (Execute Stage Extraction)
+//! This module owns the conversion/merge boundary in the processing pipeline:
+//! it transitions progress into `Converting`, builds a `MediaProcessingPlan`,
+//! dispatches to the selected processor implementation, and performs
+//! cancellation checks before returning the merged output path.
 
 use std::path::{Path, PathBuf};
 
@@ -95,8 +78,7 @@ pub(crate) async fn merge_audio_files_with_context(
         total_duration,
     );
 
-    // Use centralized engine selection via create_default_processor function
-    // This abstracts away the feature flag logic and prepares for engine flip
+    // Centralized processor selection keeps execution flow decoupled from engine wiring.
     log::debug!("Using media processor: {}", get_engine_description());
     let processor = create_default_processor();
     processor


### PR DESCRIPTION
### Motivation
- Reduce noisy, migration-history and phase-tracking comments in the execution stage and replace them with concise, evergreen documentation that describes the module's responsibility in the processing pipeline.
- Surface other modules with similar non-evergreen comments so maintainers can review and standardize module documentation across the codebase.

### Description
- Rewrote the top-level module docs in `src-tauri/src/audio/processor/execute.rs` to a concise purpose-driven explanation describing the conversion/merge boundary, stage transition to `Converting`, `MediaProcessingPlan` construction, processor dispatch, and cancellation checks.
- Replaced an implementation-history inline comment near processor selection with a short, stable rationale: centralized processor selection keeps execution flow decoupled from engine wiring.
- Performed a repository scan for similar non-evergreen/migration-phase comments and collected high-signal locations for human review, including: `src-tauri/src/audio/processor/mod.rs`, `finalize.rs`, `prepare.rs`, `src-tauri/src/audio/buffer.rs`, `src-tauri/src/audio/mod.rs`, `src-tauri/src/commands/audio.rs`, `src-tauri/src/audio/cleanup/guard.rs`, `src-tauri/src/audio/cleanup/mod.rs`, and `src/types/events.ts`.

### Testing
- Ran `cargo fmt --check`, which passed.
- Attempted the standard checks via `scripts/checks.sh standard`, but it could not complete in this environment because the `bun` tool is not installed, so the full standard suite did not run.
- Attempted `cargo clippy --all-targets -- -D warnings && cargo test`, but the run was blocked by a missing system dependency (`glib-2.0`), preventing clippy/tests from completing in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f40649f14832ab41aacc0a1ced168)