### PR TITLE
PR2: External FDK processor adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ bun install
 bun run tauri dev
 ```
 
-**AAC runtime contract**: output encoder choice and input decoder choice are separate concerns. The app stays on the single `ffmpeg-next` engine, but may select compatible AAC decoders such as `aac_at` or `libfdk_aac` at runtime for AAC-family inputs that the default decoder cannot handle. For higher quality AAC encoding and broader AAC decode compatibility on macOS, `brew install fdk-aac` and rebuild ffmpeg with `--enable-libfdk-aac`.
+**AAC runtime contract**: output encoder choice and input decoder choice are separate concerns. Normal processing uses the in-process `ffmpeg-next` engine. FDK HE-AAC output routes through an external FFmpeg/libfdk_aac processor adapter, which can force compatible AAC-family input decoders such as `aac_at` or `libfdk_aac` when the default decoder cannot handle the source. For higher quality AAC encoding and broader AAC decode compatibility on macOS, `brew install fdk-aac` and rebuild ffmpeg with `--enable-libfdk-aac`.
 
 Requires: macOS (Apple Silicon). [Download latest release →](https://github.com/Allmight97/audiobook-boss/releases)
 
@@ -54,6 +54,8 @@ Use this section as the human-facing index. `package.json` is the source of trut
 - UI proof loop: `bun run harness:verify --changed`
 - IPC bindings: `bun run bindings:generate`, `bun run bindings:check`, `bun run bindings:sync`
 - Performance: `bun run perf`, `bun run perf:quick`, `bun run perf:real`, `bun run perf:audio`, `bun run perf:list`
+- xHE-AAC fixture proof: `ABB_XHE_AAC_FIXTURE=/path/to/book.m4b cargo test -p audiobook-boss --test integration_xhe_aac_fixture_tests -- --ignored`
+  Optionally set `ABB_XHE_AAC_FFMPEG=/path/to/ffmpeg` to validate a specific FDK-capable external FFmpeg. The fixture is local-only and not committed.
 - Release: `bun run release:notes`, `bun run release:run`
   `bun run app:build` remains the direct local `.app` path.
   `bun run release:run` now preflights the DMG release artifact.

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -48,6 +48,7 @@ It is intentionally not a full contract dump. Use it to find the owning code qui
 - `get_max_concurrent_jobs`, `set_max_concurrent_jobs`, `process_audiobook_files`, `cancel_processing`
   - Rust: `src-tauri/src/commands/audio.rs`
   - Core helpers: `src-tauri/src/commands/audio_processing.rs`, `src-tauri/src/commands/audio_processing/plan.rs`, `src-tauri/src/audio/job_registry/`
+  - Processor routing: native `ffmpeg-next` and external FFmpeg/FDK adapter selection live under `src-tauri/src/audio/processor/`
   - Use: queueing, processing, cancellation, batch orchestration
 
 ### Metadata

--- a/docs/specs/runtime-architecture-pr-train.md
+++ b/docs/specs/runtime-architecture-pr-train.md
@@ -312,6 +312,19 @@ Boundary glue posture (`Refs #277`):
   metadata-save wrappers, PR2 encoder-panel init only if that UI boundary is
   touched, and optional validator/tag-preview cleanup only at the owning
   boundary.
+- 2026-04-24: Started PR2 on `arch/external-fdk-processor-adapter`. `#256`
+  was inspected before coding: doc/comment alignment fits PR2 directly, while
+  closure also requires an env-gated xHE-AAC/USAC fixture validation path and
+  PR evidence from a real local fixture.
+- 2026-04-24: PR2 implementation added the processor adapter boundary, moved
+  the external FDK worker under processor ownership, removed stale single-engine
+  language, and added an ignored `ABB_XHE_AAC_FIXTURE` validation test. The
+  previously recorded local fixture was not present on disk, so PR2 should
+  reference `#256` but not close it unless fixture evidence is added before
+  merge.
+- 2026-04-24: PR2 validation passed with `scripts/checks.sh package`, including
+  `scripts/checks.sh standard`, app packaging, and
+  `verify_aac_decoder_contract`.
 
 ## 7. Surprises And Discoveries
 

--- a/docs/specs/runtime-architecture-pr-train.md
+++ b/docs/specs/runtime-architecture-pr-train.md
@@ -319,9 +319,11 @@ Boundary glue posture (`Refs #277`):
 - 2026-04-24: PR2 implementation added the processor adapter boundary, moved
   the external FDK worker under processor ownership, removed stale single-engine
   language, and added an ignored `ABB_XHE_AAC_FIXTURE` validation test. The
-  previously recorded local fixture was not present on disk, so PR2 should
-  reference `#256` but not close it unless fixture evidence is added before
-  merge.
+  initial recorded local fixture was not present on disk, but manual ABB dev
+  validation later used two real USAC/xHE-AAC audiobooks. Both selected
+  `aac_at`, the external FDK adapter forced `aac_at`, completed 60-second
+  previews, and `ffprobe` validated both preview outputs. PR2 can now close
+  `#256`.
 - 2026-04-24: PR2 validation passed with `scripts/checks.sh package`, including
   `scripts/checks.sh standard`, app packaging, and
   `verify_aac_decoder_contract`.

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -11,7 +11,6 @@ pub mod buffer;
 pub mod cleanup;
 pub mod constants;
 pub mod context;
-pub mod external_fdk;
 pub mod file_list;
 pub mod job_registry;
 pub mod metrics;
@@ -158,5 +157,8 @@ pub use context::{OutputConfig, ProcessingContextBuilder};
 // Cleanup infrastructure - CleanupGuard used, ProcessGuard feature-gated
 pub use cleanup::CleanupGuard;
 
-// Processor plan and engine surface (single-engine)
-pub use processor::{FfmpegNextProcessor, MediaProcessingPlan, MediaProcessor};
+// Processor plan, native engine, and adapter routing surface
+pub use processor::{
+    FfmpegNextProcessor, MediaProcessingPlan, MediaProcessor, ProcessorAdapterKind,
+    ResolvedProcessorAdapter,
+};

--- a/src-tauri/src/audio/processor/adapter.rs
+++ b/src-tauri/src/audio/processor/adapter.rs
@@ -1,0 +1,241 @@
+use crate::audio::file_list::FileListInfo;
+use crate::audio::settings_encoder::{
+    resolve_encoder_type, validate_requested_encoder_available, EncoderSettings, EncoderType,
+};
+use crate::audio::toolchain::{
+    detect_encoder_availability_with_resolution, validate_external_input_decoders,
+    EncoderAvailability, ExternalToolchainPreference, ValidatedExternalToolchain,
+};
+use crate::audio::{AudioFile, DecoderSelection, ProcessingContext};
+use crate::errors::{AppError, Result};
+use crate::metadata::AudiobookMetadata;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessorAdapterKind {
+    NativeFfmpegNext,
+    ExternalFdk,
+}
+
+#[derive(Debug, Clone)]
+pub enum ResolvedProcessorAdapter {
+    NativeFfmpegNext,
+    ExternalFdk {
+        toolchain: ValidatedExternalToolchain,
+    },
+}
+
+impl ResolvedProcessorAdapter {
+    pub fn kind(&self) -> ProcessorAdapterKind {
+        match self {
+            Self::NativeFfmpegNext => ProcessorAdapterKind::NativeFfmpegNext,
+            Self::ExternalFdk { .. } => ProcessorAdapterKind::ExternalFdk,
+        }
+    }
+
+    pub fn validate_inputs(&self, file_info: &FileListInfo) -> Result<()> {
+        match self {
+            Self::NativeFfmpegNext => Ok(()),
+            Self::ExternalFdk { toolchain } => validate_external_input_decoders(
+                &file_info.files,
+                &file_info.selected_decoders,
+                toolchain,
+            ),
+        }
+    }
+
+    pub async fn execute(
+        self,
+        context: ProcessingContext,
+        files: Vec<AudioFile>,
+        selected_decoders: Vec<Option<DecoderSelection>>,
+        metadata: Option<AudiobookMetadata>,
+    ) -> Result<String> {
+        match self {
+            Self::NativeFfmpegNext => {
+                super::process_audiobook_with_context(context, files, metadata).await
+            }
+            Self::ExternalFdk { toolchain } => {
+                super::external_fdk::process_audiobook_with_external_fdk(
+                    context,
+                    files,
+                    selected_decoders,
+                    metadata,
+                    toolchain,
+                )
+                .await
+            }
+        }
+    }
+}
+
+pub fn resolve_processor_adapter(
+    encoder_settings: &EncoderSettings,
+    external_toolchain: Option<&ExternalToolchainPreference>,
+) -> Result<ResolvedProcessorAdapter> {
+    let (availability, resolution) =
+        detect_encoder_availability_with_resolution(external_toolchain);
+    resolve_processor_adapter_from_parts(encoder_settings, &availability, resolution.validated)
+}
+
+fn resolve_processor_adapter_from_parts(
+    encoder_settings: &EncoderSettings,
+    availability: &EncoderAvailability,
+    toolchain: Option<ValidatedExternalToolchain>,
+) -> Result<ResolvedProcessorAdapter> {
+    validate_requested_encoder_available(encoder_settings.encoder_type, availability)?;
+    let resolved_encoder = resolve_encoder_type(encoder_settings, availability);
+
+    if !matches!(resolved_encoder, EncoderType::FdkHeAac) {
+        return Ok(ResolvedProcessorAdapter::NativeFfmpegNext);
+    }
+
+    let toolchain = toolchain.ok_or_else(|| {
+        AppError::toolchain_required("FDK AAC requires a validated external FFmpeg toolchain.")
+    })?;
+    Ok(ResolvedProcessorAdapter::ExternalFdk { toolchain })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::settings_encoder::{BitrateMode, ChannelConfig, ThreadSetting};
+    use crate::audio::toolchain::{
+        EncoderCapabilitySource, ExternalDecoderCapabilities, ValidatedExternalToolchain,
+    };
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn resolves_non_fdk_encoder_to_native_adapter() {
+        let adapter = resolve_processor_adapter_from_parts(
+            &settings(EncoderType::NativeAac),
+            &availability(true, EncoderType::NativeAac),
+            Some(toolchain(ExternalDecoderCapabilities {
+                aac_at: true,
+                libfdk_aac: true,
+            })),
+        )
+        .expect("native adapter should resolve");
+
+        assert_eq!(adapter.kind(), ProcessorAdapterKind::NativeFfmpegNext);
+    }
+
+    #[test]
+    fn resolves_fdk_encoder_to_external_adapter() {
+        let adapter = resolve_processor_adapter_from_parts(
+            &settings(EncoderType::FdkHeAac),
+            &availability(true, EncoderType::FdkHeAac),
+            Some(toolchain(ExternalDecoderCapabilities {
+                aac_at: true,
+                libfdk_aac: true,
+            })),
+        )
+        .expect("external adapter should resolve");
+
+        assert_eq!(adapter.kind(), ProcessorAdapterKind::ExternalFdk);
+    }
+
+    #[test]
+    fn rejects_fdk_encoder_without_validated_toolchain() {
+        let err = resolve_processor_adapter_from_parts(
+            &settings(EncoderType::FdkHeAac),
+            &availability(true, EncoderType::FdkHeAac),
+            None,
+        )
+        .expect_err("missing FDK toolchain should fail");
+
+        assert!(err
+            .to_string()
+            .contains("validated external FFmpeg toolchain"));
+    }
+
+    #[test]
+    fn rejects_unavailable_requested_fdk_encoder() {
+        let err = resolve_processor_adapter_from_parts(
+            &settings(EncoderType::FdkHeAac),
+            &availability(false, EncoderType::NativeAac),
+            None,
+        )
+        .expect_err("unavailable FDK request should fail");
+
+        assert!(err.to_string().contains("FDK AAC"));
+    }
+
+    #[test]
+    fn external_adapter_rejects_unavailable_selected_decoder() {
+        let adapter = ResolvedProcessorAdapter::ExternalFdk {
+            toolchain: toolchain(ExternalDecoderCapabilities {
+                aac_at: false,
+                libfdk_aac: true,
+            }),
+        };
+        let file_info = FileListInfo {
+            files: vec![AudioFile {
+                path: Path::new("/books/input.m4b").to_path_buf(),
+                size: Some(1.0),
+                duration: Some(5.0),
+                format: Some("M4B".to_string()),
+                bitrate: None,
+                sample_rate: None,
+                channels: None,
+                codec_label: Some("AAC".to_string()),
+                selected_decoder: Some("Apple AAC".to_string()),
+                is_valid: true,
+                error: None,
+            }],
+            selected_decoders: vec![Some(DecoderSelection {
+                decoder_id: "aac_at".to_string(),
+                decoder_label: "Apple AAC".to_string(),
+            })],
+            total_duration: 5.0,
+            total_size: 1.0,
+            valid_count: 1,
+            invalid_count: 0,
+        };
+
+        let err = adapter
+            .validate_inputs(&file_info)
+            .expect_err("unsupported selected decoder should fail");
+
+        assert!(err.to_string().contains("does not expose decoder 'aac_at'"));
+    }
+
+    fn settings(encoder_type: EncoderType) -> EncoderSettings {
+        EncoderSettings {
+            encoder_type,
+            bitrate_kbps: 64,
+            bitrate_mode: BitrateMode::Cbr,
+            channels: ChannelConfig::Auto,
+            afterburner: false,
+            threads: ThreadSetting::Auto,
+            twoloop: true,
+        }
+    }
+
+    fn availability(fdk_available: bool, auto_encoder: EncoderType) -> EncoderAvailability {
+        EncoderAvailability {
+            fdk_available,
+            fdk_source: if fdk_available {
+                EncoderCapabilitySource::Detected
+            } else {
+                EncoderCapabilitySource::None
+            },
+            aac_at_available: false,
+            native_aac_available: true,
+            auto_encoder,
+            detected_toolchain_path: None,
+            override_toolchain_path: None,
+            active_toolchain_path: None,
+            override_invalid: false,
+            override_error: None,
+            status_message: String::new(),
+        }
+    }
+
+    fn toolchain(decoder_capabilities: ExternalDecoderCapabilities) -> ValidatedExternalToolchain {
+        ValidatedExternalToolchain {
+            ffmpeg_path: PathBuf::from("/usr/local/bin/ffmpeg"),
+            source: EncoderCapabilitySource::Detected,
+            decoder_capabilities,
+        }
+    }
+}

--- a/src-tauri/src/audio/processor/engine.rs
+++ b/src-tauri/src/audio/processor/engine.rs
@@ -1,4 +1,4 @@
-//! ffmpeg-next engine implementation (single-engine path)
+//! ffmpeg-next engine implementation (native in-process path)
 
 use std::path::Path;
 use std::sync::Once;

--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::Command;
 use tokio::time::{sleep, Duration};
 
-pub async fn process_audiobook_with_external_fdk(
+pub(super) async fn process_audiobook_with_external_fdk(
     context: ProcessingContext,
     files: Vec<AudioFile>,
     selected_decoders: Vec<Option<DecoderSelection>>,
@@ -160,8 +160,6 @@ fn expected_duration_seconds(
     total.max(1.0)
 }
 
-// EXCEPTION: this temporary worker orchestration is split in PR2 when external FDK becomes a processor adapter.
-#[allow(clippy::too_many_lines)]
 async fn run_external_ffmpeg(
     context: &ProcessingContext,
     ui: &ProgressEmitter,
@@ -171,6 +169,36 @@ async fn run_external_ffmpeg(
     temp_output: &Path,
     total_duration_seconds: f64,
 ) -> Result<()> {
+    log_external_inputs(files, selected_decoders);
+    let mut child =
+        spawn_external_ffmpeg(context, toolchain, files, selected_decoders, temp_output)?;
+    let stdout = take_child_stdout(&mut child)?;
+    let stderr = take_child_stderr(&mut child)?;
+    let mut progress_lines = BufReader::new(stdout).lines();
+    let stderr_task = tokio::spawn(read_stderr_to_string(stderr));
+    let current_file = files
+        .first()
+        .map(|file| sanitize_path_for_display(&file.path));
+
+    monitor_external_progress(
+        context,
+        ui,
+        &mut child,
+        &mut progress_lines,
+        total_duration_seconds,
+        current_file.clone(),
+    )
+    .await?;
+
+    let status = child.wait().await?;
+    let stderr_output = stderr_task.await.unwrap_or_default();
+    ensure_external_success(status, &stderr_output)?;
+
+    ui.emit_converting_progress(89.0, "External FDK encode complete.", current_file, None);
+    Ok(())
+}
+
+fn log_external_inputs(files: &[AudioFile], selected_decoders: &[Option<DecoderSelection>]) {
     for (file, selection) in files.iter().zip(selected_decoders.iter()) {
         log::info!(
             "external_fdk_input path={} selected_decoder_id={} selected_decoder={} forced_input_decoder={}",
@@ -186,7 +214,15 @@ async fn run_external_ffmpeg(
             external_input_decoder_name(selection.as_ref()).unwrap_or("auto"),
         );
     }
+}
 
+fn spawn_external_ffmpeg(
+    context: &ProcessingContext,
+    toolchain: &ValidatedExternalToolchain,
+    files: &[AudioFile],
+    selected_decoders: &[Option<DecoderSelection>],
+    temp_output: &Path,
+) -> Result<tokio::process::Child> {
     let mut command = Command::new(&toolchain.ffmpeg_path);
     command.stdin(Stdio::null());
     command.stdout(Stdio::piped());
@@ -200,53 +236,55 @@ async fn run_external_ffmpeg(
         temp_output,
     ));
 
-    let mut child = command.spawn().map_err(|error| {
+    command.spawn().map_err(|error| {
         AppError::ProcessTermination(format!(
             "Failed to launch external ffmpeg '{}': {}",
             sanitize_path_for_display(&toolchain.ffmpeg_path),
             error
         ))
-    })?;
+    })
+}
 
-    let stdout = child.stdout.take().ok_or_else(|| {
+fn take_child_stdout(child: &mut tokio::process::Child) -> Result<tokio::process::ChildStdout> {
+    child.stdout.take().ok_or_else(|| {
         AppError::ProcessTermination("External ffmpeg stdout was unavailable.".to_string())
-    })?;
-    let stderr = child.stderr.take().ok_or_else(|| {
+    })
+}
+
+fn take_child_stderr(child: &mut tokio::process::Child) -> Result<tokio::process::ChildStderr> {
+    child.stderr.take().ok_or_else(|| {
         AppError::ProcessTermination("External ffmpeg stderr was unavailable.".to_string())
-    })?;
+    })
+}
 
-    let mut progress_lines = BufReader::new(stdout).lines();
-    let stderr_task = tokio::spawn(async move {
-        let mut reader = BufReader::new(stderr);
-        let mut buffer = String::new();
-        let _ = reader.read_to_string(&mut buffer).await;
-        buffer
-    });
+async fn read_stderr_to_string(stderr: tokio::process::ChildStderr) -> String {
+    let mut reader = BufReader::new(stderr);
+    let mut buffer = String::new();
+    let _ = reader.read_to_string(&mut buffer).await;
+    buffer
+}
 
+async fn monitor_external_progress<R>(
+    context: &ProcessingContext,
+    ui: &ProgressEmitter,
+    child: &mut tokio::process::Child,
+    progress_lines: &mut tokio::io::Lines<R>,
+    total_duration_seconds: f64,
+    current_file: Option<String>,
+) -> Result<()>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
     let total_ms = (total_duration_seconds * 1000.0).max(1.0);
-    let current_file = files
-        .first()
-        .map(|file| sanitize_path_for_display(&file.path));
-
     loop {
         tokio::select! {
             line = progress_lines.next_line() => {
                 match line {
-                    Ok(Some(line)) => {
-                        if let Some(progress_ms) = parse_progress_ms(&line) {
-                            let percentage = ((progress_ms / total_ms) * 89.0) as f32;
-                            ui.emit_converting_progress(
-                                percentage.clamp(1.0, 89.0),
-                                "Encoding with external FDK AAC...",
-                                current_file.clone(),
-                                None,
-                            );
-                        }
-                    }
+                    Ok(Some(line)) => emit_external_progress(ui, &line, total_ms, current_file.clone()),
                     Ok(None) => break,
                     Err(error) => {
                         terminate_external_child_best_effort(
-                            &mut child,
+                            child,
                             "after external ffmpeg progress read failure",
                         )
                         .await;
@@ -260,7 +298,7 @@ async fn run_external_ffmpeg(
             _ = sleep(Duration::from_millis(200)) => {
                 if context.is_cancelled() {
                     terminate_external_child_best_effort(
-                        &mut child,
+                        child,
                         "after external ffmpeg cancellation",
                     )
                     .await;
@@ -270,21 +308,38 @@ async fn run_external_ffmpeg(
             }
         }
     }
+    Ok(())
+}
 
-    let status = child.wait().await?;
-    let stderr_output = stderr_task.await.unwrap_or_default();
-    if !status.success() {
-        let details = stderr_output
-            .lines()
-            .last()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("External ffmpeg process failed.");
-        return Err(AppError::ProcessTermination(details.to_string()));
+fn emit_external_progress(
+    ui: &ProgressEmitter,
+    line: &str,
+    total_ms: f64,
+    current_file: Option<String>,
+) {
+    if let Some(progress_ms) = parse_progress_ms(line) {
+        let percentage = ((progress_ms / total_ms) * 89.0) as f32;
+        ui.emit_converting_progress(
+            percentage.clamp(1.0, 89.0),
+            "Encoding with external FDK AAC...",
+            current_file,
+            None,
+        );
+    }
+}
+
+fn ensure_external_success(status: std::process::ExitStatus, stderr_output: &str) -> Result<()> {
+    if status.success() {
+        return Ok(());
     }
 
-    ui.emit_converting_progress(89.0, "External FDK encode complete.", current_file, None);
-    Ok(())
+    let details = stderr_output
+        .lines()
+        .last()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("External ffmpeg process failed.");
+    Err(AppError::ProcessTermination(details.to_string()))
 }
 
 async fn terminate_external_child_best_effort(child: &mut tokio::process::Child, context: &str) {
@@ -456,7 +511,7 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
-    const MINIMAL_JPEG: &[u8] = include_bytes!("../../tests/support/minimal.jpg");
+    const MINIMAL_JPEG: &[u8] = include_bytes!("../../../tests/support/minimal.jpg");
 
     #[tokio::test]
     async fn worker_processes_with_fake_external_ffmpeg() {

--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -180,7 +180,7 @@ async fn run_external_ffmpeg(
         .first()
         .map(|file| sanitize_path_for_display(&file.path));
 
-    monitor_external_progress(
+    let progress_result = monitor_external_progress(
         context,
         ui,
         &mut child,
@@ -188,10 +188,27 @@ async fn run_external_ffmpeg(
         total_duration_seconds,
         current_file.clone(),
     )
-    .await?;
+    .await;
+    if let Err(error) = progress_result {
+        let stderr_output = await_stderr_reader(
+            stderr_task,
+            "after external ffmpeg progress monitoring ended",
+        )
+        .await;
+        log_external_stderr_on_early_exit(&stderr_output);
+        return Err(error);
+    }
 
-    let status = child.wait().await?;
-    let stderr_output = stderr_task.await.unwrap_or_default();
+    let status = match child.wait().await {
+        Ok(status) => status,
+        Err(error) => {
+            let stderr_output =
+                await_stderr_reader(stderr_task, "after external ffmpeg wait failed").await;
+            log_external_stderr_on_early_exit(&stderr_output);
+            return Err(error.into());
+        }
+    };
+    let stderr_output = await_stderr_reader(stderr_task, "after external ffmpeg exit").await;
     ensure_external_success(status, &stderr_output)?;
 
     ui.emit_converting_progress(89.0, "External FDK encode complete.", current_file, None);
@@ -264,6 +281,25 @@ async fn read_stderr_to_string(stderr: tokio::process::ChildStderr) -> String {
     buffer
 }
 
+async fn await_stderr_reader(
+    stderr_task: tokio::task::JoinHandle<String>,
+    context: &str,
+) -> String {
+    match stderr_task.await {
+        Ok(output) => output,
+        Err(error) => {
+            log::warn!("External ffmpeg stderr reader task failed {context}: {error}");
+            String::new()
+        }
+    }
+}
+
+fn log_external_stderr_on_early_exit(stderr_output: &str) {
+    if let Some(details) = last_nonempty_stderr_line(stderr_output) {
+        log::warn!("External ffmpeg stderr before early exit: {details}");
+    }
+}
+
 async fn monitor_external_progress<R>(
     context: &ProcessingContext,
     ui: &ProgressEmitter,
@@ -333,13 +369,17 @@ fn ensure_external_success(status: std::process::ExitStatus, stderr_output: &str
         return Ok(());
     }
 
-    let details = stderr_output
-        .lines()
-        .last()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("External ffmpeg process failed.");
+    let details =
+        last_nonempty_stderr_line(stderr_output).unwrap_or("External ffmpeg process failed.");
     Err(AppError::ProcessTermination(details.to_string()))
+}
+
+fn last_nonempty_stderr_line(stderr_output: &str) -> Option<&str> {
+    stderr_output
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
 }
 
 async fn terminate_external_child_best_effort(child: &mut tokio::process::Child, context: &str) {

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -4,9 +4,10 @@
 //!   - prepare.rs   : validation, workspace setup, sample rate detection
 //!   - execute.rs   : merge / ffmpeg execution
 //!   - finalize.rs  : metadata writing, output move, cleanup
-//!   - selection.rs : engine selection
+//!   - adapter.rs   : native vs external processor adapter resolution
 //!
-//! Single-engine architecture using ffmpeg-next (`FfmpegNextProcessor`).
+//! The default path uses in-process ffmpeg-next (`FfmpegNextProcessor`).
+//! FDK HE-AAC routes through an external FFmpeg/libfdk_aac adapter when selected.
 
 // Imports for orchestrator function
 use crate::audio::context::ProcessingContext;
@@ -17,9 +18,11 @@ use crate::metadata::AudiobookMetadata;
 use std::time::Duration;
 
 // Submodules
+pub mod adapter;
 pub mod encoder;
 pub mod engine;
 pub mod execute;
+pub mod external_fdk;
 pub mod finalize;
 pub mod frame_pipeline;
 pub mod plan;
@@ -29,6 +32,7 @@ pub mod selection;
 pub mod streams;
 
 // Re-exports
+pub use adapter::{resolve_processor_adapter, ProcessorAdapterKind, ResolvedProcessorAdapter};
 pub use engine::FfmpegNextProcessor;
 pub use plan::{MediaProcessingPlan, MediaProcessor};
 pub use prepare::detect_input_sample_rate;

--- a/src-tauri/src/audio/processor/plan.rs
+++ b/src-tauri/src/audio/processor/plan.rs
@@ -63,7 +63,9 @@ impl MediaProcessingPlan {
 /// Trait defining a media processor boundary for executing processing plans.
 ///
 /// This provides a stable interface for media processing implementations.
-/// Currently uses ffmpeg-next as the single processing engine.
+/// The default implementation is the native ffmpeg-next path; command-level
+/// encoder selection routes external FDK work through the processor adapter
+/// boundary before execution reaches this plan.
 pub trait MediaProcessor {
     fn execute<'a>(
         &'a self,

--- a/src-tauri/src/audio/processor/selection.rs
+++ b/src-tauri/src/audio/processor/selection.rs
@@ -1,10 +1,10 @@
 //! Engine selection module for media processing
 //!
-//! Provides access to the single FFmpeg processing engine.
+//! Provides access to the default native FFmpeg processing engine.
 //!
 //! ## Processing Engine
 //!
-//! - **Single Engine**: Uses `FfmpegNextProcessor` - Rust FFmpeg bindings
+//! - **Native Engine**: Uses `FfmpegNextProcessor` - Rust FFmpeg bindings
 //!
 //! ## Engine Characteristics
 //!
@@ -16,7 +16,7 @@
 
 use crate::audio::processor::FfmpegNextProcessor;
 
-/// The default media processor implementation (single-engine state).
+/// The default native media processor implementation.
 ///
 /// Retained as a type alias so future experimental engines (e.g., hardware
 /// accelerated or alternative codecs) can slot in with minimal churn.
@@ -26,7 +26,7 @@ pub type DefaultProcessor = FfmpegNextProcessor;
 ///
 /// Always returns the current engine description.
 pub fn get_engine_description() -> &'static str {
-    "FfmpegNextProcessor (single-engine)"
+    "FfmpegNextProcessor (native ffmpeg-next)"
 }
 
 /// Creates an instance of the default media processor.

--- a/src-tauri/src/audio/toolchain.rs
+++ b/src-tauri/src/audio/toolchain.rs
@@ -78,6 +78,12 @@ pub(crate) struct ToolchainResolution {
 pub fn detect_encoder_availability(
     preference: Option<&ExternalToolchainPreference>,
 ) -> EncoderAvailability {
+    detect_encoder_availability_with_resolution(preference).0
+}
+
+pub(crate) fn detect_encoder_availability_with_resolution(
+    preference: Option<&ExternalToolchainPreference>,
+) -> (EncoderAvailability, ToolchainResolution) {
     let native_aac = settings_encoder::is_encoder_available_by_name("aac");
     let aac_at =
         cfg!(target_os = "macos") && settings_encoder::is_encoder_available_by_name("aac_at");
@@ -91,19 +97,20 @@ pub fn detect_encoder_availability(
         EncoderType::NativeAac
     };
 
-    EncoderAvailability {
+    let availability = EncoderAvailability {
         fdk_available,
         fdk_source: resolution.fdk_source,
         aac_at_available: aac_at,
         native_aac_available: native_aac,
         auto_encoder,
-        detected_toolchain_path: resolution.detected_toolchain_path,
-        override_toolchain_path: resolution.override_toolchain_path,
-        active_toolchain_path: resolution.active_toolchain_path,
+        detected_toolchain_path: resolution.detected_toolchain_path.clone(),
+        override_toolchain_path: resolution.override_toolchain_path.clone(),
+        active_toolchain_path: resolution.active_toolchain_path.clone(),
         override_invalid: resolution.override_invalid,
-        override_error: resolution.override_error,
-        status_message: resolution.status_message,
-    }
+        override_error: resolution.override_error.clone(),
+        status_message: resolution.status_message.clone(),
+    };
+    (availability, resolution)
 }
 
 pub(crate) fn resolve_external_toolchain(

--- a/src-tauri/src/commands/audio_processing.rs
+++ b/src-tauri/src/commands/audio_processing.rs
@@ -2,14 +2,8 @@ use crate::audio;
 use crate::audio::file_list::FileListInfo;
 use crate::audio::job_registry::{CancellationChecker, JobId};
 use crate::audio::output_path::{OutputKind, PlannedOutputAction, ResolvedOutputPlan};
-use crate::audio::settings_encoder::{
-    resolve_encoder_type, validate_encoder_settings, validate_requested_encoder_available,
-    EncoderType,
-};
-use crate::audio::toolchain::{
-    detect_encoder_availability, resolve_external_toolchain, validate_external_input_decoders,
-    ExternalToolchainPreference,
-};
+use crate::audio::settings_encoder::validate_encoder_settings;
+use crate::audio::toolchain::ExternalToolchainPreference;
 use crate::audio::{QueueEvent, QueueItem};
 use crate::commands::audio_types::{
     JobType, ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
@@ -157,18 +151,11 @@ fn validate_external_processing_contract_with_file_info(
     payload: &ProcessPayload,
     file_info: &FileListInfo,
 ) -> Result<()> {
-    let availability = detect_encoder_availability(payload.external_toolchain.as_ref());
-    validate_requested_encoder_available(payload.settings.encoder_type, &availability)?;
-    let resolved_encoder = resolve_encoder_type(&payload.settings, &availability);
-    if !matches!(resolved_encoder, EncoderType::FdkHeAac) {
-        return Ok(());
-    }
-
-    let resolution = resolve_external_toolchain(payload.external_toolchain.as_ref());
-    let toolchain = resolution.validated.ok_or_else(|| {
-        AppError::toolchain_required("FDK AAC requires a validated external FFmpeg toolchain.")
-    })?;
-    validate_external_input_decoders(&file_info.files, &file_info.selected_decoders, &toolchain)?;
+    let adapter = audio::processor::resolve_processor_adapter(
+        &payload.settings,
+        payload.external_toolchain.as_ref(),
+    )?;
+    adapter.validate_inputs(file_info)?;
     Ok(())
 }
 
@@ -456,31 +443,13 @@ async fn execute_processing_job(
         selected_decoders,
         ..
     } = file_info;
-    let availability = detect_encoder_availability(external_toolchain.as_ref());
-    validate_requested_encoder_available(encoder_settings.encoder_type, &availability)?;
-    let resolved_encoder =
-        audio::settings_encoder::resolve_encoder_type(&encoder_settings, &availability);
-
-    if matches!(
-        resolved_encoder,
-        audio::settings_encoder::EncoderType::FdkHeAac
-    ) {
-        let resolution = resolve_external_toolchain(external_toolchain.as_ref());
-        let toolchain = resolution.validated.ok_or_else(|| {
-            AppError::toolchain_required("FDK AAC requires a validated external FFmpeg toolchain.")
-        })?;
-        validate_external_input_decoders(&files, &selected_decoders, &toolchain)?;
-        return audio::external_fdk::process_audiobook_with_external_fdk(
-            context,
-            files,
-            selected_decoders,
-            metadata,
-            toolchain,
-        )
-        .await;
-    }
-
-    audio::processor::process_audiobook_with_context(context, files, metadata).await
+    let adapter = audio::processor::resolve_processor_adapter(
+        &encoder_settings,
+        external_toolchain.as_ref(),
+    )?;
+    adapter
+        .execute(context, files, selected_decoders, metadata)
+        .await
 }
 
 fn emit_terminal_failed_event(

--- a/src-tauri/tests/integration_ffmpeg_tests.rs
+++ b/src-tauri/tests/integration_ffmpeg_tests.rs
@@ -22,8 +22,8 @@ fn ensure_media() -> Option<PathBuf> {
 }
 
 #[test]
-fn test_engine_is_single_and_available() {
-    // After the nuclear transition, engine selection should report ffmpeg-next only.
+fn test_native_engine_is_available() {
+    // Engine diagnostics should report the native in-process ffmpeg-next path.
     let description = get_engine_description();
     assert!(
         description.contains("FfmpegNextProcessor"),
@@ -79,10 +79,10 @@ fn test_ffmpeg_next_dependency_available() {
 
 #[test]
 fn test_compilation_status_report() {
-    println!("=== FFmpeg-next Integration Test Status (Single Engine) ===");
+    println!("=== FFmpeg-next Integration Test Status (Native Engine) ===");
     println!("Test media file path: {}", TEST_MEDIA_FILE);
     println!("Media file exists: {}", ensure_media().is_some());
-    println!("✓ Single-engine ffmpeg-next architecture active (no feature flags)");
+    println!("✓ Native ffmpeg-next architecture active (no feature flags)");
     let media_path = PathBuf::from(TEST_MEDIA_FILE);
     assert_eq!(
         media_path

--- a/src-tauri/tests/integration_xhe_aac_fixture_tests.rs
+++ b/src-tauri/tests/integration_xhe_aac_fixture_tests.rs
@@ -1,0 +1,76 @@
+use audiobook_boss_lib::audio::settings_encoder::{
+    BitrateMode, ChannelConfig as EncoderChannelConfig, EncoderSettings, EncoderType, ThreadSetting,
+};
+use audiobook_boss_lib::audio::toolchain::ExternalToolchainPreference;
+use audiobook_boss_lib::audio::{self, OutputConfig, SampleRateConfig};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires ABB_XHE_AAC_FIXTURE and an external FFmpeg with libfdk_aac"]
+async fn xhe_aac_fixture_encodes_short_external_fdk_preview_when_configured() {
+    let input_path = fixture_path();
+    assert!(
+        input_path.exists() && input_path.is_file(),
+        "ABB_XHE_AAC_FIXTURE must point at an xHE-AAC/USAC audiobook fixture"
+    );
+
+    let file_info = audio::get_file_list_info(std::slice::from_ref(&input_path))
+        .expect("fixture should be inspectable");
+    assert_eq!(file_info.valid_count, 1, "fixture should be valid");
+
+    let settings = EncoderSettings {
+        encoder_type: EncoderType::FdkHeAac,
+        bitrate_kbps: 64,
+        bitrate_mode: BitrateMode::Vbr(3),
+        channels: EncoderChannelConfig::Auto,
+        afterburner: true,
+        threads: ThreadSetting::Auto,
+        twoloop: true,
+    };
+    let toolchain_preference = toolchain_preference();
+    let adapter =
+        audio::processor::resolve_processor_adapter(&settings, toolchain_preference.as_ref())
+            .expect("external FDK adapter should resolve for fixture validation");
+    adapter
+        .validate_inputs(&file_info)
+        .expect("selected decoder should be available in the external toolchain");
+
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let output_path = temp_dir.path().join("xhe-aac-preview.m4b");
+    let mut context = audio::ProcessingContext::new_headless(
+        Arc::new(audio::session::ProcessingSession::new()),
+        settings,
+        SampleRateConfig::Auto,
+        OutputConfig::for_preview(&output_path),
+    );
+    context.preview = Some(audio::context::PreviewConfig::new(20.0));
+
+    let result = adapter
+        .execute(context, file_info.files, file_info.selected_decoders, None)
+        .await
+        .expect("external FDK preview should encode the xHE-AAC fixture");
+
+    assert!(result.contains("Successfully created preview"));
+    assert!(output_path.exists(), "preview output should exist");
+    let output_info = audio::get_file_list_info(std::slice::from_ref(&output_path))
+        .expect("preview output should be inspectable");
+    assert_eq!(output_info.valid_count, 1, "preview output should be valid");
+}
+
+fn fixture_path() -> PathBuf {
+    std::env::var_os("ABB_XHE_AAC_FIXTURE")
+        .map(PathBuf::from)
+        .expect("set ABB_XHE_AAC_FIXTURE to a local xHE-AAC/USAC audiobook fixture")
+}
+
+fn toolchain_preference() -> Option<ExternalToolchainPreference> {
+    std::env::var("ABB_XHE_AAC_FFMPEG")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|override_path| ExternalToolchainPreference {
+            override_path: Some(override_path),
+        })
+}


### PR DESCRIPTION
## Summary

- Routes native vs FDK execution through a new `audio::processor` adapter boundary instead of command orchestration choosing the worker directly.
- Moves the external FDK worker under processor ownership and splits the external ffmpeg runner into focused helpers while preserving progress, cancellation, temp cleanup, metadata rewrite, and final commit behavior.
- Updates README/API/spec/docs and processor comments so ABB no longer presents runtime processing as embedded `ffmpeg-next` only.
- Adds an ignored/env-gated xHE-AAC fixture validation test: `ABB_XHE_AAC_FIXTURE=/path/to/book.m4b cargo test -p audiobook-boss --test integration_xhe_aac_fixture_tests -- --ignored`. Optional `ABB_XHE_AAC_FFMPEG=/path/to/ffmpeg` pins the external FFmpeg.
- Accounts for the spawned external-FFmpeg stderr reader task on early progress/cancel errors, child wait errors, and normal process exit.

Closes #256.

## Real-fixture evidence for #256

Manual ABB dev validation used two real USAC/xHE-AAC audiobooks:

- `Star Trek: The Motion Picture.m4b`
- `Science, Being, & Becoming: The Spiritual Lives of Scientists.m4b`

Observed runtime evidence:

- encoder availability resolved `auto_encoder: FdkHeAac`
- both files validated with `selected_decoder_id=aac_at selected_decoder=Apple AAC`
- external FDK adapter logged `forced_input_decoder=aac_at` for both files
- both 60-second preview jobs completed successfully
- `ffprobe` validated both preview outputs with 60-second AAC audio streams and embedded MJPEG cover-art streams

## Validation

- `cargo test -p audiobook-boss adapter --lib`
- `cargo test -p audiobook-boss external_fdk --lib`
- `cargo test -p audiobook-boss toolchain --lib`
- `cargo test -p audiobook-boss --test integration_xhe_aac_fixture_tests --no-run`
- `cargo run --manifest-path src-tauri/Cargo.toml --bin verify_aac_decoder_contract --quiet`
- `scripts/checks.sh standard`
- `scripts/checks.sh package`
- `bash scripts/check-context-surface.sh`

Package gate built: `/Users/jstar/Projects/audiobook-boss/target/release/bundle/macos/AudioBook Boss.app`.
