### PR TITLE
PR4: clarify metadata draft intent boundary

### DIFF
--- a/docs/specs/runtime-architecture-pr-train.md
+++ b/docs/specs/runtime-architecture-pr-train.md
@@ -337,6 +337,13 @@ Boundary glue posture (`Refs #277`):
   Initial review posture is `Refs #272`, not automatic closure, because final
   artifact commit and some terminal progress emission intentionally remain under
   processor/finalize ownership unless review confirms this satisfies the RFC.
+- 2026-04-24: Started PR4 on `arch/metadata-draft-intent`. Introduced
+  `src/ui/metadataDraft.ts` as the UI draft owner above the lower-level
+  `MetadataIntentPatch` wire contract, routed single selection, multi-selection,
+  lookup queue, processing overlay, and pending-save state through that owner,
+  removed metadata-save store wrappers, deduplicated sequence validation, and
+  updated Rust/generated metadata-intent docs. PR4 is expected to close `#273`
+  and `#267`, reference `#277`, and leave `#270` open.
 
 ## 7. Surprises And Discoveries
 

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -23,8 +23,9 @@ pub mod passthrough;
 
 /// Represents audiobook metadata.
 ///
-/// `track` and `disk` are preserved for read compatibility with files in the wild,
-/// but ABB does not expose them as supported writable metadata-intent fields.
+/// `track`, `disk`, and `comment` are preserved for read compatibility with files
+/// in the wild, but ABB does not expose them as supported UI draft write fields.
+/// `album_sort` is writable only through explicit backend intent.
 ///
 /// Field mapping for Plex/Audiobookshelf compatibility:
 /// - `artist` = Author (also written to AlbumArtist)
@@ -116,10 +117,13 @@ impl MetadataWritePlan {
     }
 }
 
-/// Writable metadata-intent surface for ABB.
+/// Writable metadata-intent contract for ABB.
 ///
-/// This intentionally omits `track` and `disk`; those tags remain readable in
-/// [`AudiobookMetadata`] but are not part of the supported write contract.
+/// UI drafts support title, author, album, narrator, genre, publication date,
+/// description, series, subseries, and cover-art intent. `album_sort` is included
+/// as an explicit backend operation for set, clear, preserve, or recompute.
+/// Read-compatible `track`, `disk`, and `comment` fields remain outside this
+/// write-intent contract.
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type, Default)]
 pub struct MetadataIntentPatch {
     #[serde(default)]
@@ -716,21 +720,23 @@ mod tests {
     }
 
     #[test]
-    fn metadata_intent_patch_write_contract_keeps_track_and_disk_read_only() {
+    fn metadata_intent_patch_write_contract_keeps_read_compatible_fields_out_of_write_intent() {
         let patch = MetadataIntentPatch::from(AudiobookMetadata {
             title: Some("Read Compatible".to_string()),
             track: Some((3, Some(12))),
             disk: Some((1, Some(2))),
+            comment: Some("Reader note".to_string()),
             ..Default::default()
         });
 
         let resolved = patch
             .to_write_metadata()
-            .expect("write metadata should still compile without track/disk support");
+            .expect("write metadata should still compile without read-compatible fields");
 
         assert_eq!(resolved.title.as_deref(), Some("Read Compatible"));
         assert_eq!(resolved.track, None);
         assert_eq!(resolved.disk, None);
+        assert_eq!(resolved.comment, None);
     }
 
     #[test]

--- a/src/harness/scenarios.test.ts
+++ b/src/harness/scenarios.test.ts
@@ -12,6 +12,8 @@ describe('harness scenario routing', () => {
 		const scenarios = resolveHarnessScenariosForPaths([
 			'src/ui/metadataLookup.ts',
 			'src/ui/metadataForm/MetadataFormFieldsIsland.svelte',
+			'src/ui/metadataDraft.ts',
+			'src/ui/metadataSaveState.ts',
 		]);
 
 		expect(scenarios.map((scenario) => scenario.id)).toContain('metadata-edit');

--- a/src/harness/scenarios.ts
+++ b/src/harness/scenarios.ts
@@ -152,6 +152,8 @@ const SCENARIOS: readonly HarnessScenario[] = [
 		matchers: [
 			/^src\/ui\/metadataForm(?:\/|\.ts$)/,
 			/^src\/ui\/metadataLookup(?:\/|\.ts$)/,
+			/^src\/ui\/metadataDraft\.ts$/,
+			/^src\/ui\/metadataSaveState\.ts$/,
 			/^src\/ui\/metadataState\.ts$/,
 			/^src\/ui\/coverArt(?:\/|\.ts$)/,
 			/^src\/ui\/fileList\/metadataPanel\.ts$/,

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -175,8 +175,9 @@ export type AudioFile = {
 /**
  *  Represents audiobook metadata.
  *
- *  `track` and `disk` are preserved for read compatibility with files in the wild,
- *  but ABB does not expose them as supported writable metadata-intent fields.
+ *  `track`, `disk`, and `comment` are preserved for read compatibility with files
+ *  in the wild, but ABB does not expose them as supported UI draft write fields.
+ *  `album_sort` is writable only through explicit backend intent.
  *
  *  Field mapping for Plex/Audiobookshelf compatibility:
  *  - `artist` = Author (also written to AlbumArtist)
@@ -310,10 +311,13 @@ export type FileListInfo = {
 export type JobType = "merge" | "batch";
 
 /**
- *  Writable metadata-intent surface for ABB.
+ *  Writable metadata-intent contract for ABB.
  *
- *  This intentionally omits `track` and `disk`; those tags remain readable in
- *  [`AudiobookMetadata`] but are not part of the supported write contract.
+ *  UI drafts support title, author, album, narrator, genre, publication date,
+ *  description, series, subseries, and cover-art intent. `album_sort` is included
+ *  as an explicit backend operation for set, clear, preserve, or recompute.
+ *  Read-compatible `track`, `disk`, and `comment` fields remain outside this
+ *  write-intent contract.
  */
 export type MetadataIntentPatch = {
 	title?: PatchOp<string>,

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -11,8 +11,9 @@
  * - album_sort = TSOA library sort value; preserved unless explicit set/clear/recompute intent is sent
  * - date = Publication date (YYYY or YYYY-MM in ©day)
  *
- * `track` and `disk` remain readable for compatibility, but ABB does not expose
- * them as supported writable metadata-intent fields.
+ * `track`, `disk`, and `comment` remain readable for compatibility, but ABB does
+ * not expose them as supported UI draft write fields. `album_sort` is writable
+ * only through explicit backend intent.
  */
 
 import type {

--- a/src/types/metadataIntent.test.ts
+++ b/src/types/metadataIntent.test.ts
@@ -146,11 +146,12 @@ describe('metadata intent patch helpers', () => {
 		});
 	});
 
-	it('ignores read-only track and disk fields when building write intent', () => {
+	it('ignores read-only track, disk, and comment fields when building write intent', () => {
 		const patch = buildMetadataIntentPatchFromMetadata({
 			title: 'Writable',
 			track: [3, 12],
 			disk: [1, 2],
+			comment: 'Reader note',
 		} as unknown as Parameters<typeof buildMetadataIntentPatchFromMetadata>[0]);
 
 		expect(patch).toEqual({

--- a/src/ui/__tests__/metadata-save-pending-flow.test.ts
+++ b/src/ui/__tests__/metadata-save-pending-flow.test.ts
@@ -79,10 +79,6 @@ vi.mock('../metadataState', () => ({
 
 vi.mock('../metadataSaveState', () => ({
 	metadataSaveInProgressStore: writable(false),
-	isMetadataSaveInProgress: () => context.metadataSaveInProgress,
-	setMetadataSaveInProgress: (value: boolean) => {
-		context.metadataSaveInProgress = value;
-	},
 }));
 
 function getStatusText(): HTMLElement {

--- a/src/ui/__tests__/metadataDraft.test.ts
+++ b/src/ui/__tests__/metadataDraft.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	applyMetadataDraftIntent,
+	buildMetadataDraftIntent,
+	hasActionableMetadataDraftIntent,
+	toMetadataDraft,
+} from '../metadataDraft';
+
+describe('metadata draft intent', () => {
+	it('keeps normal UI drafts inside the supported write surface', () => {
+		const draft = toMetadataDraft({
+			title: ' Draft Title ',
+			album_sort: 'Curated Sort',
+			comment: 'Reader note',
+			track: [1, 12],
+			disk: [1, 1],
+		});
+
+		expect(draft).toEqual({ title: ' Draft Title ' });
+	});
+
+	it('does not emit album sort or read-only fields from normal draft metadata', () => {
+		const patch = buildMetadataDraftIntent({
+			title: 'Book',
+			album_sort: 'Curated Sort',
+			comment: 'Reader note',
+			track: [1, 12],
+			disk: [1, 1],
+		});
+
+		expect(patch).toEqual({
+			title: { op: 'set', value: 'Book' },
+		});
+	});
+
+	it('preserves clear intent when applying draft patches', () => {
+		const patch = buildMetadataDraftIntent({ title: '', cover_art: [] });
+
+		expect(hasActionableMetadataDraftIntent(patch)).toBe(true);
+		expect(applyMetadataDraftIntent({ title: 'Old', artist: 'Author' }, patch)).toEqual({
+			artist: 'Author',
+		});
+	});
+});

--- a/src/ui/__tests__/metadataState-pending.test.ts
+++ b/src/ui/__tests__/metadataState-pending.test.ts
@@ -13,6 +13,7 @@ import {
 	applyMetadataIntentPatch,
 	buildMetadataIntentPatchFromMetadata,
 } from '../../types/metadataIntent';
+import { buildMetadataDraftIntent } from '../metadataDraft';
 
 describe('metadataState pending draft tracking', () => {
 	beforeEach(() => {
@@ -38,6 +39,22 @@ describe('metadataState pending draft tracking', () => {
 		expect(getPendingMetadataEntries()).toEqual([['/a.mp3', { title: 'Book A' }]]);
 		expect(getPendingMetadataIntentEntries()).toEqual([
 			['/a.mp3', { title: { op: 'set', value: 'Book A' } }],
+		]);
+	});
+
+	it('uses UI draft intent when no explicit pending patch is provided', () => {
+		setMetadataForFile(
+			'/a.mp3',
+			{
+				title: 'Book A',
+				album_sort: 'Curated Sort',
+				comment: 'Reader note',
+			},
+			{ markPending: true },
+		);
+
+		expect(getPendingMetadataIntentEntries()).toEqual([
+			['/a.mp3', buildMetadataDraftIntent({ title: 'Book A' })],
 		]);
 	});
 

--- a/src/ui/__tests__/metadataValidation.test.ts
+++ b/src/ui/__tests__/metadataValidation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	getSeriesPartValidationError,
+	getSubseriesPartValidationError,
+} from '../metadataValidation';
+
+describe('metadata validation', () => {
+	it('accepts empty and plain sequence values', () => {
+		expect(getSeriesPartValidationError(undefined)).toBeNull();
+		expect(getSeriesPartValidationError('')).toBeNull();
+		expect(getSeriesPartValidationError(' 24 ')).toBeNull();
+		expect(getSubseriesPartValidationError('3.5')).toBeNull();
+	});
+
+	it('preserves series and subseries validation messages', () => {
+		expect(getSeriesPartValidationError('1/2')).toBe(
+			"Series sequence (#) cannot include '/'. Use a plain number like 24.",
+		);
+		expect(getSubseriesPartValidationError('1/2')).toBe(
+			"Sub-series sequence (#) cannot include '/'. Use a plain number like 24.",
+		);
+	});
+});

--- a/src/ui/core/actions.ts
+++ b/src/ui/core/actions.ts
@@ -1,8 +1,10 @@
+import { get } from 'svelte/store';
+
 import { tauriClient } from '../../lib/tauri/client';
 import { getCurrentFileList } from '../fileList';
 import { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/actions';
 import { clearPendingMetadataForFile, getPendingMetadataIntentEntries } from '../metadataState';
-import { isMetadataSaveInProgress, setMetadataSaveInProgress } from '../metadataSaveState';
+import { metadataSaveInProgressStore } from '../metadataSaveState';
 import { resetDirtyState } from '../metadataForm';
 import {
 	initStatusPanel,
@@ -26,13 +28,13 @@ export async function saveMetadataFromUI(): Promise<void> {
 
 	pushStatusPanelTransientStatus('Preparing metadata save...', { ttlMs: 1_000 });
 
-	if (isMetadataSaveInProgress()) {
+	if (get(metadataSaveInProgressStore)) {
 		pushStatusPanelTransientStatus('Save already in progress...', { ttlMs: 1_500 });
 		return;
 	}
 
 	try {
-		setMetadataSaveInProgress(true);
+		metadataSaveInProgressStore.set(true);
 		await persistPendingMetadataDraftsForCurrentSelection({ showStatus: false });
 
 		const validFilePaths = new Set(
@@ -80,7 +82,7 @@ export async function saveMetadataFromUI(): Promise<void> {
 		console.error('Failed to save metadata:', error);
 		pushStatusPanelTransientStatus('Save failed - see console', { ttlMs: 3_000 });
 	} finally {
-		setMetadataSaveInProgress(false);
+		metadataSaveInProgressStore.set(false);
 	}
 }
 

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -9,10 +9,10 @@ import {
 	setMetadataForFile,
 } from '../metadataState';
 import {
-	applyMetadataIntentPatch,
-	buildMetadataIntentPatchFromMetadata,
-	hasActionableMetadataIntentPatch,
-} from '../../types/metadataIntent';
+	applyMetadataDraftIntent,
+	buildMetadataDraftIntent,
+	hasActionableMetadataDraftIntent,
+} from '../metadataDraft';
 import {
 	getSeriesPartValidationError,
 	getSubseriesPartValidationError,
@@ -221,11 +221,11 @@ function persistSingleSelectionMetadata(file: AudioFile | null): boolean {
 	}
 
 	const existing = getMetadataForFile(file.path) ?? {};
-	const intentPatch = buildMetadataIntentPatchFromMetadata(metadata);
-	if (!hasActionableMetadataIntentPatch(intentPatch)) {
+	const intentPatch = buildMetadataDraftIntent(metadata);
+	if (!hasActionableMetadataDraftIntent(intentPatch)) {
 		return false;
 	}
-	const merged = applyMetadataIntentPatch(existing, intentPatch);
+	const merged = applyMetadataDraftIntent(existing, intentPatch);
 	if (metadataEqualsNullish(existing, merged)) {
 		return false;
 	}
@@ -362,14 +362,14 @@ export async function stageMetadataToSelection(options?: {
 	}
 
 	await ensureMetadataForFiles(selectedFiles);
-	const intentPatch = buildMetadataIntentPatchFromMetadata(changes);
-	if (!hasActionableMetadataIntentPatch(intentPatch)) {
+	const intentPatch = buildMetadataDraftIntent(changes);
+	if (!hasActionableMetadataDraftIntent(intentPatch)) {
 		return false;
 	}
 
 	selectedFiles.forEach((file) => {
 		const existing = getMetadataForFile(file.path) ?? {};
-		const merged = applyMetadataIntentPatch(existing, intentPatch);
+		const merged = applyMetadataDraftIntent(existing, intentPatch);
 		if (!metadataEqualsNullish(existing, merged)) {
 			setMetadataForFile(file.path, merged, {
 				markPending: true,

--- a/src/ui/fileList/events.ts
+++ b/src/ui/fileList/events.ts
@@ -1,5 +1,7 @@
+import { get } from 'svelte/store';
+
 import { getCurrentFileList, isOrderLocked } from './state';
-import { isMetadataSaveInProgress } from '../metadataSaveState';
+import { metadataSaveInProgressStore } from '../metadataSaveState';
 import { setFileListDragState } from './viewState.svelte';
 import {
 	clearSelectionAction,
@@ -29,7 +31,7 @@ function resetDragState(): void {
 }
 
 export function onFileListClick(index: number, event: MouseEvent): void {
-	if (isMetadataSaveInProgress()) return;
+	if (get(metadataSaveInProgressStore)) return;
 	if (!hasValidIndex(index)) return;
 
 	const multi = event.ctrlKey || event.metaKey;
@@ -42,7 +44,7 @@ export function onFileListClick(index: number, event: MouseEvent): void {
 }
 
 export function onFileListMoveUp(index: number, event: MouseEvent): void {
-	if (isMetadataSaveInProgress() || isOrderLocked()) return;
+	if (get(metadataSaveInProgressStore) || isOrderLocked()) return;
 	if (index <= 0 || !hasValidIndex(index)) return;
 
 	stopInteraction(event);
@@ -50,7 +52,7 @@ export function onFileListMoveUp(index: number, event: MouseEvent): void {
 }
 
 export function onFileListMoveDown(index: number, event: MouseEvent): void {
-	if (isMetadataSaveInProgress() || isOrderLocked()) return;
+	if (get(metadataSaveInProgressStore) || isOrderLocked()) return;
 	if (!hasValidIndex(index)) return;
 	const fileList = getCurrentFileList();
 	if (!fileList || index >= fileList.files.length - 1) return;
@@ -60,7 +62,7 @@ export function onFileListMoveDown(index: number, event: MouseEvent): void {
 }
 
 export function onFileListRemove(index: number, event: MouseEvent): void {
-	if (isMetadataSaveInProgress() || isOrderLocked()) return;
+	if (get(metadataSaveInProgressStore) || isOrderLocked()) return;
 	if (!hasValidIndex(index)) return;
 
 	stopInteraction(event);
@@ -68,7 +70,7 @@ export function onFileListRemove(index: number, event: MouseEvent): void {
 }
 
 export function onFileListKeyDown(e: KeyboardEvent): void {
-	if (isMetadataSaveInProgress()) return;
+	if (get(metadataSaveInProgressStore)) return;
 	if (!getCurrentFileList()) return;
 	if (isTextInputTarget(e.target)) return;
 
@@ -92,7 +94,7 @@ function isTextInputTarget(target: EventTarget | null): boolean {
 }
 
 export function onFileListDragStart(index: number, e: DragEvent): void {
-	if (isMetadataSaveInProgress() || isOrderLocked()) return;
+	if (get(metadataSaveInProgressStore) || isOrderLocked()) return;
 	if (!e.dataTransfer || !hasValidIndex(index)) return;
 
 	const item = e.currentTarget as HTMLElement | null;
@@ -105,7 +107,7 @@ export function onFileListDragStart(index: number, e: DragEvent): void {
 }
 
 export function onFileListDragOver(index: number, e: DragEvent): void {
-	if (isMetadataSaveInProgress()) return;
+	if (get(metadataSaveInProgressStore)) return;
 	if (isOrderLocked()) return;
 	e.preventDefault();
 	if (!e.dataTransfer) return;
@@ -120,7 +122,7 @@ export function onFileListDragOver(index: number, e: DragEvent): void {
 }
 
 export function onFileListDrop(index: number, e: DragEvent): void {
-	if (isMetadataSaveInProgress()) return;
+	if (get(metadataSaveInProgressStore)) return;
 	if (isOrderLocked()) return;
 	e.preventDefault();
 	e.stopPropagation();

--- a/src/ui/metadataDraft.ts
+++ b/src/ui/metadataDraft.ts
@@ -1,0 +1,62 @@
+import type { AudiobookMetadata } from '../types/metadata';
+import type { MetadataIntentPatch } from '../types/metadataIntent';
+import {
+	applyMetadataIntentPatch,
+	buildMetadataIntentPatchFromMetadata,
+	hasActionableMetadataIntentPatch,
+	mergeMetadataIntentPatches,
+} from '../types/metadataIntent';
+
+export const METADATA_DRAFT_FIELDS = [
+	'title',
+	'artist',
+	'album',
+	'composer',
+	'genre',
+	'date',
+	'description',
+	'series',
+	'series_part',
+	'subseries',
+	'subseries_part',
+	'cover_art',
+] as const;
+
+export type MetadataDraftField = (typeof METADATA_DRAFT_FIELDS)[number];
+export type MetadataDraft = Partial<Pick<AudiobookMetadata, MetadataDraftField>>;
+
+export function toMetadataDraft(metadata: Partial<AudiobookMetadata>): MetadataDraft {
+	const draft: MetadataDraft = {};
+	for (const key of METADATA_DRAFT_FIELDS) {
+		if (key in metadata) {
+			(draft as Partial<Record<MetadataDraftField, unknown>>)[key] = metadata[key];
+		}
+	}
+	return draft;
+}
+
+export function buildMetadataDraftIntent(
+	metadata: Partial<AudiobookMetadata>,
+): MetadataIntentPatch {
+	return buildMetadataIntentPatchFromMetadata(toMetadataDraft(metadata));
+}
+
+export function hasActionableMetadataDraftIntent(
+	patch: MetadataIntentPatch | null | undefined,
+): patch is MetadataIntentPatch {
+	return hasActionableMetadataIntentPatch(patch);
+}
+
+export function mergeMetadataDraftIntents(
+	base: MetadataIntentPatch,
+	next: MetadataIntentPatch,
+): MetadataIntentPatch {
+	return mergeMetadataIntentPatches(base, next);
+}
+
+export function applyMetadataDraftIntent(
+	base: Partial<AudiobookMetadata>,
+	patch: MetadataIntentPatch,
+): Partial<AudiobookMetadata> {
+	return applyMetadataIntentPatch(base, patch);
+}

--- a/src/ui/metadataLookup.ts
+++ b/src/ui/metadataLookup.ts
@@ -1,11 +1,8 @@
 import { tauriClient } from '../lib/tauri/client';
 import type { AudioFile } from '../types/audio';
 import type { AudiobookMetadata, MetadataSource, OnlineMetadataResult } from '../types/metadata';
-import {
-	applyMetadataIntentPatch,
-	buildMetadataIntentPatchFromMetadata,
-	type MetadataIntentPatch,
-} from '../types/metadataIntent';
+import type { MetadataIntentPatch } from '../types/metadataIntent';
+import { applyMetadataDraftIntent, buildMetadataDraftIntent } from './metadataDraft';
 import { applyMetadataToForm, readMetadataForm } from './metadataForm';
 import { updateEstimatedSize, updateOutputPath } from './outputPanel';
 import { updateTagPreview } from './tagPreview';
@@ -124,15 +121,13 @@ function resetResults(): void {
 }
 
 function buildQueueMetadataPatch(): MetadataIntentPatch {
-	return buildMetadataIntentPatchFromMetadata(
-		readMetadataForm({ mode: 'single', includeCoverArt: false }),
-	);
+	return buildMetadataDraftIntent(readMetadataForm({ mode: 'single', includeCoverArt: false }));
 }
 
 function persistQueueMetadata(file: AudioFile, state: QueueItemState): void {
 	if (!file.isValid) return;
 	const existing = getMetadataForFile(file.path) ?? {};
-	const merged: Partial<AudiobookMetadata> = applyMetadataIntentPatch(
+	const merged: Partial<AudiobookMetadata> = applyMetadataDraftIntent(
 		existing,
 		state.metadataPatch,
 	);

--- a/src/ui/metadataSaveState.ts
+++ b/src/ui/metadataSaveState.ts
@@ -1,11 +1,3 @@
-import { get, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 
 export const metadataSaveInProgressStore = writable(false);
-
-export function setMetadataSaveInProgress(inProgress: boolean): void {
-	metadataSaveInProgressStore.set(inProgress);
-}
-
-export function isMetadataSaveInProgress(): boolean {
-	return get(metadataSaveInProgressStore);
-}

--- a/src/ui/metadataState.ts
+++ b/src/ui/metadataState.ts
@@ -1,10 +1,10 @@
 import type { AudiobookMetadata } from '../types/metadata';
 import type { MetadataIntentPatch } from '../types/metadataIntent';
 import {
-	buildMetadataIntentPatchFromMetadata,
-	hasActionableMetadataIntentPatch,
-	mergeMetadataIntentPatches,
-} from '../types/metadataIntent';
+	buildMetadataDraftIntent,
+	hasActionableMetadataDraftIntent,
+	mergeMetadataDraftIntents,
+} from './metadataDraft';
 
 const metadataByFile = new Map<string, Partial<AudiobookMetadata>>();
 const metadataIntentByFile = new Map<string, MetadataIntentPatch>();
@@ -54,10 +54,10 @@ export function setMetadataForFile(
 ): void {
 	metadataByFile.set(filePath, metadata);
 	if (options?.markPending) {
-		const nextPatch = options.intentPatch ?? buildMetadataIntentPatchFromMetadata(metadata);
-		if (hasActionableMetadataIntentPatch(nextPatch)) {
+		const nextPatch = options.intentPatch ?? buildMetadataDraftIntent(metadata);
+		if (hasActionableMetadataDraftIntent(nextPatch)) {
 			const existing = metadataIntentByFile.get(filePath) ?? {};
-			metadataIntentByFile.set(filePath, mergeMetadataIntentPatches(existing, nextPatch));
+			metadataIntentByFile.set(filePath, mergeMetadataDraftIntents(existing, nextPatch));
 		}
 		pendingSavePaths.add(filePath);
 	}

--- a/src/ui/metadataValidation.ts
+++ b/src/ui/metadataValidation.ts
@@ -8,22 +8,20 @@ const SERIES_PART_INVALID_MESSAGE =
 const SUBSERIES_PART_INVALID_MESSAGE =
 	"Sub-series sequence (#) cannot include '/'. Use a plain number like 24.";
 
-export function getSeriesPartValidationError(value: string | undefined): string | null {
+function getSequenceValidationError(value: string | undefined, message: string): string | null {
 	if (!value) return null;
 	const trimmed = value.trim();
 	if (!trimmed) return null;
 	if (trimmed.includes('/')) {
-		return SERIES_PART_INVALID_MESSAGE;
+		return message;
 	}
 	return null;
 }
 
+export function getSeriesPartValidationError(value: string | undefined): string | null {
+	return getSequenceValidationError(value, SERIES_PART_INVALID_MESSAGE);
+}
+
 export function getSubseriesPartValidationError(value: string | undefined): string | null {
-	if (!value) return null;
-	const trimmed = value.trim();
-	if (!trimmed) return null;
-	if (trimmed.includes('/')) {
-		return SUBSERIES_PART_INVALID_MESSAGE;
-	}
-	return null;
+	return getSequenceValidationError(value, SUBSERIES_PART_INVALID_MESSAGE);
 }

--- a/src/ui/statusPanel/processing.ts
+++ b/src/ui/statusPanel/processing.ts
@@ -13,12 +13,12 @@ import {
 	setMetadataForFile,
 } from '../metadataState';
 import { stageMetadataToSelection } from '../fileList/actions';
+import type { MetadataIntentPatch } from '../../types/metadataIntent';
 import {
-	applyMetadataIntentPatch,
-	buildMetadataIntentPatchFromMetadata,
-	hasActionableMetadataIntentPatch,
-	type MetadataIntentPatch,
-} from '../../types/metadataIntent';
+	applyMetadataDraftIntent,
+	buildMetadataDraftIntent,
+	hasActionableMetadataDraftIntent,
+} from '../metadataDraft';
 import * as feedback from './feedback';
 import { openGeneratedPreviewIfSingle } from './preview';
 import type { ProcessingStatus } from './state';
@@ -153,14 +153,14 @@ export async function startProcessing(
 			if (hasDirtyMetadataFields()) {
 				const selectedFileIndex = getSelectedFileIndex();
 				const formMetadata = readMetadataForm({ mode: 'single' });
-				const intentPatch = buildMetadataIntentPatchFromMetadata(formMetadata);
+				const intentPatch = buildMetadataDraftIntent(formMetadata);
 				const activeFile =
 					selectedFileIndex >= 0
 						? fileList.files[selectedFileIndex]
 						: fileList.files.find((file) => file.isValid);
-				if (activeFile?.isValid && hasActionableMetadataIntentPatch(intentPatch)) {
+				if (activeFile?.isValid && hasActionableMetadataDraftIntent(intentPatch)) {
 					const existing = getMetadataForFile(activeFile.path) ?? {};
-					currentMetadata = applyMetadataIntentPatch(existing, intentPatch);
+					currentMetadata = applyMetadataDraftIntent(existing, intentPatch);
 					setMetadataForFile(activeFile.path, currentMetadata, {
 						markPending: true,
 						intentPatch,
@@ -207,7 +207,7 @@ export async function startProcessing(
 			if (
 				mergeKey &&
 				processPayload.inputFiles.length > 0 &&
-				hasActionableMetadataIntentPatch(mergeIntentPatch)
+				hasActionableMetadataDraftIntent(mergeIntentPatch)
 			) {
 				metadataIntentPayload = {
 					[mergeKey]: mergeIntentPatch,
@@ -219,7 +219,7 @@ export async function startProcessing(
 			const filteredMetadataIntent = Object.fromEntries(
 				Object.entries(storedMetadataIntent).filter(
 					([filePath, value]) =>
-						activeInputFiles.has(filePath) && hasActionableMetadataIntentPatch(value),
+						activeInputFiles.has(filePath) && hasActionableMetadataDraftIntent(value),
 				),
 			);
 			metadataIntentPayload =


### PR DESCRIPTION
## Summary

- Introduces `src/ui/metadataDraft.ts` as the UI metadata draft owner above the lower-level `MetadataIntentPatch` wire contract.
- Routes single-selection edits, multi-selection staging, metadata lookup queue application, processing metadata overlays, and pending-save state through the draft boundary.
- Updates Rust/generated/handwritten metadata docs so the writable intent surface is truthful: UI draft fields are distinct from read-compatible fields, and `album_sort` remains explicit backend intent.
- Removes the PR4-owned metadata-save store wrappers and deduplicates series/subseries sequence validation while preserving public validator names.
- Updates harness scenario routing for the new metadata draft/save-state files.

Closes #273
Closes #267
Refs #277

## Validation

- `bun run bindings:generate`
- `bun run test -- metadataIntent metadataDraft metadataState metadata-save-pending-flow processing-metadata-staging metadataValidation`
- `cargo test --manifest-path src-tauri/Cargo.toml metadata_intent_patch -- --nocapture`
- `bun run test -- src/harness/scenarios.test.ts`
- `bun run harness:verify --changed`
- `bun run harness:verify --scenario status-processing`
- `scripts/checks.sh standard`

## Notes

- `#270` stays open. Container classification/routing is a separate metadata boundary and was not changed here.
- The first full `scripts/checks.sh standard` run hit a transient harness hang in `status-processing`; the scenario passed immediately when run alone, then the full standard gate passed on rerun.
