### PR TITLE
fix: enforce output truth on metadata writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,9 +3613,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src-tauri/src/audio/processor/adapter.rs
+++ b/src-tauri/src/audio/processor/adapter.rs
@@ -49,10 +49,17 @@ impl ResolvedProcessorAdapter {
         files: Vec<AudioFile>,
         selected_decoders: Vec<Option<DecoderSelection>>,
         metadata: Option<AudiobookMetadata>,
+        allow_passthrough_cover_art: bool,
     ) -> Result<String> {
         match self {
             Self::NativeFfmpegNext => {
-                super::process_audiobook_with_context(context, files, metadata).await
+                super::process_audiobook_with_context(
+                    context,
+                    files,
+                    metadata,
+                    allow_passthrough_cover_art,
+                )
+                .await
             }
             Self::ExternalFdk { toolchain } => {
                 super::external_fdk::process_audiobook_with_external_fdk(
@@ -60,6 +67,7 @@ impl ResolvedProcessorAdapter {
                     files,
                     selected_decoders,
                     metadata,
+                    allow_passthrough_cover_art,
                     toolchain,
                 )
                 .await

--- a/src-tauri/src/audio/processor/encoder/context.rs
+++ b/src-tauri/src/audio/processor/encoder/context.rs
@@ -130,13 +130,9 @@ pub(crate) fn setup_encoder(
         .map_err(|e| AppError::General(format!("Create output failed: {e}")))?;
 
     if let Some(metadata) = metadata {
-        match crate::metadata::set_container_metadata(&mut octx, metadata) {
-            Ok(()) => log::debug!("Container metadata set successfully"),
-            Err(e) => log::warn!(
-                "Failed to set container metadata: {} - continuing with audio processing",
-                e
-            ),
-        }
+        crate::metadata::set_container_metadata(&mut octx, metadata)
+            .map_err(|e| AppError::General(format!("Failed to set container metadata: {e}")))?;
+        log::debug!("Container metadata set successfully");
     }
 
     let stream_codec_id = ff::codec::Id::AAC;
@@ -166,7 +162,6 @@ pub(crate) fn setup_encoder(
     let ost_time_base = ost.time_base();
 
     // Pre-header cover art stream attempt
-    let mut cover_art_stream_info: Option<(usize, crate::metadata::CoverFormat)> = None;
     // Prefer user-provided cover art; otherwise reuse passthrough cover art without reprocessing.
     let selected_cover = metadata
         .and_then(|m| m.cover_art.as_ref().map(|data| (data, "user")))
@@ -176,7 +171,9 @@ pub(crate) fn setup_encoder(
                 .map(|data| (data, "passthrough"))
         });
 
-    match selected_cover {
+    let selected_cover = selected_cover.filter(|(cover_data, _)| !cover_data.is_empty());
+
+    let cover_art_stream_info = match selected_cover {
         Some((cover_data, source)) => {
             let bytes = cover_data.len();
             log::info!(
@@ -184,37 +181,29 @@ pub(crate) fn setup_encoder(
                 source,
                 bytes
             );
-            cover_art_stream_info =
-                crate::metadata::add_cover_art_stream_pre_header(&mut octx, cover_data);
+            let cover_art_stream_info =
+                crate::metadata::add_cover_art_stream_pre_header(&mut octx, cover_data)?;
             if let Some((stream_idx, format)) = cover_art_stream_info {
                 log::info!("✓ Native cover art stream added successfully (stream={}, format={:?}) - will embed during encoding", stream_idx, format);
-            } else {
-                log::warn!(
-                    "cover_art_plan decision=failed reason=stream_creation_failed source={} bytes={}",
-                    source,
-                    bytes
-                );
-                log::warn!(
-                    "✗ Native cover art stream creation failed - cover art will not be embedded"
-                );
             }
+            cover_art_stream_info
         }
-        None => log::info!("cover_art_plan decision=none reason=no_cover_art_data"),
-    }
+        None => {
+            log::info!("cover_art_plan decision=none reason=no_cover_art_data");
+            None
+        }
+    };
 
     // Chapter passthrough: copy chapters from source inputs (#66)
     // Skip in preview mode since chapters won't align with shortened output
     if !skip_chapter_passthrough {
         if let Some(p) = passthrough {
-            match crate::metadata::passthrough::add_chapters_to_output(&mut octx, &p.chapters) {
-                Ok(count) if count > 0 => {
-                    log::info!("✓ Copied {} chapters from source files", count);
-                }
-                Ok(_) => log::debug!("No chapters found to copy from source files"),
-                Err(e) => log::warn!(
-                    "Could not copy chapters from sources: {} - continuing without chapters",
-                    e
-                ),
+            let count =
+                crate::metadata::passthrough::add_chapters_to_output(&mut octx, &p.chapters)?;
+            if count > 0 {
+                log::info!("✓ Copied {} chapters from source files", count);
+            } else {
+                log::debug!("No chapters found to copy from source files");
             }
         }
     } else {
@@ -240,7 +229,7 @@ pub(crate) fn setup_encoder(
                 stream_index,
                 cover_data,
                 format,
-            );
+            )?;
             log::info!(
                 "✓ Native cover art packet written successfully to stream {}",
                 stream_index

--- a/src-tauri/src/audio/processor/encoder/context.rs
+++ b/src-tauri/src/audio/processor/encoder/context.rs
@@ -182,7 +182,17 @@ pub(crate) fn setup_encoder(
                 bytes
             );
             let cover_art_stream_info =
-                crate::metadata::add_cover_art_stream_pre_header(&mut octx, cover_data)?;
+                match crate::metadata::add_cover_art_stream_pre_header(&mut octx, cover_data) {
+                    Ok(stream_info) => stream_info,
+                    Err(error) if source == "passthrough" => {
+                        log::warn!(
+                            "Could not preserve passthrough cover art during native encoding: {}",
+                            error
+                        );
+                        None
+                    }
+                    Err(error) => return Err(error),
+                };
             if let Some((stream_idx, format)) = cover_art_stream_info {
                 log::info!("✓ Native cover art stream added successfully (stream={}, format={:?}) - will embed during encoding", stream_idx, format);
             }
@@ -198,12 +208,19 @@ pub(crate) fn setup_encoder(
     // Skip in preview mode since chapters won't align with shortened output
     if !skip_chapter_passthrough {
         if let Some(p) = passthrough {
-            let count =
-                crate::metadata::passthrough::add_chapters_to_output(&mut octx, &p.chapters)?;
-            if count > 0 {
-                log::info!("✓ Copied {} chapters from source files", count);
-            } else {
-                log::debug!("No chapters found to copy from source files");
+            match crate::metadata::passthrough::add_chapters_to_output(&mut octx, &p.chapters) {
+                Ok(count) if count > 0 => {
+                    log::info!("✓ Copied {} chapters from source files", count);
+                }
+                Ok(_) => {
+                    log::debug!("No chapters found to copy from source files");
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Could not preserve passthrough chapters during native encoding: {}",
+                        error
+                    );
+                }
             }
         }
     } else {
@@ -224,16 +241,26 @@ pub(crate) fn setup_encoder(
                 cover_data.len(),
                 source
             );
-            crate::metadata::write_cover_art_packet_post_header(
+            if let Err(error) = crate::metadata::write_cover_art_packet_post_header(
                 &mut octx,
                 stream_index,
                 cover_data,
                 format,
-            )?;
-            log::info!(
-                "✓ Native cover art packet written successfully to stream {}",
-                stream_index
-            );
+            ) {
+                if source == "passthrough" {
+                    log::warn!(
+                        "Could not preserve passthrough cover art packet during native encoding: {}",
+                        error
+                    );
+                } else {
+                    return Err(error);
+                }
+            } else {
+                log::info!(
+                    "✓ Native cover art packet written successfully to stream {}",
+                    stream_index
+                );
+            }
         } else {
             log::warn!("Cover art stream exists but no cover bytes were available for writing");
         }

--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -19,6 +19,7 @@ pub(super) async fn process_audiobook_with_external_fdk(
     files: Vec<AudioFile>,
     selected_decoders: Vec<Option<DecoderSelection>>,
     metadata: Option<AudiobookMetadata>,
+    allow_passthrough_cover_art: bool,
     toolchain: ValidatedExternalToolchain,
 ) -> Result<String> {
     if !matches!(
@@ -53,7 +54,8 @@ pub(super) async fn process_audiobook_with_external_fdk(
 
     let passthrough = collect_passthrough_metadata(&valid_files, context.preview.is_some());
 
-    let effective_metadata = merge_cover_art(metadata, passthrough.as_ref());
+    let effective_metadata =
+        merge_cover_art(metadata, passthrough.as_ref(), allow_passthrough_cover_art);
     let ui = context.new_emitter();
     ui.emit_analyzing_start("Preparing external FDK job...");
     ui.emit_analyzing_end("External FDK toolchain validated.");
@@ -111,7 +113,13 @@ pub(super) async fn process_audiobook_with_external_fdk(
 fn merge_cover_art(
     metadata: Option<AudiobookMetadata>,
     passthrough: Option<&PassthroughMetadata>,
+    allow_passthrough_cover_art: bool,
 ) -> Option<AudiobookMetadata> {
+    if !allow_passthrough_cover_art {
+        log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
+        return metadata;
+    }
+
     let passthrough_cover = passthrough
         .and_then(|value| value.cover_art.as_ref())
         .cloned();
@@ -593,6 +601,7 @@ mod tests {
             }],
             vec![None],
             None,
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -649,6 +658,7 @@ mod tests {
             ],
             vec![None, None],
             None,
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg.clone(),
                 source: EncoderCapabilitySource::Override,
@@ -679,6 +689,7 @@ mod tests {
             vec![test_audio_file(first_input), test_audio_file(second_input)],
             vec![None, None],
             None,
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -731,6 +742,7 @@ mod tests {
             vec![test_audio_file(input_path.clone())],
             vec![None],
             None,
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -787,6 +799,7 @@ mod tests {
                 title: Some("Trigger rewrite".to_string()),
                 ..AudiobookMetadata::default()
             }),
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -847,6 +860,7 @@ mod tests {
             vec![test_audio_file(input_path.clone())],
             vec![None],
             None,
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -901,6 +915,7 @@ mod tests {
             vec![test_audio_file(input_path)],
             vec![None],
             None,
+            true,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -1109,6 +1124,23 @@ mod tests {
         .expect("cover-only passthrough");
         assert!(cover_only.chapters.is_empty());
         assert_eq!(cover_only.cover_art, Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn merge_cover_art_does_not_refill_after_explicit_clear() {
+        let metadata = AudiobookMetadata {
+            cover_art: None,
+            ..AudiobookMetadata::default()
+        };
+        let passthrough = PassthroughMetadata {
+            chapters: Vec::new(),
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let merged = merge_cover_art(Some(metadata), Some(&passthrough), false)
+            .expect("metadata should remain present");
+
+        assert_eq!(merged.cover_art, None);
     }
 
     fn fdk_test_settings() -> EncoderSettings {

--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -6,7 +6,9 @@ use crate::audio::CleanupGuard;
 use crate::audio::{AudioFile, DecoderSelection, ProcessingContext, ProgressEmitter};
 use crate::errors::{sanitize_path_for_display, AppError, Result};
 use crate::metadata::ffmpeg_bridge::rewrite_metadata_with_ffmpeg;
-use crate::metadata::passthrough::{extract_passthrough_metadata, PassthroughMetadata};
+use crate::metadata::passthrough::{
+    apply_cover_art_policy, extract_passthrough_metadata, PassthroughMetadata,
+};
 use crate::metadata::AudiobookMetadata;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -52,10 +54,12 @@ pub(super) async fn process_audiobook_with_external_fdk(
     }
     validate_external_input_decoders(&valid_files, &valid_selected_decoders, &toolchain)?;
 
-    let passthrough = collect_passthrough_metadata(&valid_files, context.preview.is_some());
+    let passthrough = apply_cover_art_policy(
+        collect_passthrough_metadata(&valid_files, context.preview.is_some()),
+        allow_passthrough_cover_art,
+    );
 
-    let effective_metadata =
-        merge_cover_art(metadata, passthrough.as_ref(), allow_passthrough_cover_art);
+    let effective_metadata = merge_cover_art(metadata, passthrough.as_ref());
     let ui = context.new_emitter();
     ui.emit_analyzing_start("Preparing external FDK job...");
     ui.emit_analyzing_end("External FDK toolchain validated.");
@@ -113,13 +117,7 @@ pub(super) async fn process_audiobook_with_external_fdk(
 fn merge_cover_art(
     metadata: Option<AudiobookMetadata>,
     passthrough: Option<&PassthroughMetadata>,
-    allow_passthrough_cover_art: bool,
 ) -> Option<AudiobookMetadata> {
-    if !allow_passthrough_cover_art {
-        log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
-        return metadata;
-    }
-
     let passthrough_cover = passthrough
         .and_then(|value| value.cover_art.as_ref())
         .cloned();
@@ -1127,17 +1125,17 @@ mod tests {
     }
 
     #[test]
-    fn merge_cover_art_does_not_refill_after_explicit_clear() {
+    fn merge_cover_art_does_not_refill_when_passthrough_cover_is_filtered() {
         let metadata = AudiobookMetadata {
             cover_art: None,
             ..AudiobookMetadata::default()
         };
         let passthrough = PassthroughMetadata {
             chapters: Vec::new(),
-            cover_art: Some(vec![1, 2, 3]),
+            cover_art: None,
         };
 
-        let merged = merge_cover_art(Some(metadata), Some(&passthrough), false)
+        let merged = merge_cover_art(Some(metadata), Some(&passthrough))
             .expect("metadata should remain present");
 
         assert_eq!(merged.cover_art, None);

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -78,6 +78,7 @@ pub async fn process_audiobook_with_context(
     context: ProcessingContext,
     files: Vec<AudioFile>,
     metadata: Option<AudiobookMetadata>,
+    allow_passthrough_cover_art: bool,
 ) -> Result<String> {
     let mut reporter = ProgressReporter::new(files.len());
     let mut metrics = ProcessingMetrics::new();
@@ -92,21 +93,25 @@ pub async fn process_audiobook_with_context(
 
     // Merge passthrough cover art when user metadata is absent or missing cover art.
     let mut effective_metadata = metadata;
-    if let Some(ref passthrough) = passthrough_metadata {
-        if let Some(ref cover) = passthrough.cover_art {
-            match effective_metadata.as_mut() {
-                Some(md) => {
-                    if md.cover_art.is_none() {
-                        md.cover_art = Some(cover.clone());
+    if allow_passthrough_cover_art {
+        if let Some(ref passthrough) = passthrough_metadata {
+            if let Some(ref cover) = passthrough.cover_art {
+                match effective_metadata.as_mut() {
+                    Some(md) => {
+                        if md.cover_art.is_none() {
+                            md.cover_art = Some(cover.clone());
+                        }
                     }
-                }
-                None => {
-                    let mut md = AudiobookMetadata::new();
-                    md.cover_art = Some(cover.clone());
-                    effective_metadata = Some(md);
+                    None => {
+                        let mut md = AudiobookMetadata::new();
+                        md.cover_art = Some(cover.clone());
+                        effective_metadata = Some(md);
+                    }
                 }
             }
         }
+    } else {
+        log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
     }
 
     // Metrics accumulation (estimates)

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -14,6 +14,7 @@ use crate::audio::context::ProcessingContext;
 use crate::audio::metrics::ProcessingMetrics;
 use crate::audio::{AudioFile, ProcessingStage, ProgressReporter};
 use crate::errors::Result;
+use crate::metadata::passthrough::apply_cover_art_policy;
 use crate::metadata::AudiobookMetadata;
 use std::time::Duration;
 
@@ -88,30 +89,28 @@ pub async fn process_audiobook_with_context(
     let workflow = prepare::validate_and_prepare(&context, &files)?;
 
     // Extract passthrough metadata (chapters, original cover art) from all valid files.
-    let passthrough_metadata =
-        crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option();
+    let passthrough_metadata = apply_cover_art_policy(
+        crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option(),
+        allow_passthrough_cover_art,
+    );
 
     // Merge passthrough cover art when user metadata is absent or missing cover art.
     let mut effective_metadata = metadata;
-    if allow_passthrough_cover_art {
-        if let Some(ref passthrough) = passthrough_metadata {
-            if let Some(ref cover) = passthrough.cover_art {
-                match effective_metadata.as_mut() {
-                    Some(md) => {
-                        if md.cover_art.is_none() {
-                            md.cover_art = Some(cover.clone());
-                        }
-                    }
-                    None => {
-                        let mut md = AudiobookMetadata::new();
+    if let Some(ref passthrough) = passthrough_metadata {
+        if let Some(ref cover) = passthrough.cover_art {
+            match effective_metadata.as_mut() {
+                Some(md) => {
+                    if md.cover_art.is_none() {
                         md.cover_art = Some(cover.clone());
-                        effective_metadata = Some(md);
                     }
+                }
+                None => {
+                    let mut md = AudiobookMetadata::new();
+                    md.cover_art = Some(cover.clone());
+                    effective_metadata = Some(md);
                 }
             }
         }
-    } else {
-        log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
     }
 
     // Metrics accumulation (estimates)

--- a/src-tauri/src/bin/perf_app_e2e.rs
+++ b/src-tauri/src/bin/perf_app_e2e.rs
@@ -196,7 +196,7 @@ async fn run() -> Result<()> {
         .unwrap_or(total_duration);
 
     let start = Instant::now();
-    let message = audio::process_audiobook_with_context(context, file_info.files, None)
+    let message = audio::process_audiobook_with_context(context, file_info.files, None, true)
         .await
         .map_err(|e| anyhow!("App e2e processing failed: {e}"))?;
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;

--- a/src-tauri/src/commands/audio_processing/plan.rs
+++ b/src-tauri/src/commands/audio_processing/plan.rs
@@ -22,6 +22,7 @@ pub(crate) struct PlannedProcessingJob {
     pub(crate) input_path: Option<PathBuf>,
     pub(crate) output: ResolvedOutputPlan,
     pub(crate) metadata: Option<crate::metadata::AudiobookMetadata>,
+    pub(crate) allow_passthrough_cover_art: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -323,6 +324,9 @@ fn build_merge_processing_job(
         Some(&merge_source_path),
         merge_patch.as_ref(),
     )?;
+    let allow_passthrough_cover_art = !merge_patch
+        .as_ref()
+        .is_some_and(crate::metadata::MetadataIntentPatch::clears_cover_art);
     let merge_naming_metadata = super::resolve_naming_metadata(
         merge_metadata.as_ref(),
         Some(&merge_source_path),
@@ -351,6 +355,7 @@ fn build_merge_processing_job(
         input_path: None,
         output,
         metadata: merge_metadata,
+        allow_passthrough_cover_art,
     })
 }
 
@@ -380,6 +385,9 @@ fn build_batch_processing_jobs(
         let file_patch = metadata.and_then(|map| map.get(input)).cloned();
         let effective_metadata =
             super::resolve_effective_processing_metadata(Some(&path), file_patch.as_ref())?;
+        let allow_passthrough_cover_art = !file_patch
+            .as_ref()
+            .is_some_and(crate::metadata::MetadataIntentPatch::clears_cover_art);
         let naming_metadata = super::resolve_naming_metadata(
             effective_metadata.as_ref(),
             Some(&path),
@@ -402,6 +410,7 @@ fn build_batch_processing_jobs(
             input_path: Some(path),
             output,
             metadata: effective_metadata,
+            allow_passthrough_cover_art,
         });
     }
 
@@ -543,6 +552,7 @@ mod tests {
                     action: PlannedOutputAction::ReviewRequired,
                 },
                 metadata: None,
+                allow_passthrough_cover_art: true,
             }],
         };
 
@@ -598,6 +608,43 @@ mod tests {
         assert!(
             !planned_parent.exists(),
             "preflight planning should not create output parent directories"
+        );
+    }
+
+    #[test]
+    fn build_processing_plan_suppresses_passthrough_cover_after_explicit_clear() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let source_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root")
+            .join("media")
+            .join("media_20sec.mp3");
+        let input_path = temp_dir.path().join("input.m4b");
+        std::fs::copy(&source_fixture, &input_path).expect("copy fixture");
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            input_path.to_string_lossy().to_string(),
+            MetadataIntentPatch {
+                cover_art: PatchOp::Clear,
+                ..Default::default()
+            },
+        );
+        let payload = process_payload(|payload| {
+            payload.input_files = vec![input_path.to_string_lossy().to_string()];
+            payload.output_dir = temp_dir.path().to_string_lossy().to_string();
+        });
+        let inputs = ProcessingInputs {
+            output_naming: payload.output_naming.clone().unwrap_or_default(),
+            base_output_dir: temp_dir.path().to_path_buf(),
+            preview_seconds: None,
+        };
+
+        let plan = build_processing_plan(&payload, Some(&metadata), &inputs).expect("build plan");
+
+        assert_eq!(plan.jobs.len(), 1);
+        assert!(
+            !plan.jobs[0].allow_passthrough_cover_art,
+            "explicit cover clear must not be refilled from source passthrough"
         );
     }
 }

--- a/src-tauri/src/commands/audio_processing/run.rs
+++ b/src-tauri/src/commands/audio_processing/run.rs
@@ -246,6 +246,7 @@ async fn dispatch_merge_job(
         output_plan: planned_job.output,
         file_info,
         metadata: planned_job.metadata,
+        allow_passthrough_cover_art: planned_job.allow_passthrough_cover_art,
         preview_seconds: plan.preview_seconds,
     })
     .await?;
@@ -292,6 +293,7 @@ async fn dispatch_batch_jobs(
         let external_toolchain_cloned = payload.external_toolchain.clone();
         let sr_cloned = sample_rate.clone();
         let md_cloned = planned_job.metadata.clone();
+        let allow_passthrough_cover_art = planned_job.allow_passthrough_cover_art;
         let preview_cloned = preview_seconds;
         let input_index = planned_job.input_index;
         let output = planned_job.output.clone();
@@ -311,6 +313,7 @@ async fn dispatch_batch_jobs(
                 output_plan: output,
                 file_info,
                 metadata: md_cloned,
+                allow_passthrough_cover_art,
                 preview_seconds: preview_cloned,
             })
             .await
@@ -333,6 +336,7 @@ struct ProcessingJobRequest {
     output_plan: ResolvedOutputPlan,
     file_info: FileListInfo,
     metadata: Option<crate::metadata::AudiobookMetadata>,
+    allow_passthrough_cover_art: bool,
     preview_seconds: Option<f64>,
 }
 
@@ -357,6 +361,7 @@ async fn run_processing_job(request: ProcessingJobRequest) -> Result<ProcessResu
         context,
         request.file_info,
         request.metadata,
+        request.allow_passthrough_cover_art,
         request.encoder_settings,
         request.external_toolchain,
     )
@@ -462,6 +467,7 @@ async fn execute_processing_job(
     context: audio::ProcessingContext,
     file_info: FileListInfo,
     metadata: Option<crate::metadata::AudiobookMetadata>,
+    allow_passthrough_cover_art: bool,
     encoder_settings: audio::settings_encoder::EncoderSettings,
     external_toolchain: Option<ExternalToolchainPreference>,
 ) -> Result<String> {
@@ -475,7 +481,13 @@ async fn execute_processing_job(
         external_toolchain.as_ref(),
     )?;
     adapter
-        .execute(context, files, selected_decoders, metadata)
+        .execute(
+            context,
+            files,
+            selected_decoders,
+            metadata,
+            allow_passthrough_cover_art,
+        )
         .await
 }
 

--- a/src-tauri/src/metadata/cover_art/embedding.rs
+++ b/src-tauri/src/metadata/cover_art/embedding.rs
@@ -1,23 +1,24 @@
-use crate::errors::Result;
+use crate::errors::{AppError, Result};
 use ffmpeg_next as ff;
 
 use super::super::ffi::set_attached_pic_disposition;
 use super::format::{detect_cover_art_format, detect_image_dimensions, CoverFormat};
 
-/// Adds a cover art stream prior to header writing. Returns output stream index if added.
+/// Adds a cover art stream prior to header writing.
 ///
 /// For M4B/MP4 containers, this properly sets the `attached_pic` disposition using
 /// FFI to ensure the stream is treated as cover art rather than a regular video stream.
 pub fn add_cover_art_stream_pre_header(
     octx: &mut ff::format::context::Output,
     cover_data: &[u8],
-) -> Option<(usize, CoverFormat)> {
+) -> Result<Option<(usize, CoverFormat)>> {
     if cover_data.is_empty() {
-        return None;
+        return Ok(None);
     }
     let Some(format) = detect_cover_art_format(cover_data) else {
-        log::warn!("Unsupported cover art format (only JPEG/PNG). Cover art will be skipped.");
-        return None;
+        return Err(AppError::General(
+            "Unsupported cover art format (only JPEG and PNG are supported)".to_string(),
+        ));
     };
 
     let codec_id = match format {
@@ -25,11 +26,10 @@ pub fn add_cover_art_stream_pre_header(
         CoverFormat::Png => ff::codec::Id::PNG,
     };
     let Some(codec) = ff::encoder::find(codec_id) else {
-        log::warn!(
-            "Cover art codec {:?} missing in ffmpeg build; cover art will be skipped",
+        return Err(AppError::General(format!(
+            "Cover art codec {:?} missing in ffmpeg build",
             format
-        );
-        return None;
+        )));
     };
 
     match octx.add_stream(codec) {
@@ -37,31 +37,20 @@ pub fn add_cover_art_stream_pre_header(
             let idx = stream.index();
 
             // Configure stream parameters for cover art
-            if let Err(e) = configure_cover_art_stream_parameters(&mut stream, format, cover_data) {
-                log::warn!("Failed to configure cover art stream parameters ({}); cover art will be skipped", e);
-                return None;
-            }
+            configure_cover_art_stream_parameters(&mut stream, format, cover_data)?;
 
             // Set the ATTACHED_PIC disposition using FFI
             // This is crucial for M4B/MP4 containers to properly recognize cover art
-            if let Err(e) = set_attached_pic_disposition(octx, idx) {
-                log::warn!(
-                    "Failed to set attached_pic disposition ({}); trying without disposition",
-                    e
-                );
-            }
+            set_attached_pic_disposition(octx, idx)?;
 
             log::info!("Added cover art stream with attached_pic disposition (index={}, format={:?}, bytes={})",
                       idx, format, cover_data.len());
-            Some((idx, format))
+            Ok(Some((idx, format)))
         }
-        Err(e) => {
-            log::warn!(
-                "Failed adding cover art stream ({}); cover art will be skipped",
-                e
-            );
-            None
-        }
+        Err(e) => Err(AppError::General(format!(
+            "Failed adding cover art stream: {}",
+            e
+        ))),
     }
 }
 
@@ -75,9 +64,9 @@ pub fn write_cover_art_packet_post_header(
     stream_index: usize,
     cover_data: &[u8],
     format: CoverFormat,
-) {
+) -> Result<()> {
     if cover_data.is_empty() {
-        return;
+        return Ok(());
     }
 
     let mut pkt = ff::Packet::copy(cover_data);
@@ -89,19 +78,14 @@ pub fn write_cover_art_packet_post_header(
     pkt.set_pts(Some(0));
     pkt.set_dts(Some(0));
 
-    if let Err(e) = pkt.write_interleaved(octx) {
-        log::warn!(
-            "Failed writing cover art packet ({}); finalize stage will attempt embedding",
-            e
-        );
-    } else {
-        log::info!(
-            "Cover art packet written as attached pic (stream={}, format={:?}, size={} bytes)",
-            stream_index,
-            format,
-            cover_data.len()
-        );
-    }
+    pkt.write_interleaved(octx).map_err(AppError::Ffmpeg)?;
+    log::info!(
+        "Cover art packet written as attached pic (stream={}, format={:?}, size={} bytes)",
+        stream_index,
+        format,
+        cover_data.len()
+    );
+    Ok(())
 }
 
 /// Configures stream parameters for cover art embedding
@@ -129,10 +113,9 @@ fn configure_cover_art_stream_parameters(
         .video()
         .map_err(|e| AppError::General(format!("Failed to create video encoder context: {}", e)))?;
 
-    // Return an error when dimensions cannot be detected; the caller
-    // (add_cover_art_stream_pre_header) will log a warning and skip embedding.
-    // Using a fixed 600×600 here would produce wrong codec parameters,
-    // which is worse than omitting cover art entirely.
+    // Return an error when dimensions cannot be detected; explicit cover-art
+    // writes must not be reported as successful if the stream cannot be built.
+    // Using a fixed 600×600 here would produce wrong codec parameters.
     let (width, height) = detect_image_dimensions(cover_data, format).ok_or_else(|| {
         AppError::General(format!(
             "Cannot detect dimensions for {:?} cover art ({} bytes); skipping embedding",

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -155,6 +155,10 @@ pub struct MetadataIntentPatch {
 }
 
 impl MetadataIntentPatch {
+    pub(crate) fn clears_cover_art(&self) -> bool {
+        matches!(self.cover_art, PatchOp::Clear)
+    }
+
     pub(crate) fn apply_to_metadata(
         &self,
         mut base: AudiobookMetadata,

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -36,6 +36,23 @@ impl PassthroughMetadata {
         self.chapters.clear();
         self.into_option()
     }
+
+    pub fn without_cover_art(mut self) -> Option<Self> {
+        self.cover_art = None;
+        self.into_option()
+    }
+}
+
+pub fn apply_cover_art_policy(
+    passthrough: Option<PassthroughMetadata>,
+    allow_passthrough_cover_art: bool,
+) -> Option<PassthroughMetadata> {
+    if allow_passthrough_cover_art {
+        return passthrough;
+    }
+
+    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
+    passthrough.and_then(PassthroughMetadata::without_cover_art)
 }
 
 fn synthesize_chapters_from_files(files: &[PipelineAudioFile]) -> Vec<ChapterSpec> {
@@ -197,7 +214,7 @@ fn rescale_to_ms(value: i64, time_base: ff::Rational) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChapterSpec, PassthroughMetadata};
+    use super::{apply_cover_art_policy, ChapterSpec, PassthroughMetadata};
 
     #[test]
     fn into_option_returns_none_for_empty_passthrough() {
@@ -235,5 +252,52 @@ mod tests {
         };
 
         assert!(passthrough.cover_art_only().is_none());
+    }
+
+    #[test]
+    fn without_cover_art_preserves_chapters_and_drops_cover_art() {
+        let passthrough = PassthroughMetadata {
+            chapters: vec![ChapterSpec {
+                title: Some("Chapter 1".to_string()),
+                start_ms: 0,
+                end_ms: 1_000,
+            }],
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let without_cover = passthrough
+            .without_cover_art()
+            .expect("chapter passthrough should remain");
+
+        assert_eq!(without_cover.chapters.len(), 1);
+        assert_eq!(without_cover.cover_art, None);
+    }
+
+    #[test]
+    fn without_cover_art_returns_none_when_passthrough_only_has_cover_art() {
+        let passthrough = PassthroughMetadata {
+            chapters: Vec::new(),
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        assert!(passthrough.without_cover_art().is_none());
+    }
+
+    #[test]
+    fn apply_cover_art_policy_drops_only_cover_art_after_explicit_clear() {
+        let passthrough = PassthroughMetadata {
+            chapters: vec![ChapterSpec {
+                title: Some("Chapter 1".to_string()),
+                start_ms: 0,
+                end_ms: 1_000,
+            }],
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let effective =
+            apply_cover_art_policy(Some(passthrough), false).expect("chapter passthrough remains");
+
+        assert_eq!(effective.chapters.len(), 1);
+        assert_eq!(effective.cover_art, None);
     }
 }

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -141,6 +141,8 @@ pub fn add_chapters_to_output(
     octx: &mut ff::format::context::Output,
     chapters: &[ChapterSpec],
 ) -> Result<usize> {
+    use crate::errors::AppError;
+
     let mut copied = 0;
     if chapters.is_empty() {
         return Ok(0);
@@ -157,7 +159,12 @@ pub fn add_chapters_to_output(
             &title,
         ) {
             Ok(_) => copied += 1,
-            Err(e) => log::warn!("Failed to add chapter {} ({}): {}", idx, title, e),
+            Err(e) => {
+                return Err(AppError::General(format!(
+                    "Failed to add chapter {} ({}): {}",
+                    idx, title, e
+                )))
+            }
         }
     }
     Ok(copied)

--- a/src-tauri/src/metadata/remux.rs
+++ b/src-tauri/src/metadata/remux.rs
@@ -37,16 +37,19 @@ pub(crate) fn rewrite_metadata_with_ffmpeg_plan(
     let mut octx = ff::format::output(&temp_path).map_err(AppError::Ffmpeg)?;
     let metadata_value = metadata.map(|plan| &plan.metadata);
     let (stream_mapping, output_time_bases) = copy_streams(&ictx, &mut octx, metadata_value)?;
-    copy_chapters(&ictx, &mut octx, passthrough);
+    copy_chapters(&ictx, &mut octx, passthrough)?;
     copy_container_metadata(&ictx, &mut octx, metadata)?;
 
     let cover = select_cover_art(metadata_value, passthrough);
-    let cover_stream_info =
-        cover.and_then(|bytes| add_cover_art_stream_pre_header(&mut octx, bytes));
+    let cover_stream_info = if let Some(bytes) = cover {
+        add_cover_art_stream_pre_header(&mut octx, bytes)?
+    } else {
+        None
+    };
     octx.write_header().map_err(AppError::Ffmpeg)?;
 
     if let (Some(bytes), Some((stream_index, format))) = (cover, cover_stream_info) {
-        write_cover_art_packet_post_header(&mut octx, stream_index, bytes, format);
+        write_cover_art_packet_post_header(&mut octx, stream_index, bytes, format)?;
     }
 
     stream_copy_packets(&mut ictx, &mut octx, &stream_mapping, &output_time_bases)?;
@@ -130,14 +133,16 @@ fn copy_chapters(
     ictx: &ff::format::context::Input,
     octx: &mut ff::format::context::Output,
     passthrough: Option<&PassthroughMetadata>,
-) {
+) -> Result<()> {
+    use crate::errors::AppError;
+
     if let Some(passthrough) = passthrough {
-        let _ = crate::metadata::passthrough::add_chapters_to_output(octx, &passthrough.chapters);
-        return;
+        crate::metadata::passthrough::add_chapters_to_output(octx, &passthrough.chapters)?;
+        return Ok(());
     }
 
     if ictx.nb_chapters() == 0 {
-        return;
+        return Ok(());
     }
 
     for chapter in ictx.chapters() {
@@ -152,9 +157,15 @@ fn copy_chapters(
             chapter.end(),
             title.as_deref().unwrap_or(""),
         ) {
-            log::warn!("Failed to add chapter id {}: {}", chapter.id(), error);
+            return Err(AppError::General(format!(
+                "Failed to add chapter id {}: {}",
+                chapter.id(),
+                error
+            )));
         }
     }
+
+    Ok(())
 }
 
 fn copy_container_metadata(
@@ -180,6 +191,7 @@ fn select_cover_art<'a>(
     metadata
         .and_then(|value| value.cover_art.as_ref())
         .or_else(|| passthrough.and_then(|value| value.cover_art.as_ref()))
+        .filter(|cover_art| !cover_art.is_empty())
 }
 
 fn stream_copy_packets(

--- a/src-tauri/src/metadata/remux.rs
+++ b/src-tauri/src/metadata/remux.rs
@@ -41,15 +41,36 @@ pub(crate) fn rewrite_metadata_with_ffmpeg_plan(
     copy_container_metadata(&ictx, &mut octx, metadata)?;
 
     let cover = select_cover_art(metadata_value, passthrough);
-    let cover_stream_info = if let Some(bytes) = cover {
-        add_cover_art_stream_pre_header(&mut octx, bytes)?
+    let cover_stream_info = if let Some(selection) = cover {
+        match add_cover_art_stream_pre_header(&mut octx, selection.bytes()) {
+            Ok(stream_info) => stream_info,
+            Err(error) if selection.is_passthrough() => {
+                log::warn!(
+                    "Could not preserve passthrough cover art during metadata remux: {}",
+                    error
+                );
+                None
+            }
+            Err(error) => return Err(error),
+        }
     } else {
         None
     };
     octx.write_header().map_err(AppError::Ffmpeg)?;
 
-    if let (Some(bytes), Some((stream_index, format))) = (cover, cover_stream_info) {
-        write_cover_art_packet_post_header(&mut octx, stream_index, bytes, format)?;
+    if let (Some(selection), Some((stream_index, format))) = (cover, cover_stream_info) {
+        if let Err(error) =
+            write_cover_art_packet_post_header(&mut octx, stream_index, selection.bytes(), format)
+        {
+            if selection.is_passthrough() {
+                log::warn!(
+                    "Could not preserve passthrough cover art packet during metadata remux: {}",
+                    error
+                );
+            } else {
+                return Err(error);
+            }
+        }
     }
 
     stream_copy_packets(&mut ictx, &mut octx, &stream_mapping, &output_time_bases)?;
@@ -134,10 +155,15 @@ fn copy_chapters(
     octx: &mut ff::format::context::Output,
     passthrough: Option<&PassthroughMetadata>,
 ) -> Result<()> {
-    use crate::errors::AppError;
-
     if let Some(passthrough) = passthrough {
-        crate::metadata::passthrough::add_chapters_to_output(octx, &passthrough.chapters)?;
+        if let Err(error) =
+            crate::metadata::passthrough::add_chapters_to_output(octx, &passthrough.chapters)
+        {
+            log::warn!(
+                "Could not preserve passthrough chapters during metadata remux: {}",
+                error
+            );
+        }
         return Ok(());
     }
 
@@ -157,11 +183,7 @@ fn copy_chapters(
             chapter.end(),
             title.as_deref().unwrap_or(""),
         ) {
-            return Err(AppError::General(format!(
-                "Failed to add chapter id {}: {}",
-                chapter.id(),
-                error
-            )));
+            log::warn!("Failed to add chapter id {}: {}", chapter.id(), error);
         }
     }
 
@@ -184,14 +206,37 @@ fn copy_container_metadata(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy)]
+enum CoverArtSelection<'a> {
+    Explicit(&'a Vec<u8>),
+    Passthrough(&'a Vec<u8>),
+}
+
+impl<'a> CoverArtSelection<'a> {
+    fn bytes(self) -> &'a Vec<u8> {
+        match self {
+            Self::Explicit(bytes) | Self::Passthrough(bytes) => bytes,
+        }
+    }
+
+    fn is_passthrough(self) -> bool {
+        matches!(self, Self::Passthrough(_))
+    }
+}
+
 fn select_cover_art<'a>(
     metadata: Option<&'a AudiobookMetadata>,
     passthrough: Option<&'a PassthroughMetadata>,
-) -> Option<&'a Vec<u8>> {
+) -> Option<CoverArtSelection<'a>> {
     metadata
         .and_then(|value| value.cover_art.as_ref())
-        .or_else(|| passthrough.and_then(|value| value.cover_art.as_ref()))
-        .filter(|cover_art| !cover_art.is_empty())
+        .map(CoverArtSelection::Explicit)
+        .or_else(|| {
+            passthrough
+                .and_then(|value| value.cover_art.as_ref())
+                .map(CoverArtSelection::Passthrough)
+        })
+        .filter(|selection| !selection.bytes().is_empty())
 }
 
 fn stream_copy_packets(

--- a/src-tauri/tests/integration_cover_art_compat_tests.rs
+++ b/src-tauri/tests/integration_cover_art_compat_tests.rs
@@ -98,7 +98,7 @@ async fn covr_only_is_visible_to_ffprobe() {
 }
 
 #[test]
-fn skips_cover_art_stream_when_dimensions_are_undetectable() {
+fn fails_cover_art_stream_when_dimensions_are_undetectable() {
     ff::init().expect("ffmpeg init");
 
     let temp = TempDir::new().expect("temp dir");
@@ -109,7 +109,7 @@ fn skips_cover_art_stream_when_dimensions_are_undetectable() {
     let result = ffmpeg_add_cover_art_stream_pre_header(&mut octx, invalid_jpeg);
 
     assert!(
-        result.is_none(),
-        "cover art should be skipped when dimensions cannot be detected"
+        result.is_err(),
+        "explicit cover art writes should fail when dimensions cannot be detected"
     );
 }

--- a/src-tauri/tests/integration_fastpath_parity_tests.rs
+++ b/src-tauri/tests/integration_fastpath_parity_tests.rs
@@ -53,7 +53,7 @@ async fn encode_with_fastpath_mode(
         OutputConfig::new(output_path),
     );
 
-    audio::process_audiobook_with_context(context, input_info.files, None)
+    audio::process_audiobook_with_context(context, input_info.files, None, true)
         .await
         .expect("native AAC processing should complete")
 }

--- a/src-tauri/tests/integration_metadata_reader_matrix_tests.rs
+++ b/src-tauri/tests/integration_metadata_reader_matrix_tests.rs
@@ -115,7 +115,8 @@ fn write_minimal_m4b_with_attached_pic(output: &Path, cover_bytes: &[u8]) {
         ost.set_parameters(&enc);
         (ost.index(), ost.time_base())
     };
-    let cover_stream_info = ffmpeg_add_cover_art_stream_pre_header(&mut octx, cover_bytes);
+    let cover_stream_info =
+        ffmpeg_add_cover_art_stream_pre_header(&mut octx, cover_bytes).expect("add cover stream");
     octx.write_header().expect("write header");
 
     if let Some((cover_stream_index, format)) = cover_stream_info {
@@ -124,7 +125,8 @@ fn write_minimal_m4b_with_attached_pic(output: &Path, cover_bytes: &[u8]) {
             cover_stream_index,
             cover_bytes,
             format,
-        );
+        )
+        .expect("write cover packet");
     }
 
     let mut frame = ff::frame::Audio::empty();

--- a/src-tauri/tests/integration_metadata_tests.rs
+++ b/src-tauri/tests/integration_metadata_tests.rs
@@ -99,7 +99,8 @@ fn write_minimal_m4b_with_attached_pic(output: &Path, cover_bytes: &[u8]) {
         ost.set_parameters(&enc);
         (ost.index(), ost.time_base())
     };
-    let cover_stream_info = ffmpeg_add_cover_art_stream_pre_header(&mut octx, cover_bytes);
+    let cover_stream_info =
+        ffmpeg_add_cover_art_stream_pre_header(&mut octx, cover_bytes).expect("add cover stream");
     octx.write_header().expect("write header");
 
     if let Some((cover_stream_index, format)) = cover_stream_info {
@@ -108,7 +109,8 @@ fn write_minimal_m4b_with_attached_pic(output: &Path, cover_bytes: &[u8]) {
             cover_stream_index,
             cover_bytes,
             format,
-        );
+        )
+        .expect("write cover packet");
     }
 
     let mut frame = ff::frame::Audio::empty();

--- a/src-tauri/tests/integration_native_aac_regression_tests.rs
+++ b/src-tauri/tests/integration_native_aac_regression_tests.rs
@@ -71,7 +71,7 @@ async fn native_aac_regression_encodes_valid_output() {
         OutputConfig::new(&output_path),
     );
 
-    let result = audio::process_audiobook_with_context(context, file_info.files, None).await;
+    let result = audio::process_audiobook_with_context(context, file_info.files, None, true).await;
     assert!(
         result.is_ok(),
         "native AAC encode should complete without error: {:?}",
@@ -131,7 +131,7 @@ async fn native_aac_preview_stops_near_requested_boundary() {
     );
     context.preview = Some(audio::context::PreviewConfig::new(preview_seconds));
 
-    let result = audio::process_audiobook_with_context(context, file_info.files, None).await;
+    let result = audio::process_audiobook_with_context(context, file_info.files, None, true).await;
     assert!(
         result.is_ok(),
         "native AAC preview encode should complete without error: {:?}",

--- a/src-tauri/tests/integration_processing_flow_tests.rs
+++ b/src-tauri/tests/integration_processing_flow_tests.rs
@@ -176,7 +176,7 @@ async fn process_roundtrip_files(
         context.preview = Some(audio::context::PreviewConfig::new(seconds));
     }
 
-    audio::process_audiobook_with_context(context, input_info.files, Some(metadata))
+    audio::process_audiobook_with_context(context, input_info.files, Some(metadata), true)
         .await
         .expect("processing should complete")
 }

--- a/src-tauri/tests/integration_xhe_aac_fixture_tests.rs
+++ b/src-tauri/tests/integration_xhe_aac_fixture_tests.rs
@@ -48,7 +48,13 @@ async fn xhe_aac_fixture_encodes_short_external_fdk_preview_when_configured() {
     context.preview = Some(audio::context::PreviewConfig::new(20.0));
 
     let result = adapter
-        .execute(context, file_info.files, file_info.selected_decoders, None)
+        .execute(
+            context,
+            file_info.files,
+            file_info.selected_decoders,
+            None,
+            true,
+        )
         .await
         .expect("external FDK preview should encode the xHE-AAC fixture");
 

--- a/src/ui/__tests__/fileImport-handlers.test.ts
+++ b/src/ui/__tests__/fileImport-handlers.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fileImportUiState } from '../fileImport/state.svelte';
+
+const context = vi.hoisted(() => ({
+	openMock: vi.fn(),
+	analyzeAudioFilesMock: vi.fn(),
+	appendFileListMock: vi.fn(),
+	persistPendingDraftsMock: vi.fn(),
+}));
+
+vi.mock('../../lib/tauri/client', () => ({
+	tauriClient: {
+		open: context.openMock,
+		analyzeAudioFiles: context.analyzeAudioFilesMock,
+	},
+}));
+
+vi.mock('../fileList', () => ({
+	appendFileList: context.appendFileListMock,
+	persistPendingMetadataDraftsForCurrentSelection: context.persistPendingDraftsMock,
+}));
+
+vi.mock('../fileList/state', () => ({
+	isOrderLocked: vi.fn(() => false),
+}));
+
+describe('file import handlers', () => {
+	beforeEach(() => {
+		context.openMock.mockReset();
+		context.analyzeAudioFilesMock.mockReset();
+		context.appendFileListMock.mockReset();
+		context.persistPendingDraftsMock.mockReset();
+		fileImportUiState.errorMessage = '';
+		fileImportUiState.isDragOver = false;
+		fileImportUiState.hasFiles = false;
+	});
+
+	it('aborts importing when metadata staging fails', async () => {
+		context.openMock.mockResolvedValue(['/books/new.m4b']);
+		context.analyzeAudioFilesMock.mockResolvedValue({
+			files: [
+				{
+					path: '/books/new.m4b',
+					size: 1,
+					duration: 1,
+					isValid: true,
+					bitrate: 64,
+					sampleRate: 44_100,
+					channels: 2,
+				},
+			],
+			totalDuration: 1,
+			totalSize: 1,
+			validCount: 1,
+			invalidCount: 0,
+		});
+		context.persistPendingDraftsMock.mockResolvedValue(false);
+
+		const { handleClickToSelect } = await import('../fileImport/handlers');
+		await handleClickToSelect();
+
+		expect(context.appendFileListMock).not.toHaveBeenCalled();
+		expect(fileImportUiState.errorMessage).toBe(
+			'Fix metadata validation errors before adding files.',
+		);
+	});
+});

--- a/src/ui/__tests__/fileList-selectFile-transition.test.ts
+++ b/src/ui/__tests__/fileList-selectFile-transition.test.ts
@@ -8,6 +8,9 @@ const context = vi.hoisted(() => ({
 	getSelectedFilesMock: vi.fn(),
 	handleSelectionMock: vi.fn(() => ({ changed: true })),
 	showSingleSelectionMock: vi.fn(),
+	pushStatusPanelTransientStatusMock: vi.fn(),
+	validationErrorMock: vi.fn<() => string | null>(() => null),
+	clearSelectionMock: vi.fn(() => true),
 }));
 
 vi.mock('../metadataForm', () => ({
@@ -30,7 +33,7 @@ vi.mock('../outputPanel', () => ({
 }));
 
 vi.mock('../metadataValidation', () => ({
-	getSeriesPartValidationError: vi.fn(() => null),
+	getSeriesPartValidationError: context.validationErrorMock,
 	getSubseriesPartValidationError: vi.fn(() => null),
 }));
 
@@ -50,7 +53,7 @@ vi.mock('../fileList/events', () => ({
 }));
 
 vi.mock('../fileList/selection', () => ({
-	clearSelection: vi.fn(() => true),
+	clearSelection: context.clearSelectionMock,
 	handleSelection: context.handleSelectionMock,
 	reindexSelectionAfterMove: vi.fn(),
 	reindexSelectionAfterRemoval: vi.fn(),
@@ -65,6 +68,10 @@ vi.mock('../fileList/metadataPanel', () => ({
 	getSelectedFiles: context.getSelectedFilesMock,
 	showMultiSelection: vi.fn(async () => undefined),
 	showSingleSelection: context.showSingleSelectionMock,
+}));
+
+vi.mock('../statusPanel', () => ({
+	pushStatusPanelTransientStatus: context.pushStatusPanelTransientStatusMock,
 }));
 
 describe('selectFile transition options', () => {
@@ -111,6 +118,10 @@ describe('selectFile transition options', () => {
 		context.setMetadataForFileMock.mockClear();
 		context.handleSelectionMock.mockClear();
 		context.showSingleSelectionMock.mockClear();
+		context.pushStatusPanelTransientStatusMock.mockClear();
+		context.validationErrorMock.mockReset();
+		context.validationErrorMock.mockReturnValue(null);
+		context.clearSelectionMock.mockClear();
 		context.getSelectedFilesMock.mockReset();
 		context.getSelectedFilesMock.mockReturnValue([
 			{
@@ -137,6 +148,37 @@ describe('selectFile transition options', () => {
 			'/books/alpha.m4b',
 			{ title: 'Persisted Title' },
 			expect.objectContaining({ markPending: true }),
+		);
+	});
+
+	it('keeps the current selection when staging validation fails', async () => {
+		context.validationErrorMock.mockReturnValue('Series part must be a number');
+		const { selectFile } = await import('../fileList/actions');
+
+		await selectFile(1, { multi: false, range: false });
+
+		expect(context.handleSelectionMock).not.toHaveBeenCalled();
+		expect(context.pushStatusPanelTransientStatusMock).toHaveBeenCalledWith(
+			'Series part must be a number',
+			expect.objectContaining({ ttlMs: 2500 }),
+		);
+		expect(context.showSingleSelectionMock).not.toHaveBeenCalled();
+	});
+
+	it('keeps the current selection when clear-selection staging validation fails', async () => {
+		context.validationErrorMock.mockReturnValue('Series part must be a number');
+		context.getSelectedFilesMock.mockReturnValue([
+			{ path: '/books/alpha.m4b', isValid: true },
+			{ path: '/books/beta.m4b', isValid: true },
+		]);
+		const { clearSelectionAction } = await import('../fileList/actions');
+
+		await clearSelectionAction();
+
+		expect(context.clearSelectionMock).not.toHaveBeenCalled();
+		expect(context.pushStatusPanelTransientStatusMock).toHaveBeenCalledWith(
+			'Fix metadata validation errors before clearing the selection.',
+			expect.objectContaining({ ttlMs: 2500 }),
 		);
 	});
 });

--- a/src/ui/__tests__/metadata-save-pending-flow.test.ts
+++ b/src/ui/__tests__/metadata-save-pending-flow.test.ts
@@ -162,7 +162,7 @@ describe('metadata save pending flow', () => {
 	});
 
 	it('shows explicit status when there are no pending metadata changes', async () => {
-		context.persistPendingDraftsMock.mockResolvedValue(false);
+		context.persistPendingDraftsMock.mockResolvedValue(true);
 		context.getPendingIntentEntriesMock.mockReturnValue([]);
 
 		await saveMetadataFromUI();
@@ -175,6 +175,22 @@ describe('metadata save pending flow', () => {
 		expect(context.saveMetadataIntentToFileMock).not.toHaveBeenCalled();
 		await vi.waitFor(() => {
 			expect(getStatusText().textContent).toBe('No pending metadata changes');
+		});
+	});
+
+	it('aborts saving and surfaces an error when staging validation fails', async () => {
+		context.persistPendingDraftsMock.mockResolvedValue(false);
+		context.getPendingIntentEntriesMock.mockReturnValue([
+			['/books/a.m4b', { title: { op: 'set', value: 'A' } }],
+		]);
+
+		await saveMetadataFromUI();
+
+		expect(context.saveMetadataIntentToFileMock).not.toHaveBeenCalled();
+		expect(context.clearPendingMock).not.toHaveBeenCalled();
+		expect(context.resetDirtyStateMock).not.toHaveBeenCalled();
+		await vi.waitFor(() => {
+			expect(getStatusText().textContent).toBe('Fix metadata validation errors before saving.');
 		});
 	});
 

--- a/src/ui/__tests__/metadata-stage.test.ts
+++ b/src/ui/__tests__/metadata-stage.test.ts
@@ -9,6 +9,10 @@ import {
 } from '../metadataState';
 import type { FileListInfo } from '../../types/audio';
 
+const context = vi.hoisted(() => ({
+	validationErrorMock: vi.fn<() => string | null>(() => null),
+}));
+
 vi.mock('../fileList/metadataPanel', () => ({
 	ensureMetadataForFiles: vi.fn(async () => undefined),
 	getSelectedFiles: () => [
@@ -23,7 +27,7 @@ vi.mock('../outputPanel', () => ({
 }));
 
 vi.mock('../metadataValidation', () => ({
-	getSeriesPartValidationError: () => null,
+	getSeriesPartValidationError: context.validationErrorMock,
 	getSubseriesPartValidationError: () => null,
 }));
 
@@ -87,6 +91,16 @@ describe('stageMetadataToSelection', () => {
 		expect(didStage).toBe(true);
 		expect(getMetadataForFile('/a.mp3')).toMatchObject({ series: 'Series X' });
 		expect(getMetadataForFile('/b.mp3')).toMatchObject({ series: 'Series X' });
+		expect(getPendingMetadataEntries()).toEqual([]);
+	});
+
+	it('surfaces validation errors instead of staging invalid metadata', async () => {
+		context.validationErrorMock.mockReturnValue('Series part must be a number');
+
+		const didStage = await stageMetadataToSelection({ showStatus: false });
+
+		expect(didStage).toBe(false);
+		expect(getMetadataForFile('/a.mp3')).toBeUndefined();
 		expect(getPendingMetadataEntries()).toEqual([]);
 	});
 });

--- a/src/ui/__tests__/metadata-stage.test.ts
+++ b/src/ui/__tests__/metadata-stage.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { stageMetadataToSelection } from '../fileList/actions';
+import {
+	persistPendingMetadataDraftsForCurrentSelection,
+	stageMetadataToSelection,
+} from '../fileList/actions';
 import { setCurrentFileList, setSelectedFileIndices } from '../fileList/state';
 import {
 	clearMetadataState,
@@ -8,17 +11,21 @@ import {
 	setMetadataForFile,
 } from '../metadataState';
 import type { FileListInfo } from '../../types/audio';
+import type { AudiobookMetadata } from '../../types/metadata';
 
 const context = vi.hoisted(() => ({
 	validationErrorMock: vi.fn<() => string | null>(() => null),
+	selectedFilesMock: vi.fn(() => [
+		{ path: '/a.mp3', isValid: true },
+		{ path: '/b.mp3', isValid: true },
+	]),
+	readMetadataFormMock: vi.fn<() => Partial<AudiobookMetadata>>(() => ({ series: 'Series X' })),
+	hasDirtyMetadataFieldsMock: vi.fn(() => false),
 }));
 
 vi.mock('../fileList/metadataPanel', () => ({
 	ensureMetadataForFiles: vi.fn(async () => undefined),
-	getSelectedFiles: () => [
-		{ path: '/a.mp3', isValid: true },
-		{ path: '/b.mp3', isValid: true },
-	],
+	getSelectedFiles: context.selectedFilesMock,
 }));
 
 vi.mock('../outputPanel', () => ({
@@ -32,7 +39,8 @@ vi.mock('../metadataValidation', () => ({
 }));
 
 vi.mock('../metadataForm', () => ({
-	readMetadataForm: () => ({ series: 'Series X' }),
+	readMetadataForm: context.readMetadataFormMock,
+	hasDirtyMetadataFields: context.hasDirtyMetadataFieldsMock,
 	resetDirtyState: vi.fn(),
 }));
 
@@ -40,6 +48,17 @@ describe('stageMetadataToSelection', () => {
 	beforeEach(() => {
 		document.body.innerHTML = '';
 		clearMetadataState();
+		context.validationErrorMock.mockReset();
+		context.selectedFilesMock.mockReset();
+		context.readMetadataFormMock.mockReset();
+		context.hasDirtyMetadataFieldsMock.mockReset();
+		context.validationErrorMock.mockReturnValue(null);
+		context.selectedFilesMock.mockReturnValue([
+			{ path: '/a.mp3', isValid: true },
+			{ path: '/b.mp3', isValid: true },
+		]);
+		context.readMetadataFormMock.mockReturnValue({ series: 'Series X' });
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		const fileList: FileListInfo = {
 			files: [
 				{
@@ -102,5 +121,23 @@ describe('stageMetadataToSelection', () => {
 		expect(didStage).toBe(false);
 		expect(getMetadataForFile('/a.mp3')).toBeUndefined();
 		expect(getPendingMetadataEntries()).toEqual([]);
+	});
+
+	it('treats one valid selected file as single-selection pending metadata', async () => {
+		context.selectedFilesMock.mockReturnValue([
+			{ path: '/invalid.mp3', isValid: false },
+			{ path: '/a.mp3', isValid: true },
+		]);
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
+		context.readMetadataFormMock.mockReturnValue({ title: 'Single Valid' });
+
+		const didPersist = await persistPendingMetadataDraftsForCurrentSelection({
+			showStatus: false,
+		});
+
+		expect(didPersist).toBe(true);
+		expect(context.readMetadataFormMock).toHaveBeenCalledWith({ mode: 'single' });
+		expect(getMetadataForFile('/a.mp3')).toMatchObject({ title: 'Single Valid' });
+		expect(getMetadataForFile('/invalid.mp3')).toBeUndefined();
 	});
 });

--- a/src/ui/core/actions.ts
+++ b/src/ui/core/actions.ts
@@ -35,7 +35,13 @@ export async function saveMetadataFromUI(): Promise<void> {
 
 	try {
 		metadataSaveInProgressStore.set(true);
-		await persistPendingMetadataDraftsForCurrentSelection({ showStatus: false });
+		const staged = await persistPendingMetadataDraftsForCurrentSelection({ showStatus: false });
+		if (!staged) {
+			pushStatusPanelTransientStatus('Fix metadata validation errors before saving.', {
+				ttlMs: 3_000,
+			});
+			return;
+		}
 
 		const validFilePaths = new Set(
 			fileList.files.filter((file) => file.isValid).map((file) => file.path),

--- a/src/ui/fileImport/handlers.ts
+++ b/src/ui/fileImport/handlers.ts
@@ -155,7 +155,11 @@ async function processFilePaths(
 
 	try {
 		const fileListInfo: FileListInfo = await tauriClient.analyzeAudioFiles(filePaths);
-		await persistPendingMetadataDraftsForCurrentSelection();
+		const staged = await persistPendingMetadataDraftsForCurrentSelection();
+		if (!staged) {
+			setFileImportError('Fix metadata validation errors before adding files.');
+			return;
+		}
 		appendFileList(fileListInfo, { existingFiles });
 		clearFileImportError();
 	} catch (error) {

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -210,8 +210,8 @@ function validateSeriesFields(changes: Partial<AudiobookMetadata>): string | nul
 }
 
 function persistSingleSelectionMetadata(file: AudioFile | null): boolean {
-	if (!file?.isValid) return false;
-	if (!hasDirtyMetadataFields()) return false;
+	if (!file?.isValid) return true;
+	if (!hasDirtyMetadataFields()) return true;
 
 	const metadata = readMetadataForm({ mode: 'single' });
 	const validationError = validateSeriesFields(metadata);
@@ -223,11 +223,11 @@ function persistSingleSelectionMetadata(file: AudioFile | null): boolean {
 	const existing = getMetadataForFile(file.path) ?? {};
 	const intentPatch = buildMetadataDraftIntent(metadata);
 	if (!hasActionableMetadataDraftIntent(intentPatch)) {
-		return false;
+		return true;
 	}
 	const merged = applyMetadataDraftIntent(existing, intentPatch);
 	if (metadataEqualsNullish(existing, merged)) {
-		return false;
+		return true;
 	}
 
 	setMetadataForFile(file.path, merged, {
@@ -255,19 +255,25 @@ export async function selectFile(
 	const previousFile =
 		previousSelectionCount === 1 ? (fileList.files[previousIndex] ?? null) : null;
 
-	const selectionResult = handleSelection(index, modifiers || { multi: false, range: false });
-	if (!selectionResult.changed) return;
-
 	if (previousSelectionCount === 1 && previousIndex >= 0 && !options?.skipPersistPrevious) {
-		persistSingleSelectionMetadata(previousFile);
+		if (!persistSingleSelectionMetadata(previousFile)) {
+			return;
+		}
 	}
 
 	if (previousSelectionCount > 1) {
-		await stageMetadataToSelection({
+		const didStage = await stageMetadataToSelection({
 			showStatus: false,
 			selectedFilesOverride: previousSelectedFiles,
 		});
+		if (!didStage) {
+			setStatusMessage('Fix metadata validation errors before changing selection.');
+			return;
+		}
 	}
+
+	const selectionResult = handleSelection(index, modifiers || { multi: false, range: false });
+	if (!selectionResult.changed) return;
 
 	updateSelection();
 
@@ -296,7 +302,9 @@ export function selectAll(): void {
 		getSelectedFiles().length === 1 && selectedIndex >= 0
 			? (fileList.files[selectedIndex] ?? null)
 			: null;
-	persistSingleSelectionMetadata(previousFile);
+	if (!persistSingleSelectionMetadata(previousFile)) {
+		return;
+	}
 
 	const changed = selectAllFiles();
 	if (!changed) return;
@@ -318,13 +326,19 @@ export async function clearSelectionAction(): Promise<void> {
 		fileList && previousSelectionCount === 1 && selectedIndex >= 0
 			? (fileList.files[selectedIndex] ?? null)
 			: null;
-	persistSingleSelectionMetadata(previousFile);
+	if (!persistSingleSelectionMetadata(previousFile)) {
+		return;
+	}
 
 	if (previousSelectionCount > 1) {
-		await stageMetadataToSelection({
+		const didStage = await stageMetadataToSelection({
 			showStatus: false,
 			selectedFilesOverride: getSelectedFiles(),
 		});
+		if (!didStage) {
+			setStatusMessage('Fix metadata validation errors before clearing the selection.');
+			return;
+		}
 	}
 
 	const changed = clearSelection();
@@ -338,19 +352,19 @@ export async function stageMetadataToSelection(options?: {
 	showStatus?: boolean;
 	selectedFilesOverride?: AudioFile[];
 }): Promise<boolean> {
-	if (!getCurrentFileList()) return false;
+	if (!getCurrentFileList()) return true;
 
 	const selectedFiles = (options?.selectedFilesOverride ?? getSelectedFiles()).filter(
 		(file) => file.isValid,
 	);
-	if (selectedFiles.length === 0) return false;
+	if (selectedFiles.length === 0) return true;
 
 	const changes = readMetadataForm({ mode: 'multi', onlyDirty: true });
 	if (Object.keys(changes).length === 0) {
 		if (options?.showStatus) {
 			setStatusMessage('No metadata changes to apply');
 		}
-		return false;
+		return true;
 	}
 
 	const validationError = validateSeriesFields(changes);
@@ -364,7 +378,7 @@ export async function stageMetadataToSelection(options?: {
 	await ensureMetadataForFiles(selectedFiles);
 	const intentPatch = buildMetadataDraftIntent(changes);
 	if (!hasActionableMetadataDraftIntent(intentPatch)) {
-		return false;
+		return true;
 	}
 
 	selectedFiles.forEach((file) => {
@@ -393,14 +407,15 @@ export async function persistPendingMetadataDraftsForCurrentSelection(options?: 
 }): Promise<boolean> {
 	const selectedFiles = getSelectedFiles();
 	if (selectedFiles.length === 0) {
-		return false;
+		return true;
 	}
 	if (selectedFiles.length === 1) {
-		const changed = persistSingleSelectionMetadata(selectedFiles[0]);
-		if (changed && options?.showStatus) {
+		const hadDirtyMetadata = hasDirtyMetadataFields();
+		const persisted = persistSingleSelectionMetadata(selectedFiles[0]);
+		if (persisted && hadDirtyMetadata && options?.showStatus) {
 			setStatusMessage('Draft saved');
 		}
-		return changed;
+		return persisted;
 	}
 
 	return stageMetadataToSelection({ showStatus: options?.showStatus });

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -405,7 +405,7 @@ export async function stageMetadataToSelection(options?: {
 export async function persistPendingMetadataDraftsForCurrentSelection(options?: {
 	showStatus?: boolean;
 }): Promise<boolean> {
-	const selectedFiles = getSelectedFiles();
+	const selectedFiles = getSelectedFiles().filter((file) => file.isValid);
 	if (selectedFiles.length === 0) {
 		return true;
 	}

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -195,6 +195,21 @@ describe('startProcessing metadata staging', () => {
 		);
 	});
 
+	it('aborts processing when multi-selection staging fails', async () => {
+		context.getSelectedFileIndicesMock.mockReturnValue(new Set([0, 1]));
+		context.stageMetadataToSelectionMock.mockResolvedValue(false);
+
+		await startProcessing(processingContext());
+
+		expect(context.stageMetadataToSelectionMock).toHaveBeenCalledWith({
+			showStatus: false,
+		});
+		expect(context.processAudiobookFilesMock).not.toHaveBeenCalled();
+		expect(feedback.showError).toHaveBeenCalledWith(
+			'Fix metadata validation errors before processing.',
+		);
+	});
+
 	it('stages clear intent for dirty-but-empty metadata in merge payload', async () => {
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
 		context.readMetadataFormMock.mockReturnValue({ title: '   ' });

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -22,6 +22,8 @@ const context = vi.hoisted(() => ({
 	getMetadataIntentPatchForFileMock: vi.fn(),
 	setMetadataForFileMock: vi.fn(),
 	stageMetadataToSelectionMock: vi.fn(),
+	seriesPartValidationErrorMock: vi.fn(),
+	subseriesPartValidationErrorMock: vi.fn(),
 }));
 
 vi.mock('../../../lib/tauri/client', () => ({
@@ -69,6 +71,11 @@ vi.mock('../../fileList/actions', () => ({
 	stageMetadataToSelection: context.stageMetadataToSelectionMock,
 }));
 
+vi.mock('../../metadataValidation', () => ({
+	getSeriesPartValidationError: context.seriesPartValidationErrorMock,
+	getSubseriesPartValidationError: context.subseriesPartValidationErrorMock,
+}));
+
 vi.mock('../feedback', () => ({
 	showError: vi.fn(),
 }));
@@ -105,6 +112,8 @@ describe('startProcessing metadata staging', () => {
 		context.getMetadataIntentPatchForFileMock.mockReset();
 		context.setMetadataForFileMock.mockReset();
 		context.stageMetadataToSelectionMock.mockReset();
+		context.seriesPartValidationErrorMock.mockReset();
+		context.subseriesPartValidationErrorMock.mockReset();
 
 		context.getCurrentFileListMock.mockReturnValue({
 			files: [
@@ -148,6 +157,8 @@ describe('startProcessing metadata staging', () => {
 			results: [{ inputIndex: 0, status: 'success', message: 'ok', jobId: 'job-1' }],
 		});
 		context.readAudioMetadataMock.mockResolvedValue({});
+		context.seriesPartValidationErrorMock.mockReturnValue(null);
+		context.subseriesPartValidationErrorMock.mockReturnValue(null);
 	});
 
 	it('does not snapshot empty metadata when no dirty form edits exist', async () => {
@@ -208,6 +219,19 @@ describe('startProcessing metadata staging', () => {
 		expect(feedback.showError).toHaveBeenCalledWith(
 			'Fix metadata validation errors before processing.',
 		);
+	});
+
+	it('aborts single-selection processing when dirty series-part metadata is invalid', async () => {
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
+		context.readMetadataFormMock.mockReturnValue({ series_part: '1/2' });
+		context.seriesPartValidationErrorMock.mockReturnValue('Series part must be a number');
+
+		await startProcessing(processingContext());
+
+		expect(context.seriesPartValidationErrorMock).toHaveBeenCalledWith('1/2');
+		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
+		expect(context.processAudiobookFilesMock).not.toHaveBeenCalled();
+		expect(feedback.showError).toHaveBeenCalledWith('Series part must be a number');
 	});
 
 	it('stages clear intent for dirty-but-empty metadata in merge payload', async () => {

--- a/src/ui/statusPanel/domain/stateMachine.ts
+++ b/src/ui/statusPanel/domain/stateMachine.ts
@@ -12,7 +12,6 @@ import {
 	buildSingleCompletionFeedback,
 	cloneModel,
 	isTerminalJobStatus,
-	isTerminalProgressEvent,
 	isTerminalProgressStage,
 	recomputeStatus,
 	resolveProgressLabel,
@@ -110,7 +109,7 @@ export function applyProgress(
 	);
 	const existing = model.jobProgress.get(jobKey);
 	const prevStage = existing?.stage;
-	const isTerminal = isTerminalProgressEvent(event.stage);
+	const isTerminal = isTerminalProgressStage(event.stage);
 	const isStageTransition = prevStage !== undefined && prevStage !== event.stage;
 	const lastRender = model.lastProgressRenderByKey.get(jobKey) ?? 0;
 	const shouldThrottle =

--- a/src/ui/statusPanel/domain/stateMachineHelpers.ts
+++ b/src/ui/statusPanel/domain/stateMachineHelpers.ts
@@ -150,10 +150,6 @@ export function isTerminalProgressStage(stage: EventStage): boolean {
 	);
 }
 
-export function isTerminalProgressEvent(stage: EventStage): boolean {
-	return isTerminalProgressStage(stage);
-}
-
 export function toTerminalJobStatus(
 	stage: EventStage,
 ): Exclude<JobStatus, 'processing' | 'queued'> {

--- a/src/ui/statusPanel/processing.ts
+++ b/src/ui/statusPanel/processing.ts
@@ -146,7 +146,11 @@ export async function startProcessing(
 
 		const selectionCount = getSelectedFileIndices().size;
 		if (selectionCount > 1) {
-			await stageMetadataToSelection({ showStatus: false });
+			const staged = await stageMetadataToSelection({ showStatus: false });
+			if (!staged) {
+				feedback.showError('Fix metadata validation errors before processing.');
+				return;
+			}
 		}
 		let currentMetadata: Partial<AudiobookMetadata> = {};
 		if (selectionCount <= 1) {

--- a/src/ui/statusPanel/processing.ts
+++ b/src/ui/statusPanel/processing.ts
@@ -19,6 +19,10 @@ import {
 	buildMetadataDraftIntent,
 	hasActionableMetadataDraftIntent,
 } from '../metadataDraft';
+import {
+	getSeriesPartValidationError,
+	getSubseriesPartValidationError,
+} from '../metadataValidation';
 import * as feedback from './feedback';
 import { openGeneratedPreviewIfSingle } from './preview';
 import type { ProcessingStatus } from './state';
@@ -100,6 +104,16 @@ function summarizeBatchOutcome(result: ProcessCommandResult, filePaths: string[]
 	return `Processed ${succeeded}/${total}.${skippedSuffix}${cancelledSuffix}${failureSuffix}`;
 }
 
+function validateSeriesFields(changes: Partial<AudiobookMetadata>): string | null {
+	const seriesPartError = getSeriesPartValidationError(
+		typeof changes.series_part === 'string' ? changes.series_part : undefined,
+	);
+	const subseriesPartError = getSubseriesPartValidationError(
+		typeof changes.subseries_part === 'string' ? changes.subseries_part : undefined,
+	);
+	return seriesPartError ?? subseriesPartError;
+}
+
 export async function startProcessing(
 	context: StartProcessingContext,
 	options?: {
@@ -157,6 +171,11 @@ export async function startProcessing(
 			if (hasDirtyMetadataFields()) {
 				const selectedFileIndex = getSelectedFileIndex();
 				const formMetadata = readMetadataForm({ mode: 'single' });
+				const validationError = validateSeriesFields(formMetadata);
+				if (validationError) {
+					feedback.showError(validationError);
+					return;
+				}
 				const intentPatch = buildMetadataDraftIntent(formMetadata);
 				const activeFile =
 					selectedFileIndex >= 0


### PR DESCRIPTION
## Summary

- Patches `rustls-webpki` from `0.103.12` to `0.103.13`.
- Makes explicit metadata, cover-art, and chapter write failures propagate through the existing failed-job path instead of silently succeeding without requested output data.
- Makes metadata staging validation failures block processing, save, selection transition, clear-selection, and file-import flows.
- Removes the single-use `isTerminalProgressEvent` wrapper as natural-fit boundary cleanup.
- Writes the synthesized audit note outside the repo at the requested Obsidian inbox path.

## Validation

- `cargo test -p audiobook-boss --test integration_metadata_tests --test integration_metadata_reader_matrix_tests --test integration_cover_art_compat_tests --test integration_metadata_passthrough_tests`
- `bun run test src/ui/__tests__/metadata-stage.test.ts src/ui/__tests__/fileList-selectFile-transition.test.ts src/ui/__tests__/metadata-save-pending-flow.test.ts src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts src/ui/statusPanel/__tests__/stateMachine.test.ts src/ui/__tests__/fileImport-handlers.test.ts`
- `bun run build`
- `scripts/checks.sh standard`

## Notes

No new degraded `ProcessResultStatus` or IPC shape was introduced. Required output-write failures use the existing failed result semantics.