### PR TITLE
Fix cover clear passthrough suppression

### DIFF
--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -52,7 +52,10 @@ pub(super) async fn process_audiobook_with_external_fdk(
     }
     validate_external_input_decoders(&valid_files, &valid_selected_decoders, &toolchain)?;
 
-    let passthrough = collect_passthrough_metadata(&valid_files, context.preview.is_some());
+    let passthrough = effective_passthrough_metadata(
+        collect_passthrough_metadata(&valid_files, context.preview.is_some()),
+        allow_passthrough_cover_art,
+    );
 
     let effective_metadata =
         merge_cover_art(metadata, passthrough.as_ref(), allow_passthrough_cover_art);
@@ -116,7 +119,6 @@ fn merge_cover_art(
     allow_passthrough_cover_art: bool,
 ) -> Option<AudiobookMetadata> {
     if !allow_passthrough_cover_art {
-        log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
         return metadata;
     }
 
@@ -148,6 +150,18 @@ fn collect_passthrough_metadata(
     } else {
         passthrough.into_option()
     }
+}
+
+fn effective_passthrough_metadata(
+    passthrough: Option<PassthroughMetadata>,
+    allow_passthrough_cover_art: bool,
+) -> Option<PassthroughMetadata> {
+    if allow_passthrough_cover_art {
+        return passthrough;
+    }
+
+    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
+    passthrough.and_then(PassthroughMetadata::without_cover_art)
 }
 
 fn create_temp_dir(context: &ProcessingContext) -> Result<PathBuf> {
@@ -1141,6 +1155,24 @@ mod tests {
             .expect("metadata should remain present");
 
         assert_eq!(merged.cover_art, None);
+    }
+
+    #[test]
+    fn effective_passthrough_metadata_drops_only_cover_art_after_explicit_clear() {
+        let passthrough = PassthroughMetadata {
+            chapters: vec![crate::metadata::passthrough::ChapterSpec {
+                title: Some("Chapter 1".to_string()),
+                start_ms: 0,
+                end_ms: 1_000,
+            }],
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let effective = effective_passthrough_metadata(Some(passthrough), false)
+            .expect("chapter passthrough should remain");
+
+        assert_eq!(effective.chapters.len(), 1);
+        assert_eq!(effective.cover_art, None);
     }
 
     fn fdk_test_settings() -> EncoderSettings {

--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -6,7 +6,9 @@ use crate::audio::CleanupGuard;
 use crate::audio::{AudioFile, DecoderSelection, ProcessingContext, ProgressEmitter};
 use crate::errors::{sanitize_path_for_display, AppError, Result};
 use crate::metadata::ffmpeg_bridge::rewrite_metadata_with_ffmpeg;
-use crate::metadata::passthrough::{extract_passthrough_metadata, PassthroughMetadata};
+use crate::metadata::passthrough::{
+    apply_cover_art_policy, extract_passthrough_metadata, PassthroughMetadata,
+};
 use crate::metadata::AudiobookMetadata;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -52,13 +54,12 @@ pub(super) async fn process_audiobook_with_external_fdk(
     }
     validate_external_input_decoders(&valid_files, &valid_selected_decoders, &toolchain)?;
 
-    let passthrough = effective_passthrough_metadata(
+    let passthrough = apply_cover_art_policy(
         collect_passthrough_metadata(&valid_files, context.preview.is_some()),
         allow_passthrough_cover_art,
     );
 
-    let effective_metadata =
-        merge_cover_art(metadata, passthrough.as_ref(), allow_passthrough_cover_art);
+    let effective_metadata = merge_cover_art(metadata, passthrough.as_ref());
     let ui = context.new_emitter();
     ui.emit_analyzing_start("Preparing external FDK job...");
     ui.emit_analyzing_end("External FDK toolchain validated.");
@@ -116,12 +117,7 @@ pub(super) async fn process_audiobook_with_external_fdk(
 fn merge_cover_art(
     metadata: Option<AudiobookMetadata>,
     passthrough: Option<&PassthroughMetadata>,
-    allow_passthrough_cover_art: bool,
 ) -> Option<AudiobookMetadata> {
-    if !allow_passthrough_cover_art {
-        return metadata;
-    }
-
     let passthrough_cover = passthrough
         .and_then(|value| value.cover_art.as_ref())
         .cloned();
@@ -150,18 +146,6 @@ fn collect_passthrough_metadata(
     } else {
         passthrough.into_option()
     }
-}
-
-fn effective_passthrough_metadata(
-    passthrough: Option<PassthroughMetadata>,
-    allow_passthrough_cover_art: bool,
-) -> Option<PassthroughMetadata> {
-    if allow_passthrough_cover_art {
-        return passthrough;
-    }
-
-    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
-    passthrough.and_then(PassthroughMetadata::without_cover_art)
 }
 
 fn create_temp_dir(context: &ProcessingContext) -> Result<PathBuf> {
@@ -1141,38 +1125,20 @@ mod tests {
     }
 
     #[test]
-    fn merge_cover_art_does_not_refill_after_explicit_clear() {
+    fn merge_cover_art_does_not_refill_when_passthrough_cover_is_filtered() {
         let metadata = AudiobookMetadata {
             cover_art: None,
             ..AudiobookMetadata::default()
         };
         let passthrough = PassthroughMetadata {
             chapters: Vec::new(),
-            cover_art: Some(vec![1, 2, 3]),
+            cover_art: None,
         };
 
-        let merged = merge_cover_art(Some(metadata), Some(&passthrough), false)
+        let merged = merge_cover_art(Some(metadata), Some(&passthrough))
             .expect("metadata should remain present");
 
         assert_eq!(merged.cover_art, None);
-    }
-
-    #[test]
-    fn effective_passthrough_metadata_drops_only_cover_art_after_explicit_clear() {
-        let passthrough = PassthroughMetadata {
-            chapters: vec![crate::metadata::passthrough::ChapterSpec {
-                title: Some("Chapter 1".to_string()),
-                start_ms: 0,
-                end_ms: 1_000,
-            }],
-            cover_art: Some(vec![1, 2, 3]),
-        };
-
-        let effective = effective_passthrough_metadata(Some(passthrough), false)
-            .expect("chapter passthrough should remain");
-
-        assert_eq!(effective.chapters.len(), 1);
-        assert_eq!(effective.cover_art, None);
     }
 
     fn fdk_test_settings() -> EncoderSettings {

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -14,7 +14,7 @@ use crate::audio::context::ProcessingContext;
 use crate::audio::metrics::ProcessingMetrics;
 use crate::audio::{AudioFile, ProcessingStage, ProgressReporter};
 use crate::errors::Result;
-use crate::metadata::passthrough::PassthroughMetadata;
+use crate::metadata::passthrough::apply_cover_art_policy;
 use crate::metadata::AudiobookMetadata;
 use std::time::Duration;
 
@@ -89,27 +89,25 @@ pub async fn process_audiobook_with_context(
     let workflow = prepare::validate_and_prepare(&context, &files)?;
 
     // Extract passthrough metadata (chapters, original cover art) from all valid files.
-    let passthrough_metadata = effective_passthrough_metadata(
+    let passthrough_metadata = apply_cover_art_policy(
         crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option(),
         allow_passthrough_cover_art,
     );
 
     // Merge passthrough cover art when user metadata is absent or missing cover art.
     let mut effective_metadata = metadata;
-    if allow_passthrough_cover_art {
-        if let Some(ref passthrough) = passthrough_metadata {
-            if let Some(ref cover) = passthrough.cover_art {
-                match effective_metadata.as_mut() {
-                    Some(md) => {
-                        if md.cover_art.is_none() {
-                            md.cover_art = Some(cover.clone());
-                        }
-                    }
-                    None => {
-                        let mut md = AudiobookMetadata::new();
+    if let Some(ref passthrough) = passthrough_metadata {
+        if let Some(ref cover) = passthrough.cover_art {
+            match effective_metadata.as_mut() {
+                Some(md) => {
+                    if md.cover_art.is_none() {
                         md.cover_art = Some(cover.clone());
-                        effective_metadata = Some(md);
                     }
+                }
+                None => {
+                    let mut md = AudiobookMetadata::new();
+                    md.cover_art = Some(cover.clone());
+                    effective_metadata = Some(md);
                 }
             }
         }
@@ -157,40 +155,4 @@ pub async fn process_audiobook_with_context(
         log::info!("{}", metrics.format_summary());
     }
     Ok(result)
-}
-
-fn effective_passthrough_metadata(
-    passthrough: Option<PassthroughMetadata>,
-    allow_passthrough_cover_art: bool,
-) -> Option<PassthroughMetadata> {
-    if allow_passthrough_cover_art {
-        return passthrough;
-    }
-
-    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
-    passthrough.and_then(PassthroughMetadata::without_cover_art)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::effective_passthrough_metadata;
-    use crate::metadata::passthrough::{ChapterSpec, PassthroughMetadata};
-
-    #[test]
-    fn effective_passthrough_metadata_drops_only_cover_art_after_explicit_clear() {
-        let passthrough = PassthroughMetadata {
-            chapters: vec![ChapterSpec {
-                title: Some("Chapter 1".to_string()),
-                start_ms: 0,
-                end_ms: 1_000,
-            }],
-            cover_art: Some(vec![1, 2, 3]),
-        };
-
-        let effective = effective_passthrough_metadata(Some(passthrough), false)
-            .expect("chapter passthrough should remain");
-
-        assert_eq!(effective.chapters.len(), 1);
-        assert_eq!(effective.cover_art, None);
-    }
 }

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -14,6 +14,7 @@ use crate::audio::context::ProcessingContext;
 use crate::audio::metrics::ProcessingMetrics;
 use crate::audio::{AudioFile, ProcessingStage, ProgressReporter};
 use crate::errors::Result;
+use crate::metadata::passthrough::PassthroughMetadata;
 use crate::metadata::AudiobookMetadata;
 use std::time::Duration;
 
@@ -88,8 +89,10 @@ pub async fn process_audiobook_with_context(
     let workflow = prepare::validate_and_prepare(&context, &files)?;
 
     // Extract passthrough metadata (chapters, original cover art) from all valid files.
-    let passthrough_metadata =
-        crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option();
+    let passthrough_metadata = effective_passthrough_metadata(
+        crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option(),
+        allow_passthrough_cover_art,
+    );
 
     // Merge passthrough cover art when user metadata is absent or missing cover art.
     let mut effective_metadata = metadata;
@@ -110,8 +113,6 @@ pub async fn process_audiobook_with_context(
                 }
             }
         }
-    } else {
-        log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
     }
 
     // Metrics accumulation (estimates)
@@ -156,4 +157,40 @@ pub async fn process_audiobook_with_context(
         log::info!("{}", metrics.format_summary());
     }
     Ok(result)
+}
+
+fn effective_passthrough_metadata(
+    passthrough: Option<PassthroughMetadata>,
+    allow_passthrough_cover_art: bool,
+) -> Option<PassthroughMetadata> {
+    if allow_passthrough_cover_art {
+        return passthrough;
+    }
+
+    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
+    passthrough.and_then(PassthroughMetadata::without_cover_art)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::effective_passthrough_metadata;
+    use crate::metadata::passthrough::{ChapterSpec, PassthroughMetadata};
+
+    #[test]
+    fn effective_passthrough_metadata_drops_only_cover_art_after_explicit_clear() {
+        let passthrough = PassthroughMetadata {
+            chapters: vec![ChapterSpec {
+                title: Some("Chapter 1".to_string()),
+                start_ms: 0,
+                end_ms: 1_000,
+            }],
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let effective = effective_passthrough_metadata(Some(passthrough), false)
+            .expect("chapter passthrough should remain");
+
+        assert_eq!(effective.chapters.len(), 1);
+        assert_eq!(effective.cover_art, None);
+    }
 }

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -43,6 +43,18 @@ impl PassthroughMetadata {
     }
 }
 
+pub fn apply_cover_art_policy(
+    passthrough: Option<PassthroughMetadata>,
+    allow_passthrough_cover_art: bool,
+) -> Option<PassthroughMetadata> {
+    if allow_passthrough_cover_art {
+        return passthrough;
+    }
+
+    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
+    passthrough.and_then(PassthroughMetadata::without_cover_art)
+}
+
 fn synthesize_chapters_from_files(files: &[PipelineAudioFile]) -> Vec<ChapterSpec> {
     let mut chapters = Vec::new();
     let mut offset_ms: i64 = 0;
@@ -202,7 +214,7 @@ fn rescale_to_ms(value: i64, time_base: ff::Rational) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChapterSpec, PassthroughMetadata};
+    use super::{apply_cover_art_policy, ChapterSpec, PassthroughMetadata};
 
     #[test]
     fn into_option_returns_none_for_empty_passthrough() {
@@ -269,5 +281,23 @@ mod tests {
         };
 
         assert!(passthrough.without_cover_art().is_none());
+    }
+
+    #[test]
+    fn apply_cover_art_policy_drops_only_cover_art_after_explicit_clear() {
+        let passthrough = PassthroughMetadata {
+            chapters: vec![ChapterSpec {
+                title: Some("Chapter 1".to_string()),
+                start_ms: 0,
+                end_ms: 1_000,
+            }],
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let effective =
+            apply_cover_art_policy(Some(passthrough), false).expect("chapter passthrough remains");
+
+        assert_eq!(effective.chapters.len(), 1);
+        assert_eq!(effective.cover_art, None);
     }
 }

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -36,6 +36,11 @@ impl PassthroughMetadata {
         self.chapters.clear();
         self.into_option()
     }
+
+    pub fn without_cover_art(mut self) -> Option<Self> {
+        self.cover_art = None;
+        self.into_option()
+    }
 }
 
 fn synthesize_chapters_from_files(files: &[PipelineAudioFile]) -> Vec<ChapterSpec> {
@@ -235,5 +240,34 @@ mod tests {
         };
 
         assert!(passthrough.cover_art_only().is_none());
+    }
+
+    #[test]
+    fn without_cover_art_preserves_chapters_and_drops_cover_art() {
+        let passthrough = PassthroughMetadata {
+            chapters: vec![ChapterSpec {
+                title: Some("Chapter 1".to_string()),
+                start_ms: 0,
+                end_ms: 1_000,
+            }],
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        let without_cover = passthrough
+            .without_cover_art()
+            .expect("chapter passthrough should remain");
+
+        assert_eq!(without_cover.chapters.len(), 1);
+        assert_eq!(without_cover.cover_art, None);
+    }
+
+    #[test]
+    fn without_cover_art_returns_none_when_passthrough_only_has_cover_art() {
+        let passthrough = PassthroughMetadata {
+            chapters: Vec::new(),
+            cover_art: Some(vec![1, 2, 3]),
+        };
+
+        assert!(passthrough.without_cover_art().is_none());
     }
 }


### PR DESCRIPTION
Targets PR #285. Base branch: `fix/output-truth-audit-synthesis`.

## Summary

- Suppresses passthrough cover art before downstream native/external cover selection when processing metadata has explicit `cover_art: clear`.
- Preserves passthrough chapters while dropping only passthrough cover art.
- Keeps explicit user cover-art write failures fatal and passthrough preservation failures non-fatal.
- Adds focused Rust unit coverage for shared passthrough suppression plus native and external FDK effective-passthrough handling.

## Validation

- `cargo test -p audiobook-boss without_cover_art`
- `cargo test -p audiobook-boss effective_passthrough_metadata_drops_only_cover_art_after_explicit_clear`
- `cargo test -p audiobook-boss merge_cover_art_does_not_refill_after_explicit_clear`
- reviewer subagent pass: no findings
- `scripts/checks.sh standard`

## Notes

No TS/Rust IPC schema changes. No frontend code changes.
