### PR TITLE
[codex] test context surface plans guard

### DIFF
--- a/scripts/check-context-surface.sh
+++ b/scripts/check-context-surface.sh
@@ -49,6 +49,7 @@ removed_skills=(
 stale_doc_pattern='docs/README\.md|docs/AGENTS\.md|docs/agent-execution\.md|docs/browser-harness\.md|docs/skills-audit\.md|docs/specs/technical-reference\.md|docs/verification\.md|docs/workloop\.md'
 stale_check_pattern='check-docs-routing|check-skills-routing'
 stale_tracking_pattern='pebbles|task-tracker|\.pebbles|pb ready|pb list|pb show|pb update|pb close|~/.local/bin/pb'
+stale_planning_pattern='PLANS\.md'
 
 append_unique_paths() {
   local dest_name="$1"
@@ -70,6 +71,15 @@ append_unique_paths() {
       eval "$dest_name+=(\"\$path\")"
     done
   done
+}
+
+reject_pattern() {
+  local pattern="$1"
+  shift
+
+  if rg -n "$pattern" "$@"; then
+    exit 1
+  fi
 }
 
 [[ ! -e ".pebbles" ]] || {
@@ -186,11 +196,12 @@ append_unique_paths existing_text_surface_paths text_surface_paths spec_surface_
 existing_legacy_surface_paths=()
 append_unique_paths existing_legacy_surface_paths legacy_surface_paths
 
-! rg -n 'docs/project\.md' "${existing_text_surface_paths[@]}" >/dev/null
-! rg -n "$stale_doc_pattern" "${existing_text_surface_paths[@]}" >/dev/null
-! rg -n "$stale_check_pattern" "${existing_text_surface_paths[@]}" >/dev/null
-! rg -n "$stale_tracking_pattern" "${existing_text_surface_paths[@]}" >/dev/null
-! rg -n 'docs/decisions' "${existing_text_surface_paths[@]}" >/dev/null
-! rg -n "$removed_surface_pattern" "${existing_legacy_surface_paths[@]}" >/dev/null
+reject_pattern 'docs/project\.md' "${existing_text_surface_paths[@]}"
+reject_pattern "$stale_doc_pattern" "${existing_text_surface_paths[@]}"
+reject_pattern "$stale_check_pattern" "${existing_text_surface_paths[@]}"
+reject_pattern "$stale_tracking_pattern" "${existing_text_surface_paths[@]}"
+reject_pattern "$stale_planning_pattern" "${existing_text_surface_paths[@]}"
+reject_pattern 'docs/decisions' "${existing_text_surface_paths[@]}"
+reject_pattern "$removed_surface_pattern" "${existing_legacy_surface_paths[@]}"
 
 echo "[context-surface] OK"

--- a/scripts/check-context-surface.test.ts
+++ b/scripts/check-context-surface.test.ts
@@ -1,0 +1,111 @@
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'bun:test';
+
+const SYSTEM_BASH = '/bin/bash';
+const TEST_PATH = '/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin';
+
+function writeFile(repoRoot: string, relativePath: string, contents: string): void {
+	const filePath = path.join(repoRoot, relativePath);
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(filePath, contents);
+}
+
+function createContextSurfaceFixture(): string {
+	const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'abb-context-surface-'));
+
+	const scriptPath = path.join(repoRoot, 'scripts', 'check-context-surface.sh');
+	mkdirSync(path.dirname(scriptPath), { recursive: true });
+	writeFileSync(
+		scriptPath,
+		readFileSync(path.join(import.meta.dir, 'check-context-surface.sh'), 'utf8'),
+	);
+	chmodSync(scriptPath, 0o755);
+
+	for (const file of [
+		'README.md',
+		'AGENTS.md',
+		'docs/system-map.md',
+		'docs/ubiquitous-language.md',
+		'docs/fallbacks.md',
+		'docs/api-map.md',
+		'src/AGENTS.md',
+	]) {
+		writeFile(repoRoot, file, `${file}\n`);
+	}
+
+	writeFile(repoRoot, 'package.json', '{"name":"fixture"}\n');
+	writeFile(repoRoot, '.codex/hooks.json', '{}\n');
+	writeFile(repoRoot, '.agents/hooks.json', '{}\n');
+	writeFile(repoRoot, 'scripts/checks.sh', '#!/usr/bin/env bash\n');
+
+	for (const skill of [
+		'audiobook-metadata',
+		'decision-alignment',
+		'contract-guardrails',
+		'job-registry-and-progress',
+		'lib-research',
+		'path-security-validation',
+		'tauri-command-conventions',
+	]) {
+		writeFile(repoRoot, `.agents/skills/${skill}/SKILL.md`, `# ${skill}\n`);
+	}
+
+	for (const hook of [
+		'.agents/hooks/common.py',
+		'.agents/hooks/session_start.py',
+		'.agents/hooks/stop_context_surface.py',
+		'.agents/hooks/stop_verification_lane.py',
+		'.agents/hooks/stop_ipc_guard.py',
+	]) {
+		writeFile(repoRoot, hook, '# fixture\n');
+	}
+
+	return repoRoot;
+}
+
+function runContextSurface(repoRoot: string): {
+	status: number | null;
+	stdout: string;
+	stderr: string;
+} {
+	const result = spawnSync(SYSTEM_BASH, ['scripts/check-context-surface.sh'], {
+		cwd: repoRoot,
+		encoding: 'utf8',
+		env: {
+			HOME: process.env.HOME ?? os.tmpdir(),
+			PATH: TEST_PATH,
+			TMPDIR: process.env.TMPDIR ?? os.tmpdir(),
+		},
+	});
+
+	return {
+		status: result.status,
+		stdout: result.stdout,
+		stderr: result.stderr,
+	};
+}
+
+describe('check-context-surface.sh', () => {
+	it('rejects stale PLANS.md planning-surface references', () => {
+		const repoRoot = createContextSurfaceFixture();
+
+		try {
+			expect(runContextSurface(repoRoot).status).toBe(0);
+
+			writeFile(
+				repoRoot,
+				'AGENTS.md',
+				'Use PLANS.md as a repo-local planning ledger for long-running work.\n',
+			);
+
+			const result = runContextSurface(repoRoot);
+			expect(result.status).toBe(1);
+			expect(result.stdout).toContain('PLANS.md');
+		} finally {
+			rmSync(repoRoot, { force: true, recursive: true });
+		}
+	});
+});

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -132,8 +132,8 @@ run_standard() {
   log_step "cargo test"
   cargo test
 
-  log_step "bun test scripts/build-app.test.ts scripts/check-fallback-policy.test.ts scripts/release.test.ts"
-  bun test scripts/build-app.test.ts scripts/check-fallback-policy.test.ts scripts/release.test.ts
+  log_step "bun test scripts/build-app.test.ts scripts/check-context-surface.test.ts scripts/check-fallback-policy.test.ts scripts/release.test.ts"
+  bun test scripts/build-app.test.ts scripts/check-context-surface.test.ts scripts/check-fallback-policy.test.ts scripts/release.test.ts
 
   log_step "bun run test"
   bun run test


### PR DESCRIPTION
## Issue

Recent repo guidance changes removed PLANS.md as the long-horizon planning surface in favor of active docs/specs task specs. The weekly test-gap pass found that scripts/check-context-surface.sh had no regression coverage proving stale PLANS.md guidance would be rejected if it returned to canonical surfaces.

## Cause and effect

The context-surface script used inverted rg commands under set -e. In Bash, those inverted commands do not reliably stop execution when a forbidden pattern is found, so stale references can be printed and the script can still finish with [context-surface] OK. That makes future docs cleanup easier to regress silently.

## Fix

- Added scripts/check-context-surface.test.ts with a fixture repo that first proves the context-surface guard passes on a clean minimal surface, then injects a PLANS.md reference and expects the guard to fail.
- Added PLANS.md to the stale planning pattern set.
- Replaced the inverted rg guard calls with an explicit reject_pattern helper so forbidden matches exit deterministically.
- Added the new context-surface test to the standard direct Bun script-test lane.

## Validation

- Confirmed the new test failed before the guard fix: bun test scripts/check-context-surface.test.ts reported status 0 where the test expected failure.
- bun test scripts/check-context-surface.test.ts
- bash scripts/check-context-surface.sh
- bun test scripts/build-app.test.ts scripts/check-context-surface.test.ts scripts/check-fallback-policy.test.ts scripts/release.test.ts
- scripts/checks.sh standard
