### PR TITLE
[codex] test finalized metadata container routing

### DIFF
--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -609,6 +609,16 @@ pub(crate) fn write_finalized_metadata(
 mod tests {
     use super::*;
     use crate::errors::AppError;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn sample_mp3_fixture() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("manifest parent")
+            .join("media")
+            .join("media_20sec.mp3")
+    }
 
     #[test]
     fn metadata_intent_patch_applies_set_and_clear_ops() {
@@ -852,6 +862,21 @@ mod tests {
         assert_eq!(
             resolved.album_sort.as_deref(),
             Some("Series 02 - New Title")
+        );
+    }
+
+    #[test]
+    fn finalized_metadata_decision_uses_container_truth_not_extension() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let spoofed_m4b = temp_dir.path().join("actual-mp3.m4b");
+        std::fs::copy(sample_mp3_fixture(), &spoofed_m4b).expect("copy mp3 fixture");
+
+        let should_write = should_write_finalized_metadata(&spoofed_m4b)
+            .expect("finalized metadata decision should probe container");
+
+        assert!(
+            !should_write,
+            "actual MP3 containers renamed as .m4b should stay on the FFmpeg metadata path"
         );
     }
 


### PR DESCRIPTION
## Issue

The recent metadata routing work moved ABB toward probing the real media container instead of trusting file extensions. Existing tests covered command-level read/write behavior for mislabeled files, but final processing has a separate metadata finalization decision through `should_write_finalized_metadata`.

## Cause and effect

If that finalization decision regressed to extension-based routing, an actual MP3 container renamed as `.m4b` could be sent back through the MP4/mp4ameta finalization path. That would be the wrong boundary for files whose real container should stay on the FFmpeg metadata path, and it could turn a valid processing result into a metadata-stage failure.

## Fix

Added a focused regression test at the metadata module boundary. The test copies the real `media_20sec.mp3` fixture to a temporary `.m4b` path and asserts `should_write_finalized_metadata` returns `false`, proving the finalization decision uses container truth rather than extension truth.

## Validation

- `cargo test finalized_metadata_decision_uses_container_truth_not_extension`
- `scripts/checks.sh standard`

The first `standard` run reached the frontend test step and failed because `vitest` was not installed in the worktree. I ran `bun install` and reran `scripts/checks.sh standard`; the rerun passed completely.
