### PR TITLE
Harden resource lifetime edges

### DIFF
--- a/.agents/skills/resource-lifetime-audit/SKILL.md
+++ b/.agents/skills/resource-lifetime-audit/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: resource-lifetime-audit
+description: Audit and fix Audiobook Boss resource-lifetime foot-guns with high bug potential. Use when the user asks to hunt for lifecycle bugs, file-handle contention, Windows/cross-platform file behavior, temp-file cleanup, process lifetime, FFmpeg/mp4ameta reopen issues, rename/replace semantics, or "similar in-kind" high-ROI issues.
+---
+
+# Resource Lifetime Audit
+
+## Goal
+
+Find small, high-impact lifecycle hazards before they become user-visible bugs. Focus on important boundaries first: audio processing, metadata read/write/remux, output artifact commit, path validation, cleanup, cancellation, and external process handling.
+
+## Hunt Pattern
+
+Search for code that crosses one lifecycle phase into another:
+
+- probe/open/read -> reopen same path
+- FFmpeg context -> mp4ameta read/write on same path
+- write temp -> rename/copy/replace final path
+- spawn process -> read pipes -> cancel/kill/wait
+- register cleanup -> remove path from cleanup ownership
+- validate path -> persist or write path
+
+For each candidate, ask:
+
+1. What resource is still alive?
+2. What opens, mutates, deletes, renames, or replaces the same resource next?
+3. Does this rely on macOS/POSIX behavior that may fail on Windows?
+4. Would a failure cause false success, file loss, residue, stuck jobs, or noisy retries?
+5. Is the fix local and testable?
+
+## Priority
+
+Prioritize findings that touch:
+
+- source audiobook files
+- final output artifacts
+- metadata writes and cover art
+- FFmpeg input/output contexts
+- external FFmpeg processes
+- cleanup/cancellation terminal paths
+
+Defer low-impact style cleanup unless it prevents repeated lifecycle mistakes.
+
+## Fix Shape
+
+Prefer explicit ownership transitions:
+
+- Drop FFmpeg probe contexts before reopening the same path.
+- Keep replacement behavior in the owning boundary.
+- Use backup/rollback or create-new semantics instead of assuming rename-over-existing is portable.
+- Remove cleanup ownership only after the durable artifact is committed.
+- Map file/path errors through existing `AppError` patterns.
+
+Add focused tests when behavior is deterministic without real media. Use `scripts/checks.sh standard` for code changes.
+
+## Report Shape
+
+Lead with the category name, affected boundary, impact, and fix. Use "resource-lifetime foot-gun" for hazards that are not always active bugs but have credible cross-platform or edge-case failure paths.

--- a/.agents/skills/resource-lifetime-audit/agents/openai.yaml
+++ b/.agents/skills/resource-lifetime-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Resource Lifetime Audit"
+  short_description: "Find high-ROI handle lifetime foot-guns"
+  default_prompt: "Use $resource-lifetime-audit to find high-ROI file handle, process, temp file, and replacement lifetime foot-guns in this ABB change."

--- a/scripts/check-public-api-strips.sh
+++ b/scripts/check-public-api-strips.sh
@@ -70,6 +70,9 @@ export type { TauriCommand };'
 
 status_panel_exports="$(extract_export_blocks src/ui/statusPanel/index.ts)"
 compare_block "Status Panel Runtime Public API Strip" "$status_panel_exports" 'export {
+beginMetadataSaveInStatusPanel,
+completeMetadataSaveInStatusPanel,
+failMetadataSaveInStatusPanel,
 initStatusPanel,
 isStatusPanelProcessing,
 pushStatusPanelTransientStatus,

--- a/src-tauri/src/audio/processor/streams.rs
+++ b/src-tauri/src/audio/processor/streams.rs
@@ -480,8 +480,8 @@ fn open_best_audio_decoder(path: &Path) -> Result<OpenedAudioInput> {
         let inspect_stream = best_audio_stream(&inspect_ctx, path)?;
         inspect_stream.parameters()
     };
-    let selected_candidate = select_decoder_candidate(path, &params)?;
     drop(inspect_ctx);
+    let selected_candidate = select_decoder_candidate(path, &params)?;
 
     let input = open_input_context(path)?;
     let stream = best_audio_stream(&input, path)?;

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -10,6 +10,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub(crate) mod save_batch;
+pub use save_batch::{
+    save_metadata_batch, MetadataSaveBatchResult, MetadataSaveRequest, MetadataSaveResultEntry,
+    MetadataSaveResultStatus, MetadataSaveSummary,
+};
+
 /// Reads metadata from an audio file
 /// Returns metadata as JSON-serializable struct
 #[tauri::command]

--- a/src-tauri/src/commands/metadata/save_batch.rs
+++ b/src-tauri/src/commands/metadata/save_batch.rs
@@ -1,0 +1,353 @@
+use crate::audio::path_validation::validate_input_audio_path;
+use crate::commands::CommandResult;
+use crate::errors::{sanitize_path_str_for_display, AppError, AppErrorEnvelope, Result};
+use crate::metadata::MetadataIntentPatch;
+use crate::processing::{
+    CancellationChecker, EventStage, JobId, ProgressEvent, QueueEvent, QueueItem,
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::Emitter;
+
+pub type MetadataSaveSummary = crate::processing::ProcessResultSummary;
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataSaveRequest {
+    pub file_path: String,
+    pub metadata_patch: MetadataIntentPatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum MetadataSaveResultStatus {
+    Success,
+    Cancelled,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataSaveResultEntry {
+    pub input_index: usize,
+    pub file_path: String,
+    pub status: MetadataSaveResultStatus,
+    pub message: String,
+    pub error: Option<AppErrorEnvelope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataSaveBatchResult {
+    pub summary: MetadataSaveSummary,
+    pub results: Vec<MetadataSaveResultEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct MetadataSaveProgress {
+    input_index: usize,
+    file_path: String,
+    stage: EventStage,
+    percentage: f32,
+    message: String,
+    job_id: Option<String>,
+}
+
+impl MetadataSaveBatchResult {
+    fn new(results: Vec<MetadataSaveResultEntry>) -> Self {
+        let succeeded = results
+            .iter()
+            .filter(|result| result.status == MetadataSaveResultStatus::Success)
+            .count();
+        let cancelled = results
+            .iter()
+            .filter(|result| result.status == MetadataSaveResultStatus::Cancelled)
+            .count();
+        let failed = results.len().saturating_sub(succeeded + cancelled);
+        Self {
+            summary: MetadataSaveSummary {
+                total: results.len(),
+                succeeded,
+                skipped: 0,
+                cancelled,
+                failed,
+            },
+            results,
+        }
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn save_metadata_batch(
+    window: tauri::Window,
+    registry: tauri::State<'_, crate::ManagedJobRegistry>,
+    items: Vec<MetadataSaveRequest>,
+) -> CommandResult<MetadataSaveBatchResult> {
+    if items.is_empty() {
+        return Err(AppError::InvalidInput("No metadata changes to save".to_string()).into());
+    }
+
+    if registry.is_global_cancelled() && registry.get_aggregate_status().await.total_jobs == 0 {
+        registry.reset_global_cancel();
+    }
+
+    let (job_id, _permit) = registry.register_job().await?;
+    let cancellation = registry.cancellation_checker(job_id).await;
+    emit_metadata_save_queue(&window, &items);
+    let result = save_metadata_batch_impl(items, job_id, cancellation, |progress| {
+        emit_metadata_save_progress(&window, progress);
+    })
+    .await;
+
+    match &result {
+        Ok(_) => registry.complete_job(job_id).await,
+        Err(error) => registry.fail_job(job_id, error.to_string()).await,
+    }
+
+    Ok(result?)
+}
+
+async fn save_metadata_batch_impl<F>(
+    items: Vec<MetadataSaveRequest>,
+    job_id: JobId,
+    cancellation: CancellationChecker,
+    mut emit_progress: F,
+) -> Result<MetadataSaveBatchResult>
+where
+    F: FnMut(MetadataSaveProgress),
+{
+    let total = items.len();
+    let mut results = Vec::with_capacity(total);
+    let job_id_string = job_id.to_string();
+
+    for (index, item) in items.into_iter().enumerate() {
+        if cancellation.is_cancelled() {
+            push_cancelled_entries(
+                index,
+                item,
+                total,
+                &job_id_string,
+                &mut results,
+                &mut emit_progress,
+            );
+            continue;
+        }
+
+        let display_name = sanitize_path_str_for_display(&item.file_path);
+        emit_progress(MetadataSaveProgress {
+            input_index: index,
+            file_path: item.file_path.clone(),
+            stage: EventStage::Writing,
+            percentage: 0.0,
+            message: format!("Saving metadata {}/{}: {}", index + 1, total, display_name),
+            job_id: Some(job_id_string.clone()),
+        });
+
+        let file_path = item.file_path;
+        let metadata_patch = item.metadata_patch;
+        let item_result = tokio::task::spawn_blocking({
+            let file_path = file_path.clone();
+            move || save_metadata_item(&file_path, metadata_patch)
+        })
+        .await
+        .map_err(|error| AppError::General(format!("Metadata save task failed: {error}")))?;
+
+        match item_result {
+            Ok(()) => {
+                let message = format!("Saved metadata: {}", display_name);
+                emit_progress(MetadataSaveProgress {
+                    input_index: index,
+                    file_path: file_path.clone(),
+                    stage: EventStage::Completed,
+                    percentage: 100.0,
+                    message: message.clone(),
+                    job_id: Some(job_id_string.clone()),
+                });
+                results.push(MetadataSaveResultEntry {
+                    input_index: index,
+                    file_path,
+                    status: MetadataSaveResultStatus::Success,
+                    message,
+                    error: None,
+                });
+            }
+            Err(error) => {
+                let envelope = AppErrorEnvelope::from(error);
+                let message = format!("Failed metadata save: {}", display_name);
+                log::error!("{}: {}", message, envelope.message);
+                emit_progress(MetadataSaveProgress {
+                    input_index: index,
+                    file_path: file_path.clone(),
+                    stage: EventStage::Failed,
+                    percentage: 100.0,
+                    message: envelope.message.clone(),
+                    job_id: Some(job_id_string.clone()),
+                });
+                results.push(MetadataSaveResultEntry {
+                    input_index: index,
+                    file_path,
+                    status: MetadataSaveResultStatus::Failed,
+                    message,
+                    error: Some(envelope),
+                });
+            }
+        }
+    }
+
+    Ok(MetadataSaveBatchResult::new(results))
+}
+
+fn push_cancelled_entries<F>(
+    index: usize,
+    item: MetadataSaveRequest,
+    total: usize,
+    job_id: &str,
+    results: &mut Vec<MetadataSaveResultEntry>,
+    emit_progress: &mut F,
+) where
+    F: FnMut(MetadataSaveProgress),
+{
+    let message = "Metadata save cancelled.".to_string();
+    emit_progress(MetadataSaveProgress {
+        input_index: index,
+        file_path: item.file_path.clone(),
+        stage: EventStage::Cancelled,
+        percentage: 0.0,
+        message: format!("{} {}/{}", message, index + 1, total),
+        job_id: Some(job_id.to_string()),
+    });
+    results.push(MetadataSaveResultEntry {
+        input_index: index,
+        file_path: item.file_path,
+        status: MetadataSaveResultStatus::Cancelled,
+        message,
+        error: None,
+    });
+}
+
+fn save_metadata_item(file_path: &str, metadata_patch: MetadataIntentPatch) -> Result<()> {
+    let path = PathBuf::from(file_path);
+    let validated_path = validate_input_audio_path(&path)?;
+    log::info!("Saving metadata to: {}", validated_path.display());
+
+    let write_plan = metadata_patch.to_write_plan()?;
+    crate::metadata::save_metadata_with_plan(&validated_path, &write_plan)?;
+
+    log::info!("Metadata saved to: {}", validated_path.display());
+    Ok(())
+}
+
+fn emit_metadata_save_queue(window: &tauri::Window, items: &[MetadataSaveRequest]) {
+    let queue_event = QueueEvent {
+        items: items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| QueueItem {
+                input_index: index,
+                file_path: item.file_path.clone(),
+            })
+            .collect(),
+        max_concurrent: 1,
+    };
+    let _ = window.emit(crate::audio::constants::QUEUE_EVENT_NAME, &queue_event);
+}
+
+fn emit_metadata_save_progress(window: &tauri::Window, progress: MetadataSaveProgress) {
+    let event = ProgressEvent {
+        stage: progress.stage,
+        percentage: progress.percentage,
+        message: progress.message,
+        current_file: Some(progress.file_path),
+        eta_seconds: None,
+        job_id: progress.job_id,
+        input_index: Some(progress.input_index),
+    };
+    let _ = window.emit(crate::audio::constants::PROGRESS_EVENT_NAME, &event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::PatchOp;
+    use crate::processing::JobRegistry;
+
+    fn title_patch(title: &str) -> MetadataIntentPatch {
+        MetadataIntentPatch {
+            title: PatchOp::Set(title.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn metadata_batch_returns_ordered_per_file_failures_without_aborting() {
+        let items = vec![
+            MetadataSaveRequest {
+                file_path: "/definitely/missing-a.m4b".to_string(),
+                metadata_patch: title_patch("A"),
+            },
+            MetadataSaveRequest {
+                file_path: "/definitely/missing-b.m4b".to_string(),
+                metadata_patch: title_patch("B"),
+            },
+        ];
+        let mut progress = Vec::new();
+        let registry = JobRegistry::new(1);
+        let (job_id, _permit) = registry.register_job().await.expect("register job");
+        let cancellation = registry.cancellation_checker(job_id).await;
+
+        let result =
+            save_metadata_batch_impl(items, job_id, cancellation, |event| progress.push(event))
+                .await
+                .expect("batch should report per-file failures");
+
+        assert_eq!(result.summary.total, 2);
+        assert_eq!(result.summary.succeeded, 0);
+        assert_eq!(result.summary.failed, 2);
+        assert_eq!(result.results[0].input_index, 0);
+        assert_eq!(result.results[1].input_index, 1);
+        assert_eq!(result.results[0].status, MetadataSaveResultStatus::Failed);
+        assert_eq!(result.results[1].status, MetadataSaveResultStatus::Failed);
+        assert_eq!(progress.len(), 4);
+        assert_eq!(progress[0].stage, EventStage::Writing);
+        assert_eq!(progress[1].stage, EventStage::Failed);
+        assert_eq!(progress[2].stage, EventStage::Writing);
+        assert_eq!(progress[3].stage, EventStage::Failed);
+    }
+
+    #[tokio::test]
+    async fn metadata_batch_cancels_remaining_items_between_writes() {
+        let items = vec![
+            MetadataSaveRequest {
+                file_path: "/definitely/missing-a.m4b".to_string(),
+                metadata_patch: title_patch("A"),
+            },
+            MetadataSaveRequest {
+                file_path: "/definitely/missing-b.m4b".to_string(),
+                metadata_patch: title_patch("B"),
+            },
+        ];
+        let registry = JobRegistry::new(1);
+        let (job_id, _permit) = registry.register_job().await.expect("register job");
+        let cancellation = registry.cancellation_checker(job_id).await;
+        registry.cancel_all();
+        let mut progress = Vec::new();
+
+        let result =
+            save_metadata_batch_impl(items, job_id, cancellation, |event| progress.push(event))
+                .await
+                .expect("cancelled batch should return terminal item results");
+
+        assert_eq!(result.summary.total, 2);
+        assert_eq!(result.summary.succeeded, 0);
+        assert_eq!(result.summary.failed, 0);
+        assert_eq!(result.summary.cancelled, 2);
+        assert!(result
+            .results
+            .iter()
+            .all(|entry| entry.status == MetadataSaveResultStatus::Cancelled));
+        assert!(progress
+            .iter()
+            .all(|event| event.stage == EventStage::Cancelled));
+    }
+}

--- a/src-tauri/src/file_replace.rs
+++ b/src-tauri/src/file_replace.rs
@@ -1,0 +1,148 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+fn backup_path_for(destination: &Path) -> io::Result<PathBuf> {
+    let parent = destination.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "replacement destination has no parent directory",
+        )
+    })?;
+    let file_name = destination.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "replacement destination has no file name",
+        )
+    })?;
+
+    Ok(parent.join(format!(
+        ".abb_replace_{}_{}",
+        uuid::Uuid::new_v4(),
+        file_name.to_string_lossy()
+    )))
+}
+
+fn replace_file_with_ops<R, M>(
+    source: &Path,
+    destination: &Path,
+    backup_path: &Path,
+    mut rename: R,
+    mut remove_file: M,
+) -> io::Result<()>
+where
+    R: FnMut(&Path, &Path) -> io::Result<()>,
+    M: FnMut(&Path) -> io::Result<()>,
+{
+    match rename(source, destination) {
+        Ok(()) => return Ok(()),
+        Err(error) if !destination.exists() => return Err(error),
+        Err(error) => {
+            let destination_type = std::fs::symlink_metadata(destination)?.file_type();
+            if !destination_type.is_file() {
+                return Err(error);
+            }
+        }
+    }
+
+    rename(destination, backup_path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("failed to move existing destination aside for replacement: {error}"),
+        )
+    })?;
+
+    match rename(source, destination) {
+        Ok(()) => {
+            let _ = remove_file(backup_path);
+            Ok(())
+        }
+        Err(replace_error) => {
+            if let Err(rollback_error) = rename(backup_path, destination) {
+                return Err(io::Error::new(
+                    replace_error.kind(),
+                    format!(
+                        "failed to install replacement and failed to restore original destination: {replace_error}; rollback: {rollback_error}"
+                    ),
+                ));
+            }
+            Err(replace_error)
+        }
+    }
+}
+
+pub(crate) fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    let backup_path = backup_path_for(destination)?;
+    replace_file_with_ops(
+        source,
+        destination,
+        &backup_path,
+        |from, to| std::fs::rename(from, to),
+        |path| std::fs::remove_file(path),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use tempfile::TempDir;
+
+    #[test]
+    fn replace_file_overwrites_existing_destination() {
+        let root = TempDir::new().expect("temp root");
+        let source = root.path().join("source.m4b");
+        let destination = root.path().join("destination.m4b");
+
+        std::fs::write(&source, b"new").expect("write source");
+        std::fs::write(&destination, b"old").expect("write destination");
+
+        replace_file(&source, &destination).expect("replace file");
+
+        assert_eq!(
+            std::fs::read(&destination).expect("read destination"),
+            b"new"
+        );
+        assert!(!source.exists(), "source should be consumed");
+    }
+
+    #[test]
+    fn replace_file_rolls_back_when_install_after_backup_fails() {
+        let root = TempDir::new().expect("temp root");
+        let source = root.path().join("source.m4b");
+        let destination = root.path().join("destination.m4b");
+        let backup = root.path().join("backup.m4b");
+        let calls = Cell::new(0);
+
+        std::fs::write(&source, b"new").expect("write source");
+        std::fs::write(&destination, b"old").expect("write destination");
+
+        let result = replace_file_with_ops(
+            &source,
+            &destination,
+            &backup,
+            |from, to| {
+                calls.set(calls.get() + 1);
+                match calls.get() {
+                    1 => Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "destination exists",
+                    )),
+                    3 => Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "replacement blocked",
+                    )),
+                    _ => std::fs::rename(from, to),
+                }
+            },
+            |path| std::fs::remove_file(path),
+        );
+
+        assert!(result.is_err(), "replacement should fail");
+        assert_eq!(
+            std::fs::read(&destination).expect("read destination"),
+            b"old"
+        );
+        assert_eq!(std::fs::read(&source).expect("read source"), b"new");
+        assert!(!backup.exists(), "backup should be consumed by rollback");
+    }
+}

--- a/src-tauri/src/file_replace.rs
+++ b/src-tauri/src/file_replace.rs
@@ -53,7 +53,7 @@ where
 
     match rename(source, destination) {
         Ok(()) => {
-            let _ = remove_file(backup_path);
+            cleanup_backup_after_success(backup_path, &mut remove_file);
             Ok(())
         }
         Err(replace_error) => {
@@ -68,6 +68,37 @@ where
             Err(replace_error)
         }
     }
+}
+
+fn cleanup_backup_after_success<M>(backup_path: &Path, remove_file: &mut M)
+where
+    M: FnMut(&Path) -> io::Result<()>,
+{
+    if let Err(error) = remove_file(backup_path) {
+        #[cfg(windows)]
+        {
+            if clear_readonly_backup(backup_path).is_ok() && remove_file(backup_path).is_ok() {
+                return;
+            }
+        }
+
+        log::warn!(
+            "Replacement succeeded, but failed to remove backup '{}': {}",
+            backup_path.display(),
+            error
+        );
+    }
+}
+
+#[cfg(windows)]
+fn clear_readonly_backup(backup_path: &Path) -> io::Result<()> {
+    let metadata = std::fs::metadata(backup_path)?;
+    let mut permissions = metadata.permissions();
+    if permissions.readonly() {
+        permissions.set_readonly(false);
+        std::fs::set_permissions(backup_path, permissions)?;
+    }
+    Ok(())
 }
 
 pub(crate) fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
@@ -144,5 +175,45 @@ mod tests {
         );
         assert_eq!(std::fs::read(&source).expect("read source"), b"new");
         assert!(!backup.exists(), "backup should be consumed by rollback");
+    }
+
+    #[test]
+    fn replace_file_reports_success_when_backup_cleanup_fails_after_install() {
+        let root = TempDir::new().expect("temp root");
+        let source = root.path().join("source.m4b");
+        let destination = root.path().join("destination.m4b");
+        let backup = root.path().join("backup.m4b");
+        let calls = Cell::new(0);
+
+        std::fs::write(&source, b"new").expect("write source");
+        std::fs::write(&destination, b"old").expect("write destination");
+
+        replace_file_with_ops(
+            &source,
+            &destination,
+            &backup,
+            |from, to| {
+                calls.set(calls.get() + 1);
+                match calls.get() {
+                    1 => Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "destination exists",
+                    )),
+                    _ => std::fs::rename(from, to),
+                }
+            },
+            |_path| Err(io::Error::new(io::ErrorKind::PermissionDenied, "locked")),
+        )
+        .expect("successful install should remain successful");
+
+        assert_eq!(
+            std::fs::read(&destination).expect("read destination"),
+            b"new"
+        );
+        assert!(!source.exists(), "source should be consumed");
+        assert_eq!(
+            std::fs::read(&backup).expect("read leftover backup"),
+            b"old"
+        );
     }
 }

--- a/src-tauri/src/ipc_contract.rs
+++ b/src-tauri/src/ipc_contract.rs
@@ -14,6 +14,7 @@ pub fn builder() -> Builder<tauri::Wry> {
             crate::commands::load_cover_art_file,
             crate::commands::load_cover_art_from_url,
             crate::commands::save_metadata_to_file,
+            crate::commands::metadata::save_batch::save_metadata_batch,
             crate::commands::search_online_metadata,
             crate::commands::analyze_audio_files,
             crate::commands::validate_encoder_settings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod commands;
 mod errors;
+mod file_replace;
 pub mod ipc_contract;
 mod metadata;
 pub mod output_artifact;

--- a/src-tauri/src/metadata/remux.rs
+++ b/src-tauri/src/metadata/remux.rs
@@ -92,7 +92,7 @@ pub(crate) fn rewrite_metadata_with_ffmpeg_plan_as(
     drop(octx);
     drop(ictx);
 
-    std::fs::rename(&temp_path, input_path).map_err(AppError::Io)?;
+    crate::file_replace::replace_file(&temp_path, input_path).map_err(AppError::Io)?;
     Ok(())
 }
 

--- a/src-tauri/src/output_artifact/commit.rs
+++ b/src-tauri/src/output_artifact/commit.rs
@@ -141,7 +141,7 @@ fn commit_temp_output_to_artifact(
             )));
         }
     }
-    match std::fs::rename(&temp_output, final_path) {
+    match crate::file_replace::replace_file(&temp_output, final_path) {
         Ok(()) => {
             log::info!(
                 "finalize_move method=rename-replace status=ok dest={}",

--- a/src/lib/behavior-contract.test.ts
+++ b/src/lib/behavior-contract.test.ts
@@ -23,6 +23,7 @@ const EXPECTED_COMMAND_NAMES = [
 	'process_audiobook_files',
 	'read_audio_metadata',
 	'refresh_external_toolchain',
+	'save_metadata_batch',
 	'save_metadata_to_file',
 	'search_online_metadata',
 	'set_max_concurrent_jobs',

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -50,6 +50,7 @@ export const commands = {
 	 *  3. Handles cover art: preserves existing if not provided, replaces if new art given
 	 */
 	saveMetadataToFile: (filePath: string, metadataPatch: MetadataIntentPatch) => typedError<null, AppErrorEnvelope>(__TAURI_INVOKE("save_metadata_to_file", { filePath, metadataPatch })),
+	saveMetadataBatch: (items: MetadataSaveRequest[]) => typedError<MetadataSaveBatchResult, AppErrorEnvelope>(__TAURI_INVOKE("save_metadata_batch", { items })),
 	searchOnlineMetadata: (query: string, sources: MetadataSource[] | null, limit: number | null) => typedError<OnlineMetadataResult[], AppErrorEnvelope>(__TAURI_INVOKE("search_online_metadata", { query, sources, limit })),
 	/**
 	 *  Validates and analyzes a list of audio files
@@ -334,6 +335,26 @@ export type MetadataIntentPatch = {
 	album_sort?: AlbumSortPatchOp,
 	cover_art?: PatchOp<number[]>,
 };
+
+export type MetadataSaveBatchResult = {
+	summary: ProcessResultSummary,
+	results: MetadataSaveResultEntry[],
+};
+
+export type MetadataSaveRequest = {
+	filePath: string,
+	metadataPatch: MetadataIntentPatch,
+};
+
+export type MetadataSaveResultEntry = {
+	inputIndex: number,
+	filePath: string,
+	status: MetadataSaveResultStatus,
+	message: string,
+	error: AppErrorEnvelope | null,
+};
+
+export type MetadataSaveResultStatus = "success" | "cancelled" | "failed";
 
 export type MetadataSource = "audnexus" | "openlibrary";
 

--- a/src/lib/tauri-client.test.ts
+++ b/src/lib/tauri-client.test.ts
@@ -94,9 +94,69 @@ describe('tauriClient nullish adapters', () => {
 		expect(args.metadataPatch.artist).toBeUndefined();
 	});
 
-	it('exposes saveMetadataIntentToFile as the sole metadata-save helper', async () => {
+	it('compiles every metadata intent patch in a batch save', async () => {
+		const { invoke } = await import('@tauri-apps/api/core');
+		const mockInvoke = vi.mocked(invoke);
+		mockInvoke.mockResolvedValueOnce({
+			summary: {
+				total: 2,
+				succeeded: 1,
+				skipped: 0,
+				cancelled: 0,
+				failed: 1,
+			},
+			results: [
+				{
+					inputIndex: 0,
+					filePath: '/books/a.m4b',
+					status: 'success',
+					message: 'ok',
+					error: null,
+				},
+				{
+					inputIndex: 1,
+					filePath: '/books/b.m4b',
+					status: 'failed',
+					message: 'bad',
+					error: null,
+				},
+			],
+		});
+
+		const { tauriClient } = await import('./tauri/client');
+		const result = await tauriClient.saveMetadataBatch([
+			{
+				filePath: '/books/a.m4b',
+				metadataPatch: { title: { op: 'set', value: 'A' } },
+			},
+			{
+				filePath: '/books/b.m4b',
+				metadataPatch: { title: { op: 'clear' }, cover_art: { op: 'clear' } },
+			},
+		]);
+
+		const lastCall = mockInvoke.mock.calls[mockInvoke.mock.calls.length - 1];
+		const [commandName, args] = lastCall as [
+			string,
+			{
+				items: Array<{
+					filePath: string;
+					metadataPatch: Record<string, unknown>;
+				}>;
+			},
+		];
+		expect(commandName).toBe('save_metadata_batch');
+		expect(args.items).toHaveLength(2);
+		expect(args.items[0]?.metadataPatch.title).toEqual({ op: 'set', value: 'A' });
+		expect(args.items[1]?.metadataPatch.title).toEqual({ op: 'clear' });
+		expect(args.items[1]?.metadataPatch.cover_art).toEqual({ op: 'clear' });
+		expect(result.results[1]?.error).toBeUndefined();
+	});
+
+	it('exposes metadata-save helpers without the legacy metadata alias', async () => {
 		const { tauriClient } = await import('./tauri/client');
 		expect(typeof tauriClient.saveMetadataIntentToFile).toBe('function');
+		expect(typeof tauriClient.saveMetadataBatch).toBe('function');
 		expect('saveMetadataToFile' in tauriClient).toBe(false);
 	});
 

--- a/src/lib/tauri-public-api.contract.test.ts
+++ b/src/lib/tauri-public-api.contract.test.ts
@@ -19,6 +19,7 @@ const EXPECTED_TAURI_CLIENT_METHODS = [
 	'processAudiobookFiles',
 	'readAudioMetadata',
 	'refreshExternalToolchain',
+	'saveMetadataBatch',
 	'saveMetadataIntentToFile',
 	'searchOnlineMetadata',
 	'setMaxConcurrentJobs',
@@ -35,6 +36,7 @@ describe('Tauri Runtime Boundary public API contract', () => {
 	it('keeps command and app event names exposed through the boundary', () => {
 		expect(TAURI_COMMAND_NAMES).toContain('process_audiobook_files');
 		expect(TAURI_COMMAND_NAMES).toContain('preflight_processing_plan');
+		expect(TAURI_COMMAND_NAMES).toContain('save_metadata_batch');
 		expect([...TAURI_APP_EVENT_NAMES]).toEqual(['processing-progress', 'processing-queue']);
 	});
 });

--- a/src/lib/tauri/client.ts
+++ b/src/lib/tauri/client.ts
@@ -19,7 +19,7 @@ import type {
 	ProcessingPreflightPlan,
 	OutputKind,
 } from '../../types/audio';
-import type { AudiobookMetadata, MetadataSource } from '../../types/metadata';
+import type { AudiobookMetadata, MetadataSaveRequest, MetadataSource } from '../../types/metadata';
 import type { MetadataIntentPatch } from '../../types/metadataIntent';
 import { commandSpecs, type CommandResult, type TauriCommand } from './commands';
 import { normalizeProgressEvent, normalizeQueueEvent } from './normalizers';
@@ -90,6 +90,9 @@ export const tauriClient = {
 		metadataIntent: MetadataIntentPatch,
 	): Promise<CommandResult<'save_metadata_to_file'>> =>
 		commandSpecs.save_metadata_to_file({ filePath, metadataIntent }),
+	saveMetadataBatch: (
+		items: MetadataSaveRequest[],
+	): Promise<CommandResult<'save_metadata_batch'>> => commandSpecs.save_metadata_batch({ items }),
 	searchOnlineMetadata: (args: {
 		query: string;
 		sources: MetadataSource[] | null;

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -9,7 +9,7 @@ import type {
 	ProcessPayload,
 	ProcessingPreflightPlan,
 } from '../../types/audio';
-import type { AudiobookMetadata, MetadataSource } from '../../types/metadata';
+import type { AudiobookMetadata, MetadataSaveRequest, MetadataSource } from '../../types/metadata';
 import { compileMetadataIntentPatch, type MetadataIntentPatch } from '../../types/metadataIntent';
 import { normalizeAppError, unwrapGeneratedResult } from './appError';
 import {
@@ -20,6 +20,7 @@ import {
 	normalizeFileList,
 	normalizeLookupResult,
 	normalizeMetadata,
+	normalizeMetadataSaveBatchResult,
 	normalizeNullish,
 	normalizeProcessResult,
 } from './normalizers';
@@ -91,6 +92,13 @@ function compileMetadataIntentMap(
 	);
 }
 
+function compileMetadataSaveRequests(items: MetadataSaveRequest[]): MetadataSaveRequest[] {
+	return items.map((item) => ({
+		filePath: item.filePath,
+		metadataPatch: compileMetadataIntentPatch(item.metadataPatch),
+	}));
+}
+
 export const commandSpecs = {
 	ping: (_args?: undefined) => runGeneratedCommand(generatedCommands.ping()),
 	echo: (args: { input: string }) => runGeneratedCommand(generatedCommands.echo(args.input)),
@@ -110,6 +118,11 @@ export const commandSpecs = {
 				args.filePath,
 				compileMetadataIntentPatch(args.metadataIntent),
 			),
+		),
+	save_metadata_batch: (args: { items: MetadataSaveRequest[] }) =>
+		runGeneratedCommand(
+			generatedCommands.saveMetadataBatch(compileMetadataSaveRequests(args.items)),
+			normalizeMetadataSaveBatchResult,
 		),
 	search_online_metadata: (args: {
 		query: string;

--- a/src/lib/tauri/normalizers.ts
+++ b/src/lib/tauri/normalizers.ts
@@ -17,6 +17,7 @@ import type {
 	AudiobookMetadata as GeneratedAudiobookMetadata,
 	EncoderAvailability as GeneratedEncoderAvailability,
 	FileListInfo as GeneratedFileListInfo,
+	MetadataSaveBatchResult as GeneratedMetadataSaveBatchResult,
 	OnlineMetadataResult as GeneratedOnlineMetadataResult,
 	ProcessCommandResult as GeneratedProcessCommandResult,
 	ProcessPayload as GeneratedProcessPayload,
@@ -29,7 +30,11 @@ import type {
 	ProcessCommandResult,
 	ProcessPayload,
 } from '../../types/audio';
-import type { AudiobookMetadata, OnlineMetadataResult } from '../../types/metadata';
+import type {
+	AudiobookMetadata,
+	MetadataSaveBatchResult,
+	OnlineMetadataResult,
+} from '../../types/metadata';
 import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
 import type { NullToOptionalDeep } from '../../types/ipc';
 import { normalizeAppError } from './appError';
@@ -196,6 +201,19 @@ export function normalizeProcessResult(
 	result: GeneratedProcessCommandResult,
 ): ProcessCommandResult {
 	const normalized = normalizeNullish(result) as ProcessCommandResult;
+	return {
+		...normalized,
+		results: (normalized.results ?? []).map((entry) => ({
+			...entry,
+			error: entry.error == null ? undefined : normalizeAppError(entry.error),
+		})),
+	};
+}
+
+export function normalizeMetadataSaveBatchResult(
+	result: GeneratedMetadataSaveBatchResult,
+): MetadataSaveBatchResult {
+	const normalized = normalizeNullish(result) as MetadataSaveBatchResult;
 	return {
 		...normalized,
 		results: (normalized.results ?? []).map((entry) => ({

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -118,6 +118,63 @@ vi.mock('@tauri-apps/api/core', () => ({
 					],
 				});
 			}
+			case 'save_metadata_batch': {
+				mockJobCounter += 1;
+				const jobId = `mock-metadata-save-${mockJobCounter}`;
+				const args = _args as
+					| {
+							items?: Array<{
+								filePath: string;
+								metadataPatch: Record<string, unknown>;
+							}>;
+					  }
+					| undefined;
+				const items = args?.items ?? [];
+				emitTestEvent('processing-queue', {
+					items: items.map((item, index) => ({
+						input_index: index,
+						file_path: item.filePath,
+						job_id: jobId,
+					})),
+					max_concurrent: 1,
+				});
+				for (const [index, item] of items.entries()) {
+					emitTestEvent('processing-progress', {
+						stage: 'writing',
+						percentage: 0,
+						message: `Saving metadata ${index + 1}/${items.length}`,
+						current_file: item.filePath,
+						eta_seconds: null,
+						job_id: jobId,
+						input_index: index,
+					});
+					emitTestEvent('processing-progress', {
+						stage: 'completed',
+						percentage: 100,
+						message: `Saved metadata ${index + 1}/${items.length}`,
+						current_file: item.filePath,
+						eta_seconds: 0,
+						job_id: jobId,
+						input_index: index,
+					});
+				}
+				return Promise.resolve({
+					summary: {
+						total: items.length,
+						succeeded: items.length,
+						skipped: 0,
+						cancelled: 0,
+						failed: 0,
+					},
+					results: items.map((item, index) => ({
+						inputIndex: index,
+						filePath: item.filePath,
+						status: 'success',
+						message: 'Metadata saved',
+						error: null,
+					})),
+				});
+			}
 			case 'cancel_processing': {
 				const args = _args as { jobId?: string | null } | undefined;
 				emitTestEvent('processing-progress', {

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -18,9 +18,14 @@
 
 import type {
 	AudiobookMetadata as GeneratedAudiobookMetadata,
+	MetadataSaveBatchResult as GeneratedMetadataSaveBatchResult,
+	MetadataSaveRequest as GeneratedMetadataSaveRequest,
+	MetadataSaveResultEntry as GeneratedMetadataSaveResultEntry,
+	MetadataSaveResultStatus as GeneratedMetadataSaveResultStatus,
 	MetadataSource as GeneratedMetadataSource,
 	OnlineMetadataResult as GeneratedOnlineMetadataResult,
 } from '../lib/generated/tauri';
+import type { AppErrorEnvelope } from '../lib/tauri/appError';
 import type { NullToOptionalDeep } from './ipc';
 
 /**
@@ -35,3 +40,23 @@ export type AudiobookMetadataMap = Record<string, AudiobookMetadata>;
 export type MetadataSource = GeneratedMetadataSource;
 
 export type OnlineMetadataResult = NullToOptionalDeep<GeneratedOnlineMetadataResult>;
+
+export type MetadataSaveRequest = GeneratedMetadataSaveRequest;
+
+export type MetadataSaveResultError = AppErrorEnvelope;
+
+export type MetadataSaveResultEntry = Omit<
+	NullToOptionalDeep<GeneratedMetadataSaveResultEntry>,
+	'error'
+> & {
+	error?: MetadataSaveResultError | null;
+};
+
+export type MetadataSaveBatchResult = Omit<
+	NullToOptionalDeep<GeneratedMetadataSaveBatchResult>,
+	'results'
+> & {
+	results: MetadataSaveResultEntry[];
+};
+
+export type MetadataSaveResultStatus = GeneratedMetadataSaveResultStatus;

--- a/src/ui/__tests__/metadata-save-pending-flow.test.ts
+++ b/src/ui/__tests__/metadata-save-pending-flow.test.ts
@@ -2,11 +2,14 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 
 const context = vi.hoisted(() => ({
-	saveMetadataIntentToFileMock: vi.fn(),
+	saveMetadataBatchMock: vi.fn(),
 	persistPendingDraftsMock: vi.fn(async () => false),
 	getPendingIntentEntriesMock: vi.fn(() => [] as Array<[string, Record<string, unknown>]>),
 	clearPendingMock: vi.fn(),
 	resetDirtyStateMock: vi.fn(),
+	beginMetadataSaveMock: vi.fn(async () => undefined),
+	completeMetadataSaveMock: vi.fn(),
+	failMetadataSaveMock: vi.fn(),
 	getCurrentFileListMock: vi.fn(() => ({
 		files: [
 			{ path: '/books/a.m4b', isValid: true },
@@ -19,7 +22,7 @@ const context = vi.hoisted(() => ({
 
 vi.mock('../../lib/tauri/client', () => ({
 	tauriClient: {
-		saveMetadataIntentToFile: context.saveMetadataIntentToFileMock,
+		saveMetadataBatch: context.saveMetadataBatchMock,
 		listen: vi.fn(async () => () => {}),
 		open: vi.fn(),
 		analyzeAudioFiles: vi.fn(async () => ({
@@ -46,6 +49,9 @@ vi.mock('../jobControls', () => ({
 	getMaxConcurrentStatus: vi.fn(() => ({ effective: 2, selection: 'auto' })),
 }));
 vi.mock('../statusPanel/index', () => ({
+	beginMetadataSaveInStatusPanel: context.beginMetadataSaveMock,
+	completeMetadataSaveInStatusPanel: context.completeMetadataSaveMock,
+	failMetadataSaveInStatusPanel: context.failMetadataSaveMock,
 	initStatusPanel: vi.fn(),
 	isStatusPanelProcessing: () => context.statusPanelProcessing,
 	pushStatusPanelTransientStatus: (message: string) => {
@@ -104,10 +110,13 @@ describe('metadata save pending flow', () => {
 	});
 
 	beforeEach(() => {
-		context.saveMetadataIntentToFileMock.mockReset();
+		context.saveMetadataBatchMock.mockReset();
 		context.persistPendingDraftsMock.mockReset();
 		context.clearPendingMock.mockReset();
 		context.resetDirtyStateMock.mockReset();
+		context.beginMetadataSaveMock.mockClear();
+		context.completeMetadataSaveMock.mockClear();
+		context.failMetadataSaveMock.mockClear();
 		context.getPendingIntentEntriesMock.mockReset();
 		context.metadataSaveInProgress = false;
 		context.statusPanelProcessing = false;
@@ -126,19 +135,46 @@ describe('metadata save pending flow', () => {
 			['/books/a.m4b', { title: { op: 'set', value: 'A' } }],
 			['/books/b.m4b', { title: { op: 'set', value: 'B' } }],
 		]);
-		context.saveMetadataIntentToFileMock.mockResolvedValue(undefined);
+		context.saveMetadataBatchMock.mockResolvedValue({
+			summary: { total: 2, succeeded: 2, skipped: 0, cancelled: 0, failed: 0 },
+			results: [
+				{
+					inputIndex: 0,
+					filePath: '/books/a.m4b',
+					status: 'success',
+					message: 'saved',
+				},
+				{
+					inputIndex: 1,
+					filePath: '/books/b.m4b',
+					status: 'success',
+					message: 'saved',
+				},
+			],
+		});
 
 		await saveMetadataFromUI();
 
 		await vi.waitFor(() => {
-			expect(context.saveMetadataIntentToFileMock).toHaveBeenCalledTimes(2);
+			expect(context.saveMetadataBatchMock).toHaveBeenCalledTimes(1);
 		});
+		expect(context.beginMetadataSaveMock).toHaveBeenCalledTimes(1);
+		expect(context.saveMetadataBatchMock).toHaveBeenCalledWith([
+			{
+				filePath: '/books/a.m4b',
+				metadataPatch: { title: { op: 'set', value: 'A' } },
+			},
+			{
+				filePath: '/books/b.m4b',
+				metadataPatch: { title: { op: 'set', value: 'B' } },
+			},
+		]);
 		expect(context.persistPendingDraftsMock).toHaveBeenCalledWith({ showStatus: false });
 		expect(context.clearPendingMock).toHaveBeenCalledTimes(2);
 		expect(context.clearPendingMock).toHaveBeenCalledWith('/books/a.m4b');
 		expect(context.clearPendingMock).toHaveBeenCalledWith('/books/b.m4b');
 		expect(context.resetDirtyStateMock).toHaveBeenCalledTimes(1);
-		expect(getStatusText().textContent).toContain('Metadata saved (2 files)!');
+		expect(context.completeMetadataSaveMock).toHaveBeenCalledTimes(1);
 	});
 
 	it('retains failed files in pending state and surfaces partial failure summary', async () => {
@@ -147,18 +183,66 @@ describe('metadata save pending flow', () => {
 			['/books/a.m4b', { title: { op: 'set', value: 'A' } }],
 			['/books/b.m4b', { title: { op: 'set', value: 'B' } }],
 		]);
-		context.saveMetadataIntentToFileMock
-			.mockResolvedValueOnce(undefined)
-			.mockRejectedValueOnce(new Error('write failed'));
+		context.saveMetadataBatchMock.mockResolvedValue({
+			summary: { total: 2, succeeded: 1, skipped: 0, cancelled: 0, failed: 1 },
+			results: [
+				{
+					inputIndex: 0,
+					filePath: '/books/a.m4b',
+					status: 'success',
+					message: 'saved',
+				},
+				{
+					inputIndex: 1,
+					filePath: '/books/b.m4b',
+					status: 'failed',
+					message: 'write failed',
+				},
+			],
+		});
 
 		await saveMetadataFromUI();
 
 		await vi.waitFor(() => {
-			expect(context.saveMetadataIntentToFileMock).toHaveBeenCalledTimes(2);
+			expect(context.saveMetadataBatchMock).toHaveBeenCalledTimes(1);
 		});
 		expect(context.clearPendingMock).toHaveBeenCalledTimes(1);
 		expect(context.clearPendingMock).toHaveBeenCalledWith('/books/a.m4b');
-		expect(getStatusText().textContent).toBe('Saved 1/2. Failed: b.m4b');
+		expect(context.completeMetadataSaveMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('retains cancelled files in pending state', async () => {
+		context.persistPendingDraftsMock.mockResolvedValue(true);
+		context.getPendingIntentEntriesMock.mockReturnValue([
+			['/books/a.m4b', { title: { op: 'set', value: 'A' } }],
+			['/books/b.m4b', { title: { op: 'set', value: 'B' } }],
+		]);
+		context.saveMetadataBatchMock.mockResolvedValue({
+			summary: { total: 2, succeeded: 1, skipped: 0, cancelled: 1, failed: 0 },
+			results: [
+				{
+					inputIndex: 0,
+					filePath: '/books/a.m4b',
+					status: 'success',
+					message: 'saved',
+				},
+				{
+					inputIndex: 1,
+					filePath: '/books/b.m4b',
+					status: 'cancelled',
+					message: 'cancelled',
+				},
+			],
+		});
+
+		await saveMetadataFromUI();
+
+		await vi.waitFor(() => {
+			expect(context.saveMetadataBatchMock).toHaveBeenCalledTimes(1);
+		});
+		expect(context.clearPendingMock).toHaveBeenCalledTimes(1);
+		expect(context.clearPendingMock).toHaveBeenCalledWith('/books/a.m4b');
+		expect(context.completeMetadataSaveMock).toHaveBeenCalledTimes(1);
 	});
 
 	it('shows explicit status when there are no pending metadata changes', async () => {
@@ -172,7 +256,7 @@ describe('metadata save pending flow', () => {
 				showStatus: false,
 			});
 		});
-		expect(context.saveMetadataIntentToFileMock).not.toHaveBeenCalled();
+		expect(context.saveMetadataBatchMock).not.toHaveBeenCalled();
 		await vi.waitFor(() => {
 			expect(getStatusText().textContent).toBe('No pending metadata changes');
 		});
@@ -186,7 +270,7 @@ describe('metadata save pending flow', () => {
 
 		await saveMetadataFromUI();
 
-		expect(context.saveMetadataIntentToFileMock).not.toHaveBeenCalled();
+		expect(context.saveMetadataBatchMock).not.toHaveBeenCalled();
 		expect(context.clearPendingMock).not.toHaveBeenCalled();
 		expect(context.resetDirtyStateMock).not.toHaveBeenCalled();
 		await vi.waitFor(() => {
@@ -204,7 +288,7 @@ describe('metadata save pending flow', () => {
 		await saveMetadataFromUI();
 
 		expect(context.persistPendingDraftsMock).not.toHaveBeenCalled();
-		expect(context.saveMetadataIntentToFileMock).not.toHaveBeenCalled();
+		expect(context.saveMetadataBatchMock).not.toHaveBeenCalled();
 		expect(context.clearPendingMock).not.toHaveBeenCalled();
 		expect(context.resetDirtyStateMock).not.toHaveBeenCalled();
 		expect(getStatusText().textContent).toBe('Idle');

--- a/src/ui/core/actions.ts
+++ b/src/ui/core/actions.ts
@@ -7,6 +7,9 @@ import { clearPendingMetadataForFile, getPendingMetadataIntentEntries } from '..
 import { metadataSaveInProgressStore } from '../metadataSaveState';
 import { resetDirtyState } from '../metadataForm';
 import {
+	beginMetadataSaveInStatusPanel,
+	completeMetadataSaveInStatusPanel,
+	failMetadataSaveInStatusPanel,
 	initStatusPanel,
 	isStatusPanelProcessing,
 	pushStatusPanelTransientStatus,
@@ -54,38 +57,30 @@ export async function saveMetadataFromUI(): Promise<void> {
 			return;
 		}
 
-		let successCount = 0;
-		let failureCount = 0;
-		const failedFiles: string[] = [];
+		await beginMetadataSaveInStatusPanel();
+		const result = await tauriClient.saveMetadataBatch(
+			pendingEntries.map(([filePath, metadataIntent]) => ({
+				filePath,
+				metadataPatch: metadataIntent,
+			})),
+		);
 
-		for (const [index, [filePath, metadataIntent]] of pendingEntries.entries()) {
-			pushStatusPanelTransientStatus(`Saving ${index + 1}/${pendingEntries.length}...`, {
-				ttlMs: 1_200,
-			});
-
-			try {
-				await tauriClient.saveMetadataIntentToFile(filePath, metadataIntent);
-				clearPendingMetadataForFile(filePath);
-				successCount++;
-			} catch (error) {
-				failureCount++;
-				failedFiles.push(filePath.split(/[\\/]/).pop() || filePath);
-				console.error(`Failed metadata save for ${filePath}:`, error);
+		for (const entry of result.results) {
+			if (entry.status === 'success') {
+				clearPendingMetadataForFile(entry.filePath);
+			} else if (entry.status === 'failed') {
+				console.error(`Failed metadata save for ${entry.filePath}:`, entry.error ?? entry.message);
 			}
 		}
 
 		resetDirtyState();
-		console.log(`Metadata save complete: success=${successCount}, failed=${failureCount}`);
-
-		const message =
-			failureCount === 0
-				? successCount > 1
-					? `Metadata saved (${successCount} files)!`
-					: 'Metadata saved!'
-				: `Saved ${successCount}/${pendingEntries.length}. Failed: ${failedFiles.join(', ')}`;
-		pushStatusPanelTransientStatus(message, { ttlMs: 3_000 });
+		console.log(
+			`Metadata save complete: success=${result.summary.succeeded}, failed=${result.summary.failed}, cancelled=${result.summary.cancelled}`,
+		);
+		completeMetadataSaveInStatusPanel(result);
 	} catch (error) {
 		console.error('Failed to save metadata:', error);
+		failMetadataSaveInStatusPanel('Save failed - see console');
 		pushStatusPanelTransientStatus('Save failed - see console', { ttlMs: 3_000 });
 	} finally {
 		metadataSaveInProgressStore.set(false);

--- a/src/ui/statusPanel/AGENTS.md
+++ b/src/ui/statusPanel/AGENTS.md
@@ -1,6 +1,6 @@
 ## Public API Strip
 - Import status runtime symbols from `src/ui/statusPanel` unless a local exception is documented.
-- Exports: `initStatusPanel`, `isStatusPanelProcessing`, `pushStatusPanelTransientStatus`, `triggerCancelAllFromStatusPanel`, `triggerProcessFromStatusPanel`, `updateStatusPanelConcurrencyStatus`, `StatusPanelIsland`.
+- Exports: `beginMetadataSaveInStatusPanel`, `completeMetadataSaveInStatusPanel`, `failMetadataSaveInStatusPanel`, `initStatusPanel`, `isStatusPanelProcessing`, `pushStatusPanelTransientStatus`, `triggerCancelAllFromStatusPanel`, `triggerProcessFromStatusPanel`, `updateStatusPanelConcurrencyStatus`, `StatusPanelIsland`.
 
 ## Private Cluster
 - Files: `controller.ts`, `runtimeApi.ts`, `events.ts`, `feedback.ts`, `formatting.ts`, `processing.ts`, `preview.ts`, `render.ts`, `state.ts`, `viewState.svelte.ts`, `viewTypes.ts`, `domain/`, `services/`, `__tests__/`, `StatusPanelIsland.svelte`.

--- a/src/ui/statusPanel/StatusPanelIsland.svelte
+++ b/src/ui/statusPanel/StatusPanelIsland.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import type { EventStage } from '../../types/events';
 	import {
 		initStatusPanel,
 		triggerCancelAllFromStatusPanel,
@@ -7,9 +8,15 @@
 	} from './controller';
 	import { statusPanelViewState } from './viewState.svelte';
 
+	let isQueueExpanded = false;
+
 	onMount(() => {
 		initStatusPanel();
 	});
+
+	$: if (statusPanelViewState.jobItems.length === 0) {
+		isQueueExpanded = false;
+	}
 
 	function handleProcessClick(): void {
 		triggerProcessFromStatusPanel();
@@ -19,18 +26,52 @@
 		triggerCancelAllFromStatusPanel();
 	}
 
-	function getJobLabel(item: (typeof statusPanelViewState.jobItems)[number]): string {
-		const percentage = typeof item.percentage === 'number' ? ` (${item.percentage.toFixed(1)}%)` : '';
-		return `${item.label} • ${item.statusText}${percentage}`;
+	function toggleQueue(): void {
+		isQueueExpanded = !isQueueExpanded;
+	}
+
+	function getJobPercentageText(item: (typeof statusPanelViewState.jobItems)[number]): string {
+		return typeof item.percentage === 'number' ? ` (${item.percentage.toFixed(1)}%)` : '';
+	}
+
+	function getJobStatusLabel(item: (typeof statusPanelViewState.jobItems)[number]): string {
+		return `${item.statusText}${getJobPercentageText(item)}`;
+	}
+
+	function getJobStatusClass(item: (typeof statusPanelViewState.jobItems)[number]): string {
+		if (item.status === 'processing') return 'is-active';
+		if (item.status === 'queued') return 'is-queued';
+		if (item.status === 'completed' || item.status === 'skipped') return 'is-complete';
+		if (item.status === 'failed') return 'is-failed';
+		if (item.status === 'cancelled') return 'is-cancelled';
+		return '';
+	}
+
+	function getCount(
+		items: typeof statusPanelViewState.jobItems,
+		statuses: Array<(typeof statusPanelViewState.jobItems)[number]['status']>,
+	): number {
+		return items.filter((item) => statuses.includes(item.status)).length;
+	}
+
+	function getActiveStageLabel(stage?: EventStage): string {
+		if (stage === 'writing') return 'writing';
+		if (stage === 'converting') return 'converting';
+		if (stage === 'analyzing') return 'analyzing';
+		return 'running';
+	}
+
+	function getActiveChipLabel(items: typeof statusPanelViewState.jobItems): string | null {
+		const activeItems = items.filter((item) => item.status === 'processing');
+		if (activeItems.length === 0) return null;
+		const labels = new Set(activeItems.map((item) => getActiveStageLabel(item.stage)));
+		const label = labels.size === 1 ? Array.from(labels)[0] : 'running';
+		return `${activeItems.length} ${label}`;
 	}
 
 	function handleCancelJob(item: (typeof statusPanelViewState.jobItems)[number]): void {
 		if (!item.canCancel || !item.cancelId || !item.onCancel) return;
 		item.onCancel(item.cancelId);
-	}
-
-	function getProgressText(): string {
-		return `${statusPanelViewState.progressPercentage.toFixed(1)}%`;
 	}
 </script>
 
@@ -51,7 +92,9 @@
       <div class="flex justify-between mb-0.5">
         <span class="text-xs"
           >Progress:
-          <span class="property-value" id="percentage-processed">{getProgressText()}</span></span
+          <span class="property-value" id="percentage-processed"
+            >{statusPanelViewState.progressPercentage.toFixed(1)}%</span
+          ></span
         >
         <span id="status-text" class="text-xs font-semibold">{statusPanelViewState.statusText}</span>
       </div>
@@ -72,14 +115,48 @@
       <div id="concurrency-status" class="text-xs muted-text mt-1">
         {statusPanelViewState.concurrencyText}
       </div>
-      <div id="job-list" class="text-xs muted-text mt-1">
+      {#if statusPanelViewState.jobItems.length > 0}
+        <div class="queue-summary-row" id="queue-summary">
+          <div class="queue-chip-group" aria-label="Queue status summary">
+            {#if getActiveChipLabel(statusPanelViewState.jobItems)}
+              <span class="queue-chip is-active" data-testid="queue-chip-active">{getActiveChipLabel(statusPanelViewState.jobItems)}</span>
+            {/if}
+            {#if getCount(statusPanelViewState.jobItems, ['queued']) > 0}
+              <span class="queue-chip is-queued" data-testid="queue-chip-queued">{getCount(statusPanelViewState.jobItems, ['queued'])} queued</span>
+            {/if}
+            {#if getCount(statusPanelViewState.jobItems, ['completed', 'skipped']) > 0}
+              <span class="queue-chip is-complete" data-testid="queue-chip-complete">{getCount(statusPanelViewState.jobItems, ['completed', 'skipped'])} complete</span>
+            {/if}
+            {#if getCount(statusPanelViewState.jobItems, ['failed']) > 0}
+              <span class="queue-chip is-failed" data-testid="queue-chip-failed">{getCount(statusPanelViewState.jobItems, ['failed'])} failed</span>
+            {/if}
+            {#if getCount(statusPanelViewState.jobItems, ['cancelled']) > 0}
+              <span class="queue-chip is-cancelled" data-testid="queue-chip-cancelled">{getCount(statusPanelViewState.jobItems, ['cancelled'])} cancelled</span>
+            {/if}
+          </div>
+          <button
+            id="queue-toggle-button"
+            class="queue-toggle-button"
+            aria-expanded={isQueueExpanded}
+            aria-controls="job-list"
+            on:click={toggleQueue}
+          >
+            {isQueueExpanded ? 'Hide queue' : 'View queue'}
+          </button>
+        </div>
+      {/if}
+      <div
+        id="job-list"
+        class="queue-job-list"
+        hidden={!isQueueExpanded || statusPanelViewState.jobItems.length === 0}
+      >
         {#each statusPanelViewState.jobItems as item (item.key)}
-          <div class="flex items-center justify-between gap-2 mb-1">
-            <span class="flex-1">{getJobLabel(item)}</span>
+          <div class={`queue-job-row ${getJobStatusClass(item)}`}>
+            <span class="queue-job-label">{item.label}</span>
+            <span class="queue-job-status">{getJobStatusLabel(item)}</span>
             <button
               id={"cancel-" + item.key}
               class="job-cancel-button"
-              style="padding: 0.1rem 0.4rem;"
               disabled={
                 statusPanelViewState.cancelAllPending || !item.canCancel || !item.cancelId || !item.onCancel
               }
@@ -91,7 +168,7 @@
         {/each}
       </div>
     </div>
-    <div class="flex gap-2">
+    <div class="status-actions">
       <button
         id="process-button"
         class="btn-pill btn-pill-primary"
@@ -119,7 +196,7 @@
 
 	.status-panel-content {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 1rem;
 	}
 
@@ -146,6 +223,12 @@
 	.progress-details {
 		flex: 1;
 		min-width: 0;
+	}
+
+	.status-actions {
+		display: flex;
+		flex-shrink: 0;
+		gap: 0.5rem;
 	}
 
 	.progress-bar-bg {
@@ -192,9 +275,9 @@
 	}
 
 	.job-cancel-button {
-		padding: 0.5rem 1rem;
+		padding: 0.35rem 0.75rem;
 		border: none;
-		border-radius: 0.375rem;
+		border-radius: 0.5rem;
 		background-color: var(--accent-secondary);
 		color: var(--text-inverse);
 		font-weight: 500;
@@ -210,5 +293,150 @@
 	.job-cancel-button:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.queue-summary-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+
+	.queue-chip-group {
+		display: flex;
+		flex: 1;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+		min-width: 0;
+	}
+
+	.queue-chip {
+		display: inline-flex;
+		align-items: center;
+		min-height: 1.35rem;
+		padding: 0.15rem 0.55rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 700;
+		line-height: 1;
+		white-space: nowrap;
+	}
+
+	.queue-chip.is-active {
+		background: rgba(59, 130, 246, 0.22);
+		color: #bfdbfe;
+	}
+
+	.queue-chip.is-queued {
+		background: rgba(245, 158, 11, 0.18);
+		color: #fcd34d;
+	}
+
+	.queue-chip.is-complete {
+		background: rgba(16, 185, 129, 0.16);
+		color: #86efac;
+	}
+
+	.queue-chip.is-failed {
+		background: rgba(239, 68, 68, 0.18);
+		color: #fca5a5;
+	}
+
+	.queue-chip.is-cancelled {
+		background: rgba(156, 163, 175, 0.2);
+		color: var(--text-muted);
+	}
+
+	.queue-toggle-button {
+		min-height: 2rem;
+		padding: 0.25rem 0.75rem;
+		border: 1px solid var(--border-secondary);
+		border-radius: 0.5rem;
+		background: var(--bg-input);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: 0.8rem;
+		font-weight: 700;
+		white-space: nowrap;
+		transition: all 0.2s ease-in-out;
+	}
+
+	.queue-toggle-button:hover,
+	.queue-toggle-button:focus-visible {
+		border-color: var(--accent-primary);
+		color: var(--accent-primary-hover);
+		outline: none;
+	}
+
+	.queue-job-list {
+		max-height: 16rem;
+		margin-top: 0.5rem;
+		overflow-y: auto;
+		border: 1px solid var(--border-primary);
+		border-radius: 0.5rem;
+		background: color-mix(in srgb, var(--bg-panel) 78%, var(--bg-main) 22%);
+	}
+
+	.queue-job-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto auto;
+		align-items: center;
+		gap: 0.75rem;
+		min-height: 2.5rem;
+		padding: 0.45rem 0.6rem;
+		border-bottom: 1px solid var(--border-primary);
+	}
+
+	.queue-job-row:last-child {
+		border-bottom: none;
+	}
+
+	.queue-job-row.is-active {
+		background: rgba(59, 130, 246, 0.12);
+	}
+
+	.queue-job-label {
+		min-width: 0;
+		overflow: hidden;
+		color: var(--text-secondary);
+		font-weight: 600;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.queue-job-status {
+		color: var(--text-muted);
+		font-weight: 600;
+		white-space: nowrap;
+	}
+
+	.queue-job-row.is-active .queue-job-status {
+		color: #bfdbfe;
+	}
+
+	.queue-job-row.is-queued .queue-job-status {
+		color: #fcd34d;
+	}
+
+	.queue-job-row.is-failed .queue-job-status {
+		color: #fca5a5;
+	}
+
+	@media (max-width: 900px) {
+		.status-panel-content,
+		.queue-summary-row,
+		.status-actions {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.queue-job-row {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.queue-job-status {
+			white-space: normal;
+		}
 	}
 </style>

--- a/src/ui/statusPanel/__tests__/renderIncrements.test.ts
+++ b/src/ui/statusPanel/__tests__/renderIncrements.test.ts
@@ -97,10 +97,13 @@ describe('renderJobList incremental updates', () => {
 		expect(statusPanelViewState.jobItems.map((item) => item.key)).toEqual(['idx:0', 'idx:1']);
 		expect(statusPanelViewState.jobItems[0]).toMatchObject({
 			label: 'alpha.m4b',
+			status: 'queued',
 			statusText: 'Queued • #1 of 2',
 		});
 		expect(statusPanelViewState.jobItems[1]).toMatchObject({
 			label: 'beta.m4b',
+			status: 'processing',
+			stage: 'writing',
 			statusText: 'Writing Metadata',
 			percentage: 50,
 		});

--- a/src/ui/statusPanel/__tests__/runtime-api-contract.test.ts
+++ b/src/ui/statusPanel/__tests__/runtime-api-contract.test.ts
@@ -6,6 +6,9 @@ import * as statusPanel from '..';
 
 const EXPECTED_STATUS_PANEL_EXPORTS = [
 	'StatusPanelIsland',
+	'beginMetadataSaveInStatusPanel',
+	'completeMetadataSaveInStatusPanel',
+	'failMetadataSaveInStatusPanel',
 	'initStatusPanel',
 	'isStatusPanelProcessing',
 	'pushStatusPanelTransientStatus',

--- a/src/ui/statusPanel/__tests__/stateMachine.test.ts
+++ b/src/ui/statusPanel/__tests__/stateMachine.test.ts
@@ -259,7 +259,7 @@ describe('statusPanel state machine', () => {
 			},
 		]);
 		expect(buildBatchCompletionFeedback(result.model)).toEqual({
-			kind: 'success',
+			kind: 'info',
 			message: 'Processed 1/2. Cancelled: 1.',
 		});
 	});

--- a/src/ui/statusPanel/__tests__/statusPanel-island.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-island.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import StatusPanelIsland from '../StatusPanelIsland.svelte';
-import { resetStatusPanelViewState } from '../viewState.svelte';
+import { resetStatusPanelViewState, statusPanelViewState } from '../viewState.svelte';
 
 const { initStatusPanelLogicMock, triggerProcessMock, triggerCancelAllMock } = vi.hoisted(() => ({
 	initStatusPanelLogicMock: vi.fn(() => ({ isCurrentlyProcessing: false })),
@@ -56,5 +57,74 @@ describe('StatusPanel island mount', () => {
 
 		expect(triggerProcessMock).toHaveBeenCalledTimes(1);
 		expect(triggerCancelAllMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps queue rows collapsed behind visible status chips until requested', async () => {
+		const cancelJobMock = vi.fn();
+		render(StatusPanelIsland);
+
+		statusPanelViewState.jobItems = [
+			{
+				key: 'completed',
+				label: 'Book 22 - Renegade World.m4b',
+				status: 'completed',
+				statusText: 'Completed',
+				percentage: 100,
+				canCancel: false,
+			},
+			{
+				key: 'processing',
+				label: 'Book 02 - Dust World.m4b',
+				status: 'processing',
+				stage: 'writing',
+				statusText: 'Writing Metadata',
+				percentage: 0,
+				canCancel: true,
+				cancelId: 'job-1',
+				onCancel: cancelJobMock,
+			},
+			{
+				key: 'queued',
+				label: 'Book 01 - Steel World.m4b',
+				status: 'queued',
+				statusText: 'Queued • #3 of 3',
+				canCancel: false,
+			},
+		];
+		statusPanelViewState.progressPercentage = 41.7;
+		await tick();
+
+		expect(document.getElementById('percentage-processed')?.textContent).toBe('41.7%');
+		expect(document.querySelector('[data-testid="queue-chip-active"]')?.textContent).toBe(
+			'1 writing',
+		);
+		expect(document.querySelector('[data-testid="queue-chip-queued"]')?.textContent).toBe(
+			'1 queued',
+		);
+		expect(document.querySelector('[data-testid="queue-chip-complete"]')?.textContent).toBe(
+			'1 complete',
+		);
+
+		const jobList = document.getElementById('job-list') as HTMLDivElement;
+		const toggle = document.getElementById('queue-toggle-button') as HTMLButtonElement;
+		expect(toggle.textContent).toContain('View queue');
+		expect(toggle.getAttribute('aria-expanded')).toBe('false');
+		expect(jobList.hidden).toBe(true);
+
+		toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		await tick();
+		expect(toggle.textContent).toContain('Hide queue');
+		expect(toggle.getAttribute('aria-expanded')).toBe('true');
+		expect(jobList.hidden).toBe(false);
+		expect(document.querySelectorAll('.queue-job-row')).toHaveLength(3);
+
+		const cancelButton = document.getElementById('cancel-processing') as HTMLButtonElement;
+		cancelButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(cancelJobMock).toHaveBeenCalledWith('job-1');
+
+		toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		await tick();
+		expect(toggle.textContent).toContain('View queue');
+		expect(jobList.hidden).toBe(true);
 	});
 });

--- a/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
@@ -287,7 +287,7 @@ describe('StatusPanel lifecycle', () => {
 		expect(showErrorSpy).toHaveBeenCalledWith('Processed 1/2. Failed: beta.m4b');
 	});
 
-	it('uses a success override when batch results include completed and cancelled entries', () => {
+	it('uses an info override when batch results include completed and cancelled entries', () => {
 		const controller = new StatusPanelRuntime();
 		seedDisabledControls();
 
@@ -331,8 +331,8 @@ describe('StatusPanel lifecycle', () => {
 
 		vi.advanceTimersByTime(2000);
 
-		expect(showSuccessSpy).toHaveBeenCalledWith('Processed 1/2. Cancelled: 1.');
-		expect(showInfoSpy).not.toHaveBeenCalled();
+		expect(showInfoSpy).toHaveBeenCalledWith('Processed 1/2. Cancelled: 1.');
+		expect(showSuccessSpy).not.toHaveBeenCalled();
 		expect(getStepText()).toBe('Processed 1/2. Cancelled: 1.');
 	});
 

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -1,4 +1,5 @@
 import { tauriClient } from '../../lib/tauri/client';
+import type { MetadataSaveBatchResult } from '../../types/metadata';
 import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
 import { setFileOrderLocked } from '../fileList/actions';
 import { getCurrentFileList } from '../fileList/state.svelte';
@@ -8,6 +9,7 @@ import { buildQueueLabels, extractFilenameFromProgress } from './formatting';
 import { startProcessing as startProcessingAction } from './processing';
 import { renderConcurrencyStatus, renderJobList, renderStatus } from './render';
 import { buildStatus, type AggregateProgress, type ProcessingStatus } from './state';
+import { buildMetadataSaveCompletionFeedback } from './metadataSaveFeedback';
 import type { ProcessCommandResult } from '../../types/audio';
 import { calculateAggregateProgressAndStage } from './domain/aggregate';
 import { buildJobKey as buildJobKeyDomain } from './domain/jobKeys';
@@ -82,6 +84,41 @@ export class StatusPanelRuntime {
 
 	public setBatchCompletionMessage(message: string | null): void {
 		this.model = withBatchCompletionMessage(this.model, message);
+	}
+
+	public async beginMetadataSave(): Promise<void> {
+		this.clearSingleCompletionTimeout();
+		this.clearBatchCompletionTimeout();
+		this.model = withCurrentJobType(
+			{
+				...this.model,
+				isProcessing: true,
+				batchCompletionMessageOverride: null,
+			},
+			'metadataSave',
+		);
+		this.updateStatus(buildStatus('writing', 0, 'Preparing metadata save...'));
+		setJobControlsEnabled(false);
+		setFileOrderLocked(true);
+		await this.progressSubscription.start();
+		this.renderModel();
+	}
+
+	public completeMetadataSave(result: MetadataSaveBatchResult): void {
+		const feedbackResult = buildMetadataSaveCompletionFeedback(result);
+		this.setBatchCompletionMessage(feedbackResult.message);
+		if (this.model.jobProgress.size === 0) {
+			this.model = resetStatusPanelModel();
+			this.applyIdleSideEffects();
+			this.showCompletionFeedback(feedbackResult);
+		}
+	}
+
+	public failMetadataSave(message = 'Save failed - see console'): void {
+		const feedbackResult: StatusPanelCompletionFeedback = { kind: 'error', message };
+		this.model = resetStatusPanelModel();
+		this.applyIdleSideEffects();
+		this.showCompletionFeedback(feedbackResult);
 	}
 
 	public reconcileProcessResult(result: ProcessCommandResult): void {
@@ -414,6 +451,18 @@ export function triggerProcessFromStatusPanel(options?: { previewSeconds?: numbe
 
 export function triggerCancelAllFromStatusPanel(): void {
 	void statusPanelInstance?.requestCancelAll();
+}
+
+export function beginMetadataSaveInStatusPanel(): Promise<void> {
+	return initStatusPanel().beginMetadataSave();
+}
+
+export function completeMetadataSaveInStatusPanel(result: MetadataSaveBatchResult): void {
+	initStatusPanel().completeMetadataSave(result);
+}
+
+export function failMetadataSaveInStatusPanel(message?: string): void {
+	initStatusPanel().failMetadataSave(message);
 }
 
 export function pushStatusPanelTransientStatus(

--- a/src/ui/statusPanel/domain/stateMachineHelpers.ts
+++ b/src/ui/statusPanel/domain/stateMachineHelpers.ts
@@ -19,17 +19,17 @@ export function buildBatchCompletionFeedback(
 	const hasCompleted = statuses.includes('completed');
 	const hasSkipped = statuses.includes('skipped');
 
-	if (hasFailed) {
+	if (model.batchCompletionMessageOverride !== null) {
 		return {
-			kind: 'error',
-			message: model.batchCompletionMessageOverride ?? 'One or more files failed to process.',
+			kind: hasFailed ? 'error' : hasCancelled ? 'info' : hasCompleted ? 'success' : 'info',
+			message: model.batchCompletionMessageOverride,
 		};
 	}
 
-	if (model.batchCompletionMessageOverride !== null) {
+	if (hasFailed) {
 		return {
-			kind: hasCompleted ? 'success' : 'info',
-			message: model.batchCompletionMessageOverride,
+			kind: 'error',
+			message: 'One or more files failed to process.',
 		};
 	}
 

--- a/src/ui/statusPanel/domain/stateMachineTypes.ts
+++ b/src/ui/statusPanel/domain/stateMachineTypes.ts
@@ -7,7 +7,7 @@ export const MERGE_SKIP_HOLD_MS = 1500;
 export const PROGRESS_THROTTLE_MS = 1000;
 
 export type CompletionFeedbackKind = 'success' | 'error' | 'info';
-export type JobType = 'merge' | 'batch';
+export type JobType = 'merge' | 'batch' | 'metadataSave';
 
 export interface StatusPanelCompletionFeedback {
 	kind: CompletionFeedbackKind;

--- a/src/ui/statusPanel/index.ts
+++ b/src/ui/statusPanel/index.ts
@@ -1,4 +1,7 @@
 export {
+	beginMetadataSaveInStatusPanel,
+	completeMetadataSaveInStatusPanel,
+	failMetadataSaveInStatusPanel,
 	initStatusPanel,
 	isStatusPanelProcessing,
 	pushStatusPanelTransientStatus,

--- a/src/ui/statusPanel/metadataSaveFeedback.ts
+++ b/src/ui/statusPanel/metadataSaveFeedback.ts
@@ -1,0 +1,39 @@
+import type { MetadataSaveBatchResult } from '../../types/metadata';
+import type { StatusPanelCompletionFeedback } from './domain/stateMachine';
+
+export function buildMetadataSaveCompletionFeedback(
+	result: MetadataSaveBatchResult,
+): StatusPanelCompletionFeedback {
+	const total = result.summary.total;
+	const succeeded = result.summary.succeeded;
+	const failedEntries = result.results.filter((entry) => entry.status === 'failed');
+	const cancelled = result.summary.cancelled;
+
+	if (failedEntries.length > 0) {
+		const failedNames = failedEntries.map((entry) => filenameFromPath(entry.filePath)).join(', ');
+		const cancelledSuffix = cancelled > 0 ? ` Cancelled: ${cancelled}.` : '';
+		return {
+			kind: 'error',
+			message: `Saved ${succeeded}/${total}. Failed: ${failedNames}.${cancelledSuffix}`,
+		};
+	}
+
+	if (cancelled > 0) {
+		return {
+			kind: 'info',
+			message:
+				succeeded > 0
+					? `Saved ${succeeded}/${total}. Cancelled: ${cancelled}.`
+					: 'Metadata save cancelled.',
+		};
+	}
+
+	return {
+		kind: 'success',
+		message: succeeded > 1 ? `Metadata saved (${succeeded} files)!` : 'Metadata saved!',
+	};
+}
+
+function filenameFromPath(filePath: string): string {
+	return filePath.split(/[\\/]/).pop() || filePath;
+}

--- a/src/ui/statusPanel/render.ts
+++ b/src/ui/statusPanel/render.ts
@@ -115,7 +115,9 @@ export function renderJobList(
 		const item: JobListItem = {
 			key,
 			label: job.label,
+			status: job.status,
 			statusText,
+			stage: job.stage,
 			canCancel,
 			cancelId: job.jobId,
 			onCancel: canCancel ? onCancel : undefined,

--- a/src/ui/statusPanel/viewTypes.ts
+++ b/src/ui/statusPanel/viewTypes.ts
@@ -1,7 +1,12 @@
+import type { EventStage } from '../../types/events';
+import type { JobStatus } from './state';
+
 export type JobListItem = {
 	key: string;
 	label: string;
+	status: JobStatus;
 	statusText: string;
+	stage?: EventStage;
 	percentage?: number;
 	canCancel: boolean;
 	cancelId?: string;


### PR DESCRIPTION
## Goal

This PR has two major objectives:

1. Address the three high-ROI resource-lifetime findings from the PR #305 follow-up audit.
2. Add a repo-specific `resource-lifetime-audit` skill so JStar or an agent can explicitly focus on this category of handle/process/temp-file/replacement foot-gun without adding another AGENTS skill-ledger entry.

## Changes

- Drop the audio decoder inspection context before candidate decoder probes reopen the same input path.
- Add a shared private `file_replace` helper that keeps normal rename fast paths but falls back to backup/rollback replacement for existing files when rename-over-existing is not portable.
- Use the shared replacement helper for metadata FFmpeg remux source replacement and final output artifact `ReplaceExisting` commits.
- Add focused unit coverage for replacement success and rollback behavior.
- Add `.agents/skills/resource-lifetime-audit` with concise hunt/fix/report guidance.

## Validation

- `python3 /Users/jstar/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/resource-lifetime-audit`
- `cargo test file_replace`
- `cargo test commit_temp_output`
- `cargo test audio::processor::streams`
- `scripts/checks.sh standard`
