### PR TITLE
[codex] Align ontology terms and disable doctests

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -26,8 +26,8 @@
 | **Terminal Truth** | The backend-owned final report of what happened to a job or batch, used by the UI for user-visible completion state. | optimistic status, frontend truth |
 | **Metadata Intent Patch** | An explicit patch-op payload that preserves whether a metadata field is being set, cleared, or left alone. | raw metadata object, sentinel mutation |
 | **Patch Op** | A single explicit metadata action such as `set`, `clear`, or `noop` used to preserve user intent across the boundary. | magic empty value, implicit clear |
-| **Preflight Processing Plan** | A backend-generated preview of how a processing request will execute before the actual long-running job begins. | dry guess, UI-only estimate |
-| **Output Naming Preview** | The backend-owned computation of the intended output path before collision suffixing or final processing writes. | frontend filename guess |
+| **Processing Preflight Plan** | A backend-generated preview of how a processing request will execute before the actual long-running job begins. | dry guess, UI-only estimate |
+| **Output Path Preview** | The backend-owned computation of the intended output path before collision suffixing or final processing writes. | frontend filename guess, audio preview |
 | **Fallback** | A deliberately registered temporary compatibility or integrity path with a concrete trigger, observable signal, and sunset condition. | convenience workaround, silent compatibility shim |
 | **Fallback Register** | The canonical list of still-active fallbacks that repo checks enforce and sunset-date. | misc exceptions, hidden legacy notes |
 
@@ -89,8 +89,11 @@
 
 - "API", "command surface", and "runtime boundary" can blur together. Prefer **IPC Contract** for the Rust-exported command/event set and **Runtime Boundary** for the handwritten TS adapter seam.
 - "generated bindings" can sound like the primary client. Prefer **Generated Bindings** for drift detection and typed integration, and **tauriClient** for the real runtime adapter.
-- "fallback" can drift into "temporary workaround." Prefer **Fallback** only for registered, observable, sunset-bound behavior; otherwise call it a bug, compatibility requirement, or design decision.
-- "metadata" and "metadata intent" are not interchangeable. Prefer **Metadata Intent Patch** when the important question is user intent to set, clear, or preserve a field.
+- "preview" can mean different things. Prefer **Output Path Preview** for path derivation, **Processing Preflight Plan** for pre-run backend review, **audio preview** for a short media render, and **preview artifact** for the file created by that render.
+- "fallback" can drift into "temporary workaround." Prefer **Fallback** only for registered, observable, sunset-bound behavior; otherwise call it a compatibility path, recovery default, bug, or design decision.
+- "metadata" and "metadata intent" are not interchangeable. Prefer **Metadata Intent Patch** when the important question is user intent to set, clear, or preserve a field; use metadata draft, write plan, lookup result, or tag projection when those narrower concepts are meant.
+- "gate", "check", "test", and "smoke test" are different confidence shapes. Prefer **Standard Gate** for `scripts/checks.sh standard`, **Boundary Assertion** for repo scripts that block broken imports or policy drift, **Contract Test** for public API behavior, and **UI Workflow Smoke Test** for deterministic user-flow proof.
+- Product names and implementation names should not blur together. For example, **Book Binder** is user-facing product language; **Merge** is the processing job type.
 - "minimal churn" can be mistaken for "smallest diff." Prefer **Minimal Churn** as fewer correction loops and less rework, even when the better fix is somewhat broader.
 - "status", "progress", and "terminal outcome" are not interchangeable. Prefer **Terminal Outcome** only for final per-job status and **Terminal Truth** for the backend-owned final report.
 - "module" alone is ambiguous in ABB. Prefer **Grey-Box Module** for the owned Public-API + Private-Cluster unit, and **Private Cluster File** for any implementation file inside one.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,9 @@ default-run = "audiobook-boss"
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "audiobook_boss_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+# ABB treats backend contract coverage as unit/integration tests plus IPC and
+# boundary checks; rustdoc examples are not a supported test surface today.
+doctest = false
 
 [build-dependencies]
 tauri-build = { version = "2.5.6", features = [] }

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -61,11 +61,11 @@ export type ExternalToolchainPreference = NullToOptionalDeep<GeneratedExternalTo
 export type OutputNamingConfig = NullToOptionalDeep<GeneratedOutputNamingConfig>;
 
 // Combined UI output configuration used by the UI boundary
-export interface OutputConfig {
+export interface ProcessingRequestConfig {
 	encoderSettings: EncoderSettings;
 	toolchainSettings: ExternalToolchainPreference;
 	sampleRate: SampleRateConfig;
-	outputPath: string; // backend contract name; stores the selected output directory
+	outputDirectory: string;
 	outputNaming: OutputNamingConfig;
 }
 

--- a/src/ui/__tests__/outputPanel-store-driven.test.ts
+++ b/src/ui/__tests__/outputPanel-store-driven.test.ts
@@ -3,7 +3,7 @@ import { defaultEncoderSettings } from '../../types/audio';
 import { updateEstimatedSize } from '../outputPanel/preview';
 import {
 	outputPanelState,
-	readOutputConfigForProcessing,
+	readProcessingRequestConfig,
 	updateAbsIncludeYear,
 	updateEncoderSettings,
 	updateNamingPreset,
@@ -40,10 +40,10 @@ describe('output panel state-driven contracts', () => {
 	});
 
 	it('reads processing output config from canonical state selector', () => {
-		const config = readOutputConfigForProcessing();
+		const config = readProcessingRequestConfig();
 
 		expect(config).toMatchObject({
-			outputPath: '/tmp/out',
+			outputDirectory: '/tmp/out',
 			sampleRate: 'auto',
 			toolchainSettings: {},
 			outputNaming: { preset: 'absDefault', includeYear: false, customTemplate: undefined },
@@ -55,7 +55,7 @@ describe('output panel state-driven contracts', () => {
 		updateNamingPreset('customTemplate');
 		updateNamingTemplate('   ');
 
-		const config = readOutputConfigForProcessing();
+		const config = readProcessingRequestConfig();
 		expect(config.outputNaming).toMatchObject({
 			preset: 'customTemplate',
 			customTemplate: '{author}/{title}',

--- a/src/ui/metadataLookup/MetadataLookupIsland.svelte
+++ b/src/ui/metadataLookup/MetadataLookupIsland.svelte
@@ -220,7 +220,7 @@
 							</div>
 						<span
 							class="metadata-lookup-source"
-							class:is-fallback={result.source === 'openlibrary'}
+							class:is-secondary-source={result.source === 'openlibrary'}
 						>
 							{result.source === 'audnexus'
 								? (result.audibleOnly ? 'Audible-only' : 'Audnexus')
@@ -294,7 +294,7 @@
 		font-size: 0.7rem;
 	}
 
-	.metadata-lookup-source.is-fallback {
+	.metadata-lookup-source.is-secondary-source {
 		color: var(--text-muted);
 	}
 

--- a/src/ui/outputPanel/index.ts
+++ b/src/ui/outputPanel/index.ts
@@ -14,6 +14,6 @@ export function initOutputPanel(): void {
 }
 
 export { getState } from './state.svelte';
-export { readOutputConfigForProcessing } from './state.svelte';
+export { readProcessingRequestConfig } from './state.svelte';
 export { updateOutputPath, updateEstimatedSize, getCurrentMetadata } from './preview';
 export { default as OutputPanelIsland } from './OutputPanelIsland.svelte';

--- a/src/ui/outputPanel/state.svelte.ts
+++ b/src/ui/outputPanel/state.svelte.ts
@@ -1,7 +1,7 @@
 import type {
 	EncoderSettings,
 	ExternalToolchainPreference,
-	OutputConfig,
+	ProcessingRequestConfig,
 	OutputNamingConfig,
 	SampleRateConfig,
 } from '../../types/audio';
@@ -77,7 +77,7 @@ export function getOutputNamingConfig(): OutputNamingConfig {
 	};
 }
 
-export function readOutputConfigForProcessing(): OutputConfig {
+export function readProcessingRequestConfig(): ProcessingRequestConfig {
 	if (!outputPanelState.outputDirectory) {
 		throw new Error('Output directory not selected');
 	}
@@ -86,7 +86,7 @@ export function readOutputConfigForProcessing(): OutputConfig {
 		encoderSettings: outputPanelState.encoderSettings,
 		toolchainSettings: outputPanelState.toolchainSettings,
 		sampleRate: outputPanelState.sampleRate,
-		outputPath: outputPanelState.outputDirectory,
+		outputDirectory: outputPanelState.outputDirectory,
 		outputNaming: getOutputNamingConfig(),
 	};
 }

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -12,7 +12,7 @@ const context = vi.hoisted(() => ({
 	getCurrentFileListMock: vi.fn(),
 	getSelectedFileIndexMock: vi.fn(),
 	getSelectedFileIndicesMock: vi.fn(),
-	readOutputConfigForProcessingMock: vi.fn(),
+	readProcessingRequestConfigMock: vi.fn(),
 	updateOutputPathMock: vi.fn(),
 	getJobTypeMock: vi.fn(),
 	readMetadataFormMock: vi.fn(),
@@ -42,7 +42,7 @@ vi.mock('../../fileList/state.svelte', () => ({
 }));
 
 vi.mock('../../outputPanel', () => ({
-	readOutputConfigForProcessing: context.readOutputConfigForProcessingMock,
+	readProcessingRequestConfig: context.readProcessingRequestConfigMock,
 	updateOutputPath: context.updateOutputPathMock,
 }));
 
@@ -83,7 +83,7 @@ function processingContext() {
 		setProcessingState: vi.fn(),
 		updateArtThumbnail: vi.fn(async () => undefined),
 		startProgressListener: vi.fn(async () => undefined),
-		setCurrentJobType: vi.fn(),
+		setCurrentWorkKind: vi.fn(),
 		setBatchCompletionMessage: vi.fn(),
 		handleCancellation: vi.fn(),
 		resetToIdle: vi.fn(),
@@ -99,7 +99,7 @@ describe('startProcessing metadata staging', () => {
 		context.getCurrentFileListMock.mockReset();
 		context.getSelectedFileIndexMock.mockReset();
 		context.getSelectedFileIndicesMock.mockReset();
-		context.readOutputConfigForProcessingMock.mockReset();
+		context.readProcessingRequestConfigMock.mockReset();
 		context.updateOutputPathMock.mockReset();
 		context.getJobTypeMock.mockReset();
 		context.readMetadataFormMock.mockReset();
@@ -121,11 +121,11 @@ describe('startProcessing metadata staging', () => {
 		});
 		context.getSelectedFileIndexMock.mockReturnValue(0);
 		context.getSelectedFileIndicesMock.mockReturnValue(new Set([0]));
-		context.readOutputConfigForProcessingMock.mockReturnValue({
+		context.readProcessingRequestConfigMock.mockReturnValue({
 			encoderSettings: defaultEncoderSettings(),
 			toolchainSettings: {},
 			sampleRate: 'auto',
-			outputPath: '/tmp/out',
+			outputDirectory: '/tmp/out',
 			outputNaming: { preset: 'absDefault', includeYear: false, customTemplate: undefined },
 		});
 		context.getJobTypeMock.mockReturnValue('merge');

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -31,7 +31,7 @@ import {
 	reconcileProcessResult,
 	resetStatusPanelModel,
 	withBatchCompletionMessage,
-	withCurrentJobType,
+	withCurrentWorkKind,
 	type StatusPanelCompletionFeedback,
 	type StatusPanelIntent,
 	type StatusPanelModel,
@@ -70,8 +70,8 @@ export class StatusPanelRuntime {
 				},
 				updateArtThumbnail: () => this.coverArt.syncForCurrentList(),
 				startProgressListener: () => this.progressSubscription.start(),
-				setCurrentJobType: (jobType) => {
-					this.model = withCurrentJobType(this.model, jobType);
+				setCurrentWorkKind: (workKind) => {
+					this.model = withCurrentWorkKind(this.model, workKind);
 				},
 				setBatchCompletionMessage: (message) => this.setBatchCompletionMessage(message),
 				reconcileProcessResult: (result) => this.reconcileProcessResult(result),
@@ -89,7 +89,7 @@ export class StatusPanelRuntime {
 	public async beginMetadataSave(): Promise<void> {
 		this.clearSingleCompletionTimeout();
 		this.clearBatchCompletionTimeout();
-		this.model = withCurrentJobType(
+		this.model = withCurrentWorkKind(
 			{
 				...this.model,
 				isProcessing: true,
@@ -143,7 +143,7 @@ export class StatusPanelRuntime {
 	public applyProgress(event: ProcessingProgressEvent): void {
 		const jobKey = this.buildJobKey(event.input_index, event.job_id ?? undefined);
 		const existing = this.model.jobProgress.get(jobKey);
-		const label = existing?.label ?? this.buildFallbackLabel(event);
+		const label = existing?.label ?? this.buildInferredProgressLabel(event);
 		const transition = applyProgress(this.model, event, Date.now(), { label });
 
 		if (transition.model === this.model && transition.intents.length === 0) {
@@ -228,9 +228,9 @@ export class StatusPanelRuntime {
 		return buildJobKeyDomain(inputIndex, jobId);
 	}
 
-	private buildFallbackLabel(event: ProcessingProgressEvent): string {
+	private buildInferredProgressLabel(event: ProcessingProgressEvent): string {
 		const fileList = getCurrentFileList();
-		if (this.model.currentJobType === 'merge' && fileList?.files?.length) {
+		if (this.model.currentWorkKind === 'merge' && fileList?.files?.length) {
 			const firstValidFile = fileList.files.find((file) => file.isValid);
 			if (firstValidFile?.path) {
 				return buildQueueLabels([firstValidFile.path])[0] ?? firstValidFile.path;
@@ -408,7 +408,7 @@ export class StatusPanelRuntime {
 		this.updateConcurrencyIndicator(aggregate);
 		this.updateStatus(this.model.currentStatus);
 
-		if (this.model.currentJobType === 'batch' && this.model.latestProgressEvent) {
+		if (this.model.currentWorkKind === 'batch' && this.model.latestProgressEvent) {
 			const event = this.model.latestProgressEvent;
 			const indexedPath =
 				typeof event.input_index === 'number' ? this.findFilePathByIndex(event.input_index) : null;

--- a/src/ui/statusPanel/domain/stateMachine.ts
+++ b/src/ui/statusPanel/domain/stateMachine.ts
@@ -24,7 +24,7 @@ import {
 	MERGE_SKIP_HOLD_MS,
 	PROGRESS_THROTTLE_MS,
 	SINGLE_COMPLETION_HOLD_MS,
-	type JobType,
+	type StatusPanelWorkKind,
 	type SingleCompletionHoldIntent,
 	type StatusPanelCompletionFeedback,
 	type StatusPanelIntent,
@@ -49,7 +49,7 @@ export function createStatusPanelModel(): StatusPanelModel {
 		lastProgressRenderByKey: new Map(),
 		currentStatus: createInitialStatus(),
 		isProcessing: false,
-		currentJobType: null,
+		currentWorkKind: null,
 		latestProgressEvent: null,
 		batchCompletionMessageOverride: null,
 	};
@@ -65,13 +65,13 @@ export function withBatchCompletionMessage(
 	};
 }
 
-export function withCurrentJobType(
+export function withCurrentWorkKind(
 	model: StatusPanelModel,
-	jobType: JobType | null,
+	workKind: StatusPanelWorkKind | null,
 ): StatusPanelModel {
 	return {
 		...model,
-		currentJobType: jobType,
+		currentWorkKind: workKind,
 	};
 }
 
@@ -88,7 +88,7 @@ export function applyQueueSnapshot(
 		lastProgressRenderByKey: new Map(),
 		currentStatus: model.currentStatus,
 		isProcessing: queueSnapshot.queueOrder.length > 0,
-		currentJobType: model.currentJobType,
+		currentWorkKind: model.currentWorkKind,
 		latestProgressEvent: model.latestProgressEvent,
 		batchCompletionMessageOverride: model.batchCompletionMessageOverride,
 	};

--- a/src/ui/statusPanel/domain/stateMachineHelpers.ts
+++ b/src/ui/statusPanel/domain/stateMachineHelpers.ts
@@ -94,7 +94,7 @@ export function cloneModel(model: StatusPanelModel): StatusPanelModel {
 		lastProgressRenderByKey: new Map(model.lastProgressRenderByKey),
 		currentStatus: model.currentStatus,
 		isProcessing: model.isProcessing,
-		currentJobType: model.currentJobType,
+		currentWorkKind: model.currentWorkKind,
 		latestProgressEvent: model.latestProgressEvent,
 		batchCompletionMessageOverride: model.batchCompletionMessageOverride,
 	};

--- a/src/ui/statusPanel/domain/stateMachineTypes.ts
+++ b/src/ui/statusPanel/domain/stateMachineTypes.ts
@@ -7,7 +7,7 @@ export const MERGE_SKIP_HOLD_MS = 1500;
 export const PROGRESS_THROTTLE_MS = 1000;
 
 export type CompletionFeedbackKind = 'success' | 'error' | 'info';
-export type JobType = 'merge' | 'batch' | 'metadataSave';
+export type StatusPanelWorkKind = 'merge' | 'batch' | 'metadataSave';
 
 export interface StatusPanelCompletionFeedback {
 	kind: CompletionFeedbackKind;
@@ -51,7 +51,7 @@ export interface StatusPanelModel {
 	lastProgressRenderByKey: Map<string, number>;
 	currentStatus: ProcessingStatus;
 	isProcessing: boolean;
-	currentJobType: JobType | null;
+	currentWorkKind: StatusPanelWorkKind | null;
 	latestProgressEvent: ProcessingProgressEvent | null;
 	batchCompletionMessageOverride: string | null;
 }

--- a/src/ui/statusPanel/processing.ts
+++ b/src/ui/statusPanel/processing.ts
@@ -1,10 +1,10 @@
 import { tauriClient } from '../../lib/tauri/client';
-import type { OutputConfig, OutputKind } from '../../types/audio';
+import type { ProcessingRequestConfig, OutputKind } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
 import { setFileOrderLocked } from '../fileList/actions';
 import { getCurrentFileList, getSelectedFileIndex } from '../fileList/state.svelte';
 import { getSelectedFileIndices } from '../fileList/state.svelte';
-import { readOutputConfigForProcessing, updateOutputPath } from '../outputPanel';
+import { readProcessingRequestConfig, updateOutputPath } from '../outputPanel';
 import { getJobType, setJobControlsEnabled } from '../jobControls';
 import { hasDirtyMetadataFields, readMetadataForm } from '../metadataForm';
 import {
@@ -36,7 +36,7 @@ interface StartProcessingContext {
 	setProcessingState: (isProcessing: boolean) => void;
 	updateArtThumbnail: () => Promise<void>;
 	startProgressListener: () => Promise<void>;
-	setCurrentJobType: (jobType: 'merge' | 'batch') => void;
+	setCurrentWorkKind: (workKind: 'merge' | 'batch') => void;
 	setBatchCompletionMessage: (message: string | null) => void;
 	reconcileProcessResult?: (result: ProcessCommandResult) => void;
 	handleCancellation: () => void;
@@ -145,11 +145,14 @@ export async function startProcessing(
 
 		console.log('StatusPanel: Files validated, getting output configuration...');
 
-		// Get output configuration
-		let outputConfig: OutputConfig;
+		// Get processing request configuration
+		let processingRequestConfig: ProcessingRequestConfig;
 		try {
-			outputConfig = readOutputConfigForProcessing();
-			console.log('StatusPanel: Output configuration retrieved:', outputConfig);
+			processingRequestConfig = readProcessingRequestConfig();
+			console.log(
+				'StatusPanel: Processing request configuration retrieved:',
+				processingRequestConfig,
+			);
 		} catch (error) {
 			console.log('StatusPanel: Settings validation failed:', error);
 			feedback.showError(`Settings validation failed: ${error}`);
@@ -196,16 +199,16 @@ export async function startProcessing(
 		}
 
 		const jobType = getJobType();
-		context.setCurrentJobType(jobType);
+		context.setCurrentWorkKind(jobType);
 
 		const processPayload: ProcessPayload = {
 			inputFiles: filePaths,
-			outputDir: outputConfig.outputPath,
-			settings: outputConfig.encoderSettings,
-			externalToolchain: outputConfig.toolchainSettings,
-			sampleRate: outputConfig.sampleRate,
+			outputDir: processingRequestConfig.outputDirectory,
+			settings: processingRequestConfig.encoderSettings,
+			externalToolchain: processingRequestConfig.toolchainSettings,
+			sampleRate: processingRequestConfig.sampleRate,
 			jobType,
-			outputNaming: outputConfig.outputNaming,
+			outputNaming: processingRequestConfig.outputNaming,
 		};
 
 		if (processPayload.jobType === 'batch') {


### PR DESCRIPTION
## Summary

This PR applies the agreed ontology-defragmentation cleanup with minimal churn:

- renames status-panel-local `JobType` language to `StatusPanelWorkKind` so it does not collide with backend/generated processing `JobType`
- renames frontend output request config from `OutputConfig.outputPath` to `ProcessingRequestConfig.outputDirectory`, matching the actual selected directory semantics
- renames a metadata lookup source CSS fallback marker to `secondary-source`, avoiding false fallback-policy language
- minimally updates `docs/ubiquitous-language.md` to align existing terms and clarify the highest-risk ambiguity clusters without adding a taxonomy section
- disables Rust doctests for the backend lib target because ABB has no current rustdoc example tests and uses unit/integration tests plus IPC/boundary checks as the supported backend test surface

## Why

The existing terms were not behaviorally broken, but several names sat on active agent decision boundaries: `JobType`, `OutputConfig`, `preview`, `fallback`, `status`, and `metadata`. Those are exactly the words future agents use when deciding where to edit. Tightening them reduces false ownership reads without widening architecture scope.

The doctest adjustment removes a low-signal default Rust harness from `cargo test`. `cargo test --doc -- --list` confirmed ABB has `0 tests, 0 benchmarks` in rustdoc examples, so this is currently check-noise reduction rather than coverage removal.

## Scope notes

- Behavior-neutral rename/doc alignment plus test-infra policy clarification.
- `docs/system-map.md` intentionally untouched; the owner is considering a separate presentation artifact for that surface.
- AGENTS and skill files were scanned for stale ontology references. No edits were needed there.
- The remaining `JobType` references are the generated/backend processing contract, not the status-panel-local model term.
- Doctests can be re-enabled later if ABB intentionally adopts rustdoc examples as executable public-contract documentation.

## Verification

- `cargo test --doc -- --list` -> `0 tests, 0 benchmarks`
- `bun run test -- src/ui/statusPanel/__tests__/runtime-api-contract.test.ts src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts src/ui/__tests__/metadataLookup-island.test.ts src/ui/__tests__/outputPanel-store-driven.test.ts`
- `bash scripts/check-context-surface.sh`
- `scripts/check-public-api-strips.sh`
- `git diff --check`
- stale-term scans for old frontend ontology names
- `scripts/checks.sh standard`
