### PR TITLE
[codex] test local app symlink read permission

### DIFF
--- a/scripts/build-app.test.ts
+++ b/scripts/build-app.test.ts
@@ -370,4 +370,31 @@ describe('refreshApplicationsLink', () => {
 			path.join(repoRoot, 'target/release/bundle/macos/Old.app'),
 		);
 	});
+
+	it('returns skipped when reading an existing symlink is permission denied', () => {
+		const { applicationsDir, repoRoot } = createRepoFixture();
+		const paths = resolveMacOsBundlePaths(repoRoot, applicationsDir);
+		mkdirSync(paths.canonicalAppPath, { recursive: true });
+		symlinkSync(
+			path.join(repoRoot, 'target/release/bundle/macos/Old.app'),
+			paths.applicationsLinkPath,
+			'dir',
+		);
+
+		const outcome = refreshApplicationsLink(paths, {
+			lstatSync,
+			mkdirSync,
+			readlinkSync: () => {
+				const error = new Error('operation not permitted') as NodeJS.ErrnoException;
+				error.code = 'EPERM';
+				throw error;
+			},
+			symlinkSync,
+			unlinkSync,
+		});
+		expect(outcome).toBe('skipped');
+		expect(readlinkSync(paths.applicationsLinkPath)).toBe(
+			path.join(repoRoot, 'target/release/bundle/macos/Old.app'),
+		);
+	});
 });

--- a/scripts/build-app.ts
+++ b/scripts/build-app.ts
@@ -304,10 +304,18 @@ export function refreshApplicationsLink(
 		return 'skipped';
 	}
 
-	const currentTarget = path.resolve(
-		path.dirname(paths.applicationsLinkPath),
-		fsOps.readlinkSync(paths.applicationsLinkPath),
-	);
+	let currentTarget: string;
+	try {
+		currentTarget = path.resolve(
+			path.dirname(paths.applicationsLinkPath),
+			fsOps.readlinkSync(paths.applicationsLinkPath),
+		);
+	} catch (error) {
+		if (isPermissionDeniedError(error)) {
+			return 'skipped';
+		}
+		throw error;
+	}
 	if (currentTarget === paths.canonicalAppPath) {
 		return 'skipped';
 	}


### PR DESCRIPTION
## Summary

This closes a small test gap in the recent local app install tooling. `refreshApplicationsLink` already treated permission failures while creating, inspecting, or replacing `/Applications` links as a skipped launcher convenience, but the path that reads an existing symlink target was not covered and still allowed `EPERM`/`EACCES` to throw.

## User impact and root cause

The local install/build flow should not fail just because macOS or the user account refuses to inspect an existing `/Applications/AudioBook Boss.app` symlink. The root cause was an unguarded `readlinkSync` call after `lstatSync` confirmed the path was a symlink; other permission-sensitive filesystem operations in the same helper already returned `skipped`.

## Fix

Wrap the `readlinkSync` call in the same permission-denied handling used by the rest of `refreshApplicationsLink`, returning `skipped` for `EPERM`/`EACCES` and preserving throw behavior for unrelated errors. Add a focused regression test that simulates `EPERM` from `readlinkSync` and verifies the stale symlink is left untouched.

## Validation

- `bun test scripts/build-app.test.ts`
- `scripts/checks.sh standard`
