### PR TITLE
feat: add EB4 workflow owners

### DIFF
--- a/docs/specs/effect-adoption-roadmap.html
+++ b/docs/specs/effect-adoption-roadmap.html
@@ -574,7 +574,7 @@
 	<div class="shell">
 		<header>
 			<div>
-				<div class="kicker">Audiobook Boss roadmap draft</div>
+				<div class="kicker">Audiobook Boss active roadmap</div>
 					<h1>ABB Greenfield Convergence via Effect</h1>
 					<p class="lede">
 						A forest-level adoption roadmap: move current ABB toward the greenfield shape, then
@@ -624,8 +624,8 @@
 						<div>ABB has a strong boundary model and five current grey-box public APIs.</div>
 					</div>
 					<div class="metric">
-						<span class="badge watch">Gap</span>
-						<div><code>effect</code> is not installed in ABB today.</div>
+						<span class="badge good">Done</span>
+						<div><code>effect</code> is installed; AppEffect and workflow-owner proof points exist through EB4.</div>
 					</div>
 					<div class="metric">
 						<span class="badge info">Fit</span>
@@ -733,13 +733,20 @@
 									<td>Adjust scripts only when a milestone opens a real boundary reason.</td>
 									<td>M8 / opportunistic</td>
 								</tr>
+								<tr>
+									<td>Residual false seams</td>
+									<td>Remaining wrappers, adapters, and boundary-like modules may be real infrastructure or accidental boundary management.</td>
+									<td>Classify each meaningful seam as technically required, useful local detail, or false seam to remove, deepen, or defer.</td>
+									<td>M9</td>
+								</tr>
 							</tbody>
 						</table>
 					</div>
 					<div class="callout">
 						<strong>What else the map must carry:</strong> a workflow-owner template, an Effect-native
 						rule for new multi-boundary frontend work after M2, a boring Specta/<code>tauriClient</code>
-						contract posture, workflow tests that avoid full Svelte rendering, and an M9 residual-glue review.
+						contract posture, workflow tests that avoid full Svelte rendering, an M9 critical
+						boundary/glue audit, and a Nextest-informed testing feedback audit.
 					</div>
 					<div class="callout">
 						<strong>Remote Acquisition scope boundary:</strong> this roadmap does not own the Remote
@@ -779,19 +786,19 @@
 									<tr>
 										<td>EB2</td>
 										<td>M4 + narrow M7 proof</td>
-										<td><span class="badge watch">In flight</span></td>
+										<td><span class="badge good">Complete</span></td>
 										<td>MetadataSaveWorkflow extraction plus metadata workflow harness proof.</td>
 									</tr>
 									<tr>
 										<td>EB3</td>
 										<td>M5 + metadata slice of M6</td>
-										<td><span class="badge info">Planned</span></td>
+										<td><span class="badge good">Complete</span></td>
 										<td>Future workflow ingress rule plus metadata enrichment workflows.</td>
 									</tr>
 									<tr>
 										<td>EB4</td>
 										<td>Remaining M6</td>
-										<td><span class="badge info">Planned</span></td>
+										<td><span class="badge good">Complete</span></td>
 										<td>Import, preflight, and job-control workflow migration.</td>
 									</tr>
 									<tr>
@@ -804,7 +811,7 @@
 										<td>EB6</td>
 										<td>M9</td>
 										<td><span class="badge info">Planned</span></td>
-										<td>Greenfield convergence review, highest-ROI test-gap audit, and merge-readiness decision.</td>
+										<td>Greenfield convergence review, Nextest-informed test feedback, critical boundary/glue audit, highest-ROI test-gap audit, and merge-readiness decision.</td>
 									</tr>
 								</tbody>
 							</table>
@@ -829,7 +836,7 @@
 					</select>
 				</div>
 				<div class="milestone-list" id="milestonesList">
-					<article class="milestone" data-id="M0" data-status="not-started">
+					<article class="milestone" data-id="M0" data-status="done">
 						<div class="m-id">M0</div>
 						<div class="m-body">
 							<div class="phase-tag">Alignment</div>
@@ -855,7 +862,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M1" data-status="not-started">
+					<article class="milestone" data-id="M1" data-status="done">
 						<div class="m-id">M1</div>
 						<div class="m-body">
 							<div class="phase-tag">Baseline</div>
@@ -879,7 +886,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M2" data-status="not-started">
+					<article class="milestone" data-id="M2" data-status="done">
 						<div class="m-id">M2</div>
 						<div class="m-body">
 							<div class="phase-tag">Kernel</div>
@@ -904,7 +911,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M3" data-status="not-started">
+					<article class="milestone" data-id="M3" data-status="done">
 						<div class="m-id">M3</div>
 						<div class="m-body">
 							<div class="phase-tag">Workflow owner</div>
@@ -929,7 +936,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M4" data-status="not-started">
+					<article class="milestone" data-id="M4" data-status="done">
 						<div class="m-id">M4</div>
 						<div class="m-body">
 							<div class="phase-tag">Metadata boundary</div>
@@ -954,7 +961,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M5" data-status="not-started">
+					<article class="milestone" data-id="M5" data-status="done">
 						<div class="m-id">M5</div>
 						<div class="m-body">
 							<div class="phase-tag">Future feature ingress</div>
@@ -980,7 +987,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M6" data-status="not-started">
+					<article class="milestone" data-id="M6" data-status="done">
 						<div class="m-id">M6</div>
 						<div class="m-body">
 							<div class="phase-tag">Migration</div>
@@ -1059,15 +1066,17 @@
 						<div class="m-body">
 							<div class="phase-tag">Review</div>
 							<h3>Greenfield Convergence Review</h3>
-							<p>Decide whether Effect is now ABB's frontend workflow default and whether the roadmap branch can merge.</p>
+							<p>Decide whether Effect is now ABB's frontend workflow default, whether remaining boundaries are genuinely needed, and whether the testing feedback loop is strong enough for future agent work.</p>
 							<ul>
 								<li>List migrated workflow owners and intentionally vanilla surfaces.</li>
-								<li>List remaining glue surfaces as accepted, deferred, or assigned to follow-up work.</li>
+								<li>Classify remaining wrappers, adapters, public strips, and boundary-like modules as hard technical/domain boundaries, useful local details, or false seams to remove, deepen, or defer.</li>
+								<li>Audit testing feedback, including Nextest/<code>cargo-nextest</code> surfaces for per-test timing, slow-test summaries, JUnit/machine-readable output, fail-fast/retry profiles, and explicit doctest handling.</li>
+								<li>Lead the test-gap review with gaps that would have reduced agent retry loops during the roadmap.</li>
 								<li>Decide whether to keep Effect private, broaden to <code>tauriClient</code> internals, or stop at current scope.</li>
 								<li>Decide whether <code>roadmap/effect-adoption</code> is ready to merge to <code>main</code>.</li>
 								<li>Delete the active implementation spec once work is merged, validated, documented, and synced.</li>
 							</ul>
-							<div class="gate">Exit gate: adoption definition is met or consciously narrowed.</div>
+							<div class="gate">Exit gate: adoption definition is met or consciously narrowed; remaining boundary management is technically required, intentionally boring, or assigned to follow-up work; testing-feedback improvements are accepted or explicitly deferred.</div>
 						</div>
 						<div class="status-box">
 							<label for="status-M9">Roadmap status</label>
@@ -1496,7 +1505,7 @@
 	</div>
 
 	<script>
-		const storageKey = "abb-effect-roadmap-status-v1";
+		const storageKey = "abb-effect-roadmap-status-v2";
 		const sourceMarkdownPath =
 			"/Users/jstar/Projects/audiobook-boss/docs/specs/effect-adoption-roadmap.md";
 		const sourceMarkdownHref = "./effect-adoption-roadmap.md";
@@ -1525,16 +1534,17 @@ Full adoption means async orchestration, typed workflow errors, service layers, 
 - An Effect-native rule for new multi-boundary frontend work after M2.
 - Boring Specta and tauriClient contract posture.
 - Workflow tests without full Svelte rendering.
-- M9 residual-glue review.
+- M9 critical boundary/glue audit.
+- M9 Nextest-informed testing feedback audit.
 
 	Engineering blocks:
 - Setup: M0-M1 complete; destination accepted and Effect baseline installed.
 - EB1: M2-M3 complete; AppEffect kernel validated by ProcessingWorkflow extraction.
-- EB2: M4 + narrow M7 proof in flight; MetadataSaveWorkflow plus metadata workflow harness proof.
-- EB3: M5 + metadata slice of M6 planned; future workflow ingress plus metadata enrichment workflows.
-- EB4: Remaining M6 planned; import, preflight, and job-control workflow migration.
+- EB2: M4 + narrow M7 proof complete; MetadataSaveWorkflow plus metadata workflow harness proof.
+- EB3: M5 + metadata slice of M6 complete; future workflow ingress plus metadata enrichment workflows.
+- EB4: Remaining M6 complete; import, preflight, and job-control workflow migration.
 - EB5: M7-M8 planned; workflow service catalog, agent proof, docs, and boundary guardrails.
-- EB6: M9 planned; greenfield convergence review, highest-ROI test-gap audit, and merge-readiness decision.
+- EB6: M9 planned; greenfield convergence review, Nextest-informed test feedback, critical boundary/glue audit, highest-ROI test-gap audit, and merge-readiness decision.
 
 	Greenfield frontend frame:
 - Keep TypeScript as the frontend language.
@@ -1590,7 +1600,7 @@ ${sourceMarkdownPath}
 			document.querySelectorAll(".milestone").forEach((milestone) => {
 				const id = milestone.dataset.id;
 				const select = milestone.querySelector("[data-status-select]");
-				const status = statuses[id] || "not-started";
+				const status = statuses[id] || milestone.dataset.status || "not-started";
 				milestone.dataset.status = status;
 				select.value = status;
 			});

--- a/docs/specs/effect-adoption-roadmap.md
+++ b/docs/specs/effect-adoption-roadmap.md
@@ -1,7 +1,7 @@
 # ABB Effect Adoption Roadmap
 
 Date: 2026-05-17
-Status: Alignment draft, not repo canon
+Status: Active roadmap surface; work through EB4 is complete, EB5-EB6 remain
 Source repo: `/Users/jstar/Projects/audiobook-boss`
 
 Artifact relationship:
@@ -55,6 +55,7 @@ These are the known current-state smells the roadmap should actively pull toward
 | Status processing orchestration | `src/ui/statusPanel/processing.ts` coordinates IPC, metadata staging, output-plan review, progress startup, cancellation, processing result handling, and user-visible status truth. | `ProcessingWorkflow` owns the multi-boundary workflow; the status panel renders and dispatches. | M3 |
 | Metadata save and intent staging | Metadata draft/state/intent behavior is spread across frontend state/actions and Rust intent truth. Some TS duplication is useful for UX, but ownership can blur. | `MetadataSaveWorkflow` owns save orchestration, typed errors, state transitions, and boundary calls while Rust remains metadata truth. | M4 |
 | Guardrail script brittleness/noise | Boundary scripts are valuable assertions, but regex/text checks can become their own maintenance surface. | Adjust scripts only when a milestone creates or changes a real boundary assertion. Guardrails support the roadmap; they do not lead it. | M8 / opportunistic |
+| Residual false seams and glue boundaries | After EB4, any remaining wrapper, adapter, or boundary-like module may be real infrastructure or accidental boundary management. | EB6 classifies each meaningful seam as hard technical boundary, useful local implementation detail, or false seam to remove, deepen, or defer with an owner. | M9 |
 
 ## What Else The Roadmap Must Carry
 
@@ -64,7 +65,8 @@ The current ask is enough to lay out the roadmap. To accomplish the destination,
 - A sequencing rule for new frontend work: after M2, new multi-boundary workflows should start Effect-native instead of adding Promise glue that must be cleaned later.
 - A contract-drift posture: Specta remains generated evidence, `tauriClient` remains the owned adapter, and direct generated-binding imports remain exceptional until explicitly approved.
 - A test-harness target: workflows should be testable without rendering whole Svelte islands or requiring live Tauri/Rust behavior.
-- A residual-glue review at the end: every remaining glue surface is either accepted as local/boring, assigned follow-up work, or consciously left outside Effect's value zone.
+- A residual-glue review at the end: every remaining boundary-management surface is either proven technically needed and narrow, accepted as local/boring, assigned follow-up work, or consciously left outside Effect's value zone.
+- A testing-feedback audit at the end: adopt the high-value parts of Nextest/`cargo-nextest` for agent loops if they improve visibility, timing, failure summaries, machine-readable output, or retry/fail-fast behavior without weakening ABB's proof gates.
 - A guardrail posture: scripts/docs change only where a milestone changes a real ownership boundary.
 
 Remote Acquisition scope boundary:
@@ -83,9 +85,9 @@ Known:
 - The five current grey-box public APIs are Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Intent Plan, and Status Panel Runtime.
 - Frontend runtime commands/events route through `src/lib/tauri/client.ts`.
 - Generated bindings are committed for drift detection and adaptation, not direct UI use.
-- `package.json` has no `effect` or `@effect/*` dependency today.
+- `package.json` now includes `effect`; the AppEffect kernel and workflow-owner pattern have proof points through EB4.
 - `docs/specs/remote-acquisition.md` is a parallel feature-planning surface. This roadmap should shape its workflow architecture if needed, but should not own its feature delivery.
-- Candidate Effect proof surfaces are status processing, metadata save, and progress subscription.
+- Completed Effect proof surfaces through EB4 include processing orchestration, metadata save, metadata lookup/enrichment, output planning, import analysis, toolchain validation, and processing cancellation.
 
 Inferred:
 
@@ -256,11 +258,11 @@ Engineering blocks are the implementation packaging for the roadmap. Milestones 
 | --- | --- | --- | --- |
 | Setup | M0-M1 | Complete | Destination accepted and Effect dependency baseline installed. |
 | EB1 | M2-M3 | Complete | AppEffect kernel validated by ProcessingWorkflow extraction. |
-| EB2 | M4 + narrow M7 proof | In flight | MetadataSaveWorkflow extraction plus metadata workflow harness proof. |
-| EB3 | M5 + metadata slice of M6 | Planned | Future workflow ingress rule plus metadata enrichment workflows. |
-| EB4 | Remaining M6 | Planned | Import, preflight, and job-control workflow migration. |
+| EB2 | M4 + narrow M7 proof | Complete | MetadataSaveWorkflow extraction plus metadata workflow harness proof. |
+| EB3 | M5 + metadata slice of M6 | Complete | Future workflow ingress rule plus metadata enrichment workflows. |
+| EB4 | Remaining M6 | Complete | Import, preflight, and job-control workflow migration. |
 | EB5 | M7-M8 | Planned | Workflow service catalog, agent proof, docs, and boundary guardrails. |
-| EB6 | M9 | Planned | Greenfield convergence review, highest-ROI test-gap audit, and merge-readiness decision. |
+| EB6 | M9 | Planned | Greenfield convergence review, Nextest-informed test-feedback audit, critical boundary/glue audit, highest-ROI test-gap audit, and merge-readiness decision. |
 
 ## Roadmap Milestones
 
@@ -424,13 +426,16 @@ Exit gate:
 
 ### M9 - Greenfield Convergence Review
 
-Purpose: decide whether Effect is now ABB's frontend workflow default.
+Purpose: decide whether Effect is now ABB's frontend workflow default, whether remaining boundaries are genuinely needed, and whether the testing feedback loop is strong enough for future agent work.
 
 Deliverables:
 
 - List of migrated workflow owners.
 - List of intentionally vanilla surfaces.
-- List of remaining known glue surfaces, each either accepted, deferred, or assigned to a follow-up issue/spec.
+- Critical boundary and seam audit: every meaningful remaining wrapper, adapter, bridge, public strip, or boundary-like module is classified as a hard technical/domain boundary, useful local implementation detail, or false seam to remove, deepen, or defer with an owner.
+- List of remaining known glue surfaces, each either technically justified and narrow, accepted as local/boring, deferred, or assigned to a follow-up issue/spec.
+- Testing feedback audit: decide which Nextest/`cargo-nextest` surfaces ABB should adopt for better agent loops, such as per-test timing, slow-test summaries, JUnit/machine-readable output, fail-fast/retry profiles, and explicit doctest handling where needed.
+- Highest-ROI test-gap audit, led by gaps that would have reduced agent retry loops during the roadmap.
 - Remaining risks and no-go zones.
 - Decision: keep Effect private to workflow owners, broaden to `tauriClient`, or stop at current scope.
 - Decision: merge `roadmap/effect-adoption` to `main`, keep it open for a narrowed roadmap, or split remaining work into new issues.
@@ -438,6 +443,8 @@ Deliverables:
 Exit gate:
 
 - Adoption definition is met or consciously narrowed.
+- Remaining boundary management is either technically required and documented, intentionally boring, or assigned to follow-up work.
+- Testing-feedback improvements are either accepted into the proof path or explicitly deferred with rationale.
 - Active implementation spec is deleted after work is merged, validated, documented, and synced.
 - The roadmap branch is ready for final sync to `main`, or the remaining work has been explicitly rerouted.
 

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -42,5 +42,8 @@ Keep Effect private to workflow owners:
   Rust as metadata write truth.
 - `MetadataLookupWorkflow` validates metadata lookup queue progression and
   lookup-result cover-art replacement.
+- `OutputPlanWorkflow`, `ToolchainValidationWorkflow`,
+  `ImportAnalysisWorkflow`, and `ProcessingCancellationWorkflow` validate the
+  remaining processing-adjacent migration surfaces from EB4.
 - Manual cover-art file, URL, drop, and clear loading remains vanilla in
   `src/ui/coverArt.ts` until that flow proves it needs a workflow owner.

--- a/src/ui/__tests__/fileImport-coverArtDrop.test.ts
+++ b/src/ui/__tests__/fileImport-coverArtDrop.test.ts
@@ -243,7 +243,9 @@ describe('File import drop vs cover art drop isolation', () => {
 		fireDragDrop({ x: 200, y: 200 }, ['/tmp/book-a.mp3']);
 		await flushAsync();
 
-		expect(document.querySelectorAll('.file-list-item')).toHaveLength(1);
+		await waitFor(() => {
+			expect(document.querySelectorAll('.file-list-item')).toHaveLength(1);
+		});
 
 		openFilesMock.mockResolvedValueOnce(['/tmp/book-b.mp3']);
 		analyzeAudioFilesMock.mockResolvedValueOnce(
@@ -321,9 +323,6 @@ describe('File import drop vs cover art drop isolation', () => {
 			expect(document.querySelectorAll('.file-list-item')).toHaveLength(1);
 			expect(fileListViewState.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
 		});
-		expect(pushStatusPanelTransientStatusMock).toHaveBeenCalledWith(
-			'No new files added. All analyzed files were already in the list.',
-			{ ttlMs: 2000 },
-		);
+		expect(fileListViewState.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
 	});
 });

--- a/src/ui/__tests__/fileImport-handlers.test.ts
+++ b/src/ui/__tests__/fileImport-handlers.test.ts
@@ -21,6 +21,7 @@ vi.mock('../fileList/actions', () => ({
 }));
 
 vi.mock('../fileList/state.svelte', () => ({
+	getCurrentFileList: vi.fn(() => null),
 	isOrderLocked: vi.fn(() => false),
 }));
 

--- a/src/ui/__tests__/metadata-save-pending-flow.test.ts
+++ b/src/ui/__tests__/metadata-save-pending-flow.test.ts
@@ -76,9 +76,11 @@ vi.mock('../metadataForm', () => ({
 
 vi.mock('../fileList/state.svelte', () => ({
 	getCurrentFileList: context.getCurrentFileListMock,
+	isOrderLocked: vi.fn(() => false),
 }));
 
 vi.mock('../fileList/actions', () => ({
+	appendFileList: vi.fn(),
 	persistPendingMetadataDraftsForCurrentSelection: context.persistPendingDraftsMock,
 }));
 

--- a/src/ui/__tests__/outputPanel-preview-resilience.test.ts
+++ b/src/ui/__tests__/outputPanel-preview-resilience.test.ts
@@ -8,6 +8,7 @@ import { metadataFormState } from '../metadataForm/state.svelte';
 import { updateOutputPath } from '../outputPanel/preview';
 import {
 	outputPanelState,
+	setOutputPreview,
 	updateOutputDirectory,
 	updateNamingPreset,
 	updateAbsIncludeYear,
@@ -20,9 +21,12 @@ vi.mock('../../lib/tauri/client', () => ({
 }));
 
 describe('output panel preview resilience', () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		vi.mocked(tauriClient.previewOutputPath).mockReset();
+		updateOutputDirectory('');
+		setOutputPreview('Select output directory...', 'No directory selected');
 		render(OutputPanelIsland);
+		await Promise.resolve();
 		populateMetadataFormSingle({
 			title: 'Ghosts',
 			album: 'Ghosts',
@@ -33,6 +37,9 @@ describe('output panel preview resilience', () => {
 		updateAbsIncludeYear(false);
 		setJobTypeSelection('merge');
 		vi.mocked(tauriClient.previewOutputPath).mockResolvedValue('/Library/Audiobooks/Ghosts.m4b');
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		vi.mocked(tauriClient.previewOutputPath).mockClear();
+		setOutputPreview('Select output directory...', 'No directory selected');
 	});
 
 	afterEach(() => {
@@ -44,7 +51,9 @@ describe('output panel preview resilience', () => {
 
 		const previewText = document.getElementById('output-preview-text');
 		await waitFor(() => {
-			expect(vi.mocked(tauriClient.previewOutputPath)).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(tauriClient.previewOutputPath)).toHaveBeenCalledWith(
+				expect.objectContaining({ outputKind: 'final' }),
+			);
 			expect(outputPanelState.previewText).toContain('/Library/Audiobooks');
 			expect(previewText?.textContent).toContain('/Library/Audiobooks');
 		});

--- a/src/ui/encoderPanel/__tests__/toolchainValidationWorkflow.test.ts
+++ b/src/ui/encoderPanel/__tests__/toolchainValidationWorkflow.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Effect, runAppEffect } from '../../../lib/effect/appEffect';
+import type { EncoderAvailability } from '../../../types/audio';
+import {
+	makeToolchainValidationWorkflowServicesLayer,
+	toolchainValidationWorkflowExecution,
+	type ToolchainValidationWorkflowServices,
+} from '../toolchainValidationWorkflow';
+
+function availability(overrides: Partial<EncoderAvailability> = {}): EncoderAvailability {
+	return {
+		fdkAvailable: true,
+		aacAtAvailable: true,
+		nativeAacAvailable: true,
+		fdkSource: 'detected',
+		autoEncoder: 'fdk_he_aac',
+		detectedToolchainPath: '/opt/homebrew/bin/ffmpeg',
+		overrideToolchainPath: undefined,
+		activeToolchainPath: '/opt/homebrew/bin/ffmpeg',
+		overrideInvalid: false,
+		overrideError: undefined,
+		statusMessage: 'FDK AAC detected and ready.',
+		...overrides,
+	};
+}
+
+function makeHarness(overrides: Partial<ToolchainValidationWorkflowServices> = {}) {
+	const services: ToolchainValidationWorkflowServices = {
+		readToolchainSettingsFromState: vi.fn(() => ({})),
+		setEncoderAvailability: vi.fn(),
+		setExternalToolchainOverridePath: vi.fn(),
+		syncAfterAvailabilityChange: vi.fn(),
+		syncAfterToolchainPathChange: vi.fn(),
+		openFile: vi.fn(async () => null),
+		listAvailableEncoders: vi.fn(async () => availability()),
+		refreshExternalToolchain: vi.fn(async () => availability({ fdkSource: 'override' })),
+		console: {
+			log: vi.fn(),
+			warn: vi.fn(),
+		},
+		...overrides,
+	};
+
+	return {
+		services,
+		layer: makeToolchainValidationWorkflowServicesLayer(services),
+	};
+}
+
+describe('ToolchainValidationWorkflow', () => {
+	it('loads initial encoder availability and synchronizes derived state', async () => {
+		const loaded = availability();
+		const harness = makeHarness({
+			listAvailableEncoders: vi.fn(async () => loaded),
+		});
+
+		await runAppEffect(
+			toolchainValidationWorkflowExecution({ type: 'hydrateAvailability' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.listAvailableEncoders).toHaveBeenCalledWith({});
+		expect(harness.services.setEncoderAvailability).toHaveBeenCalledWith(loaded);
+		expect(harness.services.syncAfterAvailabilityChange).toHaveBeenCalledTimes(1);
+	});
+
+	it('maps availability load failure to unavailable state and still syncs UI state', async () => {
+		const cause = new Error('toolchain probe failed');
+		const harness = makeHarness({
+			listAvailableEncoders: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			toolchainValidationWorkflowExecution({ type: 'hydrateAvailability' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.setEncoderAvailability).toHaveBeenCalledWith(null);
+		expect(harness.services.console.warn).toHaveBeenCalledWith(
+			'Failed to load encoder availability',
+			cause,
+		);
+		expect(harness.services.syncAfterAvailabilityChange).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing when toolchain browse is cancelled', async () => {
+		const harness = makeHarness({
+			openFile: vi.fn(async () => null),
+		});
+
+		await runAppEffect(
+			toolchainValidationWorkflowExecution({ type: 'browseToolchain' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.setExternalToolchainOverridePath).not.toHaveBeenCalled();
+		expect(harness.services.refreshExternalToolchain).not.toHaveBeenCalled();
+	});
+
+	it('stores browsed toolchain path and refreshes availability', async () => {
+		const refreshed = availability({
+			fdkSource: 'override',
+			activeToolchainPath: '/custom/ffmpeg',
+		});
+		const harness = makeHarness({
+			openFile: vi.fn(async () => '/custom/ffmpeg'),
+			refreshExternalToolchain: vi.fn(async () => refreshed),
+		});
+
+		await runAppEffect(
+			toolchainValidationWorkflowExecution({ type: 'browseToolchain' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.setExternalToolchainOverridePath).toHaveBeenCalledWith(
+			'/custom/ffmpeg',
+		);
+		expect(harness.services.syncAfterToolchainPathChange).toHaveBeenCalledTimes(1);
+		expect(harness.services.refreshExternalToolchain).toHaveBeenCalledWith({});
+		expect(harness.services.setEncoderAvailability).toHaveBeenCalledWith(refreshed);
+	});
+
+	it('clears override before refreshing availability', async () => {
+		const harness = makeHarness();
+
+		await runAppEffect(
+			toolchainValidationWorkflowExecution({ type: 'clearOverride' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.setExternalToolchainOverridePath).toHaveBeenCalledWith('');
+		expect(harness.services.syncAfterToolchainPathChange).toHaveBeenCalledTimes(1);
+		expect(harness.services.refreshExternalToolchain).toHaveBeenCalledWith({});
+	});
+});

--- a/src/ui/encoderPanel/logic.ts
+++ b/src/ui/encoderPanel/logic.ts
@@ -10,7 +10,6 @@ import {
 	readSampleRateFromState,
 	readToolchainSettingsFromState,
 	setChannelsAutoHint,
-	setEncoderAvailability,
 	setExternalToolchainOverridePath,
 	setSampleRateAutoHint,
 	type BitrateModeSelection,
@@ -18,8 +17,8 @@ import {
 } from './state.svelte';
 import type { EncoderFlavor } from '../../types/encoder';
 import type { EncoderAvailability } from '../../types/audio';
-import { tauriClient } from '../../lib/tauri/client';
 import { resetAutoResolutionHints } from './autoResolutionHints';
+import { runToolchainValidationWorkflow } from './toolchainValidationWorkflow';
 
 const DEBUG = import.meta.env.DEV;
 const debugLog = (...args: unknown[]): void => {
@@ -235,25 +234,12 @@ const syncEncoderState = (): void => {
 	updateAvailabilityHint();
 };
 
-const syncAfterStateChange = (): void => {
+export const syncAfterStateChange = (): void => {
 	syncEncoderState();
 	syncOutputSizingFromEncoderState();
 };
 
-const hydrateAvailability = async (mode: 'initial' | 'refresh' = 'initial'): Promise<void> => {
-	try {
-		const settings = readToolchainSettingsFromState();
-		const availability =
-			mode === 'refresh'
-				? await tauriClient.refreshExternalToolchain(settings)
-				: await tauriClient.listAvailableEncoders(settings);
-		debugLog('Encoder availability:', availability);
-		setEncoderAvailability(availability);
-	} catch (error) {
-		console.warn('Failed to load encoder availability', error);
-		setEncoderAvailability(null);
-	}
-
+export const syncEncoderPanelAfterAvailabilityChange = (): void => {
 	syncEncoderState();
 	syncOutputSizingFromEncoderState();
 	debugLog('Encoder panel ready');
@@ -265,7 +251,7 @@ export const initializeEncoderPanelLogic = (): void => {
 	setSampleRateAutoHint('Auto resolves from source audio.');
 	setChannelsAutoHint('Auto resolves from source audio.');
 	syncOutputSizingFromEncoderState();
-	void hydrateAvailability();
+	void runToolchainValidationWorkflow({ type: 'hydrateAvailability' });
 };
 
 export const handleFlavorChange = (event: Event): void => {
@@ -328,33 +314,19 @@ export const handleToolchainPathInput = (event: Event): void => {
 
 export const handleToolchainPathCommit = (): void => {
 	syncAfterStateChange();
-	void hydrateAvailability('refresh');
+	void runToolchainValidationWorkflow({ type: 'commitOverride' });
 };
 
 export const handleToolchainBrowse = async (): Promise<void> => {
-	try {
-		const selected = await tauriClient.openFile({
-			title: 'Select ffmpeg executable',
-		});
-		if (!selected) {
-			return;
-		}
-		setExternalToolchainOverridePath(selected);
-		syncAfterStateChange();
-		await hydrateAvailability('refresh');
-	} catch (error) {
-		console.warn('Failed to choose ffmpeg executable', error);
-	}
+	await runToolchainValidationWorkflow({ type: 'browseToolchain' });
 };
 
 export const clearToolchainOverride = (): void => {
-	setExternalToolchainOverridePath('');
-	syncAfterStateChange();
-	void hydrateAvailability('refresh');
+	void runToolchainValidationWorkflow({ type: 'clearOverride' });
 };
 
 export const refreshExternalToolchain = (): void => {
-	void hydrateAvailability('refresh');
+	void runToolchainValidationWorkflow({ type: 'refresh' });
 };
 
 export const handleSampleRateSelectionChange = (event: Event): void => {

--- a/src/ui/encoderPanel/toolchainValidationWorkflow.ts
+++ b/src/ui/encoderPanel/toolchainValidationWorkflow.ts
@@ -1,0 +1,135 @@
+import { Data, Effect, type AppEffect, runAppEffect } from '../../lib/effect/appEffect';
+import {
+	ToolchainValidationWorkflowServicesTag,
+	type ToolchainHydrationMode,
+	type ToolchainValidationWorkflowAction,
+	type ToolchainValidationWorkflowLayer,
+	type ToolchainValidationWorkflowServicesId,
+} from './toolchainValidationWorkflowServices';
+
+export {
+	ToolchainValidationWorkflowServicesTag,
+	makeToolchainValidationWorkflowServicesLayer,
+	type ToolchainHydrationMode,
+	type ToolchainValidationWorkflowAction,
+	type ToolchainValidationWorkflowLayer,
+	type ToolchainValidationWorkflowServices,
+	type ToolchainValidationWorkflowServicesId,
+} from './toolchainValidationWorkflowServices';
+
+export class ToolchainValidationWorkflowFailed extends Data.TaggedError(
+	'ToolchainValidationWorkflowFailed',
+)<{
+	readonly message: string;
+	readonly cause: unknown;
+}> {}
+
+function workflowFailure(message: string, cause: unknown): ToolchainValidationWorkflowFailed {
+	return new ToolchainValidationWorkflowFailed({ message, cause });
+}
+
+function workflowPromise<A>(
+	evaluate: () => PromiseLike<A>,
+	message: string,
+): AppEffect<A, ToolchainValidationWorkflowFailed> {
+	return Effect.tryPromise({
+		try: evaluate,
+		catch: (cause) => workflowFailure(message, cause),
+	});
+}
+
+function hydrateAvailability(
+	mode: ToolchainHydrationMode,
+): AppEffect<void, never, ToolchainValidationWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ToolchainValidationWorkflowServicesTag;
+		const settings = services.readToolchainSettingsFromState();
+		const availability = yield* workflowPromise(
+			() =>
+				mode === 'refresh'
+					? services.refreshExternalToolchain(settings)
+					: services.listAvailableEncoders(settings),
+			'Failed to load encoder availability.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.console.warn('Failed to load encoder availability', error.cause);
+					return null;
+				}),
+			),
+		);
+
+		services.console.log('Encoder availability:', availability);
+		services.setEncoderAvailability(availability);
+		services.syncAfterAvailabilityChange();
+		services.console.log('Encoder panel ready');
+	});
+}
+
+function browseToolchain(): AppEffect<void, never, ToolchainValidationWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ToolchainValidationWorkflowServicesTag;
+		const selected = yield* workflowPromise(
+			() => services.openFile({ title: 'Select ffmpeg executable' }),
+			'Failed to choose ffmpeg executable.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.console.warn('Failed to choose ffmpeg executable', error.cause);
+					return null;
+				}),
+			),
+		);
+		if (!selected) {
+			return;
+		}
+
+		services.setExternalToolchainOverridePath(selected);
+		services.syncAfterToolchainPathChange();
+		yield* hydrateAvailability('refresh');
+	});
+}
+
+function toolchainValidationWorkflowBody(
+	action: ToolchainValidationWorkflowAction,
+): AppEffect<void, never, ToolchainValidationWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ToolchainValidationWorkflowServicesTag;
+		switch (action.type) {
+			case 'hydrateAvailability':
+				yield* hydrateAvailability(action.mode ?? 'initial');
+				return;
+			case 'browseToolchain':
+				yield* browseToolchain();
+				return;
+			case 'clearOverride':
+				services.setExternalToolchainOverridePath('');
+				services.syncAfterToolchainPathChange();
+				yield* hydrateAvailability('refresh');
+				return;
+			case 'commitOverride':
+			case 'refresh':
+				yield* hydrateAvailability('refresh');
+				return;
+		}
+	});
+}
+
+async function defaultToolchainValidationWorkflowLayer(): Promise<ToolchainValidationWorkflowLayer> {
+	const live = await import('./toolchainValidationWorkflowLive');
+	return live.ToolchainValidationWorkflowLive;
+}
+
+export function toolchainValidationWorkflowExecution(
+	action: ToolchainValidationWorkflowAction,
+): AppEffect<void, never, ToolchainValidationWorkflowServicesId> {
+	return toolchainValidationWorkflowBody(action);
+}
+
+export async function runToolchainValidationWorkflow(
+	action: ToolchainValidationWorkflowAction,
+	layer?: ToolchainValidationWorkflowLayer,
+): Promise<void> {
+	const workflowLayer = layer ?? (await defaultToolchainValidationWorkflowLayer());
+	return runAppEffect(toolchainValidationWorkflowBody(action).pipe(Effect.provide(workflowLayer)));
+}

--- a/src/ui/encoderPanel/toolchainValidationWorkflowLive.ts
+++ b/src/ui/encoderPanel/toolchainValidationWorkflowLive.ts
@@ -1,0 +1,27 @@
+import { tauriClient } from '../../lib/tauri/client';
+import {
+	readToolchainSettingsFromState,
+	setEncoderAvailability,
+	setExternalToolchainOverridePath,
+} from './state.svelte';
+import { syncAfterStateChange, syncEncoderPanelAfterAvailabilityChange } from './logic';
+import {
+	makeToolchainValidationWorkflowServicesLayer,
+	type ToolchainValidationWorkflowServices,
+} from './toolchainValidationWorkflowServices';
+
+export const liveToolchainValidationWorkflowServices: ToolchainValidationWorkflowServices = {
+	readToolchainSettingsFromState,
+	setEncoderAvailability,
+	setExternalToolchainOverridePath,
+	syncAfterAvailabilityChange: syncEncoderPanelAfterAvailabilityChange,
+	syncAfterToolchainPathChange: syncAfterStateChange,
+	openFile: tauriClient.openFile,
+	listAvailableEncoders: tauriClient.listAvailableEncoders,
+	refreshExternalToolchain: tauriClient.refreshExternalToolchain,
+	console,
+};
+
+export const ToolchainValidationWorkflowLive = makeToolchainValidationWorkflowServicesLayer(
+	liveToolchainValidationWorkflowServices,
+);

--- a/src/ui/encoderPanel/toolchainValidationWorkflowServices.ts
+++ b/src/ui/encoderPanel/toolchainValidationWorkflowServices.ts
@@ -1,0 +1,47 @@
+import type { tauriClient } from '../../lib/tauri/client';
+import {
+	type AppLayer,
+	makeWorkflowLayer,
+	makeWorkflowServiceTag,
+} from '../../lib/effect/appEffect';
+import type {
+	readToolchainSettingsFromState,
+	setEncoderAvailability,
+	setExternalToolchainOverridePath,
+} from './state.svelte';
+
+export type ToolchainHydrationMode = 'initial' | 'refresh';
+
+export interface ToolchainValidationWorkflowServices {
+	readToolchainSettingsFromState: typeof readToolchainSettingsFromState;
+	setEncoderAvailability: typeof setEncoderAvailability;
+	setExternalToolchainOverridePath: typeof setExternalToolchainOverridePath;
+	syncAfterAvailabilityChange: () => void;
+	syncAfterToolchainPathChange: () => void;
+	openFile: typeof tauriClient.openFile;
+	listAvailableEncoders: typeof tauriClient.listAvailableEncoders;
+	refreshExternalToolchain: typeof tauriClient.refreshExternalToolchain;
+	console: Pick<Console, 'log' | 'warn'>;
+}
+
+export type ToolchainValidationWorkflowAction =
+	| { type: 'hydrateAvailability'; mode?: ToolchainHydrationMode }
+	| { type: 'browseToolchain' }
+	| { type: 'clearOverride' }
+	| { type: 'commitOverride' }
+	| { type: 'refresh' };
+
+export type ToolchainValidationWorkflowServicesId =
+	'EncoderPanel/ToolchainValidationWorkflowServices';
+export type ToolchainValidationWorkflowLayer = AppLayer<ToolchainValidationWorkflowServicesId>;
+
+export const ToolchainValidationWorkflowServicesTag = makeWorkflowServiceTag<
+	ToolchainValidationWorkflowServicesId,
+	ToolchainValidationWorkflowServices
+>('EncoderPanel/ToolchainValidationWorkflowServices');
+
+export function makeToolchainValidationWorkflowServicesLayer(
+	services: ToolchainValidationWorkflowServices,
+): ToolchainValidationWorkflowLayer {
+	return makeWorkflowLayer(ToolchainValidationWorkflowServicesTag, services);
+}

--- a/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
+++ b/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
@@ -127,8 +127,34 @@ describe('ImportAnalysisWorkflow', () => {
 		);
 
 		expect(harness.services.appendFileList).not.toHaveBeenCalled();
+		expect(harness.services.console.error).toHaveBeenCalledWith('Failed to analyze files:', cause);
 		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
-			`Failed to analyze files: ${cause}`,
+			'Failed to analyze files. Please try again.',
+		);
+	});
+
+	it('reports file picker failures without rendering technical details', async () => {
+		const cause = new Error('dialog failed');
+		const harness = makeHarness({
+			openFiles: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'clickToSelect',
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.analyzeAudioFiles).not.toHaveBeenCalled();
+		expect(harness.services.console.error).toHaveBeenCalledWith(
+			'Failed to open file dialog:',
+			cause,
+		);
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'Failed to open file dialog. Please try again.',
 		);
 	});
 
@@ -147,6 +173,31 @@ describe('ImportAnalysisWorkflow', () => {
 		expect(harness.services.appendFileList).not.toHaveBeenCalled();
 		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
 			'Fix metadata validation errors before adding files.',
+		);
+	});
+
+	it('reports metadata staging exceptions separately from analysis failures', async () => {
+		const cause = new Error('draft store failed');
+		const harness = makeHarness({
+			persistPendingMetadataDraftsForCurrentSelection: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'clickToSelect',
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.appendFileList).not.toHaveBeenCalled();
+		expect(harness.services.console.error).toHaveBeenCalledWith(
+			'Failed to stage metadata drafts:',
+			cause,
+		);
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'Failed to prepare metadata drafts before adding files. Please try again.',
 		);
 	});
 

--- a/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
+++ b/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Effect, runAppEffect } from '../../../lib/effect/appEffect';
+import type { AudioFile, FileListInfo } from '../../../types/audio';
+import {
+	importAnalysisWorkflowExecution,
+	makeImportAnalysisWorkflowServicesLayer,
+	type ImportAnalysisWorkflowServices,
+} from '../importAnalysisWorkflow';
+
+function audioFile(path: string): AudioFile {
+	return {
+		path,
+		isValid: true,
+		duration: 1,
+		size: 100,
+		format: 'm4b',
+	} as AudioFile;
+}
+
+function fileListInfo(files: AudioFile[] = [audioFile('/books/new.m4b')]): FileListInfo {
+	return {
+		files,
+		selectedDecoders: files.map(() => null),
+		totalDuration: files.length,
+		totalSize: files.length * 100,
+		validCount: files.length,
+		invalidCount: 0,
+	} as FileListInfo;
+}
+
+function makeHarness(overrides: Partial<ImportAnalysisWorkflowServices> = {}) {
+	const services: ImportAnalysisWorkflowServices = {
+		isOrderLocked: vi.fn(() => false),
+		openFiles: vi.fn(async () => ['/books/new.m4b']),
+		analyzeAudioFiles: vi.fn(async () => fileListInfo()),
+		persistPendingMetadataDraftsForCurrentSelection: vi.fn(async () => true),
+		appendFileList: vi.fn(),
+		pushStatusPanelTransientStatus: vi.fn(),
+		setFileImportError: vi.fn(),
+		clearFileImportError: vi.fn(),
+		console: { error: vi.fn() },
+		...overrides,
+	};
+
+	return {
+		services,
+		layer: makeImportAnalysisWorkflowServicesLayer(services),
+	};
+}
+
+describe('ImportAnalysisWorkflow', () => {
+	it('blocks import while file order is locked', async () => {
+		const harness = makeHarness({ isOrderLocked: vi.fn(() => true) });
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'clickToSelect',
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.openFiles).not.toHaveBeenCalled();
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'Order locked while processing. Wait for completion to add files.',
+		);
+	});
+
+	it('does nothing when file picker is cancelled', async () => {
+		const harness = makeHarness({ openFiles: vi.fn(async () => null) });
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'clickToSelect',
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.analyzeAudioFiles).not.toHaveBeenCalled();
+		expect(harness.services.appendFileList).not.toHaveBeenCalled();
+	});
+
+	it('reports unsupported drops before backend analysis', async () => {
+		const harness = makeHarness();
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'dropFiles',
+				paths: ['/tmp/notes.txt', '/tmp/image.png'],
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.analyzeAudioFiles).not.toHaveBeenCalled();
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'No supported audio files dropped. Please use mp3, m4a, m4b, aac, wav, flac files.',
+		);
+	});
+
+	it('filters supported drop paths before analysis', async () => {
+		const harness = makeHarness();
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'dropFiles',
+				paths: ['/tmp/a.wav', '/tmp/b.txt', '/tmp/c.M4B'],
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.analyzeAudioFiles).toHaveBeenCalledWith(['/tmp/a.wav', '/tmp/c.M4B']);
+	});
+
+	it('reports analysis failure without appending files', async () => {
+		const cause = new Error('analysis failed');
+		const harness = makeHarness({
+			analyzeAudioFiles: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'dropFiles',
+				paths: ['/tmp/a.m4b'],
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.appendFileList).not.toHaveBeenCalled();
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			`Failed to analyze files: ${cause}`,
+		);
+	});
+
+	it('does not append files when metadata staging fails', async () => {
+		const harness = makeHarness({
+			persistPendingMetadataDraftsForCurrentSelection: vi.fn(async () => false),
+		});
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'clickToSelect',
+				existingFiles: [],
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.appendFileList).not.toHaveBeenCalled();
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'Fix metadata validation errors before adding files.',
+		);
+	});
+
+	it('appends analyzed files and clears import errors on success', async () => {
+		const existingFiles = [audioFile('/books/existing.m4b')];
+		const analyzed = fileListInfo([audioFile('/books/new.m4b')]);
+		const harness = makeHarness({
+			analyzeAudioFiles: vi.fn(async () => analyzed),
+		});
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'clickToSelect',
+				existingFiles,
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.appendFileList).toHaveBeenCalledWith(analyzed, { existingFiles });
+		expect(harness.services.clearFileImportError).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports duplicate-only imports without asking file list to emit duplicate status', async () => {
+		const existingFiles = [audioFile('/books/existing.m4b')];
+		const analyzed = fileListInfo([audioFile('/books/existing.m4b')]);
+		const harness = makeHarness({
+			analyzeAudioFiles: vi.fn(async () => analyzed),
+		});
+
+		await runAppEffect(
+			importAnalysisWorkflowExecution({
+				type: 'dropFiles',
+				paths: ['/books/existing.m4b'],
+				existingFiles,
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.appendFileList).toHaveBeenCalledWith(analyzed, {
+			existingFiles,
+			showDuplicateStatus: false,
+		});
+		expect(harness.services.pushStatusPanelTransientStatus).toHaveBeenCalledWith(
+			'No new files added. All analyzed files were already in the list.',
+			{ ttlMs: 2000 },
+		);
+		expect(harness.services.clearFileImportError).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/ui/fileImport/handlers.ts
+++ b/src/ui/fileImport/handlers.ts
@@ -1,18 +1,14 @@
 import { tauriClient } from '../../lib/tauri/client';
-import type { AudioFile, FileListInfo } from '../../types/audio';
+import type { AudioFile } from '../../types/audio';
 import { isFileDropEvent } from '../../types/events';
 import { applyCoverArtDrop } from '../coverArt';
+import { getCurrentFileList } from '../fileList/state.svelte';
+import { setFileImportDragOver } from './state.svelte';
+import { enterImportAnalysisWorkflow, runImportAnalysisWorkflow } from './importAnalysisWorkflow';
 import {
-	appendFileList,
-	persistPendingMetadataDraftsForCurrentSelection,
-} from '../fileList/actions';
-import { isOrderLocked } from '../fileList/state.svelte';
-import { clearFileImportError, setFileImportDragOver, setFileImportError } from './state.svelte';
-import {
-	SUPPORTED_AUDIO_EXTENSIONS,
-	SUPPORTED_AUDIO_FORMATS_TEXT,
-	isSupportedAudioPath,
-} from './supportedAudio';
+	ImportAnalysisWorkflowLive,
+	liveImportAnalysisWorkflowServices,
+} from './importAnalysisWorkflowLive';
 
 export interface DragDropContext {
 	getCoverArtArea: () => HTMLElement | null;
@@ -102,66 +98,23 @@ export function attachTauriDragHandlers(context: DragDropContext): Unlisten {
 }
 
 export async function handleClickToSelect(existingFiles: AudioFile[] = []): Promise<void> {
-	if (isOrderLocked()) {
-		setFileImportError('Order locked while processing. Wait for completion to add files.');
+	const currentFiles =
+		existingFiles.length > 0 ? existingFiles : (getCurrentFileList()?.files ?? []);
+	const action = { type: 'clickToSelect' as const, existingFiles: currentFiles };
+	const preparedEntry = enterImportAnalysisWorkflow(liveImportAnalysisWorkflowServices, action);
+	if (!preparedEntry) {
 		return;
 	}
-
-	try {
-		const selected = await tauriClient.openFiles({
-			filters: [
-				{
-					name: 'Audio Files',
-					extensions: [...SUPPORTED_AUDIO_EXTENSIONS],
-				},
-			],
-		});
-
-		if (Array.isArray(selected) && selected.length > 0) {
-			await processFilePaths(selected, existingFiles);
-		}
-	} catch (error) {
-		setFileImportError(`Failed to open file dialog: ${error}`);
-	}
+	await runImportAnalysisWorkflow(action, ImportAnalysisWorkflowLive, preparedEntry);
 }
 
 async function handleFileDrop(paths: string[], existingFiles: AudioFile[]): Promise<void> {
-	if (isOrderLocked()) {
-		setFileImportError('Order locked while processing. Wait for completion to add files.');
+	const currentFiles =
+		existingFiles.length > 0 ? existingFiles : (getCurrentFileList()?.files ?? []);
+	const action = { type: 'dropFiles' as const, paths, existingFiles: currentFiles };
+	const preparedEntry = enterImportAnalysisWorkflow(liveImportAnalysisWorkflowServices, action);
+	if (!preparedEntry) {
 		return;
 	}
-
-	const supportedPaths = filterSupportedFiles(paths);
-	if (supportedPaths.length === 0) {
-		setFileImportError(
-			`No supported audio files dropped. Please use ${SUPPORTED_AUDIO_FORMATS_TEXT} files.`,
-		);
-		return;
-	}
-
-	await processFilePaths(supportedPaths, existingFiles);
-}
-
-function filterSupportedFiles(paths: string[]): string[] {
-	return paths.filter((path) => isSupportedAudioPath(path));
-}
-
-async function processFilePaths(
-	filePaths: string[],
-	existingFiles: AudioFile[] = [],
-): Promise<void> {
-	if (filePaths.length === 0) return;
-
-	try {
-		const fileListInfo: FileListInfo = await tauriClient.analyzeAudioFiles(filePaths);
-		const staged = await persistPendingMetadataDraftsForCurrentSelection();
-		if (!staged) {
-			setFileImportError('Fix metadata validation errors before adding files.');
-			return;
-		}
-		appendFileList(fileListInfo, { existingFiles });
-		clearFileImportError();
-	} catch (error) {
-		setFileImportError(`Failed to analyze files: ${error}`);
-	}
+	await runImportAnalysisWorkflow(action, ImportAnalysisWorkflowLive, preparedEntry);
 }

--- a/src/ui/fileImport/importAnalysisWorkflow.ts
+++ b/src/ui/fileImport/importAnalysisWorkflow.ts
@@ -66,6 +66,35 @@ function unsupportedDropMessage(): string {
 	return `No supported audio files dropped. Please use ${SUPPORTED_AUDIO_FORMATS_TEXT} files.`;
 }
 
+function reportAnalysisFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): FileListInfo | null {
+	services.console.error('Failed to analyze files:', cause);
+	services.setFileImportError('Failed to analyze files. Please try again.');
+	return null;
+}
+
+function reportMetadataStagingFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): false {
+	services.console.error('Failed to stage metadata drafts:', cause);
+	services.setFileImportError(
+		'Failed to prepare metadata drafts before adding files. Please try again.',
+	);
+	return false;
+}
+
+function reportOpenFileDialogFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): null {
+	services.console.error('Failed to open file dialog:', cause);
+	services.setFileImportError('Failed to open file dialog. Please try again.');
+	return null;
+}
+
 function hasOnlyDuplicateFiles(fileListInfo: FileListInfo, existingFiles: AudioFile[]): boolean {
 	if (existingFiles.length === 0 || fileListInfo.files.length === 0) {
 		return false;
@@ -110,8 +139,7 @@ function processFilePaths(
 		).pipe(
 			Effect.catchAll((error) =>
 				Effect.sync(() => {
-					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
-					return null as FileListInfo | null;
+					return reportAnalysisFailure(services, error.cause);
 				}),
 			),
 		);
@@ -125,8 +153,7 @@ function processFilePaths(
 		).pipe(
 			Effect.catchAll((error) =>
 				Effect.sync(() => {
-					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
-					return false;
+					return reportMetadataStagingFailure(services, error.cause);
 				}),
 			),
 		);
@@ -152,8 +179,7 @@ function processPreparedFileList(
 		).pipe(
 			Effect.catchAll((error) =>
 				Effect.sync(() => {
-					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
-					return null as FileListInfo | null;
+					return reportAnalysisFailure(services, error.cause);
 				}),
 			),
 		);
@@ -167,8 +193,7 @@ function processPreparedFileList(
 		).pipe(
 			Effect.catchAll((error) =>
 				Effect.sync(() => {
-					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
-					return false;
+					return reportMetadataStagingFailure(services, error.cause);
 				}),
 			),
 		);
@@ -206,8 +231,7 @@ function clickToSelect(
 		).pipe(
 			Effect.catchAll((error) =>
 				Effect.sync(() => {
-					services.setFileImportError(`Failed to open file dialog: ${error.cause}`);
-					return null;
+					return reportOpenFileDialogFailure(services, error.cause);
 				}),
 			),
 		);
@@ -229,8 +253,7 @@ function clickToSelectFromPrepared(
 		).pipe(
 			Effect.catchAll((error) =>
 				Effect.sync(() => {
-					services.setFileImportError(`Failed to open file dialog: ${error.cause}`);
-					return null;
+					return reportOpenFileDialogFailure(services, error.cause);
 				}),
 			),
 		);
@@ -305,7 +328,7 @@ export function enterImportAnalysisWorkflow(
 				existingFiles: action.existingFiles,
 			};
 		} catch (cause) {
-			services.setFileImportError(`Failed to open file dialog: ${cause}`);
+			reportOpenFileDialogFailure(services, cause);
 			return null;
 		}
 	}
@@ -323,7 +346,7 @@ export function enterImportAnalysisWorkflow(
 			existingFiles: action.existingFiles,
 		};
 	} catch (cause) {
-		services.setFileImportError(`Failed to analyze files: ${cause}`);
+		reportAnalysisFailure(services, cause);
 		return null;
 	}
 }

--- a/src/ui/fileImport/importAnalysisWorkflow.ts
+++ b/src/ui/fileImport/importAnalysisWorkflow.ts
@@ -1,0 +1,351 @@
+import { Data, Effect, type AppEffect, runAppEffect } from '../../lib/effect/appEffect';
+import type { AudioFile, FileListInfo } from '../../types/audio';
+import {
+	SUPPORTED_AUDIO_EXTENSIONS,
+	SUPPORTED_AUDIO_FORMATS_TEXT,
+	isSupportedAudioPath,
+} from './supportedAudio';
+import {
+	ImportAnalysisWorkflowServicesTag,
+	type ImportAnalysisWorkflowAction,
+	type ImportAnalysisWorkflowLayer,
+	type ImportAnalysisWorkflowServices,
+	type ImportAnalysisWorkflowServicesId,
+} from './importAnalysisWorkflowServices';
+
+export {
+	ImportAnalysisWorkflowServicesTag,
+	makeImportAnalysisWorkflowServicesLayer,
+	type ImportAnalysisFileListResult,
+	type ImportAnalysisWorkflowAction,
+	type ImportAnalysisWorkflowLayer,
+	type ImportAnalysisWorkflowServices,
+	type ImportAnalysisWorkflowServicesId,
+} from './importAnalysisWorkflowServices';
+
+export class ImportAnalysisWorkflowFailed extends Data.TaggedError('ImportAnalysisWorkflowFailed')<{
+	readonly message: string;
+	readonly cause: unknown;
+}> {}
+
+export type PreparedImportAnalysisWorkflowEntry =
+	| {
+			readonly type: 'openFiles';
+			readonly selectedPaths: ReturnType<ImportAnalysisWorkflowServices['openFiles']>;
+			readonly existingFiles: AudioFile[];
+	  }
+	| {
+			readonly type: 'analyzeFiles';
+			readonly fileListInfo: ReturnType<ImportAnalysisWorkflowServices['analyzeAudioFiles']>;
+			readonly existingFiles: AudioFile[];
+	  };
+
+function workflowFailure(message: string, cause: unknown): ImportAnalysisWorkflowFailed {
+	return new ImportAnalysisWorkflowFailed({ message, cause });
+}
+
+function workflowPromise<A>(
+	evaluate: () => PromiseLike<A>,
+	message: string,
+): AppEffect<A, ImportAnalysisWorkflowFailed> {
+	return Effect.tryPromise({
+		try: evaluate,
+		catch: (cause) => workflowFailure(message, cause),
+	});
+}
+
+function filterSupportedFiles(paths: string[]): string[] {
+	return paths.filter((path) => isSupportedAudioPath(path));
+}
+
+function orderLockedMessage(): string {
+	return 'Order locked while processing. Wait for completion to add files.';
+}
+
+function unsupportedDropMessage(): string {
+	return `No supported audio files dropped. Please use ${SUPPORTED_AUDIO_FORMATS_TEXT} files.`;
+}
+
+function hasOnlyDuplicateFiles(fileListInfo: FileListInfo, existingFiles: AudioFile[]): boolean {
+	if (existingFiles.length === 0 || fileListInfo.files.length === 0) {
+		return false;
+	}
+	const existingPaths = new Set(existingFiles.map((file) => file.path));
+	return fileListInfo.files.every((file) => existingPaths.has(file.path));
+}
+
+function appendAnalyzedFiles(
+	services: ImportAnalysisWorkflowServices,
+	fileListInfo: FileListInfo,
+	existingFiles: AudioFile[],
+): void {
+	if (hasOnlyDuplicateFiles(fileListInfo, existingFiles)) {
+		services.appendFileList(fileListInfo, {
+			existingFiles,
+			showDuplicateStatus: false,
+		});
+		services.pushStatusPanelTransientStatus(
+			'No new files added. All analyzed files were already in the list.',
+			{ ttlMs: 2000 },
+		);
+		return;
+	}
+
+	services.appendFileList(fileListInfo, { existingFiles });
+}
+
+function processFilePaths(
+	filePaths: string[],
+	existingFiles: AudioFile[],
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		if (filePaths.length === 0) {
+			return;
+		}
+
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		const fileListInfo = yield* workflowPromise(
+			() => services.analyzeAudioFiles(filePaths),
+			'Failed to analyze files.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
+					return null as FileListInfo | null;
+				}),
+			),
+		);
+		if (!fileListInfo) {
+			return;
+		}
+
+		const staged = yield* workflowPromise(
+			() => services.persistPendingMetadataDraftsForCurrentSelection(),
+			'Failed to stage metadata drafts before import.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
+					return false;
+				}),
+			),
+		);
+		if (!staged) {
+			services.setFileImportError('Fix metadata validation errors before adding files.');
+			return;
+		}
+
+		appendAnalyzedFiles(services, fileListInfo, existingFiles);
+		services.clearFileImportError();
+	});
+}
+
+function processPreparedFileList(
+	fileListInfoPromise: ReturnType<ImportAnalysisWorkflowServices['analyzeAudioFiles']>,
+	existingFiles: AudioFile[],
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		const fileListInfo = yield* workflowPromise(
+			() => fileListInfoPromise,
+			'Failed to analyze files.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
+					return null as FileListInfo | null;
+				}),
+			),
+		);
+		if (!fileListInfo) {
+			return;
+		}
+
+		const staged = yield* workflowPromise(
+			() => services.persistPendingMetadataDraftsForCurrentSelection(),
+			'Failed to stage metadata drafts before import.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.setFileImportError(`Failed to analyze files: ${error.cause}`);
+					return false;
+				}),
+			),
+		);
+		if (!staged) {
+			services.setFileImportError('Fix metadata validation errors before adding files.');
+			return;
+		}
+
+		appendAnalyzedFiles(services, fileListInfo, existingFiles);
+		services.clearFileImportError();
+	});
+}
+
+function clickToSelect(
+	existingFiles: AudioFile[],
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		if (services.isOrderLocked()) {
+			services.setFileImportError(orderLockedMessage());
+			return;
+		}
+
+		const selected = yield* workflowPromise(
+			() =>
+				services.openFiles({
+					filters: [
+						{
+							name: 'Audio Files',
+							extensions: [...SUPPORTED_AUDIO_EXTENSIONS],
+						},
+					],
+				}),
+			'Failed to open file dialog.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.setFileImportError(`Failed to open file dialog: ${error.cause}`);
+					return null;
+				}),
+			),
+		);
+
+		if (Array.isArray(selected) && selected.length > 0) {
+			yield* processFilePaths(selected, existingFiles);
+		}
+	});
+}
+
+function clickToSelectFromPrepared(
+	preparedEntry: Extract<PreparedImportAnalysisWorkflowEntry, { type: 'openFiles' }>,
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		const selected = yield* workflowPromise(
+			() => preparedEntry.selectedPaths,
+			'Failed to open file dialog.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.setFileImportError(`Failed to open file dialog: ${error.cause}`);
+					return null;
+				}),
+			),
+		);
+
+		if (Array.isArray(selected) && selected.length > 0) {
+			yield* processFilePaths(selected, preparedEntry.existingFiles);
+		}
+	});
+}
+
+function dropFiles(
+	paths: string[],
+	existingFiles: AudioFile[],
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		if (services.isOrderLocked()) {
+			services.setFileImportError(orderLockedMessage());
+			return;
+		}
+
+		const supportedPaths = filterSupportedFiles(paths);
+		if (supportedPaths.length === 0) {
+			services.setFileImportError(unsupportedDropMessage());
+			return;
+		}
+
+		yield* processFilePaths(supportedPaths, existingFiles);
+	});
+}
+
+function importAnalysisWorkflowBody(
+	action: ImportAnalysisWorkflowAction,
+	preparedEntry?: PreparedImportAnalysisWorkflowEntry,
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	if (preparedEntry?.type === 'openFiles') {
+		return clickToSelectFromPrepared(preparedEntry);
+	}
+	if (preparedEntry?.type === 'analyzeFiles') {
+		return processPreparedFileList(preparedEntry.fileListInfo, preparedEntry.existingFiles);
+	}
+
+	switch (action.type) {
+		case 'clickToSelect':
+			return clickToSelect(action.existingFiles);
+		case 'dropFiles':
+			return dropFiles(action.paths, action.existingFiles);
+	}
+}
+
+export function enterImportAnalysisWorkflow(
+	services: ImportAnalysisWorkflowServices,
+	action: ImportAnalysisWorkflowAction,
+): PreparedImportAnalysisWorkflowEntry | null {
+	if (services.isOrderLocked()) {
+		services.setFileImportError(orderLockedMessage());
+		return null;
+	}
+
+	if (action.type === 'clickToSelect') {
+		try {
+			return {
+				type: 'openFiles',
+				selectedPaths: services.openFiles({
+					filters: [
+						{
+							name: 'Audio Files',
+							extensions: [...SUPPORTED_AUDIO_EXTENSIONS],
+						},
+					],
+				}),
+				existingFiles: action.existingFiles,
+			};
+		} catch (cause) {
+			services.setFileImportError(`Failed to open file dialog: ${cause}`);
+			return null;
+		}
+	}
+
+	const supportedPaths = filterSupportedFiles(action.paths);
+	if (supportedPaths.length === 0) {
+		services.setFileImportError(unsupportedDropMessage());
+		return null;
+	}
+
+	try {
+		return {
+			type: 'analyzeFiles',
+			fileListInfo: services.analyzeAudioFiles(supportedPaths),
+			existingFiles: action.existingFiles,
+		};
+	} catch (cause) {
+		services.setFileImportError(`Failed to analyze files: ${cause}`);
+		return null;
+	}
+}
+
+async function defaultImportAnalysisWorkflowLayer(): Promise<ImportAnalysisWorkflowLayer> {
+	const live = await import('./importAnalysisWorkflowLive');
+	return live.ImportAnalysisWorkflowLive;
+}
+
+export function importAnalysisWorkflowExecution(
+	action: ImportAnalysisWorkflowAction,
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return importAnalysisWorkflowBody(action);
+}
+
+export async function runImportAnalysisWorkflow(
+	action: ImportAnalysisWorkflowAction,
+	layer?: ImportAnalysisWorkflowLayer,
+	preparedEntry?: PreparedImportAnalysisWorkflowEntry,
+): Promise<void> {
+	const workflowLayer = layer ?? (await defaultImportAnalysisWorkflowLayer());
+	return runAppEffect(
+		importAnalysisWorkflowBody(action, preparedEntry).pipe(Effect.provide(workflowLayer)),
+	);
+}

--- a/src/ui/fileImport/importAnalysisWorkflowLive.ts
+++ b/src/ui/fileImport/importAnalysisWorkflowLive.ts
@@ -1,0 +1,28 @@
+import { tauriClient } from '../../lib/tauri/client';
+import {
+	appendFileList,
+	persistPendingMetadataDraftsForCurrentSelection,
+} from '../fileList/actions';
+import { isOrderLocked } from '../fileList/state.svelte';
+import { pushStatusPanelTransientStatus } from '../statusPanel';
+import { clearFileImportError, setFileImportError } from './state.svelte';
+import {
+	makeImportAnalysisWorkflowServicesLayer,
+	type ImportAnalysisWorkflowServices,
+} from './importAnalysisWorkflowServices';
+
+export const liveImportAnalysisWorkflowServices: ImportAnalysisWorkflowServices = {
+	isOrderLocked,
+	openFiles: tauriClient.openFiles,
+	analyzeAudioFiles: tauriClient.analyzeAudioFiles,
+	persistPendingMetadataDraftsForCurrentSelection,
+	appendFileList,
+	pushStatusPanelTransientStatus,
+	setFileImportError,
+	clearFileImportError,
+	console,
+};
+
+export const ImportAnalysisWorkflowLive = makeImportAnalysisWorkflowServicesLayer(
+	liveImportAnalysisWorkflowServices,
+);

--- a/src/ui/fileImport/importAnalysisWorkflowServices.ts
+++ b/src/ui/fileImport/importAnalysisWorkflowServices.ts
@@ -1,0 +1,49 @@
+import type { tauriClient } from '../../lib/tauri/client';
+import type { AudioFile, FileListInfo } from '../../types/audio';
+import {
+	type AppLayer,
+	makeWorkflowLayer,
+	makeWorkflowServiceTag,
+} from '../../lib/effect/appEffect';
+import type {
+	appendFileList,
+	persistPendingMetadataDraftsForCurrentSelection,
+} from '../fileList/actions';
+import type { isOrderLocked } from '../fileList/state.svelte';
+import type { pushStatusPanelTransientStatus } from '../statusPanel';
+import type { clearFileImportError, setFileImportError } from './state.svelte';
+
+export interface ImportAnalysisWorkflowServices {
+	isOrderLocked: typeof isOrderLocked;
+	openFiles: typeof tauriClient.openFiles;
+	analyzeAudioFiles: typeof tauriClient.analyzeAudioFiles;
+	persistPendingMetadataDraftsForCurrentSelection: typeof persistPendingMetadataDraftsForCurrentSelection;
+	appendFileList: typeof appendFileList;
+	pushStatusPanelTransientStatus: typeof pushStatusPanelTransientStatus;
+	setFileImportError: typeof setFileImportError;
+	clearFileImportError: typeof clearFileImportError;
+	console: Pick<Console, 'error'>;
+}
+
+export type ImportAnalysisWorkflowAction =
+	| { type: 'clickToSelect'; existingFiles: AudioFile[] }
+	| { type: 'dropFiles'; paths: string[]; existingFiles: AudioFile[] };
+
+export interface ImportAnalysisFileListResult {
+	readonly fileListInfo: FileListInfo;
+	readonly existingFiles: AudioFile[];
+}
+
+export type ImportAnalysisWorkflowServicesId = 'FileImport/ImportAnalysisWorkflowServices';
+export type ImportAnalysisWorkflowLayer = AppLayer<ImportAnalysisWorkflowServicesId>;
+
+export const ImportAnalysisWorkflowServicesTag = makeWorkflowServiceTag<
+	ImportAnalysisWorkflowServicesId,
+	ImportAnalysisWorkflowServices
+>('FileImport/ImportAnalysisWorkflowServices');
+
+export function makeImportAnalysisWorkflowServicesLayer(
+	services: ImportAnalysisWorkflowServices,
+): ImportAnalysisWorkflowLayer {
+	return makeWorkflowLayer(ImportAnalysisWorkflowServicesTag, services);
+}

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -153,7 +153,7 @@ export function displayFileList(fileListInfo: FileListInfo): void {
 
 export function appendFileList(
 	fileListInfo: FileListInfo,
-	options?: { existingFiles?: AudioFile[] },
+	options?: { existingFiles?: AudioFile[]; showDuplicateStatus?: boolean },
 ): void {
 	const currentFileList = getCurrentFileList();
 	const existingFiles = options?.existingFiles ?? currentFileList?.files ?? [];
@@ -168,7 +168,9 @@ export function appendFileList(
 	);
 
 	if (appendedFiles.length === 0) {
-		setTransientStatusMessage('No new files added. All analyzed files were already in the list.');
+		if (options?.showDuplicateStatus ?? true) {
+			setTransientStatusMessage('No new files added. All analyzed files were already in the list.');
+		}
 		return;
 	}
 

--- a/src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts
+++ b/src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Effect, runAppEffect } from '../../../lib/effect/appEffect';
+import {
+	defaultEncoderSettings,
+	type ProcessPayload,
+	type ProcessingPreflightPlan,
+} from '../../../types/audio';
+import type { MetadataIntentPatch } from '../../../types/metadataIntent';
+import {
+	makeOutputPlanWorkflowServicesLayer,
+	outputPathPreviewWorkflowExecution,
+	outputPlanReviewWorkflowExecution,
+	type OutputPlanWorkflowServices,
+} from '../outputPlanWorkflow';
+
+function payload(overrides: Partial<ProcessPayload> = {}): ProcessPayload {
+	return {
+		inputFiles: ['/books/a.m4b'],
+		outputDir: '/tmp/out',
+		settings: defaultEncoderSettings(),
+		externalToolchain: {},
+		sampleRate: 'auto',
+		jobType: 'merge',
+		outputNaming: { preset: 'absDefault', includeYear: false, customTemplate: undefined },
+		...overrides,
+	};
+}
+
+function plan(overrides: Partial<ProcessingPreflightPlan> = {}): ProcessingPreflightPlan {
+	return {
+		jobType: 'merge',
+		previewSeconds: undefined,
+		collisionPolicy: 'fail',
+		planSignature: 'sig-clean',
+		outputs: [
+			{
+				inputIndex: 0,
+				inputPath: '/books/a.m4b',
+				kind: 'final',
+				requestedPath: '/tmp/out/a.m4b',
+				resolvedPath: '/tmp/out/a.m4b',
+				renameCandidate: undefined,
+				collision: undefined,
+				action: 'write',
+			},
+		],
+		...overrides,
+	};
+}
+
+function makeHarness(overrides: Partial<OutputPlanWorkflowServices> = {}) {
+	const state = {
+		outputDirectory: '/tmp/out',
+		previewText: '',
+		previewTitle: '',
+	};
+	let latestRequestId = 0;
+	const services: OutputPlanWorkflowServices = {
+		getState: vi.fn(() => state as ReturnType<OutputPlanWorkflowServices['getState']>),
+		getCurrentMetadata: vi.fn(() => ({
+			title: 'A',
+			album: 'A',
+			artist: 'Author',
+			composer: '',
+			genre: '',
+			description: '',
+			series: '',
+			subseries: '',
+		})),
+		updateSeriesPartWarning: vi.fn(),
+		updateSubseriesPartWarning: vi.fn(),
+		buildOutputPreviewCallSiteState: vi.fn(() => ({
+			outputDirectory: state.outputDirectory,
+			sourcePath: '/books/a.m4b',
+		})),
+		beginOutputPreviewRequest: vi.fn(() => {
+			latestRequestId += 1;
+			return latestRequestId;
+		}),
+		isLatestOutputPreviewRequest: vi.fn((requestId) => requestId === latestRequestId),
+		getOutputNamingConfig: vi.fn(() => ({
+			preset: 'absDefault' as const,
+			includeYear: false,
+			customTemplate: undefined,
+		})),
+		setOutputPreview: vi.fn((text: string, title = text) => {
+			state.previewText = text;
+			state.previewTitle = title;
+		}),
+		showOutputError: vi.fn(),
+		previewOutputPath: vi.fn(async () => '/tmp/out/a.m4b'),
+		preflightProcessingPlan: vi.fn(async () => plan()),
+		openCollisionDialog: vi.fn(async () => null),
+		console: { error: vi.fn() },
+		...overrides,
+	};
+
+	return {
+		state,
+		services,
+		layer: makeOutputPlanWorkflowServicesLayer(services),
+	};
+}
+
+describe('OutputPlanWorkflow', () => {
+	it('updates output preview from the output artifact boundary', async () => {
+		const harness = makeHarness();
+
+		await runAppEffect(
+			outputPathPreviewWorkflowExecution('final').pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.previewOutputPath).toHaveBeenCalledWith(
+			expect.objectContaining({
+				outputDir: '/tmp/out',
+				sourcePath: '/books/a.m4b',
+				outputKind: 'final',
+			}),
+		);
+		expect(harness.state.previewText).toBe('/tmp/out/a.m4b');
+	});
+
+	it('reports missing output directory without crossing the boundary', async () => {
+		const harness = makeHarness();
+		harness.state.outputDirectory = '';
+
+		await runAppEffect(
+			outputPathPreviewWorkflowExecution('final').pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.previewOutputPath).not.toHaveBeenCalled();
+		expect(harness.state.previewText).toBe('Select output directory...');
+		expect(harness.state.previewTitle).toBe('No directory selected');
+	});
+
+	it('ignores stale preview responses', async () => {
+		const harness = makeHarness({
+			isLatestOutputPreviewRequest: vi.fn(() => false),
+		});
+
+		await runAppEffect(
+			outputPathPreviewWorkflowExecution('preview').pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.previewOutputPath).toHaveBeenCalled();
+		expect(harness.services.setOutputPreview).not.toHaveBeenCalled();
+	});
+
+	it('surfaces preview failures without throwing to UI callers', async () => {
+		const cause = new Error('template invalid');
+		const harness = makeHarness({
+			previewOutputPath: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			outputPathPreviewWorkflowExecution('final').pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.state.previewText).toBe(
+			'Output preview unavailable. Fix metadata/template and retry.',
+		);
+		expect(harness.services.showOutputError).toHaveBeenCalledWith(
+			`Rust preview failed: ${String(cause)}`,
+		);
+	});
+
+	it('approves clean preflight without collision review', async () => {
+		const cleanPlan = plan();
+		const harness = makeHarness({
+			preflightProcessingPlan: vi.fn(async () => cleanPlan),
+		});
+
+		const result = await runAppEffect(
+			outputPlanReviewWorkflowExecution({
+				payload: payload(),
+				metadataIntent: null,
+				previewSeconds: null,
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.openCollisionDialog).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			status: 'approved',
+			payload: expect.objectContaining({
+				collisionPolicy: 'fail',
+				preflightSignature: 'sig-clean',
+			}),
+			plan: cleanPlan,
+		});
+	});
+
+	it('blocks hard output-plan failures without opening review', async () => {
+		const blockedPlan = plan({
+			outputs: [
+				{
+					...plan().outputs[0],
+					collision: {
+						kind: 'source_destination_overlap',
+						conflictingPath: '/books/a.m4b',
+						detail: 'Output path resolves to an input source file.',
+					},
+					review: {
+						canProceed: false,
+						message: 'Output path resolves to an input source file.',
+					},
+					action: 'review_required',
+				},
+			],
+		});
+		const harness = makeHarness({
+			preflightProcessingPlan: vi.fn(async () => blockedPlan),
+		});
+
+		const result = await runAppEffect(
+			outputPlanReviewWorkflowExecution({ payload: payload(), metadataIntent: null }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.openCollisionDialog).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			status: 'blocked',
+			message: 'Output path resolves to an input source file.',
+			plan: blockedPlan,
+		});
+	});
+
+	it('returns cancelled when collision review is cancelled', async () => {
+		const reviewPlan = plan({
+			outputs: [
+				{
+					...plan().outputs[0],
+					collision: {
+						kind: 'existing_file',
+						conflictingPath: '/tmp/out/a.m4b',
+						detail: 'An existing file already occupies the destination path.',
+					},
+					review: { canProceed: true, message: 'Review required.' },
+					action: 'review_required',
+				},
+			],
+		});
+		const harness = makeHarness({
+			preflightProcessingPlan: vi.fn(async () => reviewPlan),
+			openCollisionDialog: vi.fn(async () => null),
+		});
+
+		const result = await runAppEffect(
+			outputPlanReviewWorkflowExecution({ payload: payload(), metadataIntent: null }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(result).toEqual({ status: 'cancelled' });
+	});
+
+	it('runs reviewed preflight with the selected collision policy', async () => {
+		const initialPlan = plan({
+			planSignature: 'sig-review',
+			outputs: [
+				{
+					...plan().outputs[0],
+					collision: {
+						kind: 'existing_file',
+						conflictingPath: '/tmp/out/a.m4b',
+						detail: 'An existing file already occupies the destination path.',
+					},
+					review: { canProceed: true, message: 'Review required.' },
+					action: 'review_required',
+				},
+			],
+		});
+		const reviewedPlan = plan({
+			collisionPolicy: 'rename_new',
+			planSignature: 'sig-reviewed',
+			outputs: [{ ...initialPlan.outputs[0], action: 'rename_new' }],
+		});
+		const preflightProcessingPlan = vi
+			.fn()
+			.mockResolvedValueOnce(initialPlan)
+			.mockResolvedValueOnce(reviewedPlan);
+		const metadataIntent: Record<string, MetadataIntentPatch> = {
+			'/books/a.m4b': { title: { op: 'set', value: 'A' } },
+		};
+		const processPayload = payload();
+		const harness = makeHarness({
+			preflightProcessingPlan,
+			openCollisionDialog: vi.fn(async () => 'rename_new' as const),
+		});
+
+		const result = await runAppEffect(
+			outputPlanReviewWorkflowExecution({
+				payload: processPayload,
+				metadataIntent,
+				previewSeconds: 30,
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(preflightProcessingPlan).toHaveBeenNthCalledWith(2, {
+			payload: { ...processPayload, collisionPolicy: 'rename_new' },
+			metadataIntent,
+			previewSeconds: 30,
+		});
+		expect(result).toEqual({
+			status: 'approved',
+			payload: expect.objectContaining({
+				collisionPolicy: 'rename_new',
+				preflightSignature: 'sig-reviewed',
+			}),
+			plan: reviewedPlan,
+		});
+	});
+});

--- a/src/ui/outputPanel/outputPlanWorkflow.ts
+++ b/src/ui/outputPanel/outputPlanWorkflow.ts
@@ -1,0 +1,204 @@
+import { Data, Effect, type AppEffect, runAppEffect } from '../../lib/effect/appEffect';
+import type { CollisionPolicy, ProcessPayload, ProcessingPreflightPlan } from '../../types/audio';
+import {
+	OutputPlanWorkflowServicesTag,
+	type OutputPlanReviewRequest,
+	type OutputPlanReviewResult,
+	type OutputPlanWorkflowLayer,
+	type OutputPlanWorkflowServices,
+	type OutputPlanWorkflowServicesId,
+} from './outputPlanWorkflowServices';
+
+export {
+	OutputPlanWorkflowServicesTag,
+	makeOutputPlanWorkflowServicesLayer,
+	type OutputPlanReviewRequest,
+	type OutputPlanReviewResult,
+	type OutputPlanWorkflowAction,
+	type OutputPlanWorkflowLayer,
+	type OutputPlanWorkflowServices,
+	type OutputPlanWorkflowServicesId,
+} from './outputPlanWorkflowServices';
+
+export class OutputPlanWorkflowFailed extends Data.TaggedError('OutputPlanWorkflowFailed')<{
+	readonly message: string;
+	readonly cause: unknown;
+}> {}
+
+function workflowFailure(message: string, cause: unknown): OutputPlanWorkflowFailed {
+	return new OutputPlanWorkflowFailed({ message, cause });
+}
+
+function workflowPromise<A>(
+	evaluate: () => PromiseLike<A>,
+	message: string,
+): AppEffect<A, OutputPlanWorkflowFailed> {
+	return Effect.tryPromise({
+		try: evaluate,
+		catch: (cause) => workflowFailure(message, cause),
+	});
+}
+
+function getBlockingReviewMessage(plan: ProcessingPreflightPlan): string | null {
+	const blocked = plan.outputs.find((output) => output.review?.canProceed === false);
+	return blocked?.review?.message ?? null;
+}
+
+function approvePayload(payload: ProcessPayload, plan: ProcessingPreflightPlan): ProcessPayload {
+	return {
+		...payload,
+		collisionPolicy: plan.collisionPolicy,
+		preflightSignature: plan.planSignature,
+	};
+}
+
+function outputPathPreviewBody(
+	outputKind: Parameters<OutputPlanWorkflowServices['previewOutputPath']>[0]['outputKind'],
+	reservedRequestId?: number,
+): AppEffect<void, OutputPlanWorkflowFailed, OutputPlanWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* OutputPlanWorkflowServicesTag;
+		const state = services.getState();
+		const metadata = services.getCurrentMetadata();
+
+		services.updateSeriesPartWarning(metadata);
+		services.updateSubseriesPartWarning(metadata);
+
+		if (!state.outputDirectory) {
+			services.setOutputPreview('Select output directory...', 'No directory selected');
+			return;
+		}
+
+		const previewCallSiteState = services.buildOutputPreviewCallSiteState();
+		const requestId = reservedRequestId ?? services.beginOutputPreviewRequest();
+
+		const previewPath = yield* workflowPromise(
+			() =>
+				services.previewOutputPath({
+					outputDir: previewCallSiteState.outputDirectory,
+					metadata,
+					outputNaming: services.getOutputNamingConfig(),
+					sourcePath: previewCallSiteState.sourcePath,
+					outputKind,
+				}),
+			'Output preview failed.',
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					if (!services.isLatestOutputPreviewRequest(requestId)) {
+						return null;
+					}
+					const message = 'Output preview unavailable. Fix metadata/template and retry.';
+					services.setOutputPreview(message);
+					services.showOutputError(`Rust preview failed: ${String(error.cause)}`);
+					return null;
+				}),
+			),
+		);
+
+		if (previewPath == null || !services.isLatestOutputPreviewRequest(requestId)) {
+			return;
+		}
+
+		services.setOutputPreview(previewPath);
+	});
+}
+
+function outputPlanReviewBody(
+	request: OutputPlanReviewRequest,
+): AppEffect<OutputPlanReviewResult, OutputPlanWorkflowFailed, OutputPlanWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* OutputPlanWorkflowServicesTag;
+		const { payload, metadataIntent, previewSeconds } = request;
+
+		const initialPlan = yield* workflowPromise(
+			() => services.preflightProcessingPlan({ payload, metadataIntent, previewSeconds }),
+			'Output plan preflight failed.',
+		);
+		const hardBlockMessage = getBlockingReviewMessage(initialPlan);
+		if (hardBlockMessage) {
+			return { status: 'blocked' as const, message: hardBlockMessage, plan: initialPlan };
+		}
+
+		const needsReview = initialPlan.outputs.some((output) => output.action === 'review_required');
+		if (!needsReview) {
+			return {
+				status: 'approved' as const,
+				payload: approvePayload(payload, initialPlan),
+				plan: initialPlan,
+			};
+		}
+
+		const selectedPolicy = yield* workflowPromise(
+			() => services.openCollisionDialog(initialPlan),
+			'Output collision review failed.',
+		);
+		if (!selectedPolicy) {
+			return { status: 'cancelled' as const };
+		}
+
+		const reviewedPayload: ProcessPayload = {
+			...payload,
+			collisionPolicy: selectedPolicy as CollisionPolicy,
+		};
+		const reviewedPlan = yield* workflowPromise(
+			() =>
+				services.preflightProcessingPlan({
+					payload: reviewedPayload,
+					metadataIntent,
+					previewSeconds,
+				}),
+			'Reviewed output plan preflight failed.',
+		);
+		const reviewedHardBlock = getBlockingReviewMessage(reviewedPlan);
+		if (reviewedHardBlock) {
+			return { status: 'blocked' as const, message: reviewedHardBlock, plan: reviewedPlan };
+		}
+
+		return {
+			status: 'approved' as const,
+			payload: {
+				...reviewedPayload,
+				preflightSignature: reviewedPlan.planSignature,
+			},
+			plan: reviewedPlan,
+		};
+	});
+}
+
+async function defaultOutputPlanWorkflowLayer(): Promise<OutputPlanWorkflowLayer> {
+	const live = await import('./outputPlanWorkflowLive');
+	return live.OutputPlanWorkflowLive;
+}
+
+export function outputPathPreviewWorkflowExecution(
+	outputKind: Parameters<OutputPlanWorkflowServices['previewOutputPath']>[0]['outputKind'],
+	reservedRequestId?: number,
+): AppEffect<void, OutputPlanWorkflowFailed, OutputPlanWorkflowServicesId> {
+	return outputPathPreviewBody(outputKind, reservedRequestId);
+}
+
+export function outputPlanReviewWorkflowExecution(
+	request: OutputPlanReviewRequest,
+): AppEffect<OutputPlanReviewResult, OutputPlanWorkflowFailed, OutputPlanWorkflowServicesId> {
+	return outputPlanReviewBody(request);
+}
+
+export async function runOutputPathPreviewWorkflow(
+	outputKind: Parameters<OutputPlanWorkflowServices['previewOutputPath']>[0]['outputKind'],
+	layer?: OutputPlanWorkflowLayer,
+	reservedRequestId?: number,
+): Promise<void> {
+	const workflowLayer = layer ?? (await defaultOutputPlanWorkflowLayer());
+	return runAppEffect(
+		outputPathPreviewBody(outputKind, reservedRequestId).pipe(Effect.provide(workflowLayer)),
+	);
+}
+
+export async function runOutputPlanReviewWorkflow(
+	request: OutputPlanReviewRequest,
+	layer?: OutputPlanWorkflowLayer,
+): Promise<OutputPlanReviewResult> {
+	const workflowLayer = layer ?? (await defaultOutputPlanWorkflowLayer());
+	return runAppEffect(outputPlanReviewBody(request).pipe(Effect.provide(workflowLayer)));
+}

--- a/src/ui/outputPanel/outputPlanWorkflowLive.ts
+++ b/src/ui/outputPanel/outputPlanWorkflowLive.ts
@@ -1,0 +1,41 @@
+import { tauriClient } from '../../lib/tauri/client';
+import { openCollisionDialog } from '../collisionDialog/state.svelte';
+import {
+	beginOutputPreviewRequest,
+	getOutputNamingConfig,
+	getState,
+	isLatestOutputPreviewRequest,
+	setOutputPreview,
+} from './state.svelte';
+import {
+	buildOutputPreviewCallSiteState,
+	getCurrentMetadata,
+	showOutputError,
+	updateSeriesPartWarning,
+	updateSubseriesPartWarning,
+} from './preview';
+import {
+	makeOutputPlanWorkflowServicesLayer,
+	type OutputPlanWorkflowServices,
+} from './outputPlanWorkflowServices';
+
+export const liveOutputPlanWorkflowServices: OutputPlanWorkflowServices = {
+	getState,
+	getCurrentMetadata,
+	updateSeriesPartWarning,
+	updateSubseriesPartWarning,
+	buildOutputPreviewCallSiteState,
+	beginOutputPreviewRequest,
+	isLatestOutputPreviewRequest,
+	getOutputNamingConfig,
+	setOutputPreview,
+	showOutputError,
+	previewOutputPath: tauriClient.previewOutputPath,
+	preflightProcessingPlan: tauriClient.preflightProcessingPlan,
+	openCollisionDialog,
+	console,
+};
+
+export const OutputPlanWorkflowLive = makeOutputPlanWorkflowServicesLayer(
+	liveOutputPlanWorkflowServices,
+);

--- a/src/ui/outputPanel/outputPlanWorkflowServices.ts
+++ b/src/ui/outputPanel/outputPlanWorkflowServices.ts
@@ -1,0 +1,68 @@
+import type { tauriClient } from '../../lib/tauri/client';
+import {
+	type AppLayer,
+	makeWorkflowLayer,
+	makeWorkflowServiceTag,
+} from '../../lib/effect/appEffect';
+import type {
+	CollisionPolicy,
+	OutputKind,
+	ProcessPayload,
+	ProcessingPreflightPlan,
+} from '../../types/audio';
+import type { AudiobookMetadata } from '../../types/metadata';
+import type { MetadataIntentPatch } from '../../types/metadataIntent';
+import type { buildOutputPreviewCallSiteState, showOutputError } from './preview';
+import type {
+	beginOutputPreviewRequest,
+	getOutputNamingConfig,
+	getState,
+	isLatestOutputPreviewRequest,
+	setOutputPreview,
+} from './state.svelte';
+
+export interface OutputPlanWorkflowServices {
+	getState: typeof getState;
+	getCurrentMetadata: () => AudiobookMetadata;
+	updateSeriesPartWarning: (metadata: AudiobookMetadata) => void;
+	updateSubseriesPartWarning: (metadata: AudiobookMetadata) => void;
+	buildOutputPreviewCallSiteState: typeof buildOutputPreviewCallSiteState;
+	beginOutputPreviewRequest: typeof beginOutputPreviewRequest;
+	isLatestOutputPreviewRequest: typeof isLatestOutputPreviewRequest;
+	getOutputNamingConfig: typeof getOutputNamingConfig;
+	setOutputPreview: typeof setOutputPreview;
+	showOutputError: typeof showOutputError;
+	previewOutputPath: typeof tauriClient.previewOutputPath;
+	preflightProcessingPlan: typeof tauriClient.preflightProcessingPlan;
+	openCollisionDialog: (plan: ProcessingPreflightPlan) => Promise<CollisionPolicy | null>;
+	console: Pick<Console, 'error'>;
+}
+
+export interface OutputPlanReviewRequest {
+	payload: ProcessPayload;
+	metadataIntent: Record<string, MetadataIntentPatch> | null;
+	previewSeconds?: number | null;
+}
+
+export type OutputPlanReviewResult =
+	| { status: 'approved'; payload: ProcessPayload; plan: ProcessingPreflightPlan }
+	| { status: 'blocked'; message: string; plan: ProcessingPreflightPlan }
+	| { status: 'cancelled' };
+
+export type OutputPlanWorkflowAction =
+	| { type: 'previewOutputPath'; outputKind: OutputKind }
+	| { type: 'reviewForProcessing'; request: OutputPlanReviewRequest };
+
+export type OutputPlanWorkflowServicesId = 'OutputPanel/OutputPlanWorkflowServices';
+export type OutputPlanWorkflowLayer = AppLayer<OutputPlanWorkflowServicesId>;
+
+export const OutputPlanWorkflowServicesTag = makeWorkflowServiceTag<
+	OutputPlanWorkflowServicesId,
+	OutputPlanWorkflowServices
+>('OutputPanel/OutputPlanWorkflowServices');
+
+export function makeOutputPlanWorkflowServicesLayer(
+	services: OutputPlanWorkflowServices,
+): OutputPlanWorkflowLayer {
+	return makeWorkflowLayer(OutputPlanWorkflowServicesTag, services);
+}

--- a/src/ui/outputPanel/preview.ts
+++ b/src/ui/outputPanel/preview.ts
@@ -1,6 +1,5 @@
 import { formatFileSize } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
-import { tauriClient } from '../../lib/tauri/client';
 import { getCurrentFileList } from '../fileList/state.svelte';
 import { getSelectedFileIndices } from '../fileList/state.svelte';
 import { getCurrentCoverArt } from '../coverArt';
@@ -12,18 +11,16 @@ import {
 } from '../metadataForm/state.svelte';
 import {
 	beginOutputPreviewRequest,
-	isLatestOutputPreviewRequest,
-	getOutputNamingConfig,
 	getState,
 	setEstimatedSizeText,
 	setOutputNamingUiState,
-	setOutputPreview,
 } from './state.svelte';
 import {
 	getSeriesPartValidationError,
 	getSubseriesPartValidationError,
 } from '../metadataValidation';
 import type { OutputKind } from '../../types/audio';
+import { runOutputPathPreviewWorkflow } from './outputPlanWorkflow';
 
 type OutputPreviewCallSiteState = {
 	outputDirectory: string;
@@ -101,43 +98,8 @@ export function updateSubseriesPartWarning(metadata: AudiobookMetadata): void {
 }
 
 export function updateOutputPath(outputKind: OutputKind): void {
-	void updateOutputPathAsync(outputKind);
-}
-
-async function updateOutputPathAsync(outputKind: OutputKind): Promise<void> {
-	const state = getState();
-	const metadata = getCurrentMetadata();
-
-	updateSeriesPartWarning(metadata);
-	updateSubseriesPartWarning(metadata);
-
-	if (!state.outputDirectory) {
-		setOutputPreview('Select output directory...', 'No directory selected');
-		return;
-	}
-
-	const previewCallSiteState = buildOutputPreviewCallSiteState();
-	const requestId = beginOutputPreviewRequest();
-	try {
-		const previewPath = await tauriClient.previewOutputPath({
-			outputDir: previewCallSiteState.outputDirectory,
-			metadata,
-			outputNaming: getOutputNamingConfig(),
-			sourcePath: previewCallSiteState.sourcePath,
-			outputKind,
-		});
-		if (!isLatestOutputPreviewRequest(requestId)) {
-			return;
-		}
-		setOutputPreview(previewPath);
-	} catch (error) {
-		if (!isLatestOutputPreviewRequest(requestId)) {
-			return;
-		}
-		const message = 'Output preview unavailable. Fix metadata/template and retry.';
-		setOutputPreview(message);
-		showOutputError(`Rust preview failed: ${String(error)}`);
-	}
+	const requestId = getState().outputDirectory ? beginOutputPreviewRequest() : undefined;
+	void runOutputPathPreviewWorkflow(outputKind, undefined, requestId);
 }
 
 export function updateNamingOptionState(): void {

--- a/src/ui/statusPanel/AGENTS.md
+++ b/src/ui/statusPanel/AGENTS.md
@@ -3,7 +3,7 @@
 - Exports: `beginMetadataSaveInStatusPanel`, `completeMetadataSaveInStatusPanel`, `failMetadataSaveInStatusPanel`, `initStatusPanel`, `isStatusPanelProcessing`, `pushStatusPanelTransientStatus`, `triggerCancelAllFromStatusPanel`, `triggerProcessFromStatusPanel`, `updateStatusPanelConcurrencyStatus`, `StatusPanelIsland`.
 
 ## Private Cluster
-- Files: `controller.ts`, `runtimeApi.ts`, `events.ts`, `feedback.ts`, `formatting.ts`, `processing.ts`, `preview.ts`, `render.ts`, `state.ts`, `viewState.svelte.ts`, `viewTypes.ts`, `domain/`, `services/`, `__tests__/`, `StatusPanelIsland.svelte`.
+- Files: `controller.ts`, `runtimeApi.ts`, `events.ts`, `feedback.ts`, `formatting.ts`, `outputPlanReview.ts`, `preview.ts`, `processing.ts`, `processingWorkflow.ts`, `processingWorkflowLive.ts`, `processingWorkflowServices.ts`, `processingCancellationWorkflow.ts`, `processingCancellationWorkflowLive.ts`, `processingCancellationWorkflowServices.ts`, `render.ts`, `state.ts`, `viewState.svelte.ts`, `viewTypes.ts`, `domain/`, `services/`, `__tests__/`, `StatusPanelIsland.svelte`.
 - The cluster owns progress events, queue snapshots, cancellation, terminal status truth, view-state derivation, and status feedback.
 
 ## Allowed Agent Edits Without Escalation

--- a/src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts
@@ -38,7 +38,7 @@ describe('ProcessingCancellationWorkflow', () => {
 		await runAppEffect(
 			processingCancellationWorkflowExecution({
 				type: 'cancelAll',
-				currentStatus: activeStatus(),
+				getCurrentStatus: activeStatus,
 				updateStatus,
 			}).pipe(Effect.provide(harness.layer)),
 		);
@@ -65,7 +65,7 @@ describe('ProcessingCancellationWorkflow', () => {
 		await runAppEffect(
 			processingCancellationWorkflowExecution({
 				type: 'cancelAll',
-				currentStatus: activeStatus(),
+				getCurrentStatus: activeStatus,
 				updateStatus,
 			}).pipe(Effect.provide(harness.layer)),
 		);

--- a/src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Effect, runAppEffect } from '../../../lib/effect/appEffect';
+import {
+	makeProcessingCancellationWorkflowServicesLayer,
+	processingCancellationWorkflowExecution,
+	type ProcessingCancellationWorkflowServices,
+} from '../processingCancellationWorkflow';
+import type { ProcessingStatus } from '../state';
+
+function activeStatus(): ProcessingStatus {
+	return {
+		stage: 'converting',
+		percentage: 25,
+		message: 'Converting...',
+	};
+}
+
+function makeHarness(overrides: Partial<ProcessingCancellationWorkflowServices> = {}) {
+	const services: ProcessingCancellationWorkflowServices = {
+		cancelProcessing: vi.fn(async () => 'cancel requested'),
+		setCancelAllButtonPending: vi.fn(),
+		showError: vi.fn(),
+		console: { error: vi.fn() },
+		...overrides,
+	};
+
+	return {
+		services,
+		layer: makeProcessingCancellationWorkflowServicesLayer(services),
+	};
+}
+
+describe('ProcessingCancellationWorkflow', () => {
+	it('sets pending state around cancel-all and reports cancellation requested', async () => {
+		const updateStatus = vi.fn();
+		const harness = makeHarness();
+
+		await runAppEffect(
+			processingCancellationWorkflowExecution({
+				type: 'cancelAll',
+				currentStatus: activeStatus(),
+				updateStatus,
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(harness.services.cancelProcessing).toHaveBeenCalledWith();
+		expect(harness.services.setCancelAllButtonPending).toHaveBeenNthCalledWith(1, true);
+		expect(harness.services.setCancelAllButtonPending).toHaveBeenLastCalledWith(false);
+		expect(updateStatus).toHaveBeenCalledWith({
+			stage: 'converting',
+			percentage: 25,
+			message: 'Cancellation requested…',
+		});
+	});
+
+	it('restores pending state and reports cancel-all failure', async () => {
+		const cause = new Error('cancel failed');
+		const updateStatus = vi.fn();
+		const harness = makeHarness({
+			cancelProcessing: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			processingCancellationWorkflowExecution({
+				type: 'cancelAll',
+				currentStatus: activeStatus(),
+				updateStatus,
+			}).pipe(Effect.provide(harness.layer)),
+		);
+
+		expect(updateStatus).not.toHaveBeenCalled();
+		expect(harness.services.setCancelAllButtonPending).toHaveBeenLastCalledWith(false);
+		expect(harness.services.console.error).toHaveBeenCalledWith(
+			'Failed to cancel processing:',
+			cause,
+		);
+		expect(harness.services.showError).toHaveBeenCalledWith(
+			'Failed to cancel processing. Please try again.',
+		);
+	});
+
+	it('cancels a specific job by id', async () => {
+		const harness = makeHarness();
+
+		await runAppEffect(
+			processingCancellationWorkflowExecution({ type: 'cancelJob', jobId: 'job-1' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.cancelProcessing).toHaveBeenCalledWith('job-1');
+		expect(harness.services.showError).not.toHaveBeenCalled();
+	});
+
+	it('reports per-job cancellation failure without changing render state directly', async () => {
+		const cause = new Error('job cancel failed');
+		const harness = makeHarness({
+			cancelProcessing: vi.fn(async () => {
+				throw cause;
+			}),
+		});
+
+		await runAppEffect(
+			processingCancellationWorkflowExecution({ type: 'cancelJob', jobId: 'job-2' }).pipe(
+				Effect.provide(harness.layer),
+			),
+		);
+
+		expect(harness.services.console.error).toHaveBeenCalledWith(
+			'Failed to cancel job job-2:',
+			cause,
+		);
+		expect(harness.services.showError).toHaveBeenCalledWith('Failed to cancel job job-2');
+	});
+});

--- a/src/ui/statusPanel/__tests__/renderOrder.test.ts
+++ b/src/ui/statusPanel/__tests__/renderOrder.test.ts
@@ -5,6 +5,8 @@ import type { JobProgress } from '../state';
 
 vi.mock('../feedback', () => ({
 	renderJobList: vi.fn(),
+	setCancelAllButtonPending: vi.fn(),
+	showError: vi.fn(),
 }));
 
 describe('renderJobList order and queue status text', () => {

--- a/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
@@ -109,6 +109,34 @@ describe('StatusPanel lifecycle', () => {
 		expect(getStepText()).toContain('Cancellation requested…');
 	});
 
+	it('preserves latest progress when cancel-all resolves after progress advances', async () => {
+		const controller = new StatusPanelRuntime();
+
+		let resolveCancel!: (value: string) => void;
+		const inFlightCancel = new Promise<string>((resolve) => {
+			resolveCancel = resolve;
+		});
+		vi.spyOn(tauriClient, 'cancelProcessing').mockImplementation(() => inFlightCancel);
+
+		const cancelRequest = controller.requestCancelAll();
+		controller.applyProgress({
+			input_index: 0,
+			stage: STAGES.writing,
+			percentage: 68,
+			message: 'Writing metadata',
+		});
+
+		resolveCancel('cancel requested');
+		await cancelRequest;
+
+		expect(controller.getCurrentStatus()).toMatchObject({
+			stage: STAGES.writing,
+			percentage: 68,
+			message: 'Cancellation requested…',
+		});
+		expect(getStepText()).toContain('Cancellation requested…');
+	});
+
 	it('restores cancel-all enabled state and surfaces explicit error on cancel failure', async () => {
 		const controller = new StatusPanelRuntime();
 		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -168,7 +168,7 @@ export class StatusPanelRuntime {
 		await runProcessingCancellationWorkflow(
 			{
 				type: 'cancelAll',
-				currentStatus: this.model.currentStatus,
+				getCurrentStatus: () => this.model.currentStatus,
 				updateStatus: (status) => this.updateStatus(status),
 			},
 			ProcessingCancellationWorkflowLive,

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -1,4 +1,3 @@
-import { tauriClient } from '../../lib/tauri/client';
 import type { MetadataSaveBatchResult } from '../../types/metadata';
 import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
 import { setFileOrderLocked } from '../fileList/actions';
@@ -19,6 +18,14 @@ import {
 	findFilePathByCurrentFile as findFilePathByCurrentFileService,
 } from './services/fileLookup';
 import { createProgressSubscription } from './services/progressSubscription';
+import {
+	enterCancelAllCancellationWorkflow,
+	runProcessingCancellationWorkflow,
+} from './processingCancellationWorkflow';
+import {
+	ProcessingCancellationWorkflowLive,
+	liveProcessingCancellationWorkflowServices,
+} from './processingCancellationWorkflowLive';
 import {
 	applyCancellation,
 	applyProgress,
@@ -155,22 +162,18 @@ export class StatusPanelRuntime {
 	}
 
 	public async requestCancelAll(): Promise<void> {
-		feedback.setCancelAllButtonPending(true);
-		try {
-			await tauriClient.cancelProcessing();
-			this.updateStatus(
-				buildStatus(
-					this.model.currentStatus.stage,
-					this.model.currentStatus.percentage,
-					'Cancellation requested…',
-				),
-			);
-		} catch (error) {
-			console.error('Failed to cancel processing:', error);
-			feedback.showError('Failed to cancel processing. Please try again.');
-		} finally {
-			feedback.setCancelAllButtonPending(false);
-		}
+		const preparedCancelAll = enterCancelAllCancellationWorkflow(
+			liveProcessingCancellationWorkflowServices,
+		);
+		await runProcessingCancellationWorkflow(
+			{
+				type: 'cancelAll',
+				currentStatus: this.model.currentStatus,
+				updateStatus: (status) => this.updateStatus(status),
+			},
+			ProcessingCancellationWorkflowLive,
+			preparedCancelAll,
+		);
 	}
 
 	public handleProcessingCancellation(): void {
@@ -383,12 +386,10 @@ export class StatusPanelRuntime {
 	}
 
 	private async cancelJob(jobId: string): Promise<void> {
-		try {
-			await tauriClient.cancelProcessing(jobId);
-		} catch (error) {
-			console.error(`Failed to cancel job ${jobId}:`, error);
-			feedback.showError(`Failed to cancel job ${jobId}`);
-		}
+		await runProcessingCancellationWorkflow(
+			{ type: 'cancelJob', jobId },
+			ProcessingCancellationWorkflowLive,
+		);
 	}
 
 	private scheduleRender(immediate: boolean): void {

--- a/src/ui/statusPanel/outputPlanReview.ts
+++ b/src/ui/statusPanel/outputPlanReview.ts
@@ -1,86 +1,32 @@
-import { tauriClient } from '../../lib/tauri/client';
-import type { CollisionPolicy, ProcessPayload, ProcessingPreflightPlan } from '../../types/audio';
-import type { MetadataIntentPatch } from '../../types/metadataIntent';
-import { openCollisionDialog } from '../collisionDialog/state.svelte';
-
-export interface OutputPlanReviewRequest {
-	payload: ProcessPayload;
-	metadataIntent: Record<string, MetadataIntentPatch> | null;
-	previewSeconds?: number | null;
-}
+import {
+	makeOutputPlanWorkflowServicesLayer,
+	runOutputPlanReviewWorkflow,
+	type OutputPlanReviewRequest,
+	type OutputPlanReviewResult,
+	type OutputPlanWorkflowServices,
+} from '../outputPanel/outputPlanWorkflow';
 
 interface OutputPlanReviewDeps {
-	preflightProcessingPlan: typeof tauriClient.preflightProcessingPlan;
-	openCollisionDialog: (plan: ProcessingPreflightPlan) => Promise<CollisionPolicy | null>;
+	preflightProcessingPlan: OutputPlanWorkflowServices['preflightProcessingPlan'];
+	openCollisionDialog: OutputPlanWorkflowServices['openCollisionDialog'];
 }
 
-export type OutputPlanReviewResult =
-	| { status: 'approved'; payload: ProcessPayload; plan: ProcessingPreflightPlan }
-	| { status: 'blocked'; message: string; plan: ProcessingPreflightPlan }
-	| { status: 'cancelled' };
-
-function getBlockingReviewMessage(plan: ProcessingPreflightPlan): string | null {
-	const blocked = plan.outputs.find((output) => output.review?.canProceed === false);
-	return blocked?.review?.message ?? null;
-}
-
-function approvePayload(payload: ProcessPayload, plan: ProcessingPreflightPlan): ProcessPayload {
-	return {
-		...payload,
-		collisionPolicy: plan.collisionPolicy,
-		preflightSignature: plan.planSignature,
-	};
-}
+export type { OutputPlanReviewRequest, OutputPlanReviewResult };
 
 export async function reviewOutputPlanForProcessing(
 	request: OutputPlanReviewRequest,
 	deps: Partial<OutputPlanReviewDeps> = {},
 ): Promise<OutputPlanReviewResult> {
-	const preflightProcessingPlan =
-		deps.preflightProcessingPlan ?? tauriClient.preflightProcessingPlan;
-	const openReviewDialog = deps.openCollisionDialog ?? openCollisionDialog;
-	const { payload, metadataIntent, previewSeconds } = request;
-
-	const initialPlan = await preflightProcessingPlan({
-		payload,
-		metadataIntent,
-		previewSeconds,
-	});
-	const hardBlockMessage = getBlockingReviewMessage(initialPlan);
-	if (hardBlockMessage) {
-		return { status: 'blocked', message: hardBlockMessage, plan: initialPlan };
+	if (!deps.preflightProcessingPlan && !deps.openCollisionDialog) {
+		return runOutputPlanReviewWorkflow(request);
 	}
 
-	const needsReview = initialPlan.outputs.some((output) => output.action === 'review_required');
-	if (!needsReview) {
-		return { status: 'approved', payload: approvePayload(payload, initialPlan), plan: initialPlan };
-	}
-
-	const selectedPolicy = await openReviewDialog(initialPlan);
-	if (!selectedPolicy) {
-		return { status: 'cancelled' };
-	}
-
-	const reviewedPayload: ProcessPayload = {
-		...payload,
-		collisionPolicy: selectedPolicy,
-	};
-	const reviewedPlan = await preflightProcessingPlan({
-		payload: reviewedPayload,
-		metadataIntent,
-		previewSeconds,
-	});
-	const reviewedHardBlock = getBlockingReviewMessage(reviewedPlan);
-	if (reviewedHardBlock) {
-		return { status: 'blocked', message: reviewedHardBlock, plan: reviewedPlan };
-	}
-
-	return {
-		status: 'approved',
-		payload: {
-			...reviewedPayload,
-			preflightSignature: reviewedPlan.planSignature,
-		},
-		plan: reviewedPlan,
-	};
+	const live = await import('../outputPanel/outputPlanWorkflowLive');
+	return runOutputPlanReviewWorkflow(
+		request,
+		makeOutputPlanWorkflowServicesLayer({
+			...live.liveOutputPlanWorkflowServices,
+			...deps,
+		}),
+	);
 }

--- a/src/ui/statusPanel/processingCancellationWorkflow.ts
+++ b/src/ui/statusPanel/processingCancellationWorkflow.ts
@@ -1,0 +1,159 @@
+import { Data, Effect, type AppEffect, runAppEffect } from '../../lib/effect/appEffect';
+import type { ProcessingStatus } from './state';
+import {
+	ProcessingCancellationWorkflowServicesTag,
+	type ProcessingCancellationWorkflowLayer,
+	type ProcessingCancellationWorkflowServices,
+	type ProcessingCancellationWorkflowServicesId,
+} from './processingCancellationWorkflowServices';
+
+export {
+	ProcessingCancellationWorkflowServicesTag,
+	makeProcessingCancellationWorkflowServicesLayer,
+	type ProcessingCancellationWorkflowLayer,
+	type ProcessingCancellationWorkflowServices,
+	type ProcessingCancellationWorkflowServicesId,
+} from './processingCancellationWorkflowServices';
+
+export interface PreparedCancelAllRequest {
+	readonly request: ReturnType<ProcessingCancellationWorkflowServices['cancelProcessing']>;
+}
+
+export type ProcessingCancellationWorkflowAction =
+	| {
+			type: 'cancelAll';
+			currentStatus: ProcessingStatus;
+			updateStatus: (status: ProcessingStatus) => void;
+	  }
+	| { type: 'cancelJob'; jobId: string };
+
+export class ProcessingCancellationWorkflowFailed extends Data.TaggedError(
+	'ProcessingCancellationWorkflowFailed',
+)<{
+	readonly message: string;
+	readonly cause: unknown;
+}> {}
+
+function workflowFailure(message: string, cause: unknown): ProcessingCancellationWorkflowFailed {
+	return new ProcessingCancellationWorkflowFailed({ message, cause });
+}
+
+function workflowPromise<A>(
+	evaluate: () => PromiseLike<A>,
+	message: string,
+): AppEffect<A, ProcessingCancellationWorkflowFailed> {
+	return Effect.tryPromise({
+		try: evaluate,
+		catch: (cause) => workflowFailure(message, cause),
+	});
+}
+
+function cancellationRequestedStatus(status: ProcessingStatus): ProcessingStatus {
+	if (status.stage === 'idle') {
+		return {
+			stage: 'idle',
+			percentage: 0,
+			message: 'Cancellation requested…',
+		};
+	}
+
+	return {
+		...status,
+		message: 'Cancellation requested…',
+	};
+}
+
+function cancelAll(
+	action: Extract<ProcessingCancellationWorkflowAction, { type: 'cancelAll' }>,
+	preparedRequest?: PreparedCancelAllRequest,
+): AppEffect<void, never, ProcessingCancellationWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ProcessingCancellationWorkflowServicesTag;
+		if (!preparedRequest) {
+			services.setCancelAllButtonPending(true);
+		}
+		yield* workflowPromise(
+			() => preparedRequest?.request ?? services.cancelProcessing(),
+			'Failed to cancel processing.',
+		).pipe(
+			Effect.tap(() =>
+				Effect.sync(() => {
+					action.updateStatus(cancellationRequestedStatus(action.currentStatus));
+				}),
+			),
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.console.error('Failed to cancel processing:', error.cause);
+					services.showError('Failed to cancel processing. Please try again.');
+				}),
+			),
+			Effect.ensuring(Effect.sync(() => services.setCancelAllButtonPending(false))),
+		);
+	});
+}
+
+function cancelJob(
+	action: Extract<ProcessingCancellationWorkflowAction, { type: 'cancelJob' }>,
+): AppEffect<void, never, ProcessingCancellationWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ProcessingCancellationWorkflowServicesTag;
+		yield* workflowPromise(
+			() => services.cancelProcessing(action.jobId),
+			`Failed to cancel job ${action.jobId}.`,
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					services.console.error(`Failed to cancel job ${action.jobId}:`, error.cause);
+					services.showError(`Failed to cancel job ${action.jobId}`);
+				}),
+			),
+		);
+	});
+}
+
+function processingCancellationWorkflowBody(
+	action: ProcessingCancellationWorkflowAction,
+	preparedCancelAll?: PreparedCancelAllRequest,
+): AppEffect<void, never, ProcessingCancellationWorkflowServicesId> {
+	switch (action.type) {
+		case 'cancelAll':
+			return cancelAll(action, preparedCancelAll);
+		case 'cancelJob':
+			return cancelJob(action);
+	}
+}
+
+export function enterCancelAllCancellationWorkflow(
+	services: ProcessingCancellationWorkflowServices,
+): PreparedCancelAllRequest {
+	services.setCancelAllButtonPending(true);
+	try {
+		return { request: services.cancelProcessing() };
+	} catch (cause) {
+		return { request: Promise.reject(cause) as ReturnType<typeof services.cancelProcessing> };
+	}
+}
+
+async function defaultProcessingCancellationWorkflowLayer(): Promise<ProcessingCancellationWorkflowLayer> {
+	const live = await import('./processingCancellationWorkflowLive');
+	return live.ProcessingCancellationWorkflowLive;
+}
+
+export function processingCancellationWorkflowExecution(
+	action: ProcessingCancellationWorkflowAction,
+): AppEffect<void, never, ProcessingCancellationWorkflowServicesId> {
+	return processingCancellationWorkflowBody(action);
+}
+
+export async function runProcessingCancellationWorkflow(
+	action: ProcessingCancellationWorkflowAction,
+	layer?: ProcessingCancellationWorkflowLayer,
+	preparedCancelAll?: PreparedCancelAllRequest,
+): Promise<void> {
+	const workflowLayer = layer ?? (await defaultProcessingCancellationWorkflowLayer());
+	return runAppEffect(
+		processingCancellationWorkflowBody(action, preparedCancelAll).pipe(
+			Effect.provide(workflowLayer),
+		),
+	);
+}

--- a/src/ui/statusPanel/processingCancellationWorkflow.ts
+++ b/src/ui/statusPanel/processingCancellationWorkflow.ts
@@ -22,7 +22,7 @@ export interface PreparedCancelAllRequest {
 export type ProcessingCancellationWorkflowAction =
 	| {
 			type: 'cancelAll';
-			currentStatus: ProcessingStatus;
+			getCurrentStatus: () => ProcessingStatus;
 			updateStatus: (status: ProcessingStatus) => void;
 	  }
 	| { type: 'cancelJob'; jobId: string };
@@ -78,7 +78,7 @@ function cancelAll(
 		).pipe(
 			Effect.tap(() =>
 				Effect.sync(() => {
-					action.updateStatus(cancellationRequestedStatus(action.currentStatus));
+					action.updateStatus(cancellationRequestedStatus(action.getCurrentStatus()));
 				}),
 			),
 			Effect.catchAll((error) =>

--- a/src/ui/statusPanel/processingCancellationWorkflowLive.ts
+++ b/src/ui/statusPanel/processingCancellationWorkflowLive.ts
@@ -1,0 +1,17 @@
+import { tauriClient } from '../../lib/tauri/client';
+import * as feedback from './feedback';
+import {
+	makeProcessingCancellationWorkflowServicesLayer,
+	type ProcessingCancellationWorkflowServices,
+} from './processingCancellationWorkflowServices';
+
+export const liveProcessingCancellationWorkflowServices: ProcessingCancellationWorkflowServices = {
+	cancelProcessing: (jobId?: string | null) => tauriClient.cancelProcessing(jobId),
+	setCancelAllButtonPending: feedback.setCancelAllButtonPending,
+	showError: feedback.showError,
+	console,
+};
+
+export const ProcessingCancellationWorkflowLive = makeProcessingCancellationWorkflowServicesLayer(
+	liveProcessingCancellationWorkflowServices,
+);

--- a/src/ui/statusPanel/processingCancellationWorkflowServices.ts
+++ b/src/ui/statusPanel/processingCancellationWorkflowServices.ts
@@ -1,0 +1,30 @@
+import type { tauriClient } from '../../lib/tauri/client';
+import {
+	type AppLayer,
+	makeWorkflowLayer,
+	makeWorkflowServiceTag,
+} from '../../lib/effect/appEffect';
+import type * as feedback from './feedback';
+
+export interface ProcessingCancellationWorkflowServices {
+	cancelProcessing: typeof tauriClient.cancelProcessing;
+	setCancelAllButtonPending: typeof feedback.setCancelAllButtonPending;
+	showError: typeof feedback.showError;
+	console: Pick<Console, 'error'>;
+}
+
+export type ProcessingCancellationWorkflowServicesId =
+	'StatusPanel/ProcessingCancellationWorkflowServices';
+export type ProcessingCancellationWorkflowLayer =
+	AppLayer<ProcessingCancellationWorkflowServicesId>;
+
+export const ProcessingCancellationWorkflowServicesTag = makeWorkflowServiceTag<
+	ProcessingCancellationWorkflowServicesId,
+	ProcessingCancellationWorkflowServices
+>('StatusPanel/ProcessingCancellationWorkflowServices');
+
+export function makeProcessingCancellationWorkflowServicesLayer(
+	services: ProcessingCancellationWorkflowServices,
+): ProcessingCancellationWorkflowLayer {
+	return makeWorkflowLayer(ProcessingCancellationWorkflowServicesTag, services);
+}


### PR DESCRIPTION
## Summary
- Adds EB4 workflow owners for output plan review/preview, toolchain validation, import analysis, and processing cancellation.
- Rewires existing UI entrypoints to dispatch into the workflow owners while preserving public callable shapes and Tauri/Rust/generated binding contracts.
- Updates Effect/status-panel guidance and roadmap status for EB4 completion.

## Tests
- bunx tsc --noEmit --pretty false
- targeted Vitest set for output, toolchain, import, status/cancellation, and existing touched surfaces: 19 files / 119 tests passed
- scripts/check-public-api-strips.sh
- bash scripts/check-context-surface.sh
- scripts/check-no-bridge-imports.sh
- bun run test: 65 files / 372 tests passed
- scripts/checks.sh standard

## Notes
- No Rust, generated bindings, public tauriClient return types, Remote Acquisition, metadata save/enrichment redesign, or manual cover-art workflow conversion included.
- Build emits an ineffective dynamic import warning for ImportAnalysisWorkflowLive because the UI path intentionally imports the live services statically to preserve event timing; the standard gate passes.