### PR TITLE
doc: add effect workflow harness guardrails

### DIFF
--- a/docs/specs/effect-adoption-roadmap.html
+++ b/docs/specs/effect-adoption-roadmap.html
@@ -804,7 +804,7 @@
 									<tr>
 										<td>EB5</td>
 										<td>M7-M8</td>
-										<td><span class="badge info">Planned</span></td>
+										<td><span class="badge good">Complete</span></td>
 										<td>Workflow service catalog, agent proof, docs, and boundary guardrails.</td>
 									</tr>
 									<tr>
@@ -1011,7 +1011,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M7" data-status="not-started">
+					<article class="milestone" data-id="M7" data-status="done">
 						<div class="m-id">M7</div>
 						<div class="m-body">
 							<div class="phase-tag">Harness</div>
@@ -1022,6 +1022,7 @@
 								<li>Fake layers for deterministic tests.</li>
 								<li>Scenario tests that run workflows without rendering whole Svelte islands.</li>
 								<li>Agent-facing proof notes: owner, dependencies, terminal outcomes, and checks.</li>
+								<li>EB5 proof lives in <code>src/lib/effect/AGENTS.md</code>.</li>
 							</ul>
 							<div class="gate">Exit gate: focused workflow tests explain each major flow's dependencies and terminal outcomes.</div>
 						</div>
@@ -1036,7 +1037,7 @@
 						</div>
 					</article>
 
-					<article class="milestone" data-id="M8" data-status="not-started">
+					<article class="milestone" data-id="M8" data-status="done">
 						<div class="m-id">M8</div>
 						<div class="m-body">
 							<div class="phase-tag">Guardrails</div>
@@ -1047,6 +1048,7 @@
 								<li>Add local guidance only where imports or public strips change.</li>
 								<li>Add or adjust boundary assertions only when reach-through becomes a real risk.</li>
 								<li>Harden guardrail scripts only when a milestone opens that script surface for a real boundary reason.</li>
+								<li>EB5 tightened status-panel workflow-private import protection without adding a broad workflow guardrail.</li>
 							</ul>
 							<div class="gate">Exit gate: context checks pass; guardrails protect real boundaries without becoming a noisy parallel project.</div>
 						</div>
@@ -1543,7 +1545,7 @@ Full adoption means async orchestration, typed workflow errors, service layers, 
 - EB2: M4 + narrow M7 proof complete; MetadataSaveWorkflow plus metadata workflow harness proof.
 - EB3: M5 + metadata slice of M6 complete; future workflow ingress plus metadata enrichment workflows.
 - EB4: Remaining M6 complete; import, preflight, and job-control workflow migration.
-- EB5: M7-M8 planned; workflow service catalog, agent proof, docs, and boundary guardrails.
+- EB5: M7-M8 complete; workflow service catalog, agent proof, docs, and boundary guardrails.
 - EB6: M9 planned; greenfield convergence review, Nextest-informed test feedback, critical boundary/glue audit, highest-ROI test-gap audit, and merge-readiness decision.
 
 	Greenfield frontend frame:

--- a/docs/specs/effect-adoption-roadmap.md
+++ b/docs/specs/effect-adoption-roadmap.md
@@ -1,7 +1,7 @@
 # ABB Effect Adoption Roadmap
 
 Date: 2026-05-17
-Status: Active roadmap surface; work through EB4 is complete, EB5-EB6 remain
+Status: Active roadmap surface; work through EB5 is complete, EB6 remains
 Source repo: `/Users/jstar/Projects/audiobook-boss`
 
 Artifact relationship:
@@ -261,7 +261,7 @@ Engineering blocks are the implementation packaging for the roadmap. Milestones 
 | EB2 | M4 + narrow M7 proof | Complete | MetadataSaveWorkflow extraction plus metadata workflow harness proof. |
 | EB3 | M5 + metadata slice of M6 | Complete | Future workflow ingress rule plus metadata enrichment workflows. |
 | EB4 | Remaining M6 | Complete | Import, preflight, and job-control workflow migration. |
-| EB5 | M7-M8 | Planned | Workflow service catalog, agent proof, docs, and boundary guardrails. |
+| EB5 | M7-M8 | Complete | Workflow service catalog, agent proof, docs, and boundary guardrails. |
 | EB6 | M9 | Planned | Greenfield convergence review, Nextest-informed test-feedback audit, critical boundary/glue audit, highest-ROI test-gap audit, and merge-readiness decision. |
 
 ## Roadmap Milestones
@@ -401,6 +401,7 @@ Deliverables:
 - Scenario tests that run workflows directly without rendering entire Svelte islands.
 - Optional `@effect/vitest` adoption only after compatibility is proven.
 - Agent-facing proof notes in the active implementation spec: owner, dependencies, terminal outcomes, and checks.
+- EB5 proof lives in `src/lib/effect/AGENTS.md`: current owner catalog, fake-layer harness conventions, terminal outcomes, public-strip impact, and focused test commands.
 
 Exit gate:
 
@@ -417,6 +418,7 @@ Deliverables:
 - Add local `AGENTS.md` guidance only where Effect changes allowed imports or public-strip rules.
 - Add or adjust boundary assertions only when reach-through into workflow private clusters becomes a real risk.
 - Treat guardrail scripts as lower-priority support work: harden regex/text checks only when a milestone opens that script surface for a real boundary reason.
+- EB5 tightened the existing status-panel private-import assertion for the new workflow-private files; no broad workflow access-control surface was added.
 
 Exit gate:
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -30,6 +30,7 @@ Use these layers to locate ownership before changing behavior:
 | --- | --- |
 | Product intent | What the user believes they asked the app to do. |
 | UI state | Selected files, edits, visible status, and enabled actions. |
+| Frontend workflow coordination | Effect workflow owners for multi-boundary async orchestration, typed workflow errors, fakeable services, and terminal UI outcomes. |
 | IPC contract | Command, event, and payload shapes crossing TS <-> Rust. |
 | Backend lifecycle | Planning, queueing, execution, cancellation, skipping, and finalization. |
 | Artifact truth | Final files, tags, paths, and terminal results on disk. |
@@ -64,6 +65,8 @@ ownership or proof.
 ## Core Truth Boundaries
 
 - UI code routes runtime commands/events through `src/lib/tauri/client.ts`.
+- Multi-boundary frontend orchestration lives in named Effect workflow owners;
+  Svelte/UI modules dispatch intent and render state.
 - `tauriClient` adapts generated bindings from `src/lib/generated/tauri.ts`.
 - Rust commands are registered in `src-tauri/src/ipc_contract.rs` and implemented under `src-tauri/src/commands/`.
 - Processing plans are built before execution and reviewed before jobs run.

--- a/scripts/check-no-bridge-imports.sh
+++ b/scripts/check-no-bridge-imports.sh
@@ -95,7 +95,7 @@ if rg -n "\\b(resolve_effective_processing_metadata|resolve_naming_metadata)\\b"
 fi
 rm -f /tmp/no-metadata-intent-reach-through.out
 
-if rg -n "['\"][^'\"]*statusPanel/(viewState(?:\\.svelte)?|controller|runtimeApi|domain/stateMachine|domain/stateMachineHelpers|domain/stateMachineTypes|render|feedback|reducer[^'\"]*)" src \
+if rg -n "['\"][^'\"]*statusPanel/(viewState(?:\\.svelte)?|controller|runtimeApi|domain/stateMachine|domain/stateMachineHelpers|domain/stateMachineTypes|render|feedback|reducer[^'\"]*|processingWorkflow(?:Live|Services)?|processingCancellationWorkflow(?:Live|Services)?)" src \
   -g '*.ts' \
   -g '*.svelte' \
   -g '!src/ui/statusPanel/**' \

--- a/scripts/check-no-bridge-imports.sh
+++ b/scripts/check-no-bridge-imports.sh
@@ -95,7 +95,7 @@ if rg -n "\\b(resolve_effective_processing_metadata|resolve_naming_metadata)\\b"
 fi
 rm -f /tmp/no-metadata-intent-reach-through.out
 
-if rg -n "['\"][^'\"]*statusPanel/(viewState(?:\\.svelte)?|controller|runtimeApi|domain/stateMachine|domain/stateMachineHelpers|domain/stateMachineTypes|render|feedback|reducer[^'\"]*|processingWorkflow(?:Live|Services)?|processingCancellationWorkflow(?:Live|Services)?)" src \
+if rg -n "['\"][^'\"]*statusPanel/(viewState|controller|runtimeApi|domain/stateMachine|render|feedback|reducer|processingWorkflow|processingCancellationWorkflow)" src \
   -g '*.ts' \
   -g '*.svelte' \
   -g '!src/ui/statusPanel/**' \

--- a/scripts/check-no-bridge-imports.test.ts
+++ b/scripts/check-no-bridge-imports.test.ts
@@ -32,6 +32,7 @@ function createFixtureRepo(): string {
 		'src/lib/tauri',
 		'src/types',
 		'src/ui/outputPanel',
+		'src/ui/statusPanel',
 		'src/ui/__tests__',
 	]) {
 		mkdirSync(path.join(repoRoot, dir), { recursive: true });
@@ -229,6 +230,29 @@ describe('check-no-bridge-imports.sh', () => {
 				'Output path naming must stay in the Rust output_artifact boundary',
 			);
 			expect(result.stderr).toContain('src/ui/outputPanel/utils.ts');
+		} finally {
+			rmSync(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it('rejects status-panel workflow private imports from outside the status panel', () => {
+		const repoRoot = createFixtureRepo();
+		try {
+			writeFileSync(
+				path.join(repoRoot, 'src/ui/statusPanel/processingWorkflow.ts'),
+				'export const privateWorkflow = true;\n',
+			);
+			writeFileSync(
+				path.join(repoRoot, 'src/ui/bypass.ts'),
+				"import { privateWorkflow } from './statusPanel/processingWorkflow';\nvoid privateWorkflow;\n",
+			);
+
+			const result = runNoBridgeCheck(repoRoot);
+			expectStatus(result, 1);
+			expect(result.stderr).toContain(
+				'Code outside src/ui/statusPanel must use the status panel public API',
+			);
+			expect(result.stderr).toContain('src/ui/bypass.ts');
 		} finally {
 			rmSync(repoRoot, { force: true, recursive: true });
 		}

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -26,6 +26,38 @@ Keep Effect private to workflow owners:
   cancellation behavior where relevant, terminal results, and typed failure
   handling.
 
+## Fake-Layer Harness Shape
+
+Workflow tests should run the Effect program directly with fake services:
+
+- Build a small `makeHarness` helper in the owner test file.
+- Provide dependencies through the owner service layer, not through Svelte
+  rendering or live Tauri.
+- Prefer assertions on public workflow outcomes: visible status, state writes,
+  cleanup, terminal results, user-safe errors, and typed workflow errors.
+- Keep fake services close to the owner test unless a second owner needs the
+  same harness shape.
+- Use live layers only from UI/runtime entrypoints; tests for owners should
+  import the service layer helper and call the program or Promise bridge.
+
+## Workflow Service Catalog
+
+Current owners and proof commands:
+
+| Owner | Coordinates | Service families | Public entrypoints | Terminal outcomes and proof |
+| --- | --- | --- | --- | --- |
+| `ProcessingWorkflow` | Output-plan review, metadata staging, listener startup, process IPC, cancellation, terminal status. | File list, metadata form/state, output panel, job controls, status feedback, `tauriClient`. | `startProcessing(...)` via status-panel runtime. | Approved processing, blocked review, cancellation, failed command. `bun run test -- src/ui/statusPanel/__tests__/processingWorkflow.test.ts` |
+| `MetadataSaveWorkflow` | File availability, save lifecycle, draft persistence, pending intent filtering, batch save, cleanup. | File list, metadata form/state, status panel public strip, `tauriClient`. | `saveMetadataFromUI()` through `src/ui/core/actions.ts`. | No files, processing active, save busy, validation failure, no-op, partial/failed batch, typed failure. `bun run test -- src/ui/core/__tests__/metadataSaveWorkflow.test.ts` |
+| `MetadataLookupWorkflow` | Lookup queue, search, result apply, queue advancement, lookup-result cover-art replacement. | Metadata lookup state, file selection/list, metadata form/state, output/tag preview, cover art, `tauriClient`. | `runMetadataLookupWorkflow(...)` behind metadata lookup UI actions. | Open/search/apply/skip, queue completion, cover-art success/failure, typed failure. `bun run test -- src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts` |
+| `OutputPlanWorkflow` | Output preview, stale preview handling, preflight, collision review. | Output panel state, metadata, collision dialog, `tauriClient`. | `runOutputPathPreviewWorkflow(...)`, `runOutputPlanReviewWorkflow(...)`. | Preview success/missing dir/stale/failure, approved/block/cancel/reviewed preflight. `bun run test -- src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts` |
+| `ToolchainValidationWorkflow` | Initial availability load, manual refresh, toolchain browse, override commit/clear. | Encoder panel state and `tauriClient` toolchain calls. | `runToolchainValidationWorkflow(...)` from encoder panel logic. | Load success/fallback unavailable, browse cancel/path, override clear. `bun run test -- src/ui/encoderPanel/__tests__/toolchainValidationWorkflow.test.ts` |
+| `ImportAnalysisWorkflow` | Picker/drop import, supported-path filtering, order-lock checks, analysis, metadata draft staging, append/error cleanup. | File import state, file list, status panel public strip, `tauriClient`. | `runImportAnalysisWorkflow(...)` from import handlers. | Locked, picker cancel/failure, unsupported drop, analysis/staging failure, append success, duplicate-only. `bun run test -- src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts` |
+| `ProcessingCancellationWorkflow` | Cancel-all pending lifecycle and per-job cancellation failure reporting. | Status feedback and `tauriClient.cancelProcessing`. | `runProcessingCancellationWorkflow(...)` through status-panel controller. | Cancel-all success/failure, per-job cancel success/failure. `bun run test -- src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts` |
+
+Public-strip impact for these owners is intentionally narrow: callers keep the
+existing UI/runtime Promise or synchronous wrapper shape unless a milestone
+explicitly accepts a public API change.
+
 ## Future Workflow Ingress
 
 - New frontend work that coordinates multiple real boundaries should start with


### PR DESCRIPTION
## Summary
- Adds the EB5 workflow-owner catalog and fake-layer harness guidance to `src/lib/effect/AGENTS.md`.
- Marks M7/M8 and EB5 complete in the Effect roadmap source and HTML view.
- Records stable frontend workflow coordination ownership in `docs/system-map.md`.
- Hardens the existing no-bridge guardrail for status-panel workflow-private imports, with script test coverage.

## Guardrails
- Changed: `scripts/check-no-bridge-imports.sh` now blocks external imports of the new status-panel workflow private files.
- Intentionally not changed: no broad workflow access-control system, no new policy surface, no Nextest, no EB6 audit.

## Scratchpad
- Created during implementation, then removed before commit because the durable value was distilled into the Effect AGENTS guidance, roadmap notes, and this PR summary.

## Verification
- `bash scripts/check-context-surface.sh`
- `scripts/check-public-api-strips.sh`
- `bun test scripts/check-no-bridge-imports.test.ts`
- `scripts/checks.sh standard`

## EB6 Notes
- EB6 still owns the final convergence review, Nextest-informed test-feedback audit, and critical boundary/glue audit.