### PR TITLE
fix: batch collision skips and FDK adapter logging

### DIFF
--- a/src-tauri/src/output_artifact/review.rs
+++ b/src-tauri/src/output_artifact/review.rs
@@ -85,12 +85,14 @@ pub(crate) fn enforce_output_plan_review<'a>(
         return Err(AppError::FileValidation(output_plan_review_message(output)));
     }
 
-    if let Some(output) = outputs
-        .iter()
-        .copied()
-        .find(|output| output.action == PlannedOutputAction::ReviewRequired)
-    {
-        return Err(AppError::FileValidation(output_plan_review_message(output)));
+    if review.expected_signature.is_none() {
+        if let Some(output) = outputs
+            .iter()
+            .copied()
+            .find(|output| output.action == PlannedOutputAction::ReviewRequired)
+        {
+            return Err(AppError::FileValidation(output_plan_review_message(output)));
+        }
     }
 
     if review.expected_signature.is_none()
@@ -108,7 +110,7 @@ pub(crate) fn enforce_output_plan_review<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output_artifact::{OutputCollision, OutputKind};
+    use crate::output_artifact::{OutputCollision, OutputCollisionKind, OutputKind};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -166,6 +168,54 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Collision policy selections require"));
+    }
+
+    #[test]
+    fn allows_review_required_outputs_after_collision_review_signature() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let existing = temp_dir.path().join("existing.m4b");
+        std::fs::write(&existing, b"existing").expect("write existing");
+
+        let mut output = output_plan(
+            PlannedOutputAction::ReviewRequired,
+            temp_dir.path().join("existing.m4b"),
+        );
+        output.collision = Some(OutputCollision {
+            kind: OutputCollisionKind::ExistingFile,
+            conflicting_path: Some(existing),
+            detail: Some("An existing file already occupies the destination path.".to_string()),
+        });
+
+        enforce_output_plan_review(
+            review(Some("sig"), "sig", CollisionPolicy::Fail),
+            [&output],
+        )
+        .expect("reviewed fail policy should allow review-required outputs to be skipped at dispatch");
+    }
+
+    #[test]
+    fn rejects_unreviewed_review_required_outputs() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let existing = temp_dir.path().join("existing.m4b");
+        std::fs::write(&existing, b"existing").expect("write existing");
+
+        let mut output = output_plan(
+            PlannedOutputAction::ReviewRequired,
+            temp_dir.path().join("existing.m4b"),
+        );
+        output.collision = Some(OutputCollision {
+            kind: OutputCollisionKind::ExistingFile,
+            conflicting_path: Some(existing),
+            detail: None,
+        });
+
+        let err = enforce_output_plan_review(
+            review(None, "sig", CollisionPolicy::Fail),
+            [&output],
+        )
+        .expect_err("unreviewed review-required output should fail");
+
+        assert!(err.to_string().contains("collision review is required"));
     }
 
     #[test]

--- a/src-tauri/src/output_artifact/review.rs
+++ b/src-tauri/src/output_artifact/review.rs
@@ -93,15 +93,13 @@ pub(crate) fn enforce_output_plan_review<'a>(
         {
             return Err(AppError::FileValidation(output_plan_review_message(output)));
         }
-    }
 
-    if review.expected_signature.is_none()
-        && outputs.iter().any(|output| output.collision.is_some())
-    {
-        return Err(AppError::FileValidation(
-            "Output collisions require review before processing. Open the collision dialog and choose how to continue."
-                .to_string(),
-        ));
+        if outputs.iter().any(|output| output.collision.is_some()) {
+            return Err(AppError::FileValidation(
+                "Output collisions require review before processing. Open the collision dialog and choose how to continue."
+                    .to_string(),
+            ));
+        }
     }
 
     Ok(())
@@ -186,11 +184,14 @@ mod tests {
             detail: Some("An existing file already occupies the destination path.".to_string()),
         });
 
-        enforce_output_plan_review(
+        let result = enforce_output_plan_review(
             review(Some("sig"), "sig", CollisionPolicy::Fail),
             [&output],
-        )
-        .expect("reviewed fail policy should allow review-required outputs to be skipped at dispatch");
+        );
+
+        result.expect(
+            "reviewed fail policy should allow review-required outputs to be skipped at dispatch",
+        );
     }
 
     #[test]
@@ -209,11 +210,8 @@ mod tests {
             detail: None,
         });
 
-        let err = enforce_output_plan_review(
-            review(None, "sig", CollisionPolicy::Fail),
-            [&output],
-        )
-        .expect_err("unreviewed review-required output should fail");
+        let err = enforce_output_plan_review(review(None, "sig", CollisionPolicy::Fail), [&output])
+            .expect_err("unreviewed review-required output should fail");
 
         assert!(err.to_string().contains("collision review is required"));
     }

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -1,15 +1,14 @@
 use super::plan::{prepare_execution_plan, resolve_preflight_plan, ResolvedProcessingPlan};
 use super::terminal_outcomes::{
     build_all_skipped_batch_result, classify_processing_error, collect_batch_results,
-    review_required_skipped_result, skipped_result, terminal_failure_result,
-    ProcessingJobTerminalOutcome,
+    no_write_skipped_result, terminal_failure_result, ProcessingJobTerminalOutcome,
 };
 use crate::audio;
 use crate::audio::file_list::FileListInfo;
 use crate::audio::settings_encoder::validate_encoder_settings;
 use crate::audio::toolchain::ExternalToolchainPreference;
 use crate::errors::{AppError, Result};
-use crate::output_artifact::{OutputKind, PlannedOutputAction, ResolvedOutputPlan};
+use crate::output_artifact::{OutputKind, ResolvedOutputPlan};
 use crate::processing::job_registry::{CancellationChecker, JobId};
 use crate::processing::{
     JobType, ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
@@ -166,19 +165,16 @@ async fn dispatch_merge_job(
     payload: &ProcessPayload,
     plan: ResolvedProcessingPlan,
 ) -> Result<ProcessCommandResult> {
-    let paths: Vec<PathBuf> = payload.input_files.iter().map(PathBuf::from).collect();
-    let file_info = audio::get_file_list_info(&paths)?;
     let planned_job = plan.jobs.into_iter().next().ok_or_else(|| {
         AppError::InvalidInput("No output plan entries were built for merge processing".to_string())
     })?;
 
-    if planned_job.output.action == PlannedOutputAction::SkipExisting {
-        return Ok(ProcessCommandResult::new(
-            JobType::Merge,
-            vec![skipped_result(None, None, &planned_job.output)],
-        ));
+    if let Some(skipped) = no_write_skipped_result(None, None, &planned_job.output) {
+        return Ok(ProcessCommandResult::new(JobType::Merge, vec![skipped]));
     }
 
+    let paths: Vec<PathBuf> = payload.input_files.iter().map(PathBuf::from).collect();
+    let file_info = audio::get_file_list_info(&paths)?;
     let result = run_processing_job(ProcessingJobRequest {
         window,
         registry,
@@ -220,24 +216,9 @@ async fn dispatch_batch_jobs(
     let preview_seconds = plan.preview_seconds;
     let sample_rate = resolve_sample_rate(payload)?;
     for planned_job in plan.jobs {
-        if planned_job.output.action == PlannedOutputAction::SkipExisting {
-            let input_index = planned_job.input_index;
-            let output = planned_job.output.clone();
-            let skipped_entry = skipped_result(input_index, None, &output);
-            emit_terminal_skipped_event(
-                &window,
-                skipped_entry.input_index,
-                skipped_entry.job_id.as_deref(),
-                &skipped_entry.message,
-            );
-            scheduled_jobs.push(Box::pin(async move { Ok(skipped_entry) }));
-            continue;
-        }
-
-        if planned_job.output.action == PlannedOutputAction::ReviewRequired {
-            let input_index = planned_job.input_index;
-            let output = planned_job.output.clone();
-            let skipped_entry = review_required_skipped_result(input_index, None, &output);
+        if let Some(skipped_entry) =
+            no_write_skipped_result(planned_job.input_index, None, &planned_job.output)
+        {
             emit_terminal_skipped_event(
                 &window,
                 skipped_entry.input_index,

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -1,7 +1,8 @@
 use super::plan::{prepare_execution_plan, resolve_preflight_plan, ResolvedProcessingPlan};
 use super::terminal_outcomes::{
     build_all_skipped_batch_result, classify_processing_error, collect_batch_results,
-    skipped_result, terminal_failure_result, ProcessingJobTerminalOutcome,
+    review_required_skipped_result, skipped_result, terminal_failure_result,
+    ProcessingJobTerminalOutcome,
 };
 use crate::audio;
 use crate::audio::file_list::FileListInfo;
@@ -233,6 +234,20 @@ async fn dispatch_batch_jobs(
             continue;
         }
 
+        if planned_job.output.action == PlannedOutputAction::ReviewRequired {
+            let input_index = planned_job.input_index;
+            let output = planned_job.output.clone();
+            let skipped_entry = review_required_skipped_result(input_index, None, &output);
+            emit_terminal_skipped_event(
+                &window,
+                skipped_entry.input_index,
+                skipped_entry.job_id.as_deref(),
+                &skipped_entry.message,
+            );
+            scheduled_jobs.push(Box::pin(async move { Ok(skipped_entry) }));
+            continue;
+        }
+
         let window_cloned = window.clone();
         let registry_cloned = registry.clone();
         let settings_cloned = payload.settings.clone();
@@ -429,6 +444,15 @@ async fn execute_processing_job(
         &encoder_settings,
         external_toolchain.as_ref(),
     )?;
+    log::info!(
+        "processor adapter: kind={:?} requested_encoder={:?} external_toolchain_override={}",
+        adapter.kind(),
+        encoder_settings.encoder_type,
+        external_toolchain
+            .as_ref()
+            .and_then(|preference| preference.override_path.as_deref())
+            .unwrap_or("(auto-detect)")
+    );
     adapter
         .execute(
             context,

--- a/src-tauri/src/processing/terminal_outcomes.rs
+++ b/src-tauri/src/processing/terminal_outcomes.rs
@@ -44,6 +44,26 @@ pub(super) fn build_all_skipped_batch_result(
     Some(ProcessCommandResult::new(JobType::Batch, skipped_results))
 }
 
+pub(super) fn review_required_skipped_result(
+    input_index: Option<usize>,
+    job_id: Option<String>,
+    output: &ResolvedOutputPlan,
+) -> ProcessResultEntry {
+    let message = format!(
+        "Skipped '{}' because collision review did not authorize writing this output.",
+        sanitize_path_for_display(&output.requested_path)
+    );
+    ProcessResultEntry {
+        input_index,
+        status: ProcessResultStatus::Skipped,
+        message,
+        error: None,
+        preview_file_path: None,
+        preview_actual_seconds: None,
+        job_id,
+    }
+}
+
 pub(super) fn skipped_result(
     input_index: Option<usize>,
     job_id: Option<String>,

--- a/src-tauri/src/processing/terminal_outcomes.rs
+++ b/src-tauri/src/processing/terminal_outcomes.rs
@@ -44,13 +44,27 @@ pub(super) fn build_all_skipped_batch_result(
     Some(ProcessCommandResult::new(JobType::Batch, skipped_results))
 }
 
-pub(super) fn review_required_skipped_result(
+pub(super) fn no_write_skipped_result(
+    input_index: Option<usize>,
+    job_id: Option<String>,
+    output: &ResolvedOutputPlan,
+) -> Option<ProcessResultEntry> {
+    match output.action {
+        PlannedOutputAction::SkipExisting => Some(skipped_result(input_index, job_id, output)),
+        PlannedOutputAction::ReviewRequired => {
+            Some(review_required_skipped_result(input_index, job_id, output))
+        }
+        _ => None,
+    }
+}
+
+fn review_required_skipped_result(
     input_index: Option<usize>,
     job_id: Option<String>,
     output: &ResolvedOutputPlan,
 ) -> ProcessResultEntry {
     let message = format!(
-        "Skipped '{}' because collision review did not authorize writing this output.",
+        "Skipped '{}' because the selected collision policy does not allow overwriting this output.",
         sanitize_path_for_display(&output.requested_path)
     );
     ProcessResultEntry {
@@ -350,8 +364,9 @@ mod tests {
     use super::{
         build_all_skipped_batch_result, cancellation_error_for_failed_entry,
         classify_processing_error, classify_terminal_results, collect_batch_results,
-        is_cancellation_error, terminal_cancelled_result, terminal_failure_result,
-        ProcessingJobTerminalOutcome, RunTerminalClass, TerminalFailureEvent,
+        is_cancellation_error, no_write_skipped_result, terminal_cancelled_result,
+        terminal_failure_result, ProcessingJobTerminalOutcome, RunTerminalClass,
+        TerminalFailureEvent,
     };
     use crate::errors::{AppError, AppErrorCategory, AppErrorCode, AppErrorEnvelope};
     use crate::output_artifact::{
@@ -475,6 +490,38 @@ mod tests {
         assert!(
             build_all_skipped_batch_result(&plan).is_none(),
             "mixed runnable work must still use normal queue scheduling"
+        );
+    }
+
+    #[test]
+    fn no_write_skipped_result_covers_skip_and_review_required_outputs() {
+        let skip_existing = output_plan(
+            PlannedOutputAction::SkipExisting,
+            "/tmp/existing-output.m4b",
+        );
+        let review_required = output_plan(
+            PlannedOutputAction::ReviewRequired,
+            "/tmp/review-output.m4b",
+        );
+        let writable = output_plan(PlannedOutputAction::Write, "/tmp/new-output.m4b");
+
+        let skip_result = no_write_skipped_result(Some(0), None, &skip_existing)
+            .expect("skip-existing output should become a skipped result");
+        assert_eq!(skip_result.status, ProcessResultStatus::Skipped);
+        assert_eq!(skip_result.input_index, Some(0));
+        assert!(skip_result.message.contains("Skipped existing output"));
+
+        let review_result = no_write_skipped_result(Some(1), None, &review_required)
+            .expect("review-required output should become a skipped result");
+        assert_eq!(review_result.status, ProcessResultStatus::Skipped);
+        assert_eq!(review_result.input_index, Some(1));
+        assert!(review_result
+            .message
+            .contains("selected collision policy does not allow overwriting"));
+
+        assert!(
+            no_write_skipped_result(Some(2), None, &writable).is_none(),
+            "writable outputs must still enter normal processing"
         );
     }
 

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -46,6 +46,10 @@ vi.mock('../../outputPanel', () => ({
 	updateOutputPath: context.updateOutputPathMock,
 }));
 
+vi.mock('../../encoderPanel/logic', () => ({
+	syncAfterStateChange: vi.fn(),
+}));
+
 vi.mock('../../jobControls', () => ({
 	getJobType: context.getJobTypeMock,
 	setJobControlsEnabled: vi.fn(),

--- a/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
@@ -123,6 +123,7 @@ function workflowServices(overrides: Partial<ProcessingWorkflowServices> = {}) {
 		getSelectedFileIndex: vi.fn(() => 0),
 		getSelectedFileIndices: vi.fn(() => new Set([0])),
 		readProcessingRequestConfig: vi.fn(() => processingConfig()),
+		syncEncoderPanelBeforeProcess: vi.fn(),
 		getJobType: getJobTypeMock,
 		hasDirtyMetadataFields: vi.fn(() => false),
 		readMetadataForm: vi.fn(() => ({})),
@@ -169,6 +170,7 @@ describe('ProcessingWorkflow', () => {
 		await runWithServices(ctx, services);
 
 		expect(services.runOutputPlanReviewWorkflow).toHaveBeenCalledTimes(1);
+		expect(services.syncEncoderPanelBeforeProcess).toHaveBeenCalledTimes(1);
 		expect(ctx.setProcessingState).toHaveBeenCalledWith(true);
 		expect(ctx.updateStatus).toHaveBeenCalledWith({
 			stage: 'analyzing',

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -258,6 +258,8 @@ export function processingWorkflowProgram(
 			services.console.log('StatusPanel: Files validated, getting output configuration...'),
 		);
 
+		yield* Effect.sync(() => services.syncEncoderPanelBeforeProcess());
+
 		const processingRequestConfig = yield* readProcessingConfig(services);
 		if (!processingRequestConfig) {
 			return;

--- a/src/ui/statusPanel/processingWorkflowLive.ts
+++ b/src/ui/statusPanel/processingWorkflowLive.ts
@@ -18,6 +18,7 @@ import {
 	getSubseriesPartValidationError,
 } from '../metadataValidation';
 import { readProcessingRequestConfig, updateOutputPath } from '../outputPanel';
+import { syncAfterStateChange } from '../encoderPanel/logic';
 import { runOutputPlanReviewWorkflow } from '../outputPanel/outputPlanWorkflow';
 import * as feedback from './feedback';
 import { openGeneratedPreviewIfSingle } from './preview';
@@ -32,6 +33,7 @@ const liveProcessingWorkflowServices: ProcessingWorkflowServices = {
 	getSelectedFileIndex,
 	getSelectedFileIndices,
 	readProcessingRequestConfig,
+	syncEncoderPanelBeforeProcess: syncAfterStateChange,
 	getJobType,
 	hasDirtyMetadataFields,
 	readMetadataForm,

--- a/src/ui/statusPanel/processingWorkflowServices.ts
+++ b/src/ui/statusPanel/processingWorkflowServices.ts
@@ -24,6 +24,7 @@ import type {
 } from '../metadataValidation';
 import type { runOutputPlanReviewWorkflow } from '../outputPanel/outputPlanWorkflow';
 import type { readProcessingRequestConfig, updateOutputPath } from '../outputPanel';
+import type { syncAfterStateChange } from '../encoderPanel/logic';
 import type * as feedback from './feedback';
 import type { openGeneratedPreviewIfSingle } from './preview';
 
@@ -33,6 +34,7 @@ export interface ProcessingWorkflowServices {
 	getSelectedFileIndex: typeof getSelectedFileIndex;
 	getSelectedFileIndices: typeof getSelectedFileIndices;
 	readProcessingRequestConfig: typeof readProcessingRequestConfig;
+	syncEncoderPanelBeforeProcess: typeof syncAfterStateChange;
 	getJobType: typeof getJobType;
 	hasDirtyMetadataFields: typeof hasDirtyMetadataFields;
 	readMetadataForm: typeof readMetadataForm;


### PR DESCRIPTION
## Summary

- After collision review with a preflight signature, batch processing no longer hard-fails the entire run when some outputs remain `review_required` under Fail policy; those jobs are skipped with an explicit message while writable jobs continue.
- Processing now logs resolved processor adapter kind (`ExternalFdk` vs native) plus requested encoder and toolchain override at job start, making FDK routing visible in dev logs.
- Processing syncs encoder panel state into the output panel immediately before building the process payload, avoiding stale encoder/toolchain settings.

## Context

Manual testing showed FDK detection working (`fdk_available: true`, `encoder=FdkHeAac`) while two batch files appeared "not processed" due to `ReviewRequired` + existing output collisions—not an encoder discovery regression. Input analysis logs showing `selected_decoder=Apple AAC` reflect decode selection during file analysis, not output encoding.

## Test plan

- [x] `cargo test -p audiobook-boss --lib review::tests`
- [x] `bunx vitest run src/ui/statusPanel/__tests__/processingWorkflow.test.ts src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts`
- [ ] Manual: batch with mixed collisions — collided files skipped, clean file processes; Rust log shows `processor adapter: kind=ExternalFdk` when FDK selected
- [ ] Manual: verify output codec with `ffprobe` on a clean single-file FDK run


Made with [Cursor](https://cursor.com)