### PR TITLE
Implement metadata outcome boundary

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -10,8 +10,8 @@
 	"search.exclude": {
 		"repos/**": true
 	},
-  "plugins": {
-    "svelte": {
+	"plugins": {
+		"svelte": {
 			"enabled": true
 		}
 	}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Do not introduce a separate repo-local ticket ledger or scratch task database.
 
 - Use `docs/system-map.md` for product spine, layer ownership, and core truth boundaries before changing architecture.
 - Use `docs/ubiquitous-language.md` for canonical terms such as Grey-Box Module, Public API Strip, Private Cluster, Reach-Through, and Boundary Assertion.
-- The current grey-box Public APIs are Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Intent Plan, and Status Panel Runtime.
+- The current grey-box Public APIs are Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Outcome Plan, and Status Panel Runtime.
 - Nearest nested `AGENTS.md` files own their local Public API Strip, Private Cluster, allowed-edit, and breaking-change rules.
 - Use `docs/api-map.md` only as the runtime command/event index; do not treat it as an architecture spec.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Use this section as the human-facing index. `package.json` is the source of trut
 ## Project Operation
 
 - Agents: start in [AGENTS.md](AGENTS.md) and then follow the nearest nested `AGENTS.md`.
-- Grey-box module work is governed by the five Public APIs documented in [docs/ubiquitous-language.md](docs/ubiquitous-language.md): Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Intent Plan, and Status Panel Runtime.
+- Grey-box module work is governed by the five Public APIs documented in [docs/ubiquitous-language.md](docs/ubiquitous-language.md): Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Outcome Plan, and Status Panel Runtime.
 - For substantial multi-step work, use `.agents/skills/decision-alignment` to align outcomes with the repo owner and keep at most one active implementation spec under `docs/specs/`; these specs are working docs and are deleted when the effort is fully done.
 - For external library/API behavior, use `.agents/skills/abb-library-research` as the control plane for authenticated Context7/current docs, squashed `repos/*` reference source, route cards, subtree refresh guidance, and installed dependency truth. Reference repos are read-only research material, not app dependencies.
 - For the product/system shape, use [docs/system-map.md](docs/system-map.md) and [docs/ubiquitous-language.md](docs/ubiquitous-language.md).

--- a/docs/specs/metadata-outcome-boundary-implementation-notes.md
+++ b/docs/specs/metadata-outcome-boundary-implementation-notes.md
@@ -1,0 +1,100 @@
+# Metadata Outcome Boundary Implementation Notes
+
+Date started: 2026-05-19
+Branch: `roadmap/metadata-outcome-boundary`
+
+## Decisions Not In The Roadmap
+
+- MB1/MB2: Implemented the backend boundary in `intent_plan.rs` rather than a
+  new file. The existing file already owned effective/naming resolution, so this
+  kept the private cluster cohesive while changing the public strip.
+- MB1/MB2: `NamingMetadata` is public and re-exported from the crate root
+  because `output_artifact::build_output_path_preview` is a public test-facing
+  API. Its fields remain private; callers build it through
+  `NamingMetadata::from_metadata`.
+- MB2: Kept `MetadataOutcomeRequest` to `input_path` plus `intent_patch`; no
+  use-case enum was needed for the current processing/save/preview paths.
+
+## Behavior Mutations
+
+- No intentional user-visible behavior mutations. The Rust changes preserve
+  current observable metadata, naming, and cover-art outcomes while moving
+  ownership of projection and passthrough decisions into the metadata boundary.
+
+## Tradeoffs
+
+- MB2/MB3: Kept metadata writes as a sibling boundary function rather than a
+  field on `MetadataOutcomePlan`. Processing should not carry write facts it
+  will never consume, while metadata-only save still enters through the same
+  metadata boundary via `plan_metadata_write`.
+- MB3/MB5: `CoverArtPassthroughPolicy` is public/test-facing because
+  `audio::process_audiobook_with_context` is public for integration tests. This
+  keeps finalization policy typed end-to-end instead of converting back to a
+  boolean at the processor edge.
+- MB4: Kept the `previewOutputPath({ metadata })` tauriClient property name
+  unchanged to avoid a TS runtime boundary contract change. Renamed local
+  workflow concepts to `previewMetadataDraft`, `metadataIntentByPath`, and
+  `buildOutputPathPreviewContext`.
+- MB5: Moved passthrough cover-art merge behavior into
+  `metadata::passthrough::merge_passthrough_cover_art` so native and external
+  processors share one metadata-owned rule after the passthrough policy is
+  applied.
+- MB6-lite: Renamed active canon references from Metadata Intent Plan to
+  Metadata Outcome Plan. Older historical specs were left unchanged.
+
+## Test Changes
+
+- Updated contract/unit tests to target `plan_metadata_outcome`,
+  `plan_metadata_write`, `NamingMetadata`, and `CoverArtPassthroughPolicy`.
+- Updated output-plan workflow tests statically for the frontend naming cleanup.
+- Updated `scripts/check-public-api-strips.sh` so the metadata public-strip
+  assertion captures full multiline `intent_plan` export blocks.
+
+## Testing Gaps
+
+- First focused Rust contract run exposed two warning-gate issues and one
+  stale external-FDK unit-test helper name. Fixes: type-annotated
+  `MetadataOutcomePlan` consumption in processing, kept metadata write coverage
+  on `plan_metadata_write`, and updated the external-FDK test to call
+  `merge_passthrough_cover_art`.
+- Follow-up Rust compile exposed the remaining public processor test callsites
+  that still passed a boolean passthrough flag. Updated them to pass
+  `CoverArtPassthroughPolicy::Preserve` and removed the now-unused
+  `allow_passthrough_cover_art` helper.
+- No remaining known automated testing gaps for this roadmap slice. Validation
+  covered metadata contracts, naming projection, save/clear intent, cover-art
+  passthrough policy, processor finalization, frontend metadata intent
+  workflow, public API strips, context surface, and the full standard gate.
+  The existing xHE-AAC fixture test remains environment-gated and was ignored
+  by the standard run because `ABB_XHE_AAC_FIXTURE` and external libfdk FFmpeg
+  were not configured.
+
+## PR Summary Notes
+
+- Added `MetadataOutcomeRequest`, `MetadataOutcomePlan`, `NamingMetadata`,
+  `CoverArtPassthroughPolicy`, `plan_metadata_outcome`, and
+  `plan_metadata_write` under the metadata boundary.
+- Refactored processing/output planning and native/external processor
+  finalization to consume metadata-owned naming metadata and cover-art
+  passthrough policy.
+- Kept Tauri command payloads and generated TypeScript bindings unchanged; only
+  local frontend naming was clarified around draft metadata and intent-by-path.
+- Updated active Public API Strip docs/checks from Metadata Intent Plan to
+  Metadata Outcome Plan.
+- Validation completed:
+  `cargo test -p audiobook-boss --lib contract_tests`,
+  `cargo test -p audiobook-boss --lib metadata`,
+  `cargo test -p audiobook-boss --lib processing`,
+  `cargo test -p audiobook-boss --test unit_output_path_naming_tests`,
+  `cargo test -p audiobook-boss --lib merge_passthrough_cover_art`,
+  `cargo test -p audiobook-boss --test integration_metadata_tests metadata`,
+  `cargo test -p audiobook-boss --test integration_processing_flow_tests metadata_preservation`,
+  `cargo test -p audiobook-boss --test integration_processing_flow_tests preview_and_full_processing_preserve_series_metadata_from_source_file`,
+  targeted Vitest workflow/runtime files, `scripts/check-public-api-strips.sh`,
+  `scripts/check-no-bridge-imports.sh`, `bash scripts/check-context-surface.sh`,
+  and logged `scripts/checks.sh standard` (`/tmp/abb-standard-checks.log`,
+  exit status 0).
+
+## Unresolved Follow-Ups
+
+- None for MB1-MB5.

--- a/docs/specs/metadata-outcome-boundary-roadmap.html
+++ b/docs/specs/metadata-outcome-boundary-roadmap.html
@@ -1,0 +1,634 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ABB Metadata Outcome Boundary Roadmap</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0d1118;
+      --panel: #151b25;
+      --panel-2: #101722;
+      --border: #2b3545;
+      --text: #e7edf7;
+      --muted: #a8b3c7;
+      --soft: #7f8ca3;
+      --green: #31d48b;
+      --blue: #58a6ff;
+      --amber: #f4c542;
+      --red: #ff6b7a;
+      --violet: #a475ff;
+      --line: #3a465a;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+
+    main {
+      width: min(1180px, calc(100vw - 48px));
+      margin: 0 auto;
+      padding: 36px 0 56px;
+    }
+
+    h1, h2, h3, p { margin-top: 0; }
+    h1 { font-size: 32px; line-height: 1.1; margin-bottom: 12px; }
+    h2 { font-size: 20px; margin-bottom: 16px; }
+    h3 { font-size: 15px; margin-bottom: 8px; }
+    p { color: var(--muted); }
+
+    .hero {
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 24px;
+      margin-bottom: 28px;
+    }
+
+    .subtitle {
+      max-width: 880px;
+      font-size: 16px;
+      color: var(--muted);
+    }
+
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 18px;
+    }
+
+    .chip {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 5px 9px;
+      color: var(--muted);
+      background: #111722;
+      font-size: 12px;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    .chip.green { color: var(--green); border-color: #255f47; }
+    .chip.blue { color: var(--blue); border-color: #2a5685; }
+    .chip.amber { color: var(--amber); border-color: #6b5621; }
+    .chip.violet { color: var(--violet); border-color: #553d8a; }
+
+    .grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 18px;
+      margin-bottom: 18px;
+    }
+
+    .callout {
+      background: #122033;
+      border: 1px solid #315f91;
+      border-left: 4px solid var(--blue);
+    }
+
+    .callout strong { color: var(--text); }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(120px, 1fr));
+      gap: 10px;
+      overflow-x: auto;
+      padding-bottom: 4px;
+    }
+
+    .floor {
+      min-height: 118px;
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      position: relative;
+    }
+
+    .floor::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      right: -10px;
+      width: 10px;
+      height: 1px;
+      background: var(--line);
+    }
+
+    .floor:last-child::after { display: none; }
+
+    .floor .label {
+      color: var(--blue);
+      font-weight: 700;
+      font-size: 13px;
+      margin-bottom: 8px;
+    }
+
+    .floor .detail {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .forms {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .form-card {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      background: var(--panel-2);
+    }
+
+    .form-card .name {
+      font-weight: 750;
+      margin-bottom: 6px;
+    }
+
+    .form-card .owner {
+      color: var(--amber);
+      font-size: 12px;
+      margin-bottom: 6px;
+    }
+
+    .form-card .desc {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+
+    th, td {
+      border-bottom: 1px solid var(--border);
+      padding: 10px 8px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      color: var(--soft);
+      font-weight: 700;
+    }
+
+    td { color: var(--text); }
+    td.muted { color: var(--muted); }
+
+    .block {
+      display: grid;
+      grid-template-columns: 72px 1fr;
+      gap: 12px;
+      align-items: start;
+      border-top: 1px solid var(--border);
+      padding: 14px 0;
+    }
+
+    .block:first-child { border-top: 0; padding-top: 0; }
+    .block:last-child { padding-bottom: 0; }
+
+    .block-id {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 54px;
+      height: 32px;
+      border: 1px solid #3d6b55;
+      border-radius: 6px;
+      color: var(--green);
+      font-weight: 800;
+      background: #102018;
+    }
+
+    .block h3 { margin-bottom: 4px; }
+    .block p { margin-bottom: 0; font-size: 14px; }
+
+    .decision-list {
+      display: grid;
+      gap: 10px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .decision-list li {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      color: var(--muted);
+      background: var(--panel-2);
+    }
+
+    .decision-list strong { color: var(--text); }
+
+    .source {
+      color: var(--soft);
+      font-size: 13px;
+      border-top: 1px solid var(--border);
+      padding-top: 14px;
+      margin-top: 20px;
+    }
+
+    code {
+      background: #202838;
+      border: 1px solid #2e394c;
+      border-radius: 5px;
+      padding: 1px 5px;
+      color: #dbe7ff;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    @media (max-width: 900px) {
+      main { width: min(100vw - 28px, 1180px); padding-top: 24px; }
+      .grid.two, .grid.three, .forms { grid-template-columns: 1fr; }
+      .flow { grid-template-columns: repeat(6, 190px); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <h1>Metadata Outcome Boundary Roadmap</h1>
+      <p class="subtitle">
+        A forest-level architecture plan for making ABB metadata durable enough
+        that future agents can change metadata behavior without rediscovering
+        the same ownership traps.
+      </p>
+      <div class="chips">
+        <span class="chip green">Focus: Metadata</span>
+        <span class="chip blue">All Layers In Scope</span>
+        <span class="chip amber">Planning Thread Only</span>
+        <span class="chip violet">One Roadmap PR Preferred</span>
+      </div>
+    </section>
+
+    <section class="panel callout">
+      <h2>Destination</h2>
+      <p>
+        <strong>Metadata may flow through every gross layer, but metadata policy
+        should not live in every gross layer.</strong> The rest of the app should
+        ask the metadata boundary focused questions: what intent was expressed,
+        what effective metadata should a job use, what metadata is safe for
+        naming, and what write plan should be committed.
+      </p>
+    </section>
+
+    <section class="grid two">
+      <div class="panel">
+        <h2>Operating Model</h2>
+        <ul class="decision-list">
+          <li><strong>This thread:</strong> architecture/design alignment, roadmap shape, behavior decisions, and implementation-agent handoff prompt.</li>
+          <li><strong>Not this thread:</strong> implementation work or continuous tests/checks.</li>
+          <li><strong>Implementation:</strong> fresh Codex thread creates its own plan and works it as a goal.</li>
+          <li><strong>Review:</strong> JStar plus two GitHub PR review agents; process should serve clarity, not ceremony.</li>
+        </ul>
+      </div>
+      <div class="panel">
+        <h2>Problem Statement</h2>
+        <p>
+          Metadata policy is still partly represented as call choreography:
+          callers must know when to read source metadata, apply patches,
+          sanitize for naming, preserve or clear cover art, write tags, and
+          hand off to output or processing.
+        </p>
+        <p>
+          The target is not fewer files by itself. The target is less caller
+          knowledge and a deeper metadata outcome boundary.
+        </p>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Gross Layer Flow</h2>
+      <div class="flow" aria-label="Metadata across gross layers">
+        <div class="floor">
+          <div class="label">L1 Product Intent</div>
+          <div class="detail">User wants fields set, cleared, preserved, recomputed, or discovered.</div>
+        </div>
+        <div class="floor">
+          <div class="label">L2 UI State</div>
+          <div class="detail">Editable drafts, dirty state, queue state, cover art preview.</div>
+        </div>
+        <div class="floor">
+          <div class="label">L3 Workflows</div>
+          <div class="detail">Lookup, save, output review, process start, cancellation sequencing.</div>
+        </div>
+        <div class="floor">
+          <div class="label">L4 IPC Contract</div>
+          <div class="detail">Explicit patch ops, normalized payloads, generated contract shape.</div>
+        </div>
+        <div class="floor">
+          <div class="label">L5 Backend</div>
+          <div class="detail">Metadata planning, processing planning, final write decisions.</div>
+        </div>
+        <div class="floor">
+          <div class="label">L6 Artifact Truth</div>
+          <div class="detail">Actual tags, paths, cover art, readback, terminal result on disk.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Metadata Forms</h2>
+      <div class="forms">
+        <div class="form-card">
+          <div class="name">Metadata Draft</div>
+          <div class="owner">Owner: UI state/form</div>
+          <div class="desc">What the user currently sees or edits before it becomes explicit intent.</div>
+        </div>
+        <div class="form-card">
+          <div class="name">Metadata Intent Patch</div>
+          <div class="owner">Owner: TS helpers + Rust contract</div>
+          <div class="desc">The durable user instruction: set, clear, noop, or recompute.</div>
+        </div>
+        <div class="form-card">
+          <div class="name">Effective Metadata</div>
+          <div class="owner">Owner: Rust metadata boundary</div>
+          <div class="desc">Source metadata hydrated and patched for processing.</div>
+        </div>
+        <div class="form-card">
+          <div class="name">Naming Metadata</div>
+          <div class="owner">Owner: Rust metadata boundary</div>
+          <div class="desc">Sanitized metadata safe for output path generation.</div>
+        </div>
+        <div class="form-card">
+          <div class="name">Write Plan</div>
+          <div class="owner">Owner: Rust metadata boundary</div>
+          <div class="desc">Exact writer instruction for save/finalization behavior.</div>
+        </div>
+        <div class="form-card">
+          <div class="name">Artifact Metadata</div>
+          <div class="owner">Owner: disk/backend readback truth</div>
+          <div class="desc">What actually exists in the final file after write or processing.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Code-Backed Flow Trace</h2>
+      <div class="grid three">
+        <div>
+          <h3>Frontend Draft / Intent</h3>
+          <ul class="decision-list">
+            <li><code>metadataIntent.ts</code> owns set, clear, noop, recompute, date normalization, and generated payload compilation.</li>
+            <li><code>metadataDraft.ts</code> narrows ordinary UI drafts to writable form fields.</li>
+            <li><code>metadataState.ts</code> stores current per-file metadata plus pending intent patches.</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Workflow / IPC</h3>
+          <ul class="decision-list">
+            <li><code>metadataSaveWorkflow.ts</code> sends pending intent requests to batch save.</li>
+            <li><code>processingWorkflow.ts</code> stages dirty edits and passes metadata intent through output review and processing.</li>
+            <li><code>commands.ts</code> compiles TS intent maps before generated Rust calls.</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Backend / Artifact</h3>
+          <ul class="decision-list">
+            <li><code>intent_plan.rs</code> resolves effective metadata and naming metadata.</li>
+            <li><code>processing/plan.rs</code> currently choreographs read, patch, naming, cover policy, and output plan calls.</li>
+            <li><code>output_artifact/naming.rs</code> renders paths but must trust callers to supply naming-safe metadata.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid two">
+      <div class="panel">
+        <h2>Accepted Posture</h2>
+        <ul class="decision-list">
+          <li><strong>Primary focus:</strong> metadata before generic frontend glue.</li>
+          <li><strong>Optimization:</strong> durable agent/human maintainability.</li>
+          <li><strong>Scope:</strong> frontend, backend, and cross-layer metadata flow.</li>
+          <li><strong>Roadmap:</strong> one active spec keeps planning and later implementation honest.</li>
+          <li><strong>Glue rule:</strong> keep only real technical or ownership boundaries.</li>
+          <li><strong>Branch:</strong> dedicated <code>roadmap/metadata-outcome-boundary</code> branch.</li>
+          <li><strong>PR shape:</strong> default to one full-roadmap PR; split only for a concrete technical reason.</li>
+          <li><strong>Review reality:</strong> optimize for JStar plus two GH review agents, not ceremony.</li>
+          <li><strong>Behavior:</strong> mutable when necessary, but only after full metadata-flow tracing.</li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h2>Risk To Remove</h2>
+        <table>
+          <thead>
+            <tr><th>Risk</th><th>Target shape</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Patch treated as full metadata</td><td>Named intent/effective forms</td></tr>
+            <tr><td>Raw source metadata used for naming</td><td>Naming-safe metadata output</td></tr>
+            <tr><td>Processing owns metadata policy</td><td>Processing consumes plans</td></tr>
+            <tr><td>Frontend drops clear intent</td><td>Draft to intent path stays explicit</td></tr>
+            <tr><td>Finalize paths duplicate metadata rules</td><td>One finalization policy owner</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Library / Contract Constraints</h2>
+      <table>
+        <thead>
+          <tr><th>Surface</th><th>Constraint</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Effect</td><td>Keep Effect in workflow owners; do not move pure metadata transforms into Effect for style symmetry.</td></tr>
+          <tr><td>Tauri runtime</td><td>Keep generated command access behind <code>src/lib/tauri/*</code> and <code>tauriClient</code>.</td></tr>
+          <tr><td>Generated bindings</td><td>Do not hand-edit <code>src/lib/generated/tauri.ts</code>; regenerate if Rust/Specta contract shapes change.</td></tr>
+          <tr><td>Specta</td><td>Design against installed <code>specta</code>/<code>tauri-specta</code> <code>2.0.0-rc.24</code>, not generic upstream assumptions.</td></tr>
+          <tr><td>Svelte state</td><td>Svelte 5 state modules own UI state; metadata policy belongs in metadata boundary or explicit workflow owners.</td></tr>
+          <tr><td>Research</td><td>Use <code>abb-library-research</code> before depending on library behavior beyond current local usage.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="panel">
+      <h2>Ownership Smear To Remove</h2>
+      <table>
+        <thead>
+          <tr><th>Current smear</th><th>Roadmap target</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>processing/plan.rs</code> decides when to call metadata helpers and how to package the result.</td><td>Processing consumes one metadata outcome plan.</td></tr>
+          <tr><td>Cover-art clear is detected in planning, enforced in passthrough policy, and re-merged in processor paths.</td><td>Cover-art passthrough policy has one owner and one explicit plan fact.</td></tr>
+          <tr><td>Output naming receives an <code>AudiobookMetadata</code> value without knowing if it is raw, effective, or naming-safe.</td><td>Output artifact planning receives naming-safe metadata only.</td></tr>
+          <tr><td>Output path preview uses draft metadata while processing preflight uses explicit intent.</td><td>Frontend names preview metadata and processing intent as different forms.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="panel">
+      <h2>Trace Order Before Edits</h2>
+      <table>
+        <thead>
+          <tr><th>Behavior family</th><th>Trace through</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Output naming</td><td>Draft preview metadata, preflight intent, source hydration, legacy series-part scrub, output collision planning.</td></tr>
+          <tr><td>Save / clear intent</td><td>Dirty UI state, pending intent storage, metadata-only save, writer sentinel values, readback truth.</td></tr>
+          <tr><td>Cover art policy</td><td>Custom art, explicit clear, passthrough preservation, preview behavior, native mux, external FDK remux.</td></tr>
+          <tr><td>Finalization passthrough</td><td>Chapters, metadata writes, native/external differences, output commit ownership, terminal result truth.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="panel">
+      <h2>Coherent Work Blocks</h2>
+      <div class="block">
+        <div class="block-id">MB0</div>
+        <div>
+          <h3>Roadmap Alignment</h3>
+          <p>Create the shared spec/presentation surface, lock the destination posture, and hand off a source-backed implementation prompt.</p>
+        </div>
+      </div>
+      <div class="block">
+        <div class="block-id">MB1</div>
+        <div>
+          <h3>Metadata Form Taxonomy And Ownership</h3>
+          <p>Name each metadata form and owner so future work stops saying vague "metadata."</p>
+        </div>
+      </div>
+      <div class="block">
+        <div class="block-id">MB2</div>
+        <div>
+          <h3>Backend Metadata Planning Boundary</h3>
+          <p>Deepen the Rust metadata boundary so callers request metadata plans instead of assembling policy.</p>
+        </div>
+      </div>
+      <div class="block">
+        <div class="block-id">MB3</div>
+        <div>
+          <h3>Processing And Output Metadata Consumption</h3>
+          <p>Make processing and output planning consumers of metadata plans, not metadata-policy owners.</p>
+        </div>
+      </div>
+      <div class="block">
+        <div class="block-id">MB4</div>
+        <div>
+          <h3>Frontend Metadata Flow Cleanup</h3>
+          <p>Clarify draft, intent, save, lookup, preview, and processing paths without chasing unrelated glue.</p>
+        </div>
+      </div>
+      <div class="block">
+        <div class="block-id">MB5</div>
+        <div>
+          <h3>Metadata / Audio Processor Finalization Boundary</h3>
+          <p>Review metadata preservation, passthrough, cover art, and final tag writes across processor paths.</p>
+        </div>
+      </div>
+      <div class="block">
+        <div class="block-id">MB6</div>
+        <div>
+          <h3>Closeout, Canon Docs, And Residual Debt Routing</h3>
+          <p>Update durable docs and remove metadata architecture from the active debt loop.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel callout">
+      <h2>Behavior Definition</h2>
+      <p>
+        In this roadmap, <strong>behavior</strong> means what ABB does and
+        produces at the product boundary: visible UX state, command outcomes,
+        saved metadata, output paths, final files, tags, cover art,
+        progress/terminal status, and error handling. Internal implementation
+        shape is not behavior unless it changes an observable outcome or public
+        contract.
+      </p>
+      <p>
+        Behavior stability is the default, not a prohibition. Behavior changes
+        are allowed when they improve the metadata outcome boundary and have
+        been traced through metadata forms, gross layers, public contracts,
+        artifact truth, UX consequences, and compatibility impact.
+      </p>
+    </section>
+
+    <section class="panel">
+      <h2>Behavior Mutation Gate</h2>
+      <table>
+        <thead>
+          <tr><th>Trace</th><th>Question</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Current</td><td>What does ABB do today at the UX, command, artifact, and contract levels?</td></tr>
+          <tr><td>Target</td><td>What should ABB do instead, and why is that better for the product outcome?</td></tr>
+          <tr><td>Forms</td><td>Which metadata forms are touched: draft, intent, effective, naming, write, artifact?</td></tr>
+          <tr><td>Layers</td><td>Which gross layers observe, transform, or depend on the behavior?</td></tr>
+          <tr><td>Contracts</td><td>Does TS-Rust shape, generated binding shape, command semantics, or public strip behavior change?</td></tr>
+          <tr><td>Artifact</td><td>Do final files, tags, cover art, paths, or readback truth change?</td></tr>
+          <tr><td>Compatibility</td><td>Does ABS/Plex/Apple interoperability or legacy-file handling change?</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="panel">
+      <h2>Open Alignment Questions</h2>
+      <table>
+        <thead>
+          <tr><th>Question</th><th>Recommended default</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>How aggressive should naming/type changes be in MB1?</td>
+            <td class="muted">Rename where it changes ownership or prevents misuse; avoid cosmetic churn.</td>
+          </tr>
+          <tr>
+            <td>How much temporary duplication is acceptable?</td>
+            <td class="muted">Accept short-lived duplication only when it preserves behavior while moving ownership.</td>
+          </tr>
+          <tr>
+            <td>Which metadata behavior family should be traced first?</td>
+            <td class="muted">Start with output naming because it crosses preview, preflight, hydration, legacy series-part sanitization, and artifact planning.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="panel callout">
+      <h2>Implementation Handoff</h2>
+      <p>
+        Start a fresh implementation thread on <code>roadmap/metadata-outcome-boundary</code>.
+        Read the roadmap source plus root and nearest nested <code>AGENTS.md</code> files.
+        Use <code>audiobook-metadata</code>, <code>contract-guardrails</code>, and
+        <code>abb-library-research</code>. Pre-validate the compact Rust metadata
+        outcome plan before editing, then implement MB1-MB5 as one coherent PR
+        unless review or rollback risk gives a concrete reason to split.
+      </p>
+      <ul class="decision-list">
+        <li><strong>First move:</strong> design the metadata planning result consumed by processing and output planning.</li>
+        <li><strong>Primary invariant:</strong> preserve explicit <code>set | clear | noop</code> intent and validation-before-read ordering.</li>
+        <li><strong>Stop rule:</strong> route back to JStar before any deliberate behavior mutation not covered by the roadmap gate.</li>
+        <li><strong>Final proof:</strong> defer broad checks until PR readiness; then use focused contract tests, public-strip checks, and <code>scripts/checks.sh standard</code> before runtime readiness claims.</li>
+      </ul>
+    </section>
+
+    <p class="source">
+      Source: <code>docs/specs/metadata-outcome-boundary-roadmap.md</code>.
+      Created 2026-05-19. Updated from read-only source inspection; no tests,
+      checks, or browser smoke run in this architecture-only planning pass by request.
+    </p>
+  </main>
+</body>
+</html>

--- a/docs/specs/metadata-outcome-boundary-roadmap.md
+++ b/docs/specs/metadata-outcome-boundary-roadmap.md
@@ -1,0 +1,832 @@
+# ABB Metadata Outcome Boundary Roadmap
+
+Date: 2026-05-19
+Status: Active architecture roadmap surface; no implementation started
+Source repo: `/Users/jstar/Projects/audiobook-boss`
+
+Artifact relationship:
+
+- This Markdown file is the editable roadmap source.
+- `docs/specs/metadata-outcome-boundary-roadmap.html` is the presentation view for human review.
+- Until a generator exists, update both files when roadmap content changes.
+
+## Operating Model
+
+This thread owns architecture/design alignment only:
+
+- decide whether metadata deserves a roadmap,
+- define the roadmap shape,
+- decide which architecture, design, and behavior mutations are justified,
+- keep this spec and the companion presentation current,
+- produce an implementation-agent handoff prompt only when the roadmap is ready.
+
+This thread does **not** own implementation.
+
+Implementation will happen in a fresh Codex thread. The implementation agent
+will receive a handoff prompt, create its own plan from that prompt, and work
+that plan as a goal. Tests/checks should not be run continuously during this
+planning thread; for implementation, verification should be concentrated near
+PR readiness unless a specific design/behavior question cannot be answered
+without targeted proof.
+
+Review flow:
+
+- JStar manages roadmap alignment, implementation oversight, and outcome
+  judgment across threads.
+- The implementation agent owns code changes, local verification, PR
+  preparation, and review-response patches.
+- GitHub PR review agents provide review feedback after the PR is opened.
+- Any unexpected architecture, design, or behavior decision discovered during
+  implementation routes back through this roadmap/spec before being treated as
+  settled.
+
+## Purpose / Big Picture
+
+Metadata is a core Audiobook Boss product capability. The app is already in a
+good functional place: metadata can be read, edited, queued, saved, and carried
+into processing for many files. The remaining problem is architectural, not a
+known broken user path.
+
+The roadmap goal is to make metadata durable and maintainable enough that
+future agents and humans can change metadata features without rediscovering
+the same ownership traps.
+
+Good looks like:
+
+- Metadata policy has one deep owner instead of being preserved by call
+  choreography.
+- Every layer receives the right metadata form for its job.
+- Processing, output planning, and UI workflows ask metadata questions through
+  explicit surfaces instead of reconstructing metadata semantics locally.
+- Glue remains only where a real technical boundary requires it.
+- When the roadmap is complete, metadata architecture should stop recurring as
+  a primary refactor concern; remaining metadata work should be feature work,
+  compatibility evidence, or narrow bug repair.
+
+## Problem Statement
+
+The remaining metadata problem is that metadata policy is still partly
+represented as call choreography.
+
+In plain terms: correct behavior depends on multiple callers knowing when to
+read source metadata, apply patches, sanitize for naming, preserve or clear
+cover art, write tags, and hand off to output/processing. The issue is not
+necessarily "too many callers" by count. The issue is that too many callers
+must know metadata sequencing and policy details that should belong to a
+deeper metadata outcome boundary.
+
+This roadmap should reduce caller knowledge, not merely move code between
+files.
+
+## Scope And Constraints
+
+In scope:
+
+- Metadata forms across all gross layers: draft, intent patch, effective
+  metadata, naming metadata, write plan, artifact/readback metadata.
+- Frontend metadata state and workflows where they affect save, lookup,
+  output preview, preflight, processing, and final artifact truth.
+- TS↔Rust metadata contract shape through `tauriClient`, generated bindings,
+  and `src-tauri/src/metadata/`.
+- Backend processing/output consumers that currently assemble or interpret
+  metadata policy.
+- Audio processor/finalize surfaces only where metadata preservation,
+  passthrough, cover art, or final tag writes are involved.
+
+Non-goals:
+
+- General frontend glue cleanup unrelated to metadata flow.
+- A renderer/framework rewrite.
+- Replacing the current TS↔Rust contract model.
+- Broad audio-processing redesign outside metadata preservation/finalization.
+- Reopening audiobook tag strategy without new interoperability evidence.
+
+Constraints:
+
+- Preserve explicit `set | clear | noop` metadata intent semantics.
+- Preserve external audiobook interoperability with ABS/Plex/Apple-oriented
+  tag behavior.
+- Preserve path validation before metadata reads or writes on user-provided
+  paths.
+- Preserve artifact truth: final files, paths, tags, and terminal outcomes
+  come from backend/disk truth, not UI optimism.
+- Do not add generic managers, broad facades, or traits unless they remove
+  real caller knowledge or isolate a real external adapter.
+- Behavior changes are allowed when they are necessary to improve the metadata
+  outcome boundary, but they must be deliberate roadmap decisions. A behavior
+  mutation requires tracing the affected behavior through every metadata form,
+  gross layer, public contract, artifact output, and user-visible consequence
+  before implementation.
+
+## Solution Posture
+
+Chosen posture: subsystem redesign through largest coherent work blocks.
+
+This should not be a small cleanup sequence driven by individual files. The
+right unit is the metadata outcome boundary: the path from user metadata intent
+to final artifact metadata. File splits such as `processing/run.rs` are
+secondary effects, not the architectural destination.
+
+The roadmap optimizes for agent/human durability. In this context,
+"correctness" means correct relative to ABB's product outcomes and invariants:
+
+- user intent to set, clear, preserve, or recompute metadata survives each
+  layer,
+- source metadata is hydrated and sanitized at the right point,
+- naming metadata cannot accidentally become write metadata,
+- write plans preserve/clear the intended tags,
+- final artifacts reflect backend truth and remain interoperable.
+
+Durability wins when the code becomes difficult to misuse because each metadata
+form has a name, owner, and allowed consumer.
+
+Behavior stability is the default posture, not a hard constraint. The roadmap
+may change product behavior when the current behavior is a symptom of bad
+ownership, incomplete metadata semantics, poor user outcome, or hidden
+cross-layer coupling. In those cases, the behavior change must be designed as
+part of the roadmap rather than treated as a side effect of refactoring.
+
+## Behavior Mutation Protocol
+
+Before intentionally changing metadata behavior, capture:
+
+| Question | Required answer |
+| --- | --- |
+| Current behavior | What does ABB do today at the UX, command, artifact, and contract levels? |
+| Target behavior | What should ABB do instead, and why is that better for the product outcome? |
+| Metadata forms touched | Draft, intent patch, effective metadata, naming metadata, write plan, artifact metadata. |
+| Gross layers touched | Which of L1-L6 observe, transform, or depend on the behavior? |
+| Contract impact | Does TS↔Rust shape, generated bindings, public strips, or command semantics change? |
+| Artifact impact | Do final files, tags, cover art, paths, or readback truth change? |
+| UX impact | Does the user see a different preview, warning, save result, progress state, or error? |
+| Compatibility impact | Does ABS/Plex/Apple interoperability or legacy-file handling change? |
+| Rollback strategy | Can this be reverted locally, or does it require a coordinated contract/documentation reversal? |
+
+Allowed behavior mutation examples:
+
+- Change output naming behavior if the current behavior uses the wrong metadata
+  form or lets legacy source tags poison naming.
+- Change metadata save behavior if current dirty-state handling can drop a
+  user clear/set intent.
+- Change finalization behavior if native and external processor paths preserve
+  or write metadata inconsistently.
+- Change UX warning/error behavior if it makes metadata intent and artifact
+  truth more honest.
+
+Not allowed as incidental refactor fallout:
+
+- Different final tags because a helper moved.
+- Different path previews because naming metadata was replaced with raw
+  effective metadata.
+- Different cover-art preservation because passthrough policy was lost during
+  a processor cleanup.
+- Different command payload semantics without explicit TS↔Rust contract design.
+
+## Context And Orientation
+
+### Gross Layers
+
+| Layer | Metadata role |
+| --- | --- |
+| L1 Product intent | User wants fields set, cleared, preserved, recomputed, or discovered. |
+| L2 UI state | Editable drafts, dirty/pending state, queue state, cover art preview. |
+| L3 Workflow coordination | Lookup, save, output review, process start, and cancellation sequencing. |
+| L4 IPC contract | Explicit patch ops, normalized payloads, command/event shape. |
+| L5 Backend lifecycle | Metadata planning, processing planning, job execution, write/finalize decisions. |
+| L6 Artifact truth | Actual tags, paths, cover art, readback, and terminal result on disk. |
+
+### Metadata Forms
+
+| Form | Meaning | Desired owner | Allowed consumers |
+| --- | --- | --- | --- |
+| Metadata draft | What the UI currently displays or edits. | UI metadata state/form. | UI components and metadata workflows. |
+| Metadata intent patch | User intent: `set`, `clear`, `noop`, `recompute`. | TS metadata intent helpers + Rust metadata contract. | `tauriClient`, metadata save, process/preflight payloads. |
+| Effective metadata | Source metadata with user intent applied. | Rust metadata boundary. | Processing plan and processor execution. |
+| Naming metadata | Sanitized metadata safe for output naming. | Rust metadata boundary, consumed by output artifact planning. | Output artifact path preview/plan only. |
+| Write plan | Exact instruction for metadata writers. | Rust metadata boundary. | Metadata write commands and finalize paths. |
+| Artifact metadata | What actually exists after write/process. | Disk/backend readback truth. | UI status, verification, future imports. |
+
+### Current Shape
+
+Known from current architecture mapping and source inspection:
+
+- `src/types/metadataIntent.ts` compiles frontend metadata intent patches.
+- `src/ui/metadataDraft.ts` narrows UI drafts to writable metadata fields.
+- `src/ui/metadataState.ts` stores per-file metadata, pending paths, and
+  intent patches.
+- `src/lib/tauri/commands.ts` compiles intent patches before generated command
+  calls.
+- `src-tauri/src/metadata/intent.rs` owns `MetadataIntentPatch`, `PatchOp`,
+  `AlbumSortPatchOp`, and `MetadataWritePlan`.
+- `src-tauri/src/metadata/intent_plan.rs` owns effective metadata and naming
+  metadata resolution.
+- `src-tauri/src/processing/plan.rs` currently calls metadata resolution while
+  building processing plans and output paths.
+- `src-tauri/src/processing/run.rs` consumes planned metadata when executing
+  jobs.
+- Metadata save, lookup, output preview, and processing workflows all touch
+  metadata at different layers.
+
+### Current Code Trace
+
+Frontend draft and intent:
+
+- `src/types/metadataIntent.ts` owns frontend `MetadataIntentPatch` shape,
+  actionable-patch detection, set/clear/noop compilation, date normalization,
+  and draft-to-intent conversion.
+- `src/ui/metadataDraft.ts` limits ordinary UI drafts to writable metadata
+  fields; notably `album_sort` is not part of the generic UI draft field list.
+- `src/ui/metadataState.ts` stores both current per-file metadata and
+  per-file pending intent patches. `setMetadataForFile(..., { markPending:
+  true })` merges intent patches so explicit clear intent can survive even
+  when the merged display metadata omits the cleared key.
+
+Frontend workflows and IPC:
+
+- `src/ui/core/metadataSaveWorkflow.ts` filters pending metadata intent to
+  currently loaded valid files and sends `MetadataSaveRequest` values to
+  `tauriClient.saveMetadataBatch`.
+- `src/ui/statusPanel/processingWorkflow.ts` stages dirty metadata before
+  processing, builds a metadata-intent payload for merge or batch jobs, passes
+  the same payload through output-plan review, and then sends it to
+  `tauriClient.processAudiobookFiles`.
+- `src/ui/outputPanel/outputPlanWorkflow.ts` has two metadata paths: output path
+  preview sends the current metadata object to `tauriClient.previewOutputPath`,
+  while processing preflight sends the explicit metadata-intent payload to
+  `tauriClient.preflightProcessingPlan`.
+- `src/lib/tauri/commands.ts` is the TS runtime boundary that compiles metadata
+  intent maps and save requests into generated Rust binding payloads.
+
+Backend planning and output naming:
+
+- Metadata-only save validates the input path first, converts
+  `MetadataIntentPatch` into `MetadataWritePlan`, and then calls
+  `metadata::save_metadata_with_plan`.
+- `src-tauri/src/metadata/intent.rs` gives processing and writing different
+  interpretations of clear intent: processing clears to `None`, while write
+  plans use empty values or empty cover-art bytes where writers need an
+  explicit deletion instruction.
+- `src-tauri/src/metadata/intent_plan.rs` currently owns effective processing
+  metadata and naming metadata resolution. It reads source metadata when an
+  input path is available, applies a patch when one exists, and scrubs invalid
+  legacy source `series_part`/`subseries_part` values only for untouched-source
+  naming.
+- `src-tauri/src/processing/plan.rs` currently choreographs metadata planning:
+  validate/hydrate input files, select the per-file patch, resolve effective
+  metadata, infer passthrough-cover-art allowance from the patch, resolve naming
+  metadata, call output path preview, and then resolve output collisions.
+- `src-tauri/src/output_artifact/naming.rs` owns path rendering and strict
+  naming validation, but it still receives an `AudiobookMetadata` value and
+  must trust callers to provide the naming-safe form.
+
+Processor and finalization:
+
+- `PlannedProcessingJob` carries effective metadata plus
+  `allow_passthrough_cover_art` into `processing/run.rs` and then
+  `audio::processor::ResolvedProcessorAdapter`.
+- The native processor path extracts passthrough chapters/cover art, applies
+  the cover-art policy, fills missing cover art from passthrough, writes
+  metadata during mux, then skips finalized metadata writing for non-MP4-family
+  outputs because ffmpeg-next already handled it.
+- The external FDK path separately extracts passthrough metadata, applies the
+  same cover-art policy, merges passthrough cover art, runs external FFmpeg,
+  and then remuxes with `metadata::rewrite_metadata_with_ffmpeg` to restore
+  metadata, cover art, and chapters.
+
+### Library / Contract Constraints
+
+Source-backed planning used the `abb-library-research` route-card posture:
+local repo and installed dependency truth first; external/current docs only
+when a dependency-level behavior question cannot be answered from ABB's
+installed versions or vendored references.
+
+Relevant implementation constraints:
+
+- Effect should remain a workflow-owner tool. Do not move pure metadata
+  transforms or local UI field normalization into Effect just to make the
+  architecture look uniform.
+- Tauri runtime and generated command access remain centralized in
+  `src/lib/tauri/*`. Frontend metadata callers should go through `tauriClient`
+  and command specs, not generated invokers directly.
+- Do not hand-edit `src/lib/generated/tauri.ts`. If Rust command or Specta
+  shapes change, regenerate bindings through the repo's normal path.
+- Specta/tauri-specta contract design must match ABB's installed versions:
+  `specta = 2.0.0-rc.24`, `tauri-specta = 2.0.0-rc.24`, and
+  `specta-typescript = 0.0.11`.
+- Frontend implementation should assume Svelte 5 state modules own UI state,
+  not metadata policy. Keep policy decisions in the metadata boundary or
+  explicit workflow owners.
+- Installed runtime versions observed during planning include
+  `effect@3.21.2`, `svelte@5.55.4`, and `@tauri-apps/api@2.10.1`; if the
+  implementation depends on library behavior beyond current local usage,
+  refresh through `abb-library-research` before coding the dependency-facing
+  shape.
+
+### Ownership Smear To Remove
+
+The current code has good pieces, but several rules still depend on caller
+choreography:
+
+- The metadata boundary owns effective/naming resolution, but
+  `processing/plan.rs` decides when to call each helper and how to package the
+  result for output planning and processor execution.
+- Cover-art clear intent is detected in `processing/plan.rs`, enforced in
+  `metadata::passthrough::apply_cover_art_policy`, and then re-merged in both
+  native and external processor paths.
+- Output naming policy is split between metadata's naming scrub and
+  output-artifact's path renderer; the renderer cannot tell whether the
+  `AudiobookMetadata` it receives is raw, effective, or naming-safe.
+- Frontend output path preview uses a plain metadata object, while processing
+  preflight uses explicit intent. That may be fine as a UX preview path, but it
+  should be named and documented as a draft/naming preview path rather than
+  confused with processing metadata outcome planning.
+
+### Behavior Families To Trace First
+
+Implementation should trace these in order before moving code:
+
+1. **Output naming:** draft preview metadata, preflight intent metadata,
+   source-read hydration, legacy `series_part`/`subseries_part` scrub, and
+   output artifact collision planning.
+2. **Save and clear intent:** frontend dirty state, `set | clear | noop`
+   compilation, pending intent storage, metadata-only save, writer sentinel
+   values, and readback truth.
+3. **Cover-art policy:** custom art, explicit clear, passthrough preservation,
+   preview behavior, native processor mux, and external FDK remux.
+4. **Finalization passthrough:** chapter preservation, final metadata write
+   decisions, native/external processor differences, output commit ownership,
+   and terminal result truth.
+
+This trace order is not a PR order. It is the pre-edit evidence order that
+keeps behavior mutations deliberate instead of accidental.
+
+## Architecture Destination
+
+Destination principle:
+
+> Metadata may flow through every gross layer, but metadata policy should not
+> live in every gross layer.
+
+Desired dependency shape:
+
+```mermaid
+flowchart TB
+  UI["UI draft / queue state"]
+  WF["Metadata-aware workflows"]
+  IPC["tauriClient / IPC patch contract"]
+  MB["Metadata Outcome Boundary"]
+  OP["Output Artifact Planning"]
+  PROC["Processing Lifecycle"]
+  ART["Artifact Truth"]
+
+  UI --> WF --> IPC --> MB
+  MB -->|"naming metadata"| OP
+  MB -->|"effective metadata / write facts"| PROC
+  OP --> PROC --> ART
+  ART -. readback/import .-> MB
+```
+
+The **Metadata Outcome Boundary** should answer questions like:
+
+- What intent patch represents this user edit?
+- What source metadata must be read before processing?
+- What effective metadata should this job use?
+- What metadata is safe for output naming?
+- What write plan should a metadata-only save or final artifact commit use?
+- Should cover art be passed through, cleared, replaced, or preserved?
+
+It should not ask processing, output, or UI layers to know tag compatibility
+details, sentinel clear values, legacy source sanitization, or writer strategy.
+
+Candidate backend shape for implementation to evaluate:
+
+```rust
+pub(crate) struct MetadataOutcomeRequest<'a> {
+    pub input_path: Option<&'a Path>,
+    pub intent_patch: Option<&'a MetadataIntentPatch>,
+    pub use_case: MetadataOutcomeUseCase,
+}
+
+pub(crate) struct MetadataOutcomePlan {
+    pub effective_metadata: Option<AudiobookMetadata>,
+    pub naming_metadata: Option<NamingMetadata>,
+    pub allow_passthrough_cover_art: bool,
+    pub write_plan: Option<MetadataWritePlan>,
+}
+```
+
+This is a direction, not a committed API. The implementation agent should keep
+the public strip compact and choose names that fit the final ownership better
+than this sketch if source inspection points to a sharper shape.
+
+## Plan Of Work
+
+Default branch model:
+
+- Use a dedicated roadmap branch: `roadmap/metadata-outcome-boundary`.
+- Prefer the largest coherent PRs the roadmap can safely support. A single
+  full-roadmap PR is allowed if up-front design makes the blast radius
+  reviewable and the spec tracks progress tightly enough for recovery.
+- Default fallback is one PR per block when a single PR would make review-agent
+  findings, rollback, or local reasoning too noisy.
+- Split a block only when the split preserves the block's coherent outcome and
+  does not leave metadata ownership more ambiguous between PRs.
+- Minimize PR/process overhead: the practical reviewers are JStar plus two
+  GitHub PR review agents, so process should serve technical clarity rather
+  than simulate a larger team.
+
+### MB0: Roadmap Alignment
+
+Status: Ready for JStar review; implementation handoff draft included.
+
+Outcome:
+
+- This spec and companion presentation exist.
+- The roadmap optimizes for durable agent/human maintainability.
+- Frontend, backend, and cross-layer metadata flow are all in scope when they
+  directly affect metadata outcome truth.
+
+### MB1: Metadata Form Taxonomy And Ownership
+
+Goal:
+
+- Make every important metadata form explicit in code/docs.
+- Reduce vague use of "metadata" where a narrower form is intended.
+
+Likely changes:
+
+- Add/clarify source-level names and docs for draft, intent patch, effective
+  metadata, naming metadata, write plan, and artifact/readback metadata.
+- Update `docs/ubiquitous-language.md`, `docs/system-map.md`, and nested
+  metadata/tauri/processing guidance only after the code shape is chosen.
+- Identify public/private ownership of each form before file movement.
+
+Done evidence:
+
+- Future agents can classify any metadata value by form and owner.
+- No roadmap PR after MB1 needs to re-litigate the basic vocabulary.
+
+### MB2: Backend Metadata Planning Boundary
+
+Goal:
+
+- Deepen the Rust metadata boundary so callers request metadata plans instead
+  of assembling source-read, patch-apply, naming-sanitize, cover-art policy,
+  and write-plan decisions themselves.
+
+Likely changes:
+
+- Introduce a compact metadata planning surface inside `src-tauri/src/metadata/`.
+- Keep raw helpers private where possible.
+- Return typed results that separate effective metadata, naming metadata, write
+  intent, and passthrough/cover decisions.
+
+Watchpoints:
+
+- Do not make a generic facade that merely wraps existing functions.
+- Do not let output naming own metadata sanitization policy.
+- Preserve validation-before-read ordering for user paths.
+
+Done evidence:
+
+- `processing/plan.rs` consumes a metadata planning result rather than
+  reconstructing metadata semantics.
+- Metadata contract tests pin public behavior, not helper existence.
+
+### MB3: Processing And Output Metadata Consumption
+
+Goal:
+
+- Make processing and output planning consumers of metadata plans, not owners
+  of metadata policy.
+
+Likely changes:
+
+- Rework `src-tauri/src/processing/plan.rs` around metadata plan inputs and
+  output artifact planning.
+- Keep output artifact ownership of paths, collisions, parent dirs, and commit
+  truth.
+- Keep processing ownership of plan/execution lifecycle.
+- Make metadata-to-output naming dependencies explicit.
+
+Watchpoints:
+
+- `processing/run.rs` should not be split first if doing so preserves metadata
+  ambiguity.
+- If runner split becomes obvious during MB3, limit it to private helpers that
+  reduce lifecycle density without changing public contracts.
+
+Done evidence:
+
+- Processing plan has fewer direct metadata policy decisions.
+- Output planning receives naming-safe metadata rather than raw/effective
+  metadata when naming is the only need.
+
+### MB4: Frontend Metadata Flow Cleanup
+
+Goal:
+
+- Make frontend metadata draft/intent flow clear enough that agents do not
+  accidentally drop explicit clear intent or bypass intended workflow owners.
+
+Likely changes:
+
+- Clarify the boundary between `metadataDraft`, `metadataState`,
+  `metadataSaveWorkflow`, `metadataLookupWorkflow`, `outputPlanWorkflow`, and
+  `processingWorkflow`.
+- Remove or document direct metadata IPC calls that bypass workflow ownership
+  when they affect multi-step behavior.
+- Keep single-boundary UI helpers only when they are boring, local, and do not
+  own metadata policy.
+
+Watchpoints:
+
+- Do not chase unrelated frontend glue.
+- Do not require Effect for pure transforms or local UI rendering.
+- Preserve efficient multi-file metadata management.
+
+Done evidence:
+
+- A frontend caller can tell whether it holds a draft, an intent patch, or
+  stored per-file metadata.
+- Save, lookup, preview, and processing paths produce the same intent payload
+  semantics.
+
+### MB5: Metadata / Audio Processor Finalization Boundary
+
+Goal:
+
+- Review the metadata/audio handoff where processing produces final artifacts,
+  cover art is passed through or cleared, and tags are written or preserved.
+
+Likely changes:
+
+- Inspect native/external finalize paths only where metadata preservation,
+  cover art, passthrough, or final write behavior is involved.
+- Decide whether metadata finalize policy belongs in metadata, processor, or
+  output artifact ownership.
+- Avoid broad audio-processing redesign unless a metadata-finalization leak
+  requires it.
+
+Done evidence:
+
+- Metadata policy at finalization has one owner.
+- Native/external processor differences do not duplicate metadata commit rules
+  unnecessarily.
+
+### MB6: Closeout, Canon Docs, And Residual Debt Routing
+
+Goal:
+
+- Convert the roadmap's stable results into normal repo guidance and retire
+  the active spec.
+
+Likely changes:
+
+- Update `docs/system-map.md`, `docs/ubiquitous-language.md`, nested
+  `AGENTS.md`, and the Obsidian/testing-infra architecture artifacts to match
+  the final state.
+- Route any remaining non-blocking ideas to GitHub issues, not this spec.
+- Delete this spec after implementation, review, validation, documentation
+  alignment, and sync are complete.
+
+Done evidence:
+
+- Metadata no longer appears as unresolved architecture debt in the active
+  architecture map.
+- Future metadata work can start from canon docs and local owners, not chat
+  memory.
+
+## Accepted Decisions
+
+- Metadata is the next primary architecture focus ahead of generic frontend
+  glue.
+- Metadata may flow through every gross layer, but metadata policy should not
+  live in every gross layer.
+- Use one roadmap as the active planning and implementation state holder.
+- The roadmap optimizes for durable agent/human maintainability. Correctness is
+  defined by ABB product outcomes and invariants, not by current code shape.
+- Frontend and backend metadata flow are both in scope. The roadmap follows
+  metadata outcome truth across all gross layers.
+- Glue and boundaries are acceptable only when they correspond to real
+  technological or ownership boundaries and cannot be removed by better
+  design.
+- PRs should be the largest coherent work blocks, not the smallest possible
+  patches.
+- Use a dedicated metadata roadmap branch. Treat one full-roadmap PR as a
+  legitimate option, not an anti-pattern, if planning proves the work can stay
+  coherent and reviewable.
+- Prefer one PR for the full roadmap if the implementation plan, review-agent
+  signal, and rollback posture remain tractable. Use fewer large PRs only when
+  there is a concrete technical reason.
+- Default implementation target is one PR for the full roadmap on
+  `roadmap/metadata-outcome-boundary`. Split only if the full-roadmap PR would
+  make review-agent feedback, rollback, or outcome reasoning materially worse.
+- When this roadmap says "behavior," it means what the app does and produces at
+  the product boundary: visible UX state, command outcomes, saved metadata,
+  output paths, final files, tags, cover art, progress/terminal status, and
+  error handling. Internal implementation shape is not behavior unless it
+  changes one of those observable outcomes or a public contract.
+- Behavior mutation is explicitly on the table when needed. The roadmap should
+  not preserve bad behavior for compatibility with current internals, but every
+  mutation must be traced through the full metadata outcome path first.
+- Current metadata behavior works materially better than the old spaghetti
+  shape. The roadmap is not a rescue mission; it is a consolidation pass to
+  make the good outcome durable.
+- Implementation belongs to a separate Codex thread after this roadmap is
+  sufficiently aligned.
+
+## Open Design Questions
+
+These should be resolved before implementation starts:
+
+1. Should MB1 introduce new type names only where they change code ownership,
+   or also rename existing variables/functions aggressively for clarity?
+2. What is the acceptable amount of temporary duplication during MB2/MB3 if it
+   lets us preserve behavior while moving ownership?
+3. Which metadata behavior family should be traced first: output naming,
+   save/clear intent, cover-art handling, or finalization/passthrough?
+
+Recommended defaults:
+
+1. Rename where the name changes ownership, prevents misuse, or distinguishes a
+   metadata form. Avoid broad cosmetic renames.
+2. Permit temporary duplication inside a single MB block only when the duplicate
+   code is deleted before the block is complete or is guarded by contract tests
+   that pin the public behavior during migration.
+3. Trace output naming first because it already crosses frontend preview,
+   backend preflight, metadata hydration, legacy `series_part` sanitization, and
+   output artifact planning. Then trace save/clear intent, then cover-art
+   passthrough/finalization.
+
+## Implementation-Agent Handoff Prompt
+
+Use this prompt in the fresh implementation thread when JStar is ready to start
+code changes:
+
+```text
+You are implementing the ABB Metadata Outcome Boundary roadmap in
+/Users/jstar/Projects/audiobook-boss on branch
+roadmap/metadata-outcome-boundary.
+
+Start by reading:
+- AGENTS.md
+- docs/system-map.md
+- docs/ubiquitous-language.md
+- docs/specs/metadata-outcome-boundary-roadmap.md
+- src-tauri/src/metadata/AGENTS.md
+- src-tauri/src/processing/AGENTS.md
+- src-tauri/src/output_artifact/AGENTS.md
+- src/lib/tauri/AGENTS.md
+
+Use the audiobook-metadata, contract-guardrails, and abb-library-research
+skills. Use job-registry-and-progress only if progress/result semantics change,
+and resource-lifetime-audit only if file-handle/remux/replace behavior
+changes.
+
+Goal:
+Implement MB1-MB5 as one coherent PR if review and rollback remain tractable.
+Split only if a smaller PR still leaves a coherent metadata outcome boundary.
+
+Hard boundaries:
+- Preserve explicit set | clear | noop intent semantics.
+- Preserve path validation before source metadata reads/writes.
+- Preserve artifact truth and collision-review semantics.
+- Do not reopen tag strategy without new interoperability evidence.
+- Do not turn metadata into a generic manager/facade.
+- Do not implement unrelated frontend glue cleanup.
+
+First design move:
+Pre-validate the implementation shape before editing. Propose the compact Rust
+metadata planning result that processing should consume, including effective
+metadata, naming-safe metadata, write-plan/clear intent, and cover-art
+passthrough policy. Then implement the smallest coherent version that removes
+caller choreography from processing/output consumers.
+
+Required trace before editing:
+- Output naming from frontend preview metadata and processing preflight intent
+  through Rust naming-safe metadata and output artifact planning.
+- Save/clear intent from dirty UI state through pending intent patches,
+  metadata-only save, writer sentinel values, and readback expectations.
+- Cover-art set/clear/preserve from UI state through processing plan,
+  passthrough policy, native mux, external FDK remux, and final file truth.
+- Finalization passthrough boundaries for chapters, metadata writes, output
+  commit, and terminal success.
+
+Suggested implementation order:
+1. MB1: introduce or clarify metadata form names only where ownership or misuse
+   changes.
+2. MB2: deepen src-tauri/src/metadata/ with a compact metadata outcome planning
+   surface and contract tests.
+3. MB3: make src-tauri/src/processing/plan.rs consume metadata plans and pass
+   naming-safe metadata to output artifact planning.
+4. MB4: align frontend draft/intent/preview/process naming so the UI path is
+   clear about draft metadata versus intent payloads.
+5. MB5: clarify native/external processor finalization ownership for cover-art
+   passthrough, explicit clear, and final writes.
+6. MB6 only after code review: update canon docs/nested AGENTS if the final
+   shape differs from the current guidance, then remove the active spec once
+   implementation, review, validation, documentation alignment, and sync are
+   complete.
+
+Verification:
+Do not run broad checks continuously. Run focused tests during implementation
+only when they falsify the active risk or clarify a behavior question. Before
+PR readiness, run the relevant metadata/processing/output/frontend contract
+tests plus scripts/check-public-api-strips.sh. Run scripts/checks.sh standard
+before claiming runtime/contract behavior is ready.
+
+Route back to JStar before proceeding if implementation requires a deliberate
+behavior mutation not already covered by the roadmap's behavior mutation
+protocol.
+```
+
+## Validation And Acceptance
+
+No validation commands are run automatically in this architecture-only thread.
+
+When implementation begins, each block should define its own proof path. Likely
+proof surfaces include:
+
+- metadata intent unit tests,
+- metadata/processing/output artifact contract tests,
+- workflow tests around metadata save, lookup, output preview, and processing,
+- public API strip and bridge-import checks,
+- full `scripts/checks.sh standard` only when implementation touches runtime,
+  contract, processing, or broad behavior.
+
+Manual acceptance should include:
+
+- metadata save/readback for single and multi-file queues,
+- processing with untouched source metadata,
+- processing with partial metadata edits,
+- cover-art set/clear/preserve flows,
+- output naming with legacy source metadata and with explicit user edits,
+- final artifact metadata inspection.
+
+## Interfaces And Dependencies
+
+Surfaces likely affected:
+
+- `src/types/metadataIntent.ts`
+- `src/ui/metadataDraft.ts`
+- `src/ui/metadataState.ts`
+- `src/ui/core/metadataSaveWorkflow*`
+- `src/ui/metadataLookup/metadataLookupWorkflow*`
+- `src/ui/outputPanel/outputPlanWorkflow*`
+- `src/ui/statusPanel/processingWorkflow*`
+- `src/lib/tauri/client.ts`
+- `src/lib/tauri/commands.ts`
+- `src-tauri/src/commands/metadata.rs`
+- `src-tauri/src/commands/metadata/save_batch.rs`
+- `src-tauri/src/metadata/`
+- `src-tauri/src/processing/plan.rs`
+- `src-tauri/src/processing/run.rs`
+- `src-tauri/src/audio/processor/`
+- `src-tauri/src/output_artifact/`
+
+## Idempotence And Recovery
+
+- This spec is the restart surface for the roadmap.
+- If work is interrupted, resume from the latest completed MB block and update
+  the Progress section before continuing.
+- Do not restart from prior chat history unless this spec is clearly stale.
+- If implementation discovers the roadmap shape is wrong, update this spec
+  before continuing code movement.
+
+## Progress
+
+- 2026-05-19: Created initial active roadmap source after architecture/design
+  alignment. No implementation started. No checks run by request.
+- 2026-05-19: Created branch `roadmap/metadata-outcome-boundary` and locked
+  the planning/implementation split. This thread remains architecture/design
+  only; implementation is reserved for a future Codex thread and handoff
+  prompt.
+- 2026-05-19: Added source-backed flow trace, ownership-smear targets,
+  recommended open-question defaults, and a fresh-thread implementation
+  handoff prompt.
+- 2026-05-19: Added `abb-library-research` constraints, behavior-family trace
+  order, and stronger implementation-agent pre-edit trace requirements. No
+  tests, checks, or browser smoke were run in this architecture-only planning
+  pass by request.
+
+## Surprises And Discoveries
+
+- The prior Effect roadmap thread established a useful pattern: forest-first
+  roadmap, Markdown source, companion HTML, and largest coherent work blocks.
+- The current metadata effort should reuse that infrastructure but not inherit
+  Effect's roadmap assumptions.
+
+## Completion And Cleanup
+
+Before deleting this spec:
+
+- All selected MB blocks are implemented or explicitly removed from scope.
+- Metadata architecture debt is no longer an active recurring concern in the
+  architecture map.
+- Canon docs and nested ownership guidance reflect the final design.
+- Remaining ideas are routed to issues or future roadmaps.
+- The repo is validated and synced according to the implementation scope.
+
+Delete this file after the roadmap is complete; do not archive it as permanent
+canon.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -78,12 +78,18 @@ ownership or proof.
 
 Use these as the current durable ownership map for architecture work:
 
+In general architecture language, each entry is being shaped toward a **deep
+module**: a small interface hiding substantial implementation complexity. In
+ABB repo language, a **Grey-Box Module** is the stricter working form of that
+idea: Public API Strip, Private Cluster, nested ownership rules, boundary
+assertions, and contract tests.
+
 | Public API | Owns |
 | --- | --- |
 | Tauri Runtime Boundary | Frontend runtime calls, payload normalization, generated-binding adaptation, and event listener setup. |
 | Processing Plan | Preflight and execution planning before jobs run. |
 | Output Artifact Plan / Commit | Requested/resolved artifact paths, collision review, parent directory creation, and final artifact commit truth. |
-| Metadata Intent Plan | Explicit `set`, `clear`, and `noop` metadata intent projection for processing, naming, and writes. |
+| Metadata Outcome Plan | Metadata intent projection, source hydration, naming-safe metadata, write plans, and cover-art passthrough policy. |
 | Status Panel Runtime | Backend progress/results rendered as truthful user-visible status and controls. |
 
 Each Public API has a nearest nested `AGENTS.md` that lists the allowed import

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -26,6 +26,7 @@
 | **Terminal Truth** | The backend-owned final report of what happened to a job or batch, used by the UI for user-visible completion state. | optimistic status, frontend truth |
 | **Metadata Intent Patch** | An explicit patch-op payload that preserves whether a metadata field is being set, cleared, or left alone. | raw metadata object, sentinel mutation |
 | **Patch Op** | A single explicit metadata action such as `set`, `clear`, or `noop` used to preserve user intent across the boundary. | magic empty value, implicit clear |
+| **Metadata Outcome Plan** | The metadata boundary's backend plan that turns source metadata plus intent into effective metadata, naming metadata, write instructions, and cover-art passthrough policy. | metadata helper chain, raw metadata object |
 | **Processing Preflight Plan** | A backend-generated preview of how a processing request will execute before the actual long-running job begins. | dry guess, UI-only estimate |
 | **Output Path Preview** | The backend-owned computation of the intended output path before collision suffixing or final processing writes. | frontend filename guess, audio preview |
 | **Fallback** | A deliberately registered temporary compatibility or integrity path with a concrete trigger, observable signal, and sunset condition. | convenience workaround, silent compatibility shim |
@@ -51,17 +52,17 @@
 ## Grey-Box Module Vocabulary
 | Term | Definition | Aliases to avoid |
 | --- | --- | --- |
-| **Grey-Box Module** | An ABB ownership unit that pairs a small, deliberately published **Public API Strip** with a **Private Cluster** of implementation files. Formally: a deep module (Ousterhout) with strict information hiding (Parnas). The private cluster is AI-editable; the public API is the contract that locks behavior. | shallow module, façade-only wrapper, generic "module" |
+| **Grey-Box Module** | ABB's repo-governed form of a **Deep Module**: a small, deliberately published **Public API Strip** backed by a hidden **Private Cluster** of implementation files, boundary assertions, and contract tests. Use this term inside ABB when the ownership rules matter; use **Deep Module** in general engineering discussion. | shallow module, façade-only wrapper, generic "module", deep/grey module |
 | **Public API Strip** | The deliberately small set of public symbols (functions, types, events, commands) a grey-box module allows callers to import. Symbols outside the strip are not public even when the language would allow them to be. | exports list, "everything pub", surface area |
 | **Private Cluster** | The set of files inside a grey-box module that implement its Public API Strip. Rename-safe, split-safe, AI-editable, and not importable from outside the module. | helper files, internal utilities (unscoped) |
 | **Module Owner** | The single grey-box module a product decision or invariant belongs to. If two modules both feel partial responsibility, the rule has no owner. | shared responsibility, "wherever it ends up" |
-| **Five Public APIs** | The current ABB grey-box public-API set: Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Intent Plan, Status Panel Runtime. | "the modules" (ambiguous) |
+| **Five Public APIs** | The current ABB grey-box public-API set: Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Outcome Plan, Status Panel Runtime. | "the modules" (ambiguous), deep modules (too broad) |
 | **Reach-Through** | An import that crosses a module boundary into another module's Private Cluster. Always a smell; always names a bug, an unowned rule, or an unintentional contract. | shortcut, "just this once" |
 | **Ownership Smear** | A product rule whose implementation is split across two or more modules where each holds a partial answer and no single source of truth exists. | shared concern, "it depends" |
 | **Contract Test** | A test that pins the externally visible behavior of a grey-box module's Public API Strip. Internal cluster changes must keep contract tests green. | unit test, helper existence test |
 | **Boundary Assertion** | A repo-level script check (the `scripts/check-no-bridge-imports.sh` family) that fails CI if a Reach-Through is reintroduced. | lint suggestion, code-review note |
 | **Cluster Audit** | A non-mutating gut check of a Private Cluster's code shape: file size, function size, decision-per-function clarity, internal naming, and tests-close-to-behavior. Used to plan future internal refactors without changing the Public API Strip. | refactor sweep, "clean code pass" |
-| **Deep Module** | The published Ousterhout term (A Philosophy of Software Design) for a module with a small interface and substantial hidden implementation. ABB calls these grey-box modules locally. | shallow façade, micro-module |
+| **Deep Module** | The published Ousterhout term (*A Philosophy of Software Design*) for a module with a small interface and substantial hidden implementation. ABB **Grey-Box Modules** are deep-module-shaped ownership units, but the terms are not interchangeable: "deep module" names the design quality; "Grey-Box Module" names ABB's documented contract and edit model. | shallow façade, micro-module, grey module |
 | **Information Hiding** | The published Parnas 1972 rule that callers must not depend on a module's implementation details. The reason the Private Cluster exists at all. | encapsulation (vague), abstraction (vague) |
 
 ## Relationships
@@ -72,9 +73,11 @@
 - The **Job Registry** is the authority for **Processing Flow** lifecycle, queue state, and cancellation.
 - A **Terminal Outcome** contributes to **Terminal Truth** only after backend processing resolves the job's final state.
 - A **Metadata Intent Patch** is compiled at the **Runtime Boundary** and preserved across the **IPC Contract** so clear intent is never inferred from sentinel values.
+- A **Metadata Outcome Plan** is produced by the metadata boundary so processing and output callers consume effective metadata, naming metadata, write facts, and cover-art policy instead of rebuilding metadata sequencing.
 - A **Fallback** must appear in the **Fallback Register** and stay observable until it is removed or renewed.
 - The **Standard Gate** and focused **UI Workflow Smoke Test** coverage are proof surfaces for keeping **Contract Truth** and **Operational Truthfulness** honest.
 - A **Task Spec** is a **Durable Workflow Surface** for substantial work produced through **decision-alignment**; it complements, but does not replace, canon repo docs.
+- A **Deep Module** is the general architecture idea; a **Grey-Box Module** is ABB's stricter repo pattern for applying it.
 - A **Grey-Box Module** publishes a **Public API Strip** and hides a **Private Cluster** behind it; only one **Module Owner** holds any given product rule.
 - A **Reach-Through** is the diagnostic for an **Ownership Smear**; a **Boundary Assertion** is the script-enforced cure.
 - Each **Public API Strip** in the **Five Public APIs** set is locked by **Contract Tests**; internal cluster changes are safe when contract tests stay green.
@@ -91,11 +94,12 @@
 - "generated bindings" can sound like the primary client. Prefer **Generated Bindings** for drift detection and typed integration, and **tauriClient** for the real runtime adapter.
 - "preview" can mean different things. Prefer **Output Path Preview** for path derivation, **Processing Preflight Plan** for pre-run backend review, **audio preview** for a short media render, and **preview artifact** for the file created by that render.
 - "fallback" can drift into "temporary workaround." Prefer **Fallback** only for registered, observable, sunset-bound behavior; otherwise call it a compatibility path, recovery default, bug, or design decision.
-- "metadata" and "metadata intent" are not interchangeable. Prefer **Metadata Intent Patch** when the important question is user intent to set, clear, or preserve a field; use metadata draft, write plan, lookup result, or tag projection when those narrower concepts are meant.
+- "metadata" and "metadata intent" are not interchangeable. Prefer **Metadata Intent Patch** when the important question is user intent to set, clear, or preserve a field; use **Metadata Outcome Plan**, metadata draft, write plan, lookup result, or tag projection when those narrower concepts are meant.
 - "gate", "check", "test", and "smoke test" are different confidence shapes. Prefer **Standard Gate** for `scripts/checks.sh standard`, **Boundary Assertion** for repo scripts that block broken imports or policy drift, **Contract Test** for public API behavior, and **UI Workflow Smoke Test** for deterministic user-flow proof.
 - Product names and implementation names should not blur together. For example, **Book Binder** is user-facing product language; **Merge** is the processing job type.
 - "minimal churn" can be mistaken for "smallest diff." Prefer **Minimal Churn** as fewer correction loops and less rework, even when the better fix is somewhat broader.
 - "status", "progress", and "terminal outcome" are not interchangeable. Prefer **Terminal Outcome** only for final per-job status and **Terminal Truth** for the backend-owned final report.
+- "deep module" and "grey-box module" are related but distinct. Prefer **Deep Module** when talking to other engineers about the general design principle; prefer **Grey-Box Module** when referring to ABB's Public-API + Private-Cluster + boundary-assertion ownership unit.
 - "module" alone is ambiguous in ABB. Prefer **Grey-Box Module** for the owned Public-API + Private-Cluster unit, and **Private Cluster File** for any implementation file inside one.
 - "API" can mean three different things in ABB. Prefer **IPC Contract** for the Rust-declared command/event set, **Runtime Boundary** for the TS adapter (`tauriClient`), and **Public API Strip** for the externally allowed import set of any **Grey-Box Module**.
 - "contract" can be ambiguous. Prefer **IPC Contract** for the cross-language command/event set and **Contract Test** for the behavior-locked test of any **Grey-Box Module's** Public API Strip.

--- a/scripts/check-public-api-strips.sh
+++ b/scripts/check-public-api-strips.sh
@@ -57,10 +57,21 @@ pub(crate) struct ResolvedProcessingPlan {
 pub(crate) fn resolve_preflight_plan(
 pub(crate) fn prepare_execution_plan('
 
-metadata_intent_exports="$(extract_export_blocks src-tauri/src/metadata/mod.rs | rg "intent|intent_plan" || true)"
-compare_block "Metadata Intent Plan Public API Strip" "$metadata_intent_exports" 'pub use intent::{AlbumSortPatchOp, MetadataIntentPatch, PatchOp};
+metadata_intent_exports="$(extract_export_blocks src-tauri/src/metadata/mod.rs | awk '
+  /^pub(\(crate\))? use intent(_plan)?/ { capture=1 }
+  capture {
+    print
+    if ($0 ~ /;$/) {
+      capture=0
+    }
+  }
+')"
+compare_block "Metadata Outcome Plan Public API Strip" "$metadata_intent_exports" 'pub use intent::{AlbumSortPatchOp, MetadataIntentPatch, PatchOp};
 pub(crate) use intent::{AlbumSortWriteAction, MetadataWritePlan};
-pub(crate) use intent_plan::{resolve_effective_processing_metadata, resolve_naming_metadata};'
+pub(crate) use intent_plan::{
+plan_metadata_outcome, plan_metadata_write, MetadataOutcomePlan, MetadataOutcomeRequest,
+};
+pub use intent_plan::{CoverArtPassthroughPolicy, NamingMetadata};'
 
 tauri_client_exports="$(rg "^export (const|type)" src/lib/tauri/client.ts || true)"
 compare_block "Tauri Runtime Boundary Public API Strip" "$tauri_client_exports" 'export const tauriClient = {

--- a/src-tauri/src/audio/processor/adapter.rs
+++ b/src-tauri/src/audio/processor/adapter.rs
@@ -8,7 +8,7 @@ use crate::audio::toolchain::{
 };
 use crate::audio::{AudioFile, DecoderSelection};
 use crate::errors::{AppError, Result};
-use crate::metadata::AudiobookMetadata;
+use crate::metadata::{AudiobookMetadata, CoverArtPassthroughPolicy};
 use crate::processing::ProcessingContext;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,7 +50,7 @@ impl ResolvedProcessorAdapter {
         files: Vec<AudioFile>,
         selected_decoders: Vec<Option<DecoderSelection>>,
         metadata: Option<AudiobookMetadata>,
-        allow_passthrough_cover_art: bool,
+        cover_art_passthrough: CoverArtPassthroughPolicy,
     ) -> Result<String> {
         match self {
             Self::NativeFfmpegNext => {
@@ -58,7 +58,7 @@ impl ResolvedProcessorAdapter {
                     context,
                     files,
                     metadata,
-                    allow_passthrough_cover_art,
+                    cover_art_passthrough,
                 )
                 .await
             }
@@ -68,7 +68,7 @@ impl ResolvedProcessorAdapter {
                     files,
                     selected_decoders,
                     metadata,
-                    allow_passthrough_cover_art,
+                    cover_art_passthrough,
                     toolchain,
                 )
                 .await

--- a/src-tauri/src/audio/processor/external_fdk.rs
+++ b/src-tauri/src/audio/processor/external_fdk.rs
@@ -5,9 +5,9 @@ use crate::audio::CleanupGuard;
 use crate::audio::{AudioFile, DecoderSelection};
 use crate::errors::{sanitize_path_for_display, AppError, Result};
 use crate::metadata::passthrough::{
-    apply_cover_art_policy, extract_passthrough_metadata, PassthroughMetadata,
+    extract_passthrough_metadata, merge_passthrough_cover_art, PassthroughMetadata,
 };
-use crate::metadata::{rewrite_metadata_with_ffmpeg, AudiobookMetadata};
+use crate::metadata::{rewrite_metadata_with_ffmpeg, AudiobookMetadata, CoverArtPassthroughPolicy};
 use crate::output_artifact::{
     commit_output_artifact, finalized_output_success, OutputCommitRequest,
 };
@@ -23,7 +23,7 @@ pub(super) async fn process_audiobook_with_external_fdk(
     files: Vec<AudioFile>,
     selected_decoders: Vec<Option<DecoderSelection>>,
     metadata: Option<AudiobookMetadata>,
-    allow_passthrough_cover_art: bool,
+    cover_art_passthrough: CoverArtPassthroughPolicy,
     toolchain: ValidatedExternalToolchain,
 ) -> Result<String> {
     if !matches!(
@@ -56,12 +56,12 @@ pub(super) async fn process_audiobook_with_external_fdk(
     }
     validate_external_input_decoders(&valid_files, &valid_selected_decoders, &toolchain)?;
 
-    let passthrough = apply_cover_art_policy(
-        collect_passthrough_metadata(&valid_files, context.preview.is_some()),
-        allow_passthrough_cover_art,
-    );
+    let passthrough = cover_art_passthrough.apply_to_passthrough(collect_passthrough_metadata(
+        &valid_files,
+        context.preview.is_some(),
+    ));
 
-    let effective_metadata = merge_cover_art(metadata, passthrough.as_ref());
+    let effective_metadata = merge_passthrough_cover_art(metadata, passthrough.as_ref());
     let ui = context.new_emitter();
     ui.emit_analyzing_start("Preparing external FDK job...");
     ui.emit_analyzing_end("External FDK toolchain validated.");
@@ -115,28 +115,6 @@ pub(super) async fn process_audiobook_with_external_fdk(
     );
     ui.emit_complete(success.ui_message);
     Ok(success.result_message)
-}
-
-fn merge_cover_art(
-    metadata: Option<AudiobookMetadata>,
-    passthrough: Option<&PassthroughMetadata>,
-) -> Option<AudiobookMetadata> {
-    let passthrough_cover = passthrough
-        .and_then(|value| value.cover_art.as_ref())
-        .cloned();
-    match metadata {
-        Some(mut metadata) => {
-            if metadata.cover_art.is_none() {
-                metadata.cover_art = passthrough_cover;
-            }
-            Some(metadata)
-        }
-        None => passthrough_cover.map(|cover_art| {
-            let mut metadata = AudiobookMetadata::new();
-            metadata.cover_art = Some(cover_art);
-            metadata
-        }),
-    }
 }
 
 fn collect_passthrough_metadata(
@@ -610,7 +588,7 @@ mod tests {
             }],
             vec![None],
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -667,7 +645,7 @@ mod tests {
             ],
             vec![None, None],
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg.clone(),
                 source: EncoderCapabilitySource::Override,
@@ -698,7 +676,7 @@ mod tests {
             vec![test_audio_file(first_input), test_audio_file(second_input)],
             vec![None, None],
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -750,7 +728,7 @@ mod tests {
             vec![test_audio_file(input_path.clone())],
             vec![None],
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -806,7 +784,7 @@ mod tests {
                 title: Some("Trigger rewrite".to_string()),
                 ..AudiobookMetadata::default()
             }),
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -866,7 +844,7 @@ mod tests {
             vec![test_audio_file(input_path.clone())],
             vec![None],
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -920,7 +898,7 @@ mod tests {
             vec![test_audio_file(input_path)],
             vec![None],
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
             ValidatedExternalToolchain {
                 ffmpeg_path: fake_ffmpeg,
                 source: EncoderCapabilitySource::Override,
@@ -1132,7 +1110,7 @@ mod tests {
     }
 
     #[test]
-    fn merge_cover_art_does_not_refill_when_passthrough_cover_is_filtered() {
+    fn merge_passthrough_cover_art_does_not_refill_when_passthrough_cover_is_filtered() {
         let metadata = AudiobookMetadata {
             cover_art: None,
             ..AudiobookMetadata::default()
@@ -1142,7 +1120,7 @@ mod tests {
             cover_art: None,
         };
 
-        let merged = merge_cover_art(Some(metadata), Some(&passthrough))
+        let merged = merge_passthrough_cover_art(Some(metadata), Some(&passthrough))
             .expect("metadata should remain present");
 
         assert_eq!(merged.cover_art, None);

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -15,8 +15,8 @@ use crate::audio::cleanup::CleanupGuard;
 use crate::audio::metrics::ProcessingMetrics;
 use crate::audio::AudioFile;
 use crate::errors::Result;
-use crate::metadata::passthrough::apply_cover_art_policy;
-use crate::metadata::AudiobookMetadata;
+use crate::metadata::passthrough::merge_passthrough_cover_art;
+use crate::metadata::{AudiobookMetadata, CoverArtPassthroughPolicy};
 use crate::processing::{ProcessingContext, ProcessingStage, ProgressReporter};
 use std::time::Duration;
 
@@ -82,7 +82,7 @@ pub async fn process_audiobook_with_context(
     context: ProcessingContext,
     files: Vec<AudioFile>,
     metadata: Option<AudiobookMetadata>,
-    allow_passthrough_cover_art: bool,
+    cover_art_passthrough: CoverArtPassthroughPolicy,
 ) -> Result<String> {
     let mut reporter = ProgressReporter::new(files.len());
     let mut metrics = ProcessingMetrics::new();
@@ -95,29 +95,11 @@ pub async fn process_audiobook_with_context(
     workflow_cleanup.add_path(&workflow_temp_dir);
 
     // Extract passthrough metadata (chapters, original cover art) from all valid files.
-    let passthrough_metadata = apply_cover_art_policy(
+    let passthrough_metadata = cover_art_passthrough.apply_to_passthrough(
         crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option(),
-        allow_passthrough_cover_art,
     );
 
-    // Merge passthrough cover art when user metadata is absent or missing cover art.
-    let mut effective_metadata = metadata;
-    if let Some(ref passthrough) = passthrough_metadata {
-        if let Some(ref cover) = passthrough.cover_art {
-            match effective_metadata.as_mut() {
-                Some(md) => {
-                    if md.cover_art.is_none() {
-                        md.cover_art = Some(cover.clone());
-                    }
-                }
-                None => {
-                    let mut md = AudiobookMetadata::new();
-                    md.cover_art = Some(cover.clone());
-                    effective_metadata = Some(md);
-                }
-            }
-        }
-    }
+    let effective_metadata = merge_passthrough_cover_art(metadata, passthrough_metadata.as_ref());
 
     // Metrics accumulation (estimates)
     for file in &files {

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -9,7 +9,7 @@ use crate::audio::toolchain::{
 };
 use crate::commands::CommandResult;
 use crate::errors::AppError;
-use crate::metadata::MetadataIntentPatch;
+use crate::metadata::{MetadataIntentPatch, NamingMetadata};
 use crate::output_artifact::{build_output_path_preview, derive_output_artifact_path, OutputKind};
 use crate::processing::job_registry::JobId;
 use crate::processing::run;
@@ -110,9 +110,10 @@ pub fn preview_output_path(
     let base_output_dir = PathBuf::from(output_dir);
     let source_path_buf = source_path.as_deref().map(PathBuf::from);
     let naming = output_naming.unwrap_or_default();
+    let draft_naming_metadata = metadata.as_ref().map(NamingMetadata::from_metadata);
     let requested = build_output_path_preview(
         &base_output_dir,
-        metadata.as_ref(),
+        draft_naming_metadata.as_ref(),
         naming,
         source_path_buf.as_deref(),
     )?;

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -1,7 +1,7 @@
 use crate::audio::path_validation::{validate_input_audio_path, validate_input_image_path};
 use crate::commands::CommandResult;
 use crate::errors::{AppError, Result};
-use crate::metadata::{read_metadata, AudiobookMetadata, MetadataIntentPatch};
+use crate::metadata::{plan_metadata_write, read_metadata, AudiobookMetadata, MetadataIntentPatch};
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use reqwest::header::CONTENT_TYPE;
 use std::io;
@@ -47,7 +47,7 @@ pub async fn save_metadata_to_file(
     let result: Result<()> = tokio::task::spawn_blocking(move || {
         let path = PathBuf::from(&file_path);
         let validated_path = validate_input_audio_path(&path)?;
-        let write_plan = metadata_patch.to_write_plan()?;
+        let write_plan = plan_metadata_write(&metadata_patch)?;
 
         crate::metadata::save_metadata_with_plan(&validated_path, &write_plan)?;
 

--- a/src-tauri/src/commands/metadata/save_batch.rs
+++ b/src-tauri/src/commands/metadata/save_batch.rs
@@ -1,7 +1,7 @@
 use crate::audio::path_validation::validate_input_audio_path;
 use crate::commands::CommandResult;
 use crate::errors::{sanitize_path_str_for_display, AppError, AppErrorEnvelope, Result};
-use crate::metadata::MetadataIntentPatch;
+use crate::metadata::{plan_metadata_write, MetadataIntentPatch};
 use crate::processing::{
     CancellationChecker, EventStage, JobId, ProgressEvent, QueueEvent, QueueItem,
 };
@@ -231,7 +231,7 @@ fn save_metadata_item(file_path: &str, metadata_patch: MetadataIntentPatch) -> R
     let validated_path = validate_input_audio_path(&path)?;
     log::info!("Saving metadata to: {}", validated_path.display());
 
-    let write_plan = metadata_patch.to_write_plan()?;
+    let write_plan = plan_metadata_write(&metadata_patch)?;
     crate::metadata::save_metadata_with_plan(&validated_path, &write_plan)?;
 
     log::info!("Metadata saved to: {}", validated_path.display());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,10 @@ pub use metadata::{
     write_cover_art_packet_post_header as ffmpeg_write_cover_art_packet_post_header,
     CoverFormat as FfmpegCoverFormat,
 };
-pub use metadata::{AlbumSortPatchOp, AudiobookMetadata, MetadataIntentPatch, PatchOp};
+pub use metadata::{
+    AlbumSortPatchOp, AudiobookMetadata, CoverArtPassthroughPolicy, MetadataIntentPatch,
+    NamingMetadata, PatchOp,
+};
 
 // Test-facing passthrough helpers used by integration tests.
 pub use metadata::passthrough::{

--- a/src-tauri/src/metadata/AGENTS.md
+++ b/src-tauri/src/metadata/AGENTS.md
@@ -1,6 +1,9 @@
 ## Public API Strip
 - Import metadata boundary symbols from `crate::metadata`, not private child modules.
-- Intent symbols: `MetadataIntentPatch`, `PatchOp`, `AlbumSortPatchOp`, `resolve_effective_processing_metadata`, `resolve_naming_metadata`.
+- Intent symbols: `MetadataIntentPatch`, `PatchOp`, `AlbumSortPatchOp`.
+- Outcome symbols: `MetadataOutcomeRequest`, `MetadataOutcomePlan`,
+  `NamingMetadata`, `CoverArtPassthroughPolicy`, `plan_metadata_outcome`,
+  `plan_metadata_write`.
 - Crate-local write-plan support: `MetadataWritePlan`, `AlbumSortWriteAction`.
 
 ## Private Cluster

--- a/src-tauri/src/metadata/contract_tests.rs
+++ b/src-tauri/src/metadata/contract_tests.rs
@@ -1,8 +1,7 @@
 use crate::metadata::{
-    resolve_effective_processing_metadata, resolve_naming_metadata, AlbumSortPatchOp,
-    AudiobookMetadata, MetadataIntentPatch, PatchOp,
+    plan_metadata_outcome, plan_metadata_write, AlbumSortPatchOp, CoverArtPassthroughPolicy,
+    MetadataIntentPatch, MetadataOutcomeRequest, PatchOp,
 };
-use std::path::Path;
 
 #[test]
 fn metadata_intent_plan_contract_preserves_set_clear_noop_semantics() {
@@ -15,16 +14,28 @@ fn metadata_intent_plan_contract_preserves_set_clear_noop_semantics() {
         ..Default::default()
     };
 
-    let resolved =
-        resolve_effective_processing_metadata(None, Some(&patch)).expect("metadata resolves");
-    let metadata = resolved.expect("overlay metadata");
+    let outcome = plan_metadata_outcome(MetadataOutcomeRequest {
+        input_path: None,
+        intent_patch: Some(&patch),
+    })
+    .expect("metadata resolves");
+    let metadata = outcome.effective_metadata.expect("overlay metadata");
 
     assert_eq!(metadata.title.as_deref(), Some("Contract Title"));
     assert_eq!(metadata.artist, None);
     assert_eq!(metadata.series, None);
     assert_eq!(metadata.cover_art, None);
+    assert!(
+        matches!(
+            outcome.cover_art_passthrough,
+            CoverArtPassthroughPolicy::SuppressAfterExplicitClear
+        ),
+        "explicit cover clear should suppress passthrough cover art"
+    );
 
-    let write_plan = patch.to_write_metadata().expect("write metadata");
+    let write_plan = plan_metadata_write(&patch)
+        .expect("write metadata")
+        .metadata;
     assert_eq!(write_plan.title.as_deref(), Some("Contract Title"));
     assert_eq!(write_plan.artist.as_deref(), Some(""));
     assert_eq!(write_plan.cover_art, Some(Vec::new()));
@@ -37,44 +48,31 @@ fn metadata_intent_plan_contract_rejects_invalid_publication_dates() {
         ..Default::default()
     };
 
-    let err = resolve_effective_processing_metadata(None, Some(&patch))
-        .expect_err("invalid date should fail");
+    let err = plan_metadata_outcome(MetadataOutcomeRequest {
+        input_path: None,
+        intent_patch: Some(&patch),
+    })
+    .expect_err("invalid date should fail");
 
     assert!(err.to_string().contains("Publication date"));
 }
 
 #[test]
 fn metadata_intent_plan_contract_uses_resolved_metadata_for_naming() {
-    let resolved = AudiobookMetadata {
-        title: Some("Resolved Title".to_string()),
-        series: Some("Series".to_string()),
-        series_part: Some("7/8".to_string()),
-        ..Default::default()
-    };
-    let untouched_source_naming =
-        resolve_naming_metadata(Some(&resolved), Some(Path::new("/tmp/source.m4b")), None)
-            .expect("naming metadata");
-
-    assert_eq!(
-        untouched_source_naming.title.as_deref(),
-        Some("Resolved Title")
-    );
-    assert_eq!(untouched_source_naming.series.as_deref(), Some("Series"));
-    assert_eq!(
-        untouched_source_naming.series_part, None,
-        "untouched source naming should scrub legacy slash series parts"
-    );
-
     let patch = MetadataIntentPatch {
         title: PatchOp::Set("Patched Title".to_string()),
+        series: PatchOp::Set("Series".to_string()),
+        series_part: PatchOp::Set("7".to_string()),
         ..Default::default()
     };
-    let patched_naming = resolve_naming_metadata(
-        Some(&resolved),
-        Some(Path::new("/tmp/source.m4b")),
-        Some(&patch),
-    )
-    .expect("patched naming metadata");
+    let outcome = plan_metadata_outcome(MetadataOutcomeRequest {
+        input_path: None,
+        intent_patch: Some(&patch),
+    })
+    .expect("metadata outcome should resolve");
+    let naming = outcome.naming_metadata.expect("naming metadata");
 
-    assert_eq!(patched_naming.series_part.as_deref(), Some("7/8"));
+    assert_eq!(naming.title(), Some("Patched Title"));
+    assert_eq!(naming.series(), Some("Series"));
+    assert_eq!(naming.series_part(), Some("7"));
 }

--- a/src-tauri/src/metadata/intent_plan.rs
+++ b/src-tauri/src/metadata/intent_plan.rs
@@ -1,8 +1,129 @@
-use super::{AudiobookMetadata, MetadataIntentPatch};
+use super::{AudiobookMetadata, MetadataIntentPatch, MetadataWritePlan};
 use crate::errors::Result;
+use crate::metadata::passthrough::PassthroughMetadata;
 use std::path::Path;
 
-pub(crate) fn resolve_effective_processing_metadata(
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NamingMetadata {
+    title: Option<String>,
+    artist: Option<String>,
+    series: Option<String>,
+    series_part: Option<String>,
+    subseries: Option<String>,
+    subseries_part: Option<String>,
+    date: Option<String>,
+}
+
+impl NamingMetadata {
+    pub fn from_metadata(metadata: &AudiobookMetadata) -> Self {
+        Self {
+            title: metadata.title.clone(),
+            artist: metadata.artist.clone(),
+            series: metadata.series.clone(),
+            series_part: metadata.series_part.clone(),
+            subseries: metadata.subseries.clone(),
+            subseries_part: metadata.subseries_part.clone(),
+            date: metadata.date.clone(),
+        }
+    }
+
+    pub(crate) fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    pub(crate) fn artist(&self) -> Option<&str> {
+        self.artist.as_deref()
+    }
+
+    pub(crate) fn series(&self) -> Option<&str> {
+        self.series.as_deref()
+    }
+
+    pub(crate) fn series_part(&self) -> Option<&str> {
+        self.series_part.as_deref()
+    }
+
+    pub(crate) fn subseries(&self) -> Option<&str> {
+        self.subseries.as_deref()
+    }
+
+    pub(crate) fn subseries_part(&self) -> Option<&str> {
+        self.subseries_part.as_deref()
+    }
+
+    pub(crate) fn date(&self) -> Option<&str> {
+        self.date.as_deref()
+    }
+
+    fn scrub_legacy_source_series_parts_for_naming(&mut self) {
+        scrub_invalid_series_part_for_naming(&mut self.series_part);
+        scrub_invalid_series_part_for_naming(&mut self.subseries_part);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverArtPassthroughPolicy {
+    Preserve,
+    SuppressAfterExplicitClear,
+}
+
+impl CoverArtPassthroughPolicy {
+    pub(crate) fn from_intent_patch(patch: Option<&MetadataIntentPatch>) -> Self {
+        if patch.is_some_and(MetadataIntentPatch::clears_cover_art) {
+            Self::SuppressAfterExplicitClear
+        } else {
+            Self::Preserve
+        }
+    }
+
+    pub(crate) fn apply_to_passthrough(
+        self,
+        passthrough: Option<PassthroughMetadata>,
+    ) -> Option<PassthroughMetadata> {
+        match self {
+            Self::Preserve => passthrough,
+            Self::SuppressAfterExplicitClear => {
+                log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
+                passthrough.and_then(PassthroughMetadata::without_cover_art)
+            }
+        }
+    }
+}
+
+pub(crate) struct MetadataOutcomeRequest<'a> {
+    pub(crate) input_path: Option<&'a Path>,
+    pub(crate) intent_patch: Option<&'a MetadataIntentPatch>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MetadataOutcomePlan {
+    pub(crate) effective_metadata: Option<AudiobookMetadata>,
+    pub(crate) naming_metadata: Option<NamingMetadata>,
+    pub(crate) cover_art_passthrough: CoverArtPassthroughPolicy,
+}
+
+pub(crate) fn plan_metadata_outcome(
+    request: MetadataOutcomeRequest<'_>,
+) -> Result<MetadataOutcomePlan> {
+    let effective_metadata =
+        resolve_effective_processing_metadata(request.input_path, request.intent_patch)?;
+    let naming_metadata = resolve_naming_metadata(
+        effective_metadata.as_ref(),
+        request.input_path,
+        request.intent_patch,
+    );
+    Ok(MetadataOutcomePlan {
+        effective_metadata,
+        naming_metadata,
+        cover_art_passthrough: CoverArtPassthroughPolicy::from_intent_patch(request.intent_patch),
+    })
+}
+
+pub(crate) fn plan_metadata_write(patch: &MetadataIntentPatch) -> Result<MetadataWritePlan> {
+    patch.to_write_plan()
+}
+
+fn resolve_effective_processing_metadata(
     input_path: Option<&Path>,
     patch: Option<&MetadataIntentPatch>,
 ) -> Result<Option<AudiobookMetadata>> {
@@ -17,23 +138,18 @@ pub(crate) fn resolve_effective_processing_metadata(
     }
 }
 
-pub(crate) fn resolve_naming_metadata(
+fn resolve_naming_metadata(
     resolved_metadata: Option<&AudiobookMetadata>,
     input_path: Option<&Path>,
     patch: Option<&MetadataIntentPatch>,
-) -> Option<AudiobookMetadata> {
-    let mut naming_metadata = resolved_metadata.cloned()?;
+) -> Option<NamingMetadata> {
+    let mut naming_metadata = resolved_metadata.map(NamingMetadata::from_metadata)?;
 
     if input_path.is_some() && patch.is_none() {
-        scrub_legacy_source_series_parts_for_naming(&mut naming_metadata);
+        naming_metadata.scrub_legacy_source_series_parts_for_naming();
     }
 
     Some(naming_metadata)
-}
-
-fn scrub_legacy_source_series_parts_for_naming(metadata: &mut AudiobookMetadata) {
-    scrub_invalid_series_part_for_naming(&mut metadata.series_part);
-    scrub_invalid_series_part_for_naming(&mut metadata.subseries_part);
 }
 
 fn scrub_invalid_series_part_for_naming(value: &mut Option<String>) {
@@ -50,8 +166,11 @@ fn scrub_invalid_series_part_for_naming(value: &mut Option<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_effective_processing_metadata, resolve_naming_metadata};
-    use crate::metadata::{AudiobookMetadata, MetadataIntentPatch, PatchOp};
+    use super::{plan_metadata_outcome, MetadataOutcomeRequest};
+    use crate::metadata::{
+        plan_metadata_write, AudiobookMetadata, CoverArtPassthroughPolicy, MetadataIntentPatch,
+        PatchOp,
+    };
     use crate::output_artifact::{build_output_path, OutputNamingConfig};
     use std::path::Path;
 
@@ -68,7 +187,10 @@ mod tests {
     #[test]
     fn effective_processing_metadata_no_patch_reads_source_or_errors() {
         let missing_source = Path::new("/path/that/does/not/exist/input.m4b");
-        let outcome = resolve_effective_processing_metadata(Some(missing_source), None);
+        let outcome = plan_metadata_outcome(MetadataOutcomeRequest {
+            input_path: Some(missing_source),
+            intent_patch: None,
+        });
         assert!(
             outcome.is_err(),
             "missing input should fail read, not return empty metadata"
@@ -99,8 +221,12 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved =
-            resolve_effective_processing_metadata(None, Some(&patch)).expect("metadata resolves");
+        let resolved = plan_metadata_outcome(MetadataOutcomeRequest {
+            input_path: None,
+            intent_patch: Some(&patch),
+        })
+        .expect("metadata resolves")
+        .effective_metadata;
 
         assert_eq!(
             resolved.and_then(|value| value.title),
@@ -115,8 +241,11 @@ mod tests {
             ..Default::default()
         };
 
-        let err = resolve_effective_processing_metadata(None, Some(&patch))
-            .expect_err("invalid patch should fail");
+        let err = plan_metadata_outcome(MetadataOutcomeRequest {
+            input_path: None,
+            intent_patch: Some(&patch),
+        })
+        .expect_err("invalid patch should fail");
         assert!(
             err.to_string().contains("Publication date"),
             "unexpected error: {err}"
@@ -135,7 +264,7 @@ mod tests {
             .expect("metadata should resolve");
         let output_path = build_output_path(
             Path::new("/tmp"),
-            Some(&effective),
+            Some(&crate::metadata::NamingMetadata::from_metadata(&effective)),
             OutputNamingConfig::default(),
             None,
         )
@@ -159,15 +288,27 @@ mod tests {
             ..Default::default()
         };
 
-        let naming =
-            resolve_naming_metadata(Some(&metadata), Some(Path::new("/tmp/source.m4b")), None)
-                .expect("naming metadata should exist");
+        let naming = plan_metadata_outcome(MetadataOutcomeRequest {
+            input_path: None,
+            intent_patch: None,
+        })
+        .expect("empty request resolves");
+        assert!(
+            naming.naming_metadata.is_none(),
+            "empty request should not invent naming metadata"
+        );
+        let naming = super::resolve_naming_metadata(
+            Some(&metadata),
+            Some(Path::new("/tmp/source.m4b")),
+            None,
+        )
+        .expect("naming metadata should exist");
 
-        assert_eq!(naming.title.as_deref(), Some("Legacy Source"));
-        assert_eq!(naming.series.as_deref(), Some("Series"));
-        assert_eq!(naming.series_part, None);
-        assert_eq!(naming.subseries.as_deref(), Some("Subseries"));
-        assert_eq!(naming.subseries_part, None);
+        assert_eq!(naming.title(), Some("Legacy Source"));
+        assert_eq!(naming.series(), Some("Series"));
+        assert_eq!(naming.series_part(), None);
+        assert_eq!(naming.subseries(), Some("Subseries"));
+        assert_eq!(naming.subseries_part(), None);
 
         let output_path = build_output_path(
             Path::new("/tmp"),
@@ -196,7 +337,7 @@ mod tests {
             ..Default::default()
         };
 
-        let naming = resolve_naming_metadata(
+        let naming = super::resolve_naming_metadata(
             Some(&metadata),
             Some(Path::new("/tmp/source.m4b")),
             Some(&patch),
@@ -214,6 +355,44 @@ mod tests {
         assert!(
             err.to_string().contains("Series sequence"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn outcome_plan_reports_cover_art_clear_policy() {
+        let patch = MetadataIntentPatch {
+            cover_art: PatchOp::Clear,
+            ..Default::default()
+        };
+
+        let outcome = plan_metadata_outcome(MetadataOutcomeRequest {
+            input_path: None,
+            intent_patch: Some(&patch),
+        })
+        .expect("metadata outcome resolves");
+
+        assert!(
+            matches!(
+                outcome.cover_art_passthrough,
+                CoverArtPassthroughPolicy::SuppressAfterExplicitClear
+            ),
+            "explicit cover clear must suppress source cover art passthrough"
+        );
+    }
+
+    #[test]
+    fn metadata_write_plan_preserves_cover_art_clear() {
+        let patch = MetadataIntentPatch {
+            cover_art: PatchOp::Clear,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            plan_metadata_write(&patch)
+                .expect("write plan")
+                .metadata
+                .cover_art,
+            Some(Vec::new())
         );
     }
 }

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -24,7 +24,10 @@ mod remux;
 
 pub use intent::{AlbumSortPatchOp, MetadataIntentPatch, PatchOp};
 pub(crate) use intent::{AlbumSortWriteAction, MetadataWritePlan};
-pub(crate) use intent_plan::{resolve_effective_processing_metadata, resolve_naming_metadata};
+pub(crate) use intent_plan::{
+    plan_metadata_outcome, plan_metadata_write, MetadataOutcomePlan, MetadataOutcomeRequest,
+};
+pub use intent_plan::{CoverArtPassthroughPolicy, NamingMetadata};
 
 /// Represents audiobook metadata.
 ///

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -7,6 +7,7 @@ use ffmpeg_next as ff;
 
 use crate::audio::AudioFile as PipelineAudioFile;
 use crate::errors::Result;
+use crate::metadata::AudiobookMetadata;
 
 /// Minimal chapter representation for passthrough (milliseconds time base).
 #[derive(Debug, Clone)]
@@ -43,16 +44,26 @@ impl PassthroughMetadata {
     }
 }
 
-pub fn apply_cover_art_policy(
-    passthrough: Option<PassthroughMetadata>,
-    allow_passthrough_cover_art: bool,
-) -> Option<PassthroughMetadata> {
-    if allow_passthrough_cover_art {
-        return passthrough;
+pub(crate) fn merge_passthrough_cover_art(
+    metadata: Option<AudiobookMetadata>,
+    passthrough: Option<&PassthroughMetadata>,
+) -> Option<AudiobookMetadata> {
+    let passthrough_cover = passthrough
+        .and_then(|value| value.cover_art.as_ref())
+        .cloned();
+    match metadata {
+        Some(mut metadata) => {
+            if metadata.cover_art.is_none() {
+                metadata.cover_art = passthrough_cover;
+            }
+            Some(metadata)
+        }
+        None => passthrough_cover.map(|cover_art| {
+            let mut metadata = AudiobookMetadata::new();
+            metadata.cover_art = Some(cover_art);
+            metadata
+        }),
     }
-
-    log::info!("cover_art_plan decision=skip_passthrough reason=explicit_cover_clear");
-    passthrough.and_then(PassthroughMetadata::without_cover_art)
 }
 
 fn synthesize_chapters_from_files(files: &[PipelineAudioFile]) -> Vec<ChapterSpec> {
@@ -214,7 +225,8 @@ fn rescale_to_ms(value: i64, time_base: ff::Rational) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_cover_art_policy, ChapterSpec, PassthroughMetadata};
+    use super::{merge_passthrough_cover_art, ChapterSpec, PassthroughMetadata};
+    use crate::metadata::{AudiobookMetadata, CoverArtPassthroughPolicy};
 
     #[test]
     fn into_option_returns_none_for_empty_passthrough() {
@@ -284,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_cover_art_policy_drops_only_cover_art_after_explicit_clear() {
+    fn cover_art_passthrough_policy_drops_only_cover_art_after_explicit_clear() {
         let passthrough = PassthroughMetadata {
             chapters: vec![ChapterSpec {
                 title: Some("Chapter 1".to_string()),
@@ -294,10 +306,47 @@ mod tests {
             cover_art: Some(vec![1, 2, 3]),
         };
 
-        let effective =
-            apply_cover_art_policy(Some(passthrough), false).expect("chapter passthrough remains");
+        let effective = CoverArtPassthroughPolicy::SuppressAfterExplicitClear
+            .apply_to_passthrough(Some(passthrough))
+            .expect("chapter passthrough remains");
 
         assert_eq!(effective.chapters.len(), 1);
         assert_eq!(effective.cover_art, None);
+    }
+
+    #[test]
+    fn merge_passthrough_cover_art_fills_only_missing_cover_art() {
+        let passthrough = PassthroughMetadata {
+            chapters: Vec::new(),
+            cover_art: Some(vec![1, 2, 3]),
+        };
+        let metadata = AudiobookMetadata {
+            title: Some("Known title".to_string()),
+            cover_art: None,
+            ..Default::default()
+        };
+
+        let merged = merge_passthrough_cover_art(Some(metadata), Some(&passthrough))
+            .expect("metadata remains");
+
+        assert_eq!(merged.title.as_deref(), Some("Known title"));
+        assert_eq!(merged.cover_art, Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn merge_passthrough_cover_art_keeps_explicit_cover_art() {
+        let passthrough = PassthroughMetadata {
+            chapters: Vec::new(),
+            cover_art: Some(vec![1, 2, 3]),
+        };
+        let metadata = AudiobookMetadata {
+            cover_art: Some(vec![9]),
+            ..Default::default()
+        };
+
+        let merged = merge_passthrough_cover_art(Some(metadata), Some(&passthrough))
+            .expect("metadata remains");
+
+        assert_eq!(merged.cover_art, Some(vec![9]));
     }
 }

--- a/src-tauri/src/output_artifact/naming.rs
+++ b/src-tauri/src/output_artifact/naming.rs
@@ -128,9 +128,7 @@ fn collect_naming_values(
     } else {
         None
     };
-    let year = metadata
-        .and_then(NamingMetadata::date)
-        .and_then(|date| crate::metadata::publication_year_from_date(Some(date)));
+    let year = metadata.and_then(|value| crate::metadata::publication_year_from_date(value.date()));
 
     Ok(NamingValues {
         title,

--- a/src-tauri/src/output_artifact/naming.rs
+++ b/src-tauri/src/output_artifact/naming.rs
@@ -1,6 +1,6 @@
 use super::types::{NamingPreset, OutputNamingConfig};
 use crate::errors::{sanitize_path_for_display, AppError, Result};
-use crate::metadata::AudiobookMetadata;
+use crate::metadata::NamingMetadata;
 use std::borrow::Cow;
 use std::path::{Component, Path, PathBuf};
 
@@ -76,7 +76,7 @@ fn build_abs_title(
 }
 
 fn collect_naming_values(
-    metadata: Option<&AudiobookMetadata>,
+    metadata: Option<&NamingMetadata>,
     source_path: Option<&Path>,
 ) -> Result<NamingValues> {
     let fallback = source_path
@@ -84,12 +84,12 @@ fn collect_naming_values(
         .map(|s| s.to_string_lossy())
         .unwrap_or_else(|| Cow::from("Untitled"));
     let title_raw = metadata
-        .and_then(|m| m.title.as_deref())
+        .and_then(NamingMetadata::title)
         .unwrap_or(&fallback);
-    let series_raw = metadata.and_then(|m| m.series.as_deref());
-    let series_part_raw = metadata.and_then(|m| m.series_part.as_deref());
-    let subseries_raw = metadata.and_then(|m| m.subseries.as_deref());
-    let subseries_part_raw = metadata.and_then(|m| m.subseries_part.as_deref());
+    let series_raw = metadata.and_then(NamingMetadata::series);
+    let series_part_raw = metadata.and_then(NamingMetadata::series_part);
+    let subseries_raw = metadata.and_then(NamingMetadata::subseries);
+    let subseries_part_raw = metadata.and_then(NamingMetadata::subseries_part);
     let mut title = sanitize_component(title_raw);
     if title.is_empty() {
         title = "Untitled".to_string();
@@ -97,7 +97,7 @@ fn collect_naming_values(
 
     let mut author = sanitize_author(
         metadata
-            .and_then(|m| m.artist.as_deref())
+            .and_then(NamingMetadata::artist)
             .unwrap_or("Unknown Author"),
     );
     if author.is_empty() {
@@ -128,8 +128,9 @@ fn collect_naming_values(
     } else {
         None
     };
-    let year =
-        metadata.and_then(|m| crate::metadata::publication_year_from_date(m.date.as_deref()));
+    let year = metadata
+        .and_then(NamingMetadata::date)
+        .and_then(|date| crate::metadata::publication_year_from_date(Some(date)));
 
     Ok(NamingValues {
         title,
@@ -351,7 +352,7 @@ fn build_output_path_inner(
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn build_output_path(
     base_dir: &Path,
-    metadata: Option<&AudiobookMetadata>,
+    metadata: Option<&NamingMetadata>,
     naming: OutputNamingConfig,
     source_path: Option<&Path>,
 ) -> Result<PathBuf> {
@@ -361,7 +362,7 @@ pub(crate) fn build_output_path(
 
 pub fn build_output_path_preview(
     base_dir: &Path,
-    metadata: Option<&AudiobookMetadata>,
+    metadata: Option<&NamingMetadata>,
     naming: OutputNamingConfig,
     source_path: Option<&Path>,
 ) -> Result<PathBuf> {

--- a/src-tauri/src/processing/plan.rs
+++ b/src-tauri/src/processing/plan.rs
@@ -1,6 +1,9 @@
 use crate::audio;
 use crate::errors::{sanitize_path_for_display, AppError, Result};
-use crate::metadata::{resolve_effective_processing_metadata, resolve_naming_metadata};
+use crate::metadata::{
+    plan_metadata_outcome, CoverArtPassthroughPolicy, MetadataOutcomePlan, MetadataOutcomeRequest,
+    NamingMetadata,
+};
 use crate::output_artifact::{
     build_output_path_preview, enforce_output_plan_review, ensure_output_parent_dirs,
     CollisionPolicy, OutputKind, OutputPlanLedger, OutputPlanReview, PlannedOutputAction,
@@ -22,7 +25,7 @@ pub(crate) struct PlannedProcessingJob {
     pub(crate) input_path: Option<PathBuf>,
     pub(crate) output: ResolvedOutputPlan,
     pub(crate) metadata: Option<crate::metadata::AudiobookMetadata>,
-    pub(crate) allow_passthrough_cover_art: bool,
+    pub(crate) cover_art_passthrough: CoverArtPassthroughPolicy,
 }
 
 #[derive(Debug, Clone)]
@@ -129,7 +132,7 @@ fn build_plan_signature(
 
 fn build_requested_output_path(
     base_output_dir: &Path,
-    metadata: Option<&crate::metadata::AudiobookMetadata>,
+    metadata: Option<&NamingMetadata>,
     output_naming: OutputNamingConfig,
     source_path: Option<&Path>,
 ) -> Result<PathBuf> {
@@ -283,19 +286,14 @@ fn build_merge_processing_job(
         .first()
         .and_then(|key| metadata.and_then(|map| map.get(key)))
         .cloned();
-    let merge_metadata =
-        resolve_effective_processing_metadata(Some(&merge_source_path), merge_patch.as_ref())?;
-    let allow_passthrough_cover_art = !merge_patch
-        .as_ref()
-        .is_some_and(crate::metadata::MetadataIntentPatch::clears_cover_art);
-    let merge_naming_metadata = resolve_naming_metadata(
-        merge_metadata.as_ref(),
-        Some(&merge_source_path),
-        merge_patch.as_ref(),
-    );
+    let metadata_outcome = plan_metadata_outcome(MetadataOutcomeRequest {
+        input_path: Some(&merge_source_path),
+        intent_patch: merge_patch.as_ref(),
+    })?;
+    let metadata_outcome: MetadataOutcomePlan = metadata_outcome;
     let requested_output = build_requested_output_path(
         &inputs.base_output_dir,
-        merge_naming_metadata.as_ref(),
+        metadata_outcome.naming_metadata.as_ref(),
         inputs.output_naming.clone(),
         Some(&merge_source_path),
     )?;
@@ -315,8 +313,8 @@ fn build_merge_processing_job(
         input_index: None,
         input_path: None,
         output,
-        metadata: merge_metadata,
-        allow_passthrough_cover_art,
+        metadata: metadata_outcome.effective_metadata,
+        cover_art_passthrough: metadata_outcome.cover_art_passthrough,
     })
 }
 
@@ -344,19 +342,14 @@ fn build_batch_processing_jobs(
     for (index, path) in validated_input_paths.iter().cloned().enumerate() {
         let input = &payload.input_files[index];
         let file_patch = metadata.and_then(|map| map.get(input)).cloned();
-        let effective_metadata =
-            resolve_effective_processing_metadata(Some(&path), file_patch.as_ref())?;
-        let allow_passthrough_cover_art = !file_patch
-            .as_ref()
-            .is_some_and(crate::metadata::MetadataIntentPatch::clears_cover_art);
-        let naming_metadata = resolve_naming_metadata(
-            effective_metadata.as_ref(),
-            Some(&path),
-            file_patch.as_ref(),
-        );
+        let metadata_outcome = plan_metadata_outcome(MetadataOutcomeRequest {
+            input_path: Some(&path),
+            intent_patch: file_patch.as_ref(),
+        })?;
+        let metadata_outcome: MetadataOutcomePlan = metadata_outcome;
         let requested_output = build_requested_output_path(
             &inputs.base_output_dir,
-            naming_metadata.as_ref(),
+            metadata_outcome.naming_metadata.as_ref(),
             inputs.output_naming.clone(),
             Some(&path),
         )?;
@@ -370,8 +363,8 @@ fn build_batch_processing_jobs(
             input_index: Some(index),
             input_path: Some(path),
             output,
-            metadata: effective_metadata,
-            allow_passthrough_cover_art,
+            metadata: metadata_outcome.effective_metadata,
+            cover_art_passthrough: metadata_outcome.cover_art_passthrough,
         });
     }
 
@@ -404,7 +397,7 @@ mod tests {
     use crate::audio::settings_encoder::{
         BitrateMode, ChannelConfig, EncoderSettings, EncoderType, ThreadSetting,
     };
-    use crate::metadata::{MetadataIntentPatch, PatchOp};
+    use crate::metadata::{CoverArtPassthroughPolicy, MetadataIntentPatch, PatchOp};
     use crate::output_artifact::{CollisionPolicy, OutputKind};
     use crate::processing::{JobType, NamingPreset, OutputNamingConfig, ProcessPayload};
     use std::collections::HashMap;
@@ -698,7 +691,10 @@ mod tests {
 
         assert_eq!(plan.jobs.len(), 1);
         assert!(
-            !plan.jobs[0].allow_passthrough_cover_art,
+            matches!(
+                plan.jobs[0].cover_art_passthrough,
+                CoverArtPassthroughPolicy::SuppressAfterExplicitClear
+            ),
             "explicit cover clear must not be refilled from source passthrough"
         );
     }

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -8,6 +8,7 @@ use crate::audio::file_list::FileListInfo;
 use crate::audio::settings_encoder::validate_encoder_settings;
 use crate::audio::toolchain::ExternalToolchainPreference;
 use crate::errors::{AppError, Result};
+use crate::metadata::CoverArtPassthroughPolicy;
 use crate::output_artifact::{OutputKind, ResolvedOutputPlan};
 use crate::processing::job_registry::{CancellationChecker, JobId};
 use crate::processing::{
@@ -185,7 +186,7 @@ async fn dispatch_merge_job(
         output_plan: planned_job.output,
         file_info,
         metadata: planned_job.metadata,
-        allow_passthrough_cover_art: planned_job.allow_passthrough_cover_art,
+        cover_art_passthrough: planned_job.cover_art_passthrough,
         preview_seconds: plan.preview_seconds,
     })
     .await?;
@@ -235,7 +236,7 @@ async fn dispatch_batch_jobs(
         let external_toolchain_cloned = payload.external_toolchain.clone();
         let sr_cloned = sample_rate.clone();
         let md_cloned = planned_job.metadata.clone();
-        let allow_passthrough_cover_art = planned_job.allow_passthrough_cover_art;
+        let cover_art_passthrough = planned_job.cover_art_passthrough;
         let preview_cloned = preview_seconds;
         let input_index = planned_job.input_index;
         let output = planned_job.output.clone();
@@ -255,7 +256,7 @@ async fn dispatch_batch_jobs(
                 output_plan: output,
                 file_info,
                 metadata: md_cloned,
-                allow_passthrough_cover_art,
+                cover_art_passthrough,
                 preview_seconds: preview_cloned,
             })
             .await
@@ -278,7 +279,7 @@ struct ProcessingJobRequest {
     output_plan: ResolvedOutputPlan,
     file_info: FileListInfo,
     metadata: Option<crate::metadata::AudiobookMetadata>,
-    allow_passthrough_cover_art: bool,
+    cover_art_passthrough: CoverArtPassthroughPolicy,
     preview_seconds: Option<f64>,
 }
 
@@ -303,7 +304,7 @@ async fn run_processing_job(request: ProcessingJobRequest) -> Result<ProcessResu
         context,
         request.file_info,
         request.metadata,
-        request.allow_passthrough_cover_art,
+        request.cover_art_passthrough,
         request.encoder_settings,
         request.external_toolchain,
     )
@@ -412,7 +413,7 @@ async fn execute_processing_job(
     context: ProcessingContext,
     file_info: FileListInfo,
     metadata: Option<crate::metadata::AudiobookMetadata>,
-    allow_passthrough_cover_art: bool,
+    cover_art_passthrough: CoverArtPassthroughPolicy,
     encoder_settings: audio::settings_encoder::EncoderSettings,
     external_toolchain: Option<ExternalToolchainPreference>,
 ) -> Result<String> {
@@ -440,7 +441,7 @@ async fn execute_processing_job(
             files,
             selected_decoders,
             metadata,
-            allow_passthrough_cover_art,
+            cover_art_passthrough,
         )
         .await
 }

--- a/src-tauri/src/processing/terminal_outcomes.rs
+++ b/src-tauri/src/processing/terminal_outcomes.rs
@@ -396,7 +396,7 @@ mod tests {
             input_path: Some(PathBuf::from(format!("/tmp/input-{index}.m4b"))),
             output: output_plan(action, format!("/tmp/output-{index}.m4b")),
             metadata: None,
-            allow_passthrough_cover_art: false,
+            cover_art_passthrough: crate::metadata::CoverArtPassthroughPolicy::Preserve,
         }
     }
 

--- a/src-tauri/tests/integration_fastpath_parity_tests.rs
+++ b/src-tauri/tests/integration_fastpath_parity_tests.rs
@@ -3,6 +3,7 @@ use audiobook_boss_lib::audio::settings_encoder::{
 };
 use audiobook_boss_lib::audio::{self, SampleRateConfig};
 use audiobook_boss_lib::processing::{OutputConfig, ProcessingContext, ProcessingSession};
+use audiobook_boss_lib::CoverArtPassthroughPolicy;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -54,9 +55,14 @@ async fn encode_with_fastpath_mode(
         OutputConfig::new(output_path),
     );
 
-    audio::process_audiobook_with_context(context, input_info.files, None, true)
-        .await
-        .expect("native AAC processing should complete")
+    audio::process_audiobook_with_context(
+        context,
+        input_info.files,
+        None,
+        CoverArtPassthroughPolicy::Preserve,
+    )
+    .await
+    .expect("native AAC processing should complete")
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/tests/integration_native_aac_regression_tests.rs
+++ b/src-tauri/tests/integration_native_aac_regression_tests.rs
@@ -5,6 +5,7 @@ use audiobook_boss_lib::audio::{self, SampleRateConfig};
 use audiobook_boss_lib::processing::{
     OutputConfig, PreviewConfig, ProcessingContext, ProcessingSession,
 };
+use audiobook_boss_lib::CoverArtPassthroughPolicy;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use tempfile::TempDir;
@@ -76,7 +77,13 @@ async fn native_aac_regression_encodes_valid_output() {
         OutputConfig::new(&output_path),
     );
 
-    let result = audio::process_audiobook_with_context(context, file_info.files, None, true).await;
+    let result = audio::process_audiobook_with_context(
+        context,
+        file_info.files,
+        None,
+        CoverArtPassthroughPolicy::Preserve,
+    )
+    .await;
     assert!(
         result.is_ok(),
         "native AAC encode should complete without error: {:?}",
@@ -126,7 +133,13 @@ async fn native_aac_preview_stops_near_requested_boundary() {
     );
     context.preview = Some(PreviewConfig::new(preview_seconds));
 
-    let result = audio::process_audiobook_with_context(context, file_info.files, None, true).await;
+    let result = audio::process_audiobook_with_context(
+        context,
+        file_info.files,
+        None,
+        CoverArtPassthroughPolicy::Preserve,
+    )
+    .await;
     assert!(
         result.is_ok(),
         "native AAC preview encode should complete without error: {:?}",
@@ -186,7 +199,13 @@ async fn native_aac_removes_destination_staging_when_execute_fails() {
         error: None,
     };
 
-    let result = audio::process_audiobook_with_context(context, vec![file], None, true).await;
+    let result = audio::process_audiobook_with_context(
+        context,
+        vec![file],
+        None,
+        CoverArtPassthroughPolicy::Preserve,
+    )
+    .await;
 
     assert!(
         result.is_err(),

--- a/src-tauri/tests/integration_processing_flow_tests.rs
+++ b/src-tauri/tests/integration_processing_flow_tests.rs
@@ -13,7 +13,7 @@ use audiobook_boss_lib::processing::{
     OutputConfig, PreviewConfig, ProcessingContext, ProcessingSession, ProcessingStage,
     ProgressReporter,
 };
-use audiobook_boss_lib::AudiobookMetadata;
+use audiobook_boss_lib::{AudiobookMetadata, CoverArtPassthroughPolicy};
 use ffmpeg_next as ff;
 use mp4ameta::{FreeformIdent, Tag};
 use std::path::{Path, PathBuf};
@@ -178,9 +178,14 @@ async fn process_roundtrip_files(
         context.preview = Some(PreviewConfig::new(seconds));
     }
 
-    audio::process_audiobook_with_context(context, input_info.files, Some(metadata), true)
-        .await
-        .expect("processing should complete")
+    audio::process_audiobook_with_context(
+        context,
+        input_info.files,
+        Some(metadata),
+        CoverArtPassthroughPolicy::Preserve,
+    )
+    .await
+    .expect("processing should complete")
 }
 
 fn chapter_count(path: &Path) -> usize {

--- a/src-tauri/tests/integration_xhe_aac_fixture_tests.rs
+++ b/src-tauri/tests/integration_xhe_aac_fixture_tests.rs
@@ -6,6 +6,7 @@ use audiobook_boss_lib::audio::{self, SampleRateConfig};
 use audiobook_boss_lib::processing::{
     OutputConfig, PreviewConfig, ProcessingContext, ProcessingSession,
 };
+use audiobook_boss_lib::CoverArtPassthroughPolicy;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -56,7 +57,7 @@ async fn xhe_aac_fixture_encodes_short_external_fdk_preview_when_configured() {
             file_info.files,
             file_info.selected_decoders,
             None,
-            true,
+            CoverArtPassthroughPolicy::Preserve,
         )
         .await
         .expect("external FDK preview should encode the xHE-AAC fixture");

--- a/src-tauri/tests/unit_output_path_naming_tests.rs
+++ b/src-tauri/tests/unit_output_path_naming_tests.rs
@@ -1,7 +1,7 @@
 use audiobook_boss_lib::output_artifact::{
     build_output_path_preview, NamingPreset, OutputNamingConfig,
 };
-use audiobook_boss_lib::AudiobookMetadata;
+use audiobook_boss_lib::{AudiobookMetadata, NamingMetadata};
 use tempfile::TempDir;
 
 fn sample_metadata() -> AudiobookMetadata {
@@ -25,10 +25,15 @@ fn sample_metadata() -> AudiobookMetadata {
     }
 }
 
+fn naming_metadata(metadata: &AudiobookMetadata) -> NamingMetadata {
+    NamingMetadata::from_metadata(metadata)
+}
+
 #[test]
 fn abs_default_preview_matches_existing_abs_layout() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let metadata = sample_metadata();
+    let metadata = naming_metadata(&metadata);
     let naming = OutputNamingConfig::default();
 
     let preview = build_output_path_preview(temp_dir.path(), Some(&metadata), naming, None)
@@ -48,6 +53,7 @@ fn abs_default_preview_matches_existing_abs_layout() {
 fn custom_template_substitutes_whitelisted_tokens() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let metadata = sample_metadata();
+    let metadata = naming_metadata(&metadata);
     let naming = OutputNamingConfig {
         preset: NamingPreset::CustomTemplate,
         include_year: false,
@@ -69,6 +75,7 @@ fn custom_template_substitutes_whitelisted_tokens() {
 fn custom_template_rejects_unknown_tokens() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let metadata = sample_metadata();
+    let metadata = naming_metadata(&metadata);
     let naming = OutputNamingConfig {
         preset: NamingPreset::CustomTemplate,
         include_year: false,
@@ -84,6 +91,7 @@ fn custom_template_rejects_unknown_tokens() {
 fn custom_template_rejects_traversal_and_absolute_paths() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let metadata = sample_metadata();
+    let metadata = naming_metadata(&metadata);
 
     let traversal = OutputNamingConfig {
         preset: NamingPreset::CustomTemplate,
@@ -109,6 +117,7 @@ fn custom_template_rejects_traversal_and_absolute_paths() {
 fn custom_template_auto_appends_m4b_extension() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let metadata = sample_metadata();
+    let metadata = naming_metadata(&metadata);
     let naming = OutputNamingConfig {
         preset: NamingPreset::CustomTemplate,
         include_year: false,
@@ -132,6 +141,7 @@ fn custom_template_with_missing_series_skips_empty_segment() {
     metadata.series_part = None;
     metadata.subseries = None;
     metadata.subseries_part = None;
+    let metadata = naming_metadata(&metadata);
 
     let naming = OutputNamingConfig {
         preset: NamingPreset::CustomTemplate,

--- a/src/lib/tauri/client.ts
+++ b/src/lib/tauri/client.ts
@@ -28,7 +28,7 @@ import type { MetadataIntentPatch } from '../../types/metadataIntent';
 import { commandSpecs, type CommandResult, type TauriCommand } from './commands';
 import { normalizeProgressEvent, normalizeQueueEvent } from './normalizers';
 
-type MetadataIntentPayload = Record<string, MetadataIntentPatch>;
+type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
 type AppEventName = (typeof TAURI_APP_EVENT_NAMES)[number];
 type RuntimeEventName = Exclude<EventName, AppEventName>;
 type ProgressEventHandler = (event: { payload: ProcessingProgressEvent }) => void;
@@ -154,7 +154,7 @@ export const tauriClient = {
 	}): Promise<CommandResult<'preview_output_path'>> => commandSpecs.preview_output_path(args),
 	preflightProcessingPlan: (args: {
 		payload: ProcessPayload;
-		metadataIntent?: MetadataIntentPayload | null;
+		metadataIntent?: MetadataIntentByPath | null;
 		previewSeconds?: number | null;
 	}): Promise<ProcessingPreflightPlan> => commandSpecs.preflight_processing_plan(args),
 	getMaxConcurrentJobs: (): Promise<CommandResult<'get_max_concurrent_jobs'>> =>
@@ -165,7 +165,7 @@ export const tauriClient = {
 		commandSpecs.set_max_concurrent_jobs({ max_concurrent: maxConcurrent ?? null }),
 	processAudiobookFiles: (args: {
 		payload: ProcessPayload;
-		metadataIntent?: MetadataIntentPayload | null;
+		metadataIntent?: MetadataIntentByPath | null;
 		previewSeconds?: number | null;
 	}): Promise<ProcessCommandResult> => commandSpecs.process_audiobook_files(args),
 	cancelProcessing: (jobId?: string | null): Promise<CommandResult<'cancel_processing'>> =>

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -25,7 +25,7 @@ import {
 	normalizeProcessResult,
 } from './normalizers';
 
-type MetadataIntentPayload = Record<string, MetadataIntentPatch>;
+type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
 type GeneratedExternalToolchain = { overridePath: string | null };
 
 type UnwrapGeneratedResult<T> = T extends { status: 'error' }
@@ -78,14 +78,14 @@ function toGeneratedOutputNamingConfig(
 }
 
 function compileMetadataIntentMap(
-	metadataIntent?: MetadataIntentPayload | null,
+	metadataIntentByPath?: MetadataIntentByPath | null,
 ): Record<string, MetadataIntentPatch> | null {
-	if (!metadataIntent) {
+	if (!metadataIntentByPath) {
 		return null;
 	}
 
 	return Object.fromEntries(
-		Object.entries(metadataIntent).map(([path, value]) => [
+		Object.entries(metadataIntentByPath).map(([path, value]) => [
 			path,
 			compileMetadataIntentPatch(value),
 		]),
@@ -177,7 +177,7 @@ export const commandSpecs = {
 		),
 	preflight_processing_plan: (args: {
 		payload: ProcessPayload;
-		metadataIntent?: MetadataIntentPayload | null;
+		metadataIntent?: MetadataIntentByPath | null;
 		previewSeconds?: number | null;
 	}) =>
 		runGeneratedCommand(
@@ -194,7 +194,7 @@ export const commandSpecs = {
 		runGeneratedCommand(generatedCommands.setMaxConcurrentJobs(args.max_concurrent ?? null)),
 	process_audiobook_files: (args: {
 		payload: ProcessPayload;
-		metadataIntent?: MetadataIntentPayload | null;
+		metadataIntent?: MetadataIntentByPath | null;
 		previewSeconds?: number | null;
 	}) =>
 		runGeneratedCommand(

--- a/src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts
+++ b/src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts
@@ -57,7 +57,7 @@ function makeHarness(overrides: Partial<OutputPlanWorkflowServices> = {}) {
 	let latestRequestId = 0;
 	const services: OutputPlanWorkflowServices = {
 		getState: vi.fn(() => state as ReturnType<OutputPlanWorkflowServices['getState']>),
-		getCurrentMetadata: vi.fn(() => ({
+		readOutputPathPreviewMetadataDraft: vi.fn(() => ({
 			title: 'A',
 			album: 'A',
 			artist: 'Author',
@@ -69,7 +69,7 @@ function makeHarness(overrides: Partial<OutputPlanWorkflowServices> = {}) {
 		})),
 		updateSeriesPartWarning: vi.fn(),
 		updateSubseriesPartWarning: vi.fn(),
-		buildOutputPreviewCallSiteState: vi.fn(() => ({
+		buildOutputPathPreviewContext: vi.fn(() => ({
 			outputDirectory: state.outputDirectory,
 			sourcePath: '/books/a.m4b',
 		})),
@@ -175,7 +175,7 @@ describe('OutputPlanWorkflow', () => {
 		const result = await runAppEffect(
 			outputPlanReviewWorkflowExecution({
 				payload: payload(),
-				metadataIntent: null,
+				metadataIntentByPath: null,
 				previewSeconds: null,
 			}).pipe(Effect.provide(harness.layer)),
 		);
@@ -214,7 +214,7 @@ describe('OutputPlanWorkflow', () => {
 		});
 
 		const result = await runAppEffect(
-			outputPlanReviewWorkflowExecution({ payload: payload(), metadataIntent: null }).pipe(
+			outputPlanReviewWorkflowExecution({ payload: payload(), metadataIntentByPath: null }).pipe(
 				Effect.provide(harness.layer),
 			),
 		);
@@ -248,7 +248,7 @@ describe('OutputPlanWorkflow', () => {
 		});
 
 		const result = await runAppEffect(
-			outputPlanReviewWorkflowExecution({ payload: payload(), metadataIntent: null }).pipe(
+			outputPlanReviewWorkflowExecution({ payload: payload(), metadataIntentByPath: null }).pipe(
 				Effect.provide(harness.layer),
 			),
 		);
@@ -281,7 +281,7 @@ describe('OutputPlanWorkflow', () => {
 			.fn()
 			.mockResolvedValueOnce(initialPlan)
 			.mockResolvedValueOnce(reviewedPlan);
-		const metadataIntent: Record<string, MetadataIntentPatch> = {
+		const metadataIntentByPath: Record<string, MetadataIntentPatch> = {
 			'/books/a.m4b': { title: { op: 'set', value: 'A' } },
 		};
 		const processPayload = payload();
@@ -293,14 +293,14 @@ describe('OutputPlanWorkflow', () => {
 		const result = await runAppEffect(
 			outputPlanReviewWorkflowExecution({
 				payload: processPayload,
-				metadataIntent,
+				metadataIntentByPath,
 				previewSeconds: 30,
 			}).pipe(Effect.provide(harness.layer)),
 		);
 
 		expect(preflightProcessingPlan).toHaveBeenNthCalledWith(2, {
 			payload: { ...processPayload, collisionPolicy: 'rename_new' },
-			metadataIntent,
+			metadataIntent: metadataIntentByPath,
 			previewSeconds: 30,
 		});
 		expect(result).toEqual({

--- a/src/ui/outputPanel/outputPlanWorkflow.ts
+++ b/src/ui/outputPanel/outputPlanWorkflow.ts
@@ -62,26 +62,26 @@ function outputPathPreviewBody(
 	return Effect.gen(function* () {
 		const services = yield* OutputPlanWorkflowServicesTag;
 		const state = services.getState();
-		const metadata = services.getCurrentMetadata();
+		const previewMetadataDraft = services.readOutputPathPreviewMetadataDraft();
 
-		services.updateSeriesPartWarning(metadata);
-		services.updateSubseriesPartWarning(metadata);
+		services.updateSeriesPartWarning(previewMetadataDraft);
+		services.updateSubseriesPartWarning(previewMetadataDraft);
 
 		if (!state.outputDirectory) {
 			services.setOutputPreview('Select output directory...', 'No directory selected');
 			return;
 		}
 
-		const previewCallSiteState = services.buildOutputPreviewCallSiteState();
+		const previewContext = services.buildOutputPathPreviewContext();
 		const requestId = reservedRequestId ?? services.beginOutputPreviewRequest();
 
 		const previewPath = yield* workflowPromise(
 			() =>
 				services.previewOutputPath({
-					outputDir: previewCallSiteState.outputDirectory,
-					metadata,
+					outputDir: previewContext.outputDirectory,
+					metadata: previewMetadataDraft,
 					outputNaming: services.getOutputNamingConfig(),
-					sourcePath: previewCallSiteState.sourcePath,
+					sourcePath: previewContext.sourcePath,
 					outputKind,
 				}),
 			'Output preview failed.',
@@ -112,10 +112,15 @@ function outputPlanReviewBody(
 ): AppEffect<OutputPlanReviewResult, OutputPlanWorkflowFailed, OutputPlanWorkflowServicesId> {
 	return Effect.gen(function* () {
 		const services = yield* OutputPlanWorkflowServicesTag;
-		const { payload, metadataIntent, previewSeconds } = request;
+		const { payload, metadataIntentByPath, previewSeconds } = request;
 
 		const initialPlan = yield* workflowPromise(
-			() => services.preflightProcessingPlan({ payload, metadataIntent, previewSeconds }),
+			() =>
+				services.preflightProcessingPlan({
+					payload,
+					metadataIntent: metadataIntentByPath,
+					previewSeconds,
+				}),
 			'Output plan preflight failed.',
 		);
 		const hardBlockMessage = getBlockingReviewMessage(initialPlan);
@@ -148,7 +153,7 @@ function outputPlanReviewBody(
 			() =>
 				services.preflightProcessingPlan({
 					payload: reviewedPayload,
-					metadataIntent,
+					metadataIntent: metadataIntentByPath,
 					previewSeconds,
 				}),
 			'Reviewed output plan preflight failed.',

--- a/src/ui/outputPanel/outputPlanWorkflowLive.ts
+++ b/src/ui/outputPanel/outputPlanWorkflowLive.ts
@@ -8,8 +8,8 @@ import {
 	setOutputPreview,
 } from './state.svelte';
 import {
-	buildOutputPreviewCallSiteState,
-	getCurrentMetadata,
+	buildOutputPathPreviewContext,
+	readOutputPathPreviewMetadataDraft,
 	showOutputError,
 	updateSeriesPartWarning,
 	updateSubseriesPartWarning,
@@ -21,10 +21,10 @@ import {
 
 export const liveOutputPlanWorkflowServices: OutputPlanWorkflowServices = {
 	getState,
-	getCurrentMetadata,
+	readOutputPathPreviewMetadataDraft,
 	updateSeriesPartWarning,
 	updateSubseriesPartWarning,
-	buildOutputPreviewCallSiteState,
+	buildOutputPathPreviewContext,
 	beginOutputPreviewRequest,
 	isLatestOutputPreviewRequest,
 	getOutputNamingConfig,

--- a/src/ui/outputPanel/outputPlanWorkflowServices.ts
+++ b/src/ui/outputPanel/outputPlanWorkflowServices.ts
@@ -12,7 +12,11 @@ import type {
 } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
 import type { MetadataIntentPatch } from '../../types/metadataIntent';
-import type { buildOutputPreviewCallSiteState, showOutputError } from './preview';
+import type {
+	buildOutputPathPreviewContext,
+	OutputPathPreviewMetadataDraft,
+	showOutputError,
+} from './preview';
 import type {
 	beginOutputPreviewRequest,
 	getOutputNamingConfig,
@@ -23,10 +27,10 @@ import type {
 
 export interface OutputPlanWorkflowServices {
 	getState: typeof getState;
-	getCurrentMetadata: () => AudiobookMetadata;
+	readOutputPathPreviewMetadataDraft: () => OutputPathPreviewMetadataDraft;
 	updateSeriesPartWarning: (metadata: AudiobookMetadata) => void;
 	updateSubseriesPartWarning: (metadata: AudiobookMetadata) => void;
-	buildOutputPreviewCallSiteState: typeof buildOutputPreviewCallSiteState;
+	buildOutputPathPreviewContext: typeof buildOutputPathPreviewContext;
 	beginOutputPreviewRequest: typeof beginOutputPreviewRequest;
 	isLatestOutputPreviewRequest: typeof isLatestOutputPreviewRequest;
 	getOutputNamingConfig: typeof getOutputNamingConfig;
@@ -38,9 +42,11 @@ export interface OutputPlanWorkflowServices {
 	console: Pick<Console, 'error'>;
 }
 
+export type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
+
 export interface OutputPlanReviewRequest {
 	payload: ProcessPayload;
-	metadataIntent: Record<string, MetadataIntentPatch> | null;
+	metadataIntentByPath: MetadataIntentByPath | null;
 	previewSeconds?: number | null;
 }
 

--- a/src/ui/outputPanel/preview.ts
+++ b/src/ui/outputPanel/preview.ts
@@ -23,12 +23,14 @@ import {
 import type { OutputKind } from '../../types/audio';
 import { runOutputPathPreviewWorkflow } from './outputPlanWorkflow';
 
-type OutputPreviewCallSiteState = {
+export type OutputPathPreviewMetadataDraft = AudiobookMetadata;
+
+type OutputPathPreviewContext = {
 	outputDirectory: string;
 	sourcePath?: string;
 };
 
-export function getCurrentMetadata(): AudiobookMetadata {
+export function readOutputPathPreviewMetadataDraft(): OutputPathPreviewMetadataDraft {
 	const metadata = readMetadataForm({
 		mode: metadataFormState.mode,
 		onlyDirty: false,
@@ -51,6 +53,8 @@ export function getCurrentMetadata(): AudiobookMetadata {
 		cover_art: coverArt ?? metadata.cover_art ?? undefined,
 	};
 }
+
+export const getCurrentMetadata = readOutputPathPreviewMetadataDraft;
 
 export function updateSeriesPartWarning(metadata: AudiobookMetadata): void {
 	const seriesValue = metadata.series?.trim() ?? '';
@@ -117,7 +121,7 @@ export function updateNamingOptionState(): void {
 	});
 }
 
-export function buildOutputPreviewCallSiteState(): OutputPreviewCallSiteState {
+export function buildOutputPathPreviewContext(): OutputPathPreviewContext {
 	const state = getState();
 	const fileList = getCurrentFileList();
 	const selectedIndices = Array.from(getSelectedFileIndices()).sort((a, b) => a - b);

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -26,6 +26,8 @@ import {
 } from './processingWorkflowServices';
 import type { ProcessingStatus } from './state';
 
+type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
+
 export {
 	ProcessingWorkflowServicesTag,
 	makeProcessingWorkflowServicesLayer,
@@ -157,14 +159,19 @@ function workflowPromise<A>(
 
 function processingCommand(
 	services: ProcessingWorkflowServices,
-	payload: {
+	request: {
 		payload: ProcessPayload;
-		metadataIntent: Record<string, MetadataIntentPatch> | null;
+		metadataIntentByPath: MetadataIntentByPath | null;
 		previewSeconds?: number;
 	},
 ): AppEffect<ProcessCommandResult, ProcessingWorkflowError> {
 	return Effect.tryPromise({
-		try: () => services.processAudiobookFiles(payload),
+		try: () =>
+			services.processAudiobookFiles({
+				payload: request.payload,
+				metadataIntent: request.metadataIntentByPath,
+				previewSeconds: request.previewSeconds,
+			}),
 		catch: (cause) => {
 			const normalized = normalizeAppError(cause);
 			const wasCancelled =
@@ -345,7 +352,7 @@ export function processingWorkflowProgram(
 			}
 		}
 
-		let metadataIntentPayload: Record<string, MetadataIntentPatch> | null = null;
+		let metadataIntentByPath: MetadataIntentByPath | null = null;
 		if (processPayload.jobType === 'merge') {
 			const mergeKey = processPayload.inputFiles[0];
 			const mergeIntentPatch = mergeKey
@@ -356,28 +363,28 @@ export function processingWorkflowProgram(
 				processPayload.inputFiles.length > 0 &&
 				hasActionableMetadataDraftIntent(mergeIntentPatch)
 			) {
-				metadataIntentPayload = {
+				metadataIntentByPath = {
 					[mergeKey]: mergeIntentPatch,
 				};
 			}
 		} else {
-			const storedMetadataIntent = services.getAllMetadataIntentPatches();
+			const storedMetadataIntentByPath = services.getAllMetadataIntentPatches();
 			const activeInputFiles = new Set(processPayload.inputFiles);
-			const filteredMetadataIntent = Object.fromEntries(
-				Object.entries(storedMetadataIntent).filter(
+			const filteredMetadataIntentByPath = Object.fromEntries(
+				Object.entries(storedMetadataIntentByPath).filter(
 					([filePath, value]) =>
 						activeInputFiles.has(filePath) && hasActionableMetadataDraftIntent(value),
 				),
 			);
-			metadataIntentPayload =
-				Object.keys(filteredMetadataIntent).length > 0 ? filteredMetadataIntent : null;
+			metadataIntentByPath =
+				Object.keys(filteredMetadataIntentByPath).length > 0 ? filteredMetadataIntentByPath : null;
 		}
 
 		const reviewResult = yield* workflowPromise(
 			() =>
 				services.runOutputPlanReviewWorkflow({
 					payload: processPayload,
-					metadataIntent: metadataIntentPayload,
+					metadataIntentByPath,
 					previewSeconds: options?.previewSeconds,
 				}),
 			'Output plan review failed.',
@@ -409,7 +416,7 @@ export function processingWorkflowProgram(
 
 		const result = yield* processingCommand(services, {
 			payload: reviewResult.payload,
-			metadataIntent: metadataIntentPayload,
+			metadataIntentByPath,
 			previewSeconds: options?.previewSeconds,
 		});
 


### PR DESCRIPTION
## Summary
- Add the metadata-owned outcome surface: `MetadataOutcomeRequest`, `MetadataOutcomePlan`, `NamingMetadata`, `CoverArtPassthroughPolicy`, `plan_metadata_outcome`, and `plan_metadata_write`.
- Refactor processing/output planning plus native/external finalization to consume metadata-owned naming metadata and cover-art passthrough policy.
- Keep Tauri command payloads/generated bindings stable while clarifying local frontend naming around drafts, intent-by-path, and output preview context.
- Update active public-strip docs/checks and include the roadmap plus implementation notes artifact.

## Validation
- `cargo test -p audiobook-boss contract_tests`
- `cargo test -p audiobook-boss --lib metadata`
- `cargo test -p audiobook-boss --lib processing`
- Direct run of built `unit_output_path_naming_tests` binary
- `cargo test -p audiobook-boss --lib external_fdk`
- Targeted Vitest workflow/runtime files
- `scripts/check-public-api-strips.sh`
- `scripts/check-no-bridge-imports.sh`
- `bash scripts/check-context-surface.sh`
- `bun run fmt:check` after final docs/format updates
- `scripts/checks.sh standard` (logged at `/tmp/abb-standard-checks.log`, exit status 0)

## Notes
- No Tauri command-shape or generated TypeScript binding changes were required.
- `scripts/checks.sh standard` initially caught `.cursor/settings.json` indentation; fixed in the follow-up commit.
- The xHE-AAC fixture test remains environment-gated because `ABB_XHE_AAC_FIXTURE` and external libfdk FFmpeg were not configured locally.
