### PR TITLE
[codex] Implement operation lifecycle contract

### DIFF
--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -48,14 +48,16 @@ It is intentionally not a full contract dump. Use it to find the owning code qui
 - `get_max_concurrent_jobs`, `set_max_concurrent_jobs`, `process_audiobook_files`, `cancel_processing`
   - Rust: `src-tauri/src/commands/audio.rs`
   - Core helpers: `src-tauri/src/processing/run.rs`, `src-tauri/src/processing/plan.rs`, `src-tauri/src/processing/job_registry/`
-  - Processor routing: native `ffmpeg-next` and external FFmpeg/FDK adapter selection live under `src-tauri/src/audio/processor/`
+  - Lifecycle helpers: `src-tauri/src/processing/lifecycle.rs`, `src-tauri/src/processing/progress/`
+  - Audio execution: call the `crate::audio` public strip; native `ffmpeg-next` and external FFmpeg/FDK adapter selection remain private under `src-tauri/src/audio/processor/`
   - Use: queueing, processing, cancellation, batch orchestration
 
 ### Metadata
 
-- `read_audio_metadata`, `save_metadata_to_file`, `write_cover_art`, `load_cover_art_file`, `load_cover_art_from_url`
+- `read_audio_metadata`, `save_metadata_to_file`, `save_metadata_batch`, `write_cover_art`, `load_cover_art_file`, `load_cover_art_from_url`
   - Rust: `src-tauri/src/commands/metadata.rs`
   - Core helpers: `src-tauri/src/metadata/`, `src-tauri/src/audio/path_validation.rs`
+  - Lifecycle reporting: metadata batch save emits processing-owned queue/progress events with `operation_kind: metadataSave`
   - Note: metadata writes use intent patches at the boundary, not raw ad hoc object mutation; `track`/`disk` stay read-compatible only
 
 - `search_online_metadata`
@@ -72,10 +74,16 @@ Source files:
 
 - Rust event export: `src-tauri/src/ipc_contract.rs`
 - Rust event types: `src-tauri/src/processing/progress/mod.rs`
-- Rust event names: `src-tauri/src/audio/constants.rs`
+- Rust event names: `src-tauri/src/processing/progress/mod.rs`
+- Rust operation vocabulary: `src-tauri/src/processing/lifecycle.rs`
 - Frontend event contract: `src/types/events.ts`
 - Frontend listener boundary: `src/lib/tauri/client.ts`
 - Main UI consumer: `src/ui/statusPanel/events.ts`
+
+Lifecycle event payloads carry `operation_kind` so Status Panel can distinguish
+merge processing, batch processing, and metadata save from backend truth instead
+of caller-only choreography. Shared terminal counts use
+`OperationResultSummary` in generated bindings.
 
 ## Tauri Plugins Used At Runtime
 

--- a/docs/specs/operation-lifecycle-contract-roadmap.html
+++ b/docs/specs/operation-lifecycle-contract-roadmap.html
@@ -320,9 +320,9 @@
       </div>
       <h1>Operation Lifecycle Contract: Before / After</h1>
       <p class="subtitle">
-        The open question is whether ABB should name operation lifecycle facts
-        explicitly, instead of letting processing, metadata save, and status panel
-        infer them from separate call choreography.
+        Implementation now names ABB operation lifecycle facts explicitly under
+        processing, so processing, metadata save, and Status Panel share backend
+        operation identity instead of relying on separate call choreography.
       </p>
     </section>
 
@@ -330,7 +330,7 @@
       <h2>Short Answer</h2>
       <div class="decision">
         <div class="callout">
-          <p><strong>Accepted choice:</strong> introduce bounded lifecycle vocabulary inside <code>processing</code>, probably including an operation kind and shared result-summary vocabulary.</p>
+          <p><strong>Implemented choice:</strong> bounded lifecycle vocabulary lives inside <code>processing</code>, including <code>OperationKind</code> and shared <code>OperationResultSummary</code> vocabulary.</p>
         </div>
         <div class="callout">
           <p><strong>Why:</strong> the behavior already exists. Naming it makes the repo more agent-first because future work can ask "what operation is this?" and "what terminal truth did it produce?" without reading three unrelated flows.</p>
@@ -344,7 +344,7 @@
         <article class="diagram before">
           <div class="diagram-title">
             <h2>Before: Truth By Choreography</h2>
-            <span>current code shape</span>
+            <span>pre-implementation shape</span>
           </div>
           <div class="stack">
             <div class="box info">
@@ -372,7 +372,7 @@
         <article class="diagram after">
           <div class="diagram-title">
             <h2>After: Truth By Contract</h2>
-            <span>intended roadmap shape</span>
+            <span>implemented target shape</span>
           </div>
           <div class="stack">
             <div class="box good">
@@ -394,7 +394,7 @@
             </div>
             <div class="box neutral">
               <h3>Status Panel Runtime</h3>
-              <p>Stays a consumer/read model. If backend events include operation kind, it can consume that fact instead of relying only on caller choreography.</p>
+              <p>Stays a consumer/read model. Backend events include operation kind, so it can consume that fact instead of relying only on caller choreography.</p>
             </div>
           </div>
         </article>
@@ -420,8 +420,8 @@
             <td>Leaves future agents asking why metadata uses processing result summary and why status kind lives outside event truth.</td>
           </tr>
           <tr>
-            <td><span class="tag good">Bounded vocabulary</span><br>Accepted</td>
-            <td>Add lifecycle-level terms such as <code>OperationKind</code> and shared terminal summary vocabulary under processing lifecycle.</td>
+            <td><span class="tag good">Bounded vocabulary</span><br>Implemented</td>
+            <td>Add lifecycle-level terms such as <code>OperationKind</code> and <code>OperationResultSummary</code> under processing lifecycle.</td>
             <td>Makes the operation contract visible and reusable without inventing a new platform.</td>
             <td>May require generated binding churn and careful Status Panel consumption updates.</td>
           </tr>
@@ -436,7 +436,7 @@
     </section>
 
     <section class="section">
-      <h2>Lifecycle Flow After The Roadmap</h2>
+      <h2>Lifecycle Flow After Implementation</h2>
       <div class="flow">
         <div class="flow-step">
           <b>1. Operation starts</b>
@@ -472,10 +472,10 @@
         </p>
       </div>
       <p class="footer">
-        Temporary planning artifact. Sources: <code>docs/specs/operation-lifecycle-contract-roadmap.md</code>,
+        Temporary planning artifact, updated during implementation. Sources: <code>docs/specs/operation-lifecycle-contract-roadmap.md</code>,
         <code>src-tauri/src/processing/run.rs</code>, <code>src-tauri/src/commands/metadata/save_batch.rs</code>,
         <code>src-tauri/src/processing/progress/</code>, <code>src-tauri/src/audio/constants.rs</code>,
-        <code>src/ui/statusPanel/</code>. Validated against current main snapshot <code>22520b147e</code> on 2026-05-20.
+        <code>src/ui/statusPanel/</code>. Implementation update validated on 2026-05-20.
       </p>
     </section>
   </main>

--- a/docs/specs/operation-lifecycle-contract-roadmap.md
+++ b/docs/specs/operation-lifecycle-contract-roadmap.md
@@ -434,6 +434,11 @@ they would violate an accepted boundary or expand scope.
 - 2026-05-20: Marked roadmap handoff-ready. Remaining tactical decisions should
   be validated by the implementation agent against current code and escalated
   only if they violate accepted scope, ownership, or behavior boundaries.
+- 2026-05-20: Implementation branch validated the accepted shape: Backend
+  Lifecycle is a `processing` sub-owner; lifecycle constants moved out of
+  `audio/constants.rs`; queue/progress events now carry backend operation
+  identity; generated terminal summaries now use shared
+  `OperationResultSummary`.
 
 ## Surprises And Discoveries
 
@@ -446,6 +451,10 @@ they would violate an accepted boundary or expand scope.
   vocabulary before future long-running feature work.
 - `processing/progress` already owns the event payload types and Specta event
   names, which makes audio-owned lifecycle event constants look accidental.
+- Focused Cargo verification is currently noisier than expected: broad filters
+  and `-- --list` can still launch or walk unrelated test binaries. Exact
+  `--lib <test-name> -- --exact` commands gave cleaner lifecycle signal. Keep
+  broader testing-infra improvements deferred to issue #323.
 
 ## Accepted Decisions
 
@@ -465,6 +474,8 @@ they would violate an accepted boundary or expand scope.
 - Introduce bounded lifecycle vocabulary inside the processing-owned lifecycle
   strip, including operation identity if implementation validation confirms the
   benefit.
+- Operation identity is now accepted as contract vocabulary:
+  `processingMerge`, `processingBatch`, and `metadataSave`.
 - Implementation may move lifecycle constants out of `audio/constants.rs`.
 - Implementation may extract shared lifecycle helpers from `run.rs` and
   `metadata/save_batch.rs` if the extraction improves ownership clarity and does

--- a/docs/specs/remote-acquisition.md
+++ b/docs/specs/remote-acquisition.md
@@ -99,7 +99,7 @@ What good looks like: a user logs into Audible inside ABB, selects three titles,
 - **A2**. Scaffold `src-tauri/src/remote_source/`: provider trait, `RemoteSourceRuntime` skeleton, `Vault` trait, `AcquisitionJobRegistry` skeleton, `MaterializedAsset` + `ProvenanceManifest` types, phase event enum. Wire empty command stubs through `ipc_contract.rs`.
 - **A3**. Write `src-tauri/src/remote_source/AGENTS.md`: Public API Strip enumeration, Private Cluster enumeration, allowed agent edits, breaking-change triggers, GPL contamination rule, Vault reach-through prohibition with target script.
 - **A4**. Add boundary-assertion script `scripts/check-no-remote-source-reach-through.sh` modeled on `scripts/check-no-bridge-imports.sh` (existing pattern). Blocks: imports of `remote_source::providers::*::*` from outside the provider module; imports of `remote_source::vault::*` from anywhere outside `RemoteSourceRuntime`'s private cluster. Wire into `scripts/checks.sh standard`.
-- **A5**. Update `docs/system-map.md` (Sixth Public API row + Boundary section), `docs/api-map.md` (new command family), `docs/ubiquitous-language.md` (new terms).
+- **A5**. Update `docs/system-map.md` (seventh Public API row + Boundary section), `docs/api-map.md` (new command family), `docs/ubiquitous-language.md` (new terms).
 
 ### Phase B — Audible auth
 
@@ -242,7 +242,7 @@ Frontend sees these; never sees tokens, license blobs, decrypt keys, device blob
 - **AAX legacy is out of scope** until a real user title hits the unsupported path. Then it becomes a single-PR addition.
 - **No metadata-enrichment seam.** Existing embedded tags + existing `search_online_metadata` lookup cover the metadata need. YAGNI.
 - **No shared `JobRegistry`.** Acquisition lifecycle gets a peer `AcquisitionJobRegistry`. Processing's registry stays single-purpose.
-- **Sixth Public API.** `RemoteSourceRuntime` joins the existing five.
+- **Seventh Public API.** `RemoteSourceRuntime` would join the existing six.
 - **`LocalImportBridge` extraction** is a prerequisite for the work, not a follow-up. Done in Phase A.
 - **GPL contamination rule** is hard-binding on agents implementing the Audible provider cluster.
 - **Source acquisition format is a provenance label**, not a DRM-state label. Display "Source: Audible Widevine (DASH)" not "DRM: Widevine."
@@ -274,7 +274,7 @@ Frontend sees these; never sees tokens, license blobs, decrypt keys, device blob
 
 ### Documentation Alignment
 
-- `docs/system-map.md`: Sixth Public API row.
+- `docs/system-map.md`: seventh Public API row.
 - `docs/api-map.md`: Remote Source command + event family.
 - `docs/ubiquitous-language.md`: new terms (Remote Acquisition Plane, Materialized Asset, Acquisition Job Ledger, Vault Adapter, Provider Driver, Source Acquisition Format, Capability Matrix).
 - `src-tauri/src/remote_source/AGENTS.md`: Public API Strip, Private Cluster, allowed edits, breaking-change triggers, GPL rule.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -32,7 +32,7 @@ Use these layers to locate ownership before changing behavior:
 | UI state | Selected files, edits, visible status, and enabled actions. |
 | Frontend workflow coordination | Effect workflow owners for multi-boundary async orchestration, typed workflow errors, fakeable services, and terminal UI outcomes. |
 | IPC contract | Command, event, and payload shapes crossing TS <-> Rust. |
-| Backend lifecycle | Planning, queueing, execution, cancellation, skipping, and finalization. |
+| Backend lifecycle | Operation identity, queue/progress events, cancellation, skipping, terminal summaries, and finalization. |
 | Artifact truth | Final files, tags, paths, and terminal results on disk. |
 
 ## Boundary Rule
@@ -70,6 +70,8 @@ ownership or proof.
 - `tauriClient` adapts generated bindings from `src/lib/generated/tauri.ts`.
 - Rust commands are registered in `src-tauri/src/ipc_contract.rs` and implemented under `src-tauri/src/commands/`.
 - Processing plans are built before execution and reviewed before jobs run.
+- Backend lifecycle vocabulary and event emission live under `processing` as a
+  sub-owner/public strip; it is not a seventh Grey-Box Public API.
 - Audio engine execution owns media inspection, decoder/toolchain selection,
   encode/mux/staging behavior, and media-integrity facts behind a small public
   strip.
@@ -98,6 +100,12 @@ assertions, and contract tests.
 
 Each Public API has a nearest nested `AGENTS.md` that lists the allowed import
 strip, private cluster, edit rules, and breaking-change triggers.
+
+Backend Lifecycle is a named sub-owner inside `processing`, not a seventh
+Grey-Box Public API. It provides operation identity, progress/queue event
+vocabulary, cancellation hooks, and shared terminal-summary vocabulary for
+processing, metadata save, audio progress reporting, and Status Panel
+consumption.
 
 ## Core Invariants
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -15,12 +15,14 @@
 ## Processing And Metadata
 | Term | Definition | Aliases to avoid |
 | --- | --- | --- |
-| **Job Registry** | The backend-owned concurrency lifecycle surface that tracks processing jobs, queue state, and cancellation. | queue helper, incidental state |
+| **Job Registry** | The backend-owned active-job surface that tracks permits, queue state, and cancellation. | queue helper, incidental state |
 | **Processing Flow** | The end-to-end audiobook processing path coordinated through `process_audiobook_files`, progress events, and processor stages. | encode call, single task |
 | **Product Spine** | The user workflow from import through verification: Import, Inspect, Decide, Preflight, Process, Verify. | feature list, screen order |
 | **Product Intent** | What the user believes they asked Audiobook Boss to do with selected files, metadata, output rules, and processing settings. | UI state, backend guess |
 | **UI State** | The frontend-held state for selected files, edits, visible status, and enabled actions before or after backend truth is returned. | product truth, backend state |
-| **Backend Lifecycle** | The Rust-owned sequence that plans, queues, runs, cancels, skips, fails, succeeds, and finalizes processing work. | processing helper, job loop |
+| **Backend Lifecycle** | The `processing` sub-owner/public strip for operation identity, queue/progress event vocabulary, cancellation hooks, and terminal-summary truth used by long-running backend work. Not a seventh Grey-Box Public API. | processing helper, job loop, status UI owner |
+| **Operation Kind** | The backend-declared operation identity carried on lifecycle events, currently `processingMerge`, `processingBatch`, or `metadataSave`. | caller mode guess, UI-only work kind |
+| **Operation Result Summary** | Shared terminal counts for long-running backend operations: total, succeeded, skipped, cancelled, and failed. | processing-only summary, UI completion guess |
 | **Artifact Truth** | The final files, tags, paths, and terminal results that exist after processing or metadata operations complete. | expected output, UI summary |
 | **Terminal Outcome** | The final per-job status after processing ambiguity resolves: `success`, `skipped`, `cancelled`, or `failed`. | progress stage, current status |
 | **Terminal Truth** | The backend-owned final report of what happened to a job or batch, used by the UI for user-visible completion state. | optimistic status, frontend truth |
@@ -71,7 +73,11 @@
 - The **IPC Contract** is exported from Rust, materialized as **Generated Bindings**, and consumed through the **tauriClient** **Runtime Boundary**.
 - A **Boundary** owns normalization and validation so **Contract Truth** does not leak into scattered UI callsites.
 - The **Product Spine** moves from **Product Intent** through **UI State**, **IPC Contract**, **Backend Lifecycle**, and **Artifact Truth**.
-- The **Job Registry** is the authority for **Processing Flow** lifecycle, queue state, and cancellation.
+- The **Backend Lifecycle** strip under `processing` names operation identity,
+  queue/progress events, cancellation hooks, and shared terminal summaries for
+  processing and metadata save.
+- The **Job Registry** is the authority for active **Processing Flow** jobs,
+  queue state, permits, and cancellation.
 - A **Terminal Outcome** contributes to **Terminal Truth** only after backend processing resolves the job's final state.
 - A **Metadata Intent Patch** is compiled at the **Runtime Boundary** and preserved across the **IPC Contract** so clear intent is never inferred from sentinel values.
 - A **Metadata Outcome Plan** is produced by the metadata boundary so processing and output callers consume effective metadata, naming metadata, write facts, and cover-art policy instead of rebuilding metadata sequencing.
@@ -81,7 +87,7 @@
 - A **Deep Module** is the general architecture idea; a **Grey-Box Module** is ABB's stricter repo pattern for applying it.
 - A **Grey-Box Module** publishes a **Public API Strip** and hides a **Private Cluster** behind it; only one **Module Owner** holds any given product rule.
 - A **Reach-Through** is the diagnostic for an **Ownership Smear**; a **Boundary Assertion** is the script-enforced cure.
-- Each **Public API Strip** in the **Six Public APIs** set is locked by **Contract Tests**; internal cluster changes are safe when contract tests stay green.
+- Each **Public API Strip** in the **Six Public APIs** set is locked by **Contract Tests**; internal cluster changes are safe when contract tests stay green. **Backend Lifecycle** is instead a sub-owner/public strip inside `processing`.
 - A **Cluster Audit** inspects shape inside a **Private Cluster** without changing the **Public API Strip**; it informs future internal refactor decisions and does not, by itself, change behavior.
 
 ## Example Dialogue
@@ -100,6 +106,9 @@
 - Product names and implementation names should not blur together. For example, **Book Binder** is user-facing product language; **Merge** is the processing job type.
 - "minimal churn" can be mistaken for "smallest diff." Prefer **Minimal Churn** as fewer correction loops and less rework, even when the better fix is somewhat broader.
 - "status", "progress", and "terminal outcome" are not interchangeable. Prefer **Terminal Outcome** only for final per-job status and **Terminal Truth** for the backend-owned final report.
+- "backend lifecycle" and "Status Panel Runtime" are not interchangeable. The
+  lifecycle strip emits operation facts; Status Panel consumes them as a read
+  model.
 - "deep module" and "grey-box module" are related but distinct. Prefer **Deep Module** when talking to other engineers about the general design principle; prefer **Grey-Box Module** when referring to ABB's Public-API + Private-Cluster + boundary-assertion ownership unit.
 - "module" alone is ambiguous in ABB. Prefer **Grey-Box Module** for the owned Public-API + Private-Cluster unit, and **Private Cluster File** for any implementation file inside one.
 - "API" can mean three different things in ABB. Prefer **IPC Contract** for the Rust-declared command/event set, **Runtime Boundary** for the TS adapter (`tauriClient`), and **Public API Strip** for the externally allowed import set of any **Grey-Box Module**.

--- a/scripts/check-public-api-strips.sh
+++ b/scripts/check-public-api-strips.sh
@@ -39,11 +39,10 @@ extract_export_blocks() {
 }
 
 audio_exports="$(
-  rg "^(pub struct AudioFile|pub struct DecoderSelection|pub enum SampleRateConfig|pub\\(crate\\) mod constants;)" src-tauri/src/audio/mod.rs || true
+  rg "^(pub struct AudioFile|pub struct DecoderSelection|pub enum SampleRateConfig)" src-tauri/src/audio/mod.rs || true
   extract_export_blocks src-tauri/src/audio/mod.rs
 )"
-compare_block "Audio Engine Deep Module Public API Strip" "$audio_exports" 'pub(crate) mod constants;
-pub struct AudioFile {
+compare_block "Audio Engine Deep Module Public API Strip" "$audio_exports" 'pub struct AudioFile {
 pub struct DecoderSelection {
 pub enum SampleRateConfig {
 pub use file_list::{get_file_list_info, FileListInfo};
@@ -64,6 +63,22 @@ ExternalToolchainPreference,
 };
 pub(crate) use cleanup::CleanupGuard;
 '
+
+processing_lifecycle_exports="$(
+  rg "^(pub mod lifecycle;|pub use lifecycle::\\{OperationKind, OperationResultSummary\\};)" src-tauri/src/processing.rs || true
+  rg "^(pub enum OperationKind|pub struct OperationResultSummary)" src-tauri/src/processing/lifecycle.rs || true
+  rg "^(pub const PROGRESS_EVENT_NAME|pub const QUEUE_EVENT_NAME|pub struct ProgressEvent|pub struct QueueEvent|pub fn emit_progress_event|pub fn emit_queue_event)" src-tauri/src/processing/progress/mod.rs || true
+)"
+compare_block "Backend Lifecycle Public API Strip" "$processing_lifecycle_exports" 'pub mod lifecycle;
+pub use lifecycle::{OperationKind, OperationResultSummary};
+pub enum OperationKind {
+pub struct OperationResultSummary {
+pub const PROGRESS_EVENT_NAME: &str = "processing-progress";
+pub const QUEUE_EVENT_NAME: &str = "processing-queue";
+pub struct ProgressEvent {
+pub struct QueueEvent {
+pub fn emit_progress_event(window: &tauri::Window, event: &ProgressEvent) {
+pub fn emit_queue_event(window: &tauri::Window, event: &QueueEvent) {'
 
 output_artifact_exports="$(extract_export_blocks src-tauri/src/output_artifact/mod.rs)"
 compare_block "Output Artifact Plan / Commit Public API Strip" "$output_artifact_exports" 'pub(crate) use artifact::derive_output_artifact_path;

--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -11,9 +11,13 @@
 - Route media execution through the `crate::audio` Audio Engine Deep Module
   public strip; callers outside audio must not choose processor adapters or
   import private audio engine files directly.
+- Route backend operation lifecycle vocabulary, queue/progress events, and
+  terminal summaries through the `crate::processing` lifecycle/progress public
+  strip. Audio and metadata may report lifecycle truth there without owning the
+  lifecycle model.
 - Route metadata reads and writes through the public `metadata` boundary; outside callers should request metadata outcomes, not choose private MP4/FFmpeg strategy modules.
 - Let the metadata boundary choose MP4-family atom handling versus generic FFmpeg behavior from actual container classification, not filename suffix or caller-side fallback assumptions.
-- Use `JobRegistry` as the central concurrency lifecycle surface.
+- Use `JobRegistry` as the central active-job and cancellation surface.
 - Offload CPU-bound encoding and heavy synchronous work via `tokio::task::spawn_blocking` (or equivalent blocking-safe path).
 - Keep TS↔Rust command contracts aligned through generated bindings and drift checks.
 - Use `process_audiobook_files` for full processing flows; use dedicated auxiliary commands for non-processing tasks.

--- a/src-tauri/src/audio/AGENTS.md
+++ b/src-tauri/src/audio/AGENTS.md
@@ -16,8 +16,6 @@
   `crate::audio::processor`, `crate::audio::settings_encoder`,
   `crate::audio::toolchain`, `crate::audio::path_validation`, or
   `crate::audio::cleanup`.
-- Modules: `constants` is crate-visible for existing processing event names and
-  progress math until those constants move to the processing/status owner.
 - Types: `AudioFile`, `DecoderSelection`, `SampleRateConfig`, `FileListInfo`,
   `AacDecoderAvailability`, `EncoderSettings`, `EncoderType`, `BitrateMode`,
   `ChannelConfig`, `ThreadSetting`, `EncoderAvailability`,
@@ -32,12 +30,15 @@
 - Execution request type: `AudioExecutionRequest`.
 - Constants: `VALID_ENCODER_BITRATES`, `VALID_THREAD_COUNT_RANGE`.
 - Crate-internal helper: `CleanupGuard`.
+- Audio does not own lifecycle event names or progress math. Use
+  `crate::processing` / `processing::progress` for queue/progress event
+  vocabulary and operation lifecycle identity.
 
 ## Private Cluster
 
 - Files: `buffer.rs`, `buffer_tests.rs`, `cleanup/`, `extensions.rs`,
-  `file_list.rs`, `metrics.rs`, `path_validation.rs`, `processor/`,
-  `settings.rs`, `settings_encoder.rs`, and `toolchain.rs`.
+  `constants.rs`, `file_list.rs`, `metrics.rs`, `path_validation.rs`,
+  `processor/`, `settings.rs`, `settings_encoder.rs`, and `toolchain.rs`.
 - The cluster owns decoder/toolchain selection, media inspection,
   decode/resample/encode/mux internals, staging, cleanup, and media execution
   facts. Processing owns lifecycle orchestration and terminal normalization;

--- a/src-tauri/src/audio/constants.rs
+++ b/src-tauri/src/audio/constants.rs
@@ -1,47 +1,10 @@
-//! Constants for audio processing operations
+//! Constants for audio-owned media operations
 //!
-//! This module contains all magic numbers and constants used throughout
-//! the audio processing pipeline, grouped by functional area.
-
-// Event names
-/// Progress event name for frontend communication
-pub const PROGRESS_EVENT_NAME: &str = "processing-progress";
-/// Queue event name for batch processing snapshot
-pub const QUEUE_EVENT_NAME: &str = "processing-queue";
-
-// Progress stage percentages
-/// Progress percentage at the end of the analyzing stage (0-10%)
-pub const PROGRESS_ANALYZING_START: f32 = 0.0;
-pub const PROGRESS_ANALYZING_END: f32 = 10.0;
-
-/// Progress percentage range for the converting stage (10–79%); metadata stage starts at 90%.
-/// See `src/types/events.ts` for the frontend contract.
-pub const PROGRESS_CONVERTING_START: f32 = 10.0;
-pub const PROGRESS_CONVERTING_MAX: f32 = 79.0; // Max to avoid reaching 80% prematurely
-pub const PROGRESS_CONVERTING_RANGE: f32 = 70.0; // Range from start to end (80.0 - 10.0)
-
-/// Progress percentage range for metadata writing (90–95%)
-pub const PROGRESS_METADATA_START: f32 = 90.0;
-
-/// Progress percentage for final steps (95-100%)
-pub const PROGRESS_FINALIZING: f32 = 95.0;
-pub const PROGRESS_CLEANUP: f32 = 98.0;
-pub const PROGRESS_COMPLETE: f32 = 100.0;
-
-// Time calculation multipliers
-/// Progress percentage calculation range (maps file progress to UI progress)
-pub const PROGRESS_RANGE_MULTIPLIER: f64 = 70.0;
-
-// Time formatting constants
-/// Seconds per minute for time calculations
-pub const SECONDS_PER_MINUTE: f64 = 60.0;
+//! Processing lifecycle event names and progress math live under
+//! `crate::processing::progress`.
 
 /// Temporary merged output filename
 pub const TEMP_MERGED_FILENAME: &str = "merged.m4b";
-
-// Progress calculation weights
-/// Weight for metadata writing in progress calculations
-pub const PROGRESS_METADATA_WEIGHT: f32 = 5.0;
 
 /// Supported image file extensions for cover art (lowercase)
 pub const ALLOWED_IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 mod buffer;
 mod cleanup;
-pub(crate) mod constants;
+mod constants;
 mod extensions;
 mod file_list;
 mod metrics;

--- a/src-tauri/src/audio/processor/frame_pipeline.rs
+++ b/src-tauri/src/audio/processor/frame_pipeline.rs
@@ -52,7 +52,7 @@ fn emit_progress_update(ctx: &mut FramePipelineCtx) {
             ctx.current_file_name.as_str()
         };
         ctx.emitter.emit_converting_progress(
-            percentage.min(crate::audio::constants::PROGRESS_CONVERTING_MAX as f64) as f32,
+            percentage.min(crate::processing::progress::PROGRESS_CONVERTING_MAX as f64) as f32,
             "Converting and merging audio files...",
             Some(format!(
                 "{} ({}/{})",

--- a/src-tauri/src/commands/metadata/save_batch.rs
+++ b/src-tauri/src/commands/metadata/save_batch.rs
@@ -3,13 +3,13 @@ use crate::commands::CommandResult;
 use crate::errors::{sanitize_path_str_for_display, AppError, AppErrorEnvelope, Result};
 use crate::metadata::{plan_metadata_write, MetadataIntentPatch};
 use crate::processing::{
-    CancellationChecker, EventStage, JobId, ProgressEvent, QueueEvent, QueueItem,
+    emit_progress_event, emit_queue_event, CancellationChecker, EventStage, JobId, OperationKind,
+    OperationResultSummary, ProgressEvent, QueueEvent, QueueItem,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tauri::Emitter;
 
-pub type MetadataSaveSummary = crate::processing::ProcessResultSummary;
+pub type MetadataSaveSummary = OperationResultSummary;
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -65,7 +65,7 @@ impl MetadataSaveBatchResult {
             .count();
         let failed = results.len().saturating_sub(succeeded + cancelled);
         Self {
-            summary: MetadataSaveSummary {
+            summary: OperationResultSummary {
                 total: results.len(),
                 succeeded,
                 skipped: 0,
@@ -239,22 +239,21 @@ fn save_metadata_item(file_path: &str, metadata_patch: MetadataIntentPatch) -> R
 }
 
 fn emit_metadata_save_queue(window: &tauri::Window, items: &[MetadataSaveRequest]) {
-    let queue_event = QueueEvent {
-        items: items
-            .iter()
-            .enumerate()
-            .map(|(index, item)| QueueItem {
-                input_index: index,
-                file_path: item.file_path.clone(),
-            })
-            .collect(),
-        max_concurrent: 1,
-    };
-    let _ = window.emit(crate::audio::constants::QUEUE_EVENT_NAME, &queue_event);
+    let queue_items = items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| QueueItem {
+            input_index: index,
+            file_path: item.file_path.clone(),
+        })
+        .collect();
+    let queue_event = QueueEvent::new(OperationKind::MetadataSave, queue_items, 1);
+    emit_queue_event(window, &queue_event);
 }
 
 fn emit_metadata_save_progress(window: &tauri::Window, progress: MetadataSaveProgress) {
     let event = ProgressEvent {
+        operation_kind: OperationKind::MetadataSave,
         stage: progress.stage,
         percentage: progress.percentage,
         message: progress.message,
@@ -263,7 +262,7 @@ fn emit_metadata_save_progress(window: &tauri::Window, progress: MetadataSavePro
         job_id: progress.job_id,
         input_index: Some(progress.input_index),
     };
-    let _ = window.emit(crate::audio::constants::PROGRESS_EVENT_NAME, &event);
+    emit_progress_event(window, &event);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/processing.rs
+++ b/src-tauri/src/processing.rs
@@ -2,6 +2,7 @@ pub mod context;
 #[cfg(test)]
 mod contract_tests;
 pub mod job_registry;
+pub mod lifecycle;
 pub(crate) mod plan;
 pub mod preview_config;
 pub mod progress;
@@ -46,10 +47,12 @@ pub enum ProcessingStage {
 
 pub use context::{OutputConfig, ProcessingContext, ProcessingContextBuilder};
 pub use job_registry::{AggregateJobStatus, CancellationChecker, JobId, JobRegistry, JobState};
+pub use lifecycle::{OperationKind, OperationResultSummary};
 pub use preview_config::PreviewConfig;
 pub use progress::{
-    calculate_stage_progress, converting_percentage_from_seconds, format_eta, EventStage,
-    ProgressEmitter, ProgressEvent, ProgressReporter, QueueEvent, QueueItem,
+    calculate_stage_progress, converting_percentage_from_seconds, emit_progress_event,
+    emit_queue_event, format_eta, EventStage, ProgressEmitter, ProgressEvent, ProgressReporter,
+    QueueEvent, QueueItem,
 };
 pub use session::ProcessingSession;
 pub use types::{

--- a/src-tauri/src/processing/AGENTS.md
+++ b/src-tauri/src/processing/AGENTS.md
@@ -1,18 +1,32 @@
 ## Public API Strip
-- Import from `crate::processing::plan`, not private helpers.
-- Functions: `resolve_preflight_plan`, `prepare_execution_plan`.
-- Types: `ResolvedProcessingPlan`, `PlannedProcessingJob`.
+- Processing Plan: import from `crate::processing::plan`, not private helpers.
+  Functions: `resolve_preflight_plan`, `prepare_execution_plan`. Types:
+  `ResolvedProcessingPlan`, `PlannedProcessingJob`.
+- Backend Lifecycle: import shared lifecycle vocabulary and event helpers from
+  `crate::processing`, not `audio`, `commands`, or Status Panel internals.
+  Types: `OperationKind`, `OperationResultSummary`, `EventStage`,
+  `ProgressEvent`, `QueueEvent`, `QueueItem`, `JobId`, `CancellationChecker`.
+  Functions/helpers: `emit_progress_event`, `emit_queue_event`,
+  `ProgressEmitter`.
 
 ## Private Cluster
-- Files: `../processing.rs`, `plan.rs`, `run.rs`, `terminal_outcomes.rs`, `context/`, `job_registry/`, `progress/`, `preview_config.rs`, `session.rs`, `contract_tests.rs`.
-- The cluster owns preflight planning, execution-plan preparation, runner orchestration, processing context/session state, job lifecycle, progress event types, terminal result normalization, and their behavior tests.
+- Files: `../processing.rs`, `plan.rs`, `run.rs`, `terminal_outcomes.rs`,
+  `lifecycle.rs`, `context/`, `job_registry/`, `progress/`,
+  `preview_config.rs`, `session.rs`, `contract_tests.rs`.
+- The cluster owns preflight planning, execution-plan preparation, runner
+  orchestration, processing context/session state, backend lifecycle
+  vocabulary, job lifecycle, queue/progress event types, terminal result
+  normalization, and their behavior tests.
 
 ## Allowed Agent Edits Without Escalation
 - Change planner or runner internals when `cargo test contract_tests` and `scripts/check-public-api-strips.sh` stay green.
 - Keep preflight side-effect-free; execution may create output dirs only after review enforcement.
 - Keep runner responsibilities to encoder/toolchain validation, events, job registration, scheduler dispatch, audio execution requests through `crate::audio`, and terminal normalization.
+- Keep metadata save reporting lifecycle truth through this strip while leaving
+  metadata write policy inside metadata-owned APIs.
 
 ## Breaking-Change Triggers
 - Adding, removing, or renaming any Public API Strip symbol.
 - Changing preflight signature behavior, collision-review enforcement, metadata projection, path validation, or parent-dir side effects.
-- Moving artifact truth, metadata intent semantics, or status terminal truth out of their owning boundaries.
+- Moving artifact truth, metadata intent semantics, backend lifecycle ownership,
+  or status terminal truth out of their owning boundaries.

--- a/src-tauri/src/processing/context/processing.rs
+++ b/src-tauri/src/processing/context/processing.rs
@@ -4,6 +4,7 @@ use crate::audio::{EncoderSettings, SampleRateConfig};
 use crate::errors::sanitize_path_str_for_display;
 use crate::errors::Result;
 use crate::output_artifact::{OutputKind, PlannedOutputAction, ResolvedOutputPlan};
+use crate::processing::lifecycle::OperationKind;
 use crate::processing::preview_config::PreviewConfig;
 use crate::processing::session::ProcessingSession;
 use std::path::{Path, PathBuf};
@@ -91,6 +92,8 @@ pub struct ProcessingContext {
     pub job_id: Option<String>,
     /// Optional index of the input file in the original request
     pub input_index: Option<usize>,
+    /// Backend operation family for lifecycle events emitted by this context
+    pub operation_kind: OperationKind,
 }
 
 impl ProcessingContext {
@@ -111,6 +114,7 @@ impl ProcessingContext {
             preview: None,
             job_id: None,
             input_index: None,
+            operation_kind: OperationKind::ProcessingBatch,
         }
     }
 
@@ -130,6 +134,7 @@ impl ProcessingContext {
             preview: None,
             job_id: None,
             input_index: None,
+            operation_kind: OperationKind::ProcessingBatch,
         }
     }
 
@@ -193,10 +198,11 @@ impl ProcessingContext {
         match &self.window {
             Some(window) => crate::processing::progress::ProgressEmitter::with_context(
                 window.clone(),
+                self.operation_kind,
                 self.job_id.clone(),
                 self.input_index,
             ),
-            None => crate::processing::progress::ProgressEmitter::headless(),
+            None => crate::processing::progress::ProgressEmitter::headless_for(self.operation_kind),
         }
     }
 
@@ -226,6 +232,7 @@ pub struct ProcessingContextBuilder {
     preview: Option<PreviewConfig>,
     job_id: Option<String>,
     input_index: Option<usize>,
+    operation_kind: OperationKind,
 }
 
 impl ProcessingContextBuilder {
@@ -282,6 +289,12 @@ impl ProcessingContextBuilder {
         self
     }
 
+    /// Sets the operation kind for lifecycle reporting
+    pub fn operation_kind(mut self, operation_kind: OperationKind) -> Self {
+        self.operation_kind = operation_kind;
+        self
+    }
+
     /// Builds the ProcessingContext
     ///
     /// # Errors
@@ -327,6 +340,7 @@ impl ProcessingContextBuilder {
             preview: self.preview,
             job_id: self.job_id,
             input_index: self.input_index,
+            operation_kind: self.operation_kind,
         })
     }
 }

--- a/src-tauri/src/processing/job_registry/AGENTS.md
+++ b/src-tauri/src/processing/job_registry/AGENTS.md
@@ -4,6 +4,9 @@
 
 - Owns concurrency lifecycle and active-job state under `processing/job_registry/`.
 - Source of truth for permit discipline, scheduling behavior, and reconfiguration safety.
+- Operation identity, progress/queue event vocabulary, and shared terminal
+  summaries live in the parent `processing` lifecycle/progress public strip;
+  this directory owns active-job state, not the whole lifecycle contract.
 
 ## Preferred Path
 

--- a/src-tauri/src/processing/lifecycle.rs
+++ b/src-tauri/src/processing/lifecycle.rs
@@ -1,0 +1,32 @@
+//! Processing-owned operation lifecycle vocabulary.
+//!
+//! This module is the small backend lifecycle strip shared by processing,
+//! metadata save, audio progress emission, and status consumers. It names
+//! operation identity and shared terminal summary facts without becoming a
+//! generic operation framework.
+
+use serde::{Deserialize, Serialize};
+
+/// Backend operation family reported through progress and queue events.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum OperationKind {
+    /// Merge selected inputs into one output artifact.
+    ProcessingMerge,
+    /// Process selected inputs as one output artifact per input.
+    #[default]
+    ProcessingBatch,
+    /// Save pending metadata patches back to existing files.
+    MetadataSave,
+}
+
+/// Shared terminal outcome counts for long-running backend operations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationResultSummary {
+    pub total: usize,
+    pub succeeded: usize,
+    pub skipped: usize,
+    pub cancelled: usize,
+    pub failed: usize,
+}

--- a/src-tauri/src/processing/progress/emitter.rs
+++ b/src-tauri/src/processing/progress/emitter.rs
@@ -1,12 +1,18 @@
 //! Tauri progress event emitter
 
-use super::{EventStage, ProgressEvent};
-use crate::audio::constants::*;
+use super::{
+    emit_progress_event, EventStage, ProgressEvent, PROGRESS_ANALYZING_END,
+    PROGRESS_ANALYZING_START, PROGRESS_CLEANUP, PROGRESS_COMPLETE, PROGRESS_CONVERTING_MAX,
+    PROGRESS_CONVERTING_START, PROGRESS_FINALIZING, PROGRESS_METADATA_START,
+};
+use crate::processing::OperationKind;
 use crate::processing::ProcessingStage;
-use tauri::{Emitter, Window};
+use tauri::Window;
 
 /// Centralized progress event emitter
 pub struct ProgressEmitter {
+    /// Backend operation family this emitter reports for
+    operation_kind: OperationKind,
     /// Optional Tauri window for event emission (None in headless/test runs)
     window: Option<Window>,
     /// Optional job identifier for parallel batch processing
@@ -18,7 +24,13 @@ pub struct ProgressEmitter {
 impl ProgressEmitter {
     /// Creates a new progress emitter without job tracking (single-job mode)
     pub fn new(window: Window) -> Self {
+        Self::for_operation(window, OperationKind::ProcessingBatch)
+    }
+
+    /// Creates a new progress emitter scoped to an operation kind.
+    pub fn for_operation(window: Window, operation_kind: OperationKind) -> Self {
         Self {
+            operation_kind,
             window: Some(window),
             job_id: None,
             input_index: None,
@@ -28,6 +40,7 @@ impl ProgressEmitter {
     /// Creates a progress emitter with job tracking for parallel processing
     pub fn with_job_id(window: Window, job_id: String) -> Self {
         Self {
+            operation_kind: OperationKind::ProcessingBatch,
             window: Some(window),
             job_id: Some(job_id),
             input_index: None,
@@ -37,10 +50,12 @@ impl ProgressEmitter {
     /// Creates a progress emitter with job tracking and input index context
     pub fn with_context(
         window: Window,
+        operation_kind: OperationKind,
         job_id: Option<String>,
         input_index: Option<usize>,
     ) -> Self {
         Self {
+            operation_kind,
             window: Some(window),
             job_id,
             input_index,
@@ -49,7 +64,13 @@ impl ProgressEmitter {
 
     /// Creates a headless emitter (no UI events emitted).
     pub fn headless() -> Self {
+        Self::headless_for(OperationKind::ProcessingBatch)
+    }
+
+    /// Creates a headless emitter for a specific operation kind.
+    pub fn headless_for(operation_kind: OperationKind) -> Self {
         Self {
+            operation_kind,
             window: None,
             job_id: None,
             input_index: None,
@@ -63,6 +84,7 @@ impl ProgressEmitter {
 
     fn terminal_event(&self, stage: EventStage, message: &str) -> ProgressEvent {
         ProgressEvent {
+            operation_kind: self.operation_kind,
             stage,
             percentage: if stage == EventStage::Skipped {
                 100.0
@@ -80,7 +102,7 @@ impl ProgressEmitter {
     fn emit_terminal_event(&self, stage: EventStage, message: &str) {
         let event = self.terminal_event(stage, message);
         if let Some(window) = &self.window {
-            let _ = window.emit(PROGRESS_EVENT_NAME, &event);
+            emit_progress_event(window, &event);
         }
     }
 
@@ -220,6 +242,7 @@ impl ProgressEmitter {
         eta_seconds: Option<f64>,
     ) {
         let event = ProgressEvent {
+            operation_kind: self.operation_kind,
             stage: EventStage::from(&stage),
             percentage,
             message: message.to_string(),
@@ -230,7 +253,7 @@ impl ProgressEmitter {
         };
 
         if let Some(window) = &self.window {
-            let _ = window.emit(PROGRESS_EVENT_NAME, &event);
+            emit_progress_event(window, &event);
         }
     }
 }
@@ -242,6 +265,7 @@ mod tests {
     #[test]
     fn terminal_events_share_context_and_reset_progress() {
         let emitter = ProgressEmitter {
+            operation_kind: OperationKind::ProcessingBatch,
             window: None,
             job_id: Some("job-123".to_string()),
             input_index: Some(7),
@@ -254,6 +278,9 @@ mod tests {
         assert_eq!(failed.stage, EventStage::Failed);
         assert_eq!(cancelled.stage, EventStage::Cancelled);
         assert_eq!(skipped.stage, EventStage::Skipped);
+        assert_eq!(failed.operation_kind, OperationKind::ProcessingBatch);
+        assert_eq!(cancelled.operation_kind, OperationKind::ProcessingBatch);
+        assert_eq!(skipped.operation_kind, OperationKind::ProcessingBatch);
         assert_eq!(failed.percentage, 0.0);
         assert_eq!(cancelled.percentage, 0.0);
         assert_eq!(skipped.percentage, 100.0);

--- a/src-tauri/src/processing/progress/mod.rs
+++ b/src-tauri/src/processing/progress/mod.rs
@@ -3,9 +3,47 @@
 mod emitter;
 mod state;
 
-use crate::audio::constants::*;
+use crate::processing::lifecycle::OperationKind;
 use crate::processing::ProcessingStage;
 use serde::Serialize;
+use tauri::Emitter;
+
+// ============================================================================
+// Event Names And Progress Math
+// ============================================================================
+
+/// Progress event name for frontend communication.
+pub const PROGRESS_EVENT_NAME: &str = "processing-progress";
+/// Queue event name for batch/operation queue snapshots.
+pub const QUEUE_EVENT_NAME: &str = "processing-queue";
+
+/// Progress percentage at the start of the analyzing stage.
+pub const PROGRESS_ANALYZING_START: f32 = 0.0;
+/// Progress percentage at the end of the analyzing stage.
+pub const PROGRESS_ANALYZING_END: f32 = 10.0;
+
+/// Progress percentage range for the converting stage.
+pub const PROGRESS_CONVERTING_START: f32 = 10.0;
+/// Max converting percentage to avoid reaching finalization too early.
+pub const PROGRESS_CONVERTING_MAX: f32 = 79.0;
+/// Range from converting start to nominal converting end.
+pub const PROGRESS_CONVERTING_RANGE: f32 = 70.0;
+
+/// Progress percentage for metadata writing.
+pub const PROGRESS_METADATA_START: f32 = 90.0;
+/// Progress percentage for final artifact finalization.
+pub const PROGRESS_FINALIZING: f32 = 95.0;
+/// Progress percentage for cleanup.
+pub const PROGRESS_CLEANUP: f32 = 98.0;
+/// Progress percentage for complete.
+pub const PROGRESS_COMPLETE: f32 = 100.0;
+
+/// Progress percentage calculation range (maps file progress to UI progress).
+pub const PROGRESS_RANGE_MULTIPLIER: f64 = 70.0;
+/// Seconds per minute for ETA formatting.
+pub const SECONDS_PER_MINUTE: f64 = 60.0;
+/// Weight for metadata writing in progress calculations.
+pub const PROGRESS_METADATA_WEIGHT: f32 = 5.0;
 
 // ============================================================================
 // Data Contract (UI boundary)
@@ -51,6 +89,8 @@ impl From<ProcessingStage> for EventStage {
 /// Progress event structure for frontend communication
 #[derive(Clone, Serialize, specta::Type)]
 pub struct ProgressEvent {
+    /// Backend operation family that emitted this event
+    pub operation_kind: OperationKind,
     /// Current processing stage
     pub stage: EventStage,
     /// Progress percentage (0-100)
@@ -61,10 +101,10 @@ pub struct ProgressEvent {
     pub current_file: Option<String>,
     /// Estimated time remaining in seconds
     pub eta_seconds: Option<f64>,
-    /// Job identifier for parallel batch processing (optional for backward compat)
+    /// Job identifier when this event is tied to a registered job
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_id: Option<String>,
-    /// Original input index for batch processing (optional for backward compat)
+    /// Original input index when this event maps to one selected input
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_index: Option<usize>,
 }
@@ -72,6 +112,7 @@ pub struct ProgressEvent {
 /// Batch queue snapshot for frontend communication
 #[derive(Clone, Serialize, specta::Type)]
 pub struct QueueEvent {
+    pub operation_kind: OperationKind,
     pub items: Vec<QueueItem>,
     pub max_concurrent: usize,
 }
@@ -84,11 +125,35 @@ pub struct QueueItem {
 }
 
 impl tauri_specta::Event for ProgressEvent {
-    const NAME: &'static str = "processing-progress";
+    const NAME: &'static str = PROGRESS_EVENT_NAME;
 }
 
 impl tauri_specta::Event for QueueEvent {
-    const NAME: &'static str = "processing-queue";
+    const NAME: &'static str = QUEUE_EVENT_NAME;
+}
+
+impl QueueEvent {
+    pub fn new(
+        operation_kind: OperationKind,
+        items: Vec<QueueItem>,
+        max_concurrent: usize,
+    ) -> Self {
+        Self {
+            operation_kind,
+            items,
+            max_concurrent,
+        }
+    }
+}
+
+/// Emits a progress event through the lifecycle-owned event name.
+pub fn emit_progress_event(window: &tauri::Window, event: &ProgressEvent) {
+    let _ = window.emit(PROGRESS_EVENT_NAME, event);
+}
+
+/// Emits a queue event through the lifecycle-owned event name.
+pub fn emit_queue_event(window: &tauri::Window, event: &QueueEvent) {
+    let _ = window.emit(QUEUE_EVENT_NAME, event);
 }
 
 // ============================================================================

--- a/src-tauri/src/processing/progress/state.rs
+++ b/src-tauri/src/processing/progress/state.rs
@@ -47,7 +47,10 @@ impl ProgressReporter {
 
     /// Calculates current progress percentage
     pub fn calculate_progress(&self) -> f32 {
-        use crate::audio::constants::*;
+        use crate::processing::progress::{
+            PROGRESS_ANALYZING_END, PROGRESS_COMPLETE, PROGRESS_CONVERTING_RANGE,
+            PROGRESS_CONVERTING_START, PROGRESS_FINALIZING, PROGRESS_METADATA_WEIGHT,
+        };
 
         if self.total_files == 0 {
             return 0.0;

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -13,18 +13,17 @@ use crate::metadata::CoverArtPassthroughPolicy;
 use crate::output_artifact::{OutputKind, ResolvedOutputPlan};
 use crate::processing::job_registry::{CancellationChecker, JobId};
 use crate::processing::{
-    JobType, ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
-    ProcessingPreflightPlan,
+    emit_queue_event, OperationKind, OutputConfig, PreviewConfig, ProcessingContext,
+    ProcessingSession, ProgressEmitter, QueueEvent, QueueItem,
 };
 use crate::processing::{
-    OutputConfig, PreviewConfig, ProcessingContext, ProcessingSession, ProgressEmitter, QueueEvent,
-    QueueItem,
+    JobType, ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
+    ProcessingPreflightPlan,
 };
 use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use tauri::Emitter;
 use tokio::sync::OwnedSemaphorePermit;
 
 pub(crate) struct ProcessingRun;
@@ -132,11 +131,12 @@ fn emit_batch_queue_event(
             file_path: input.clone(),
         })
         .collect();
-    let queue_event = QueueEvent {
-        items: queue_items,
-        max_concurrent: registry.max_concurrent(),
-    };
-    let _ = window.emit(crate::audio::constants::QUEUE_EVENT_NAME, &queue_event);
+    let queue_event = QueueEvent::new(
+        OperationKind::ProcessingBatch,
+        queue_items,
+        registry.max_concurrent(),
+    );
+    emit_queue_event(window, &queue_event);
 }
 
 fn finalize_batch_results(
@@ -152,6 +152,7 @@ fn finalize_batch_results(
     for event in finalized.failure_events {
         emit_terminal_failed_event(
             window,
+            OperationKind::ProcessingBatch,
             event.input_index,
             event.job_id.as_deref(),
             &event.message,
@@ -184,6 +185,7 @@ async fn dispatch_merge_job(
         external_toolchain: payload.external_toolchain.clone(),
         sample_rate: resolve_sample_rate(payload)?,
         input_index: None,
+        operation_kind: OperationKind::ProcessingMerge,
         output_plan: planned_job.output,
         file_info,
         metadata: planned_job.metadata,
@@ -223,6 +225,7 @@ async fn dispatch_batch_jobs(
         {
             emit_terminal_skipped_event(
                 &window,
+                OperationKind::ProcessingBatch,
                 skipped_entry.input_index,
                 skipped_entry.job_id.as_deref(),
                 &skipped_entry.message,
@@ -254,6 +257,7 @@ async fn dispatch_batch_jobs(
                 external_toolchain: external_toolchain_cloned,
                 sample_rate: sr_cloned,
                 input_index,
+                operation_kind: OperationKind::ProcessingBatch,
                 output_plan: output,
                 file_info,
                 metadata: md_cloned,
@@ -277,6 +281,7 @@ struct ProcessingJobRequest {
     external_toolchain: Option<ExternalToolchainPreference>,
     sample_rate: audio::SampleRateConfig,
     input_index: Option<usize>,
+    operation_kind: OperationKind,
     output_plan: ResolvedOutputPlan,
     file_info: FileListInfo,
     metadata: Option<crate::metadata::AudiobookMetadata>,
@@ -296,6 +301,7 @@ async fn run_processing_job(request: ProcessingJobRequest) -> Result<ProcessResu
         encoder_settings: request.encoder_settings.clone(),
         sample_rate: request.sample_rate,
         input_index: request.input_index,
+        operation_kind: request.operation_kind,
         output_plan: request.output_plan.clone(),
         preview_seconds: request.preview_seconds,
     });
@@ -384,6 +390,7 @@ struct ProcessingContextRequest {
     encoder_settings: EncoderSettings,
     sample_rate: audio::SampleRateConfig,
     input_index: Option<usize>,
+    operation_kind: OperationKind,
     output_plan: ResolvedOutputPlan,
     preview_seconds: Option<f64>,
 }
@@ -400,6 +407,7 @@ fn build_processing_context(request: ProcessingContextRequest) -> (ProcessingCon
     );
     context.job_id = Some(request.job_id.to_string());
     context.input_index = request.input_index;
+    context.operation_kind = request.operation_kind;
 
     let preview_seconds_resolved = request.preview_seconds;
     if let Some(seconds) = preview_seconds_resolved {
@@ -431,12 +439,14 @@ async fn execute_processing_job(
 
 fn emit_terminal_failed_event(
     window: &tauri::Window,
+    operation_kind: OperationKind,
     input_index: Option<usize>,
     job_id: Option<&str>,
     message: &str,
 ) {
     let emitter = ProgressEmitter::with_context(
         window.clone(),
+        operation_kind,
         job_id.map(|value| value.to_string()),
         input_index,
     );
@@ -445,12 +455,14 @@ fn emit_terminal_failed_event(
 
 fn emit_terminal_skipped_event(
     window: &tauri::Window,
+    operation_kind: OperationKind,
     input_index: Option<usize>,
     job_id: Option<&str>,
     message: &str,
 ) {
     let emitter = ProgressEmitter::with_context(
         window.clone(),
+        operation_kind,
         job_id.map(|value| value.to_string()),
         input_index,
     );

--- a/src-tauri/src/processing/types.rs
+++ b/src-tauri/src/processing/types.rs
@@ -1,3 +1,4 @@
+use super::lifecycle::{OperationKind, OperationResultSummary};
 use crate::audio;
 use crate::audio::{EncoderSettings, ExternalToolchainPreference};
 use crate::errors::AppErrorEnvelope;
@@ -11,6 +12,15 @@ pub use crate::output_artifact::{
 pub enum JobType {
     Merge,
     Batch,
+}
+
+impl From<JobType> for OperationKind {
+    fn from(value: JobType) -> Self {
+        match value {
+            JobType::Merge => OperationKind::ProcessingMerge,
+            JobType::Batch => OperationKind::ProcessingBatch,
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, specta::Type)]
@@ -42,15 +52,7 @@ pub enum ProcessResultStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessResultSummary {
-    pub total: usize,
-    pub succeeded: usize,
-    pub skipped: usize,
-    pub cancelled: usize,
-    pub failed: usize,
-}
+pub type ProcessResultSummary = OperationResultSummary;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -99,7 +101,7 @@ impl ProcessCommandResult {
         let failed = results
             .len()
             .saturating_sub(succeeded + skipped + cancelled);
-        let summary = ProcessResultSummary {
+        let summary = OperationResultSummary {
             total: results.len(),
             succeeded,
             skipped,

--- a/src/lib/behavior-contract.test.ts
+++ b/src/lib/behavior-contract.test.ts
@@ -121,6 +121,7 @@ describe('behavior-first IPC smoke', () => {
 		);
 
 		expect(queueEvents.length).toBeGreaterThan(0);
+		expect(queueEvents[0]?.operation_kind).toBe('processingBatch');
 		expect(queueEvents[0]?.items.length).toBeGreaterThan(0);
 		expect(queueEvents[0]?.max_concurrent).toBeGreaterThan(0);
 
@@ -132,6 +133,7 @@ describe('behavior-first IPC smoke', () => {
 		).toBe(true);
 
 		for (const event of progressEvents) {
+			expect(event.operation_kind).toBe('processingBatch');
 			expect(event.percentage).toBeGreaterThanOrEqual(0);
 			expect(event.percentage).toBeLessThanOrEqual(100);
 			expect(typeof event.message).toBe('string');

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -337,7 +337,7 @@ export type MetadataIntentPatch = {
 };
 
 export type MetadataSaveBatchResult = {
-	summary: ProcessResultSummary,
+	summary: OperationResultSummary,
 	results: MetadataSaveResultEntry[],
 };
 
@@ -375,6 +375,24 @@ export type OnlineMetadataResult = {
 	durationSeconds: number | null,
 	coverUrl: string | null,
 	audibleOnly: boolean | null,
+};
+
+// Backend operation family reported through progress and queue events.
+export type OperationKind =
+// Merge selected inputs into one output artifact.
+"processingMerge" |
+// Process selected inputs as one output artifact per input.
+"processingBatch" |
+// Save pending metadata patches back to existing files.
+"metadataSave";
+
+// Shared terminal outcome counts for long-running backend operations.
+export type OperationResultSummary = {
+	total: number,
+	succeeded: number,
+	skipped: number,
+	cancelled: number,
+	failed: number,
 };
 
 export type OutputCollisionInfo = {
@@ -416,7 +434,7 @@ export type PlannedOutputAction = "write" | "replace_existing" | "rename_new" | 
 
 export type ProcessCommandResult = {
 	jobType: JobType,
-	summary: ProcessResultSummary,
+	summary: OperationResultSummary,
 	results: ProcessResultEntry[],
 };
 
@@ -452,14 +470,6 @@ export type ProcessResultEntry = {
  */
 export type ProcessResultStatus = "success" | "skipped" | "cancelled" | "failed";
 
-export type ProcessResultSummary = {
-	total: number,
-	succeeded: number,
-	skipped: number,
-	cancelled: number,
-	failed: number,
-};
-
 export type ProcessingPreflightPlan = {
 	jobType: JobType,
 	previewSeconds: number | null,
@@ -473,6 +483,8 @@ export type ProgressEvent = ProgressEvent_Serialize | ProgressEvent_Deserialize;
 
 // Progress event structure for frontend communication
 export type ProgressEvent_Deserialize = {
+	// Backend operation family that emitted this event
+	operation_kind: OperationKind,
 	// Current processing stage
 	stage: EventStage,
 	// Progress percentage (0-100)
@@ -483,14 +495,16 @@ export type ProgressEvent_Deserialize = {
 	current_file: string | null,
 	// Estimated time remaining in seconds
 	eta_seconds: number | null,
-	// Job identifier for parallel batch processing (optional for backward compat)
+	// Job identifier when this event is tied to a registered job
 	job_id: string | null,
-	// Original input index for batch processing (optional for backward compat)
+	// Original input index when this event maps to one selected input
 	input_index: number | null,
 };
 
 // Progress event structure for frontend communication
 export type ProgressEvent_Serialize = {
+	// Backend operation family that emitted this event
+	operation_kind: OperationKind,
 	// Current processing stage
 	stage: EventStage,
 	// Progress percentage (0-100)
@@ -501,14 +515,15 @@ export type ProgressEvent_Serialize = {
 	current_file: string | null,
 	// Estimated time remaining in seconds
 	eta_seconds: number | null,
-	// Job identifier for parallel batch processing (optional for backward compat)
+	// Job identifier when this event is tied to a registered job
 	job_id?: string | null,
-	// Original input index for batch processing (optional for backward compat)
+	// Original input index when this event maps to one selected input
 	input_index?: number | null,
 };
 
 // Batch queue snapshot for frontend communication
 export type QueueEvent = {
+	operation_kind: OperationKind,
 	items: QueueItem[],
 	max_concurrent: number,
 };

--- a/src/lib/tauri-client.test.ts
+++ b/src/lib/tauri-client.test.ts
@@ -593,6 +593,7 @@ describe('tauriClient nullish adapters', () => {
 				event: 'processing-progress',
 				id: 1,
 				payload: {
+					operation_kind: 'processingBatch',
 					stage: 'converting',
 					percentage: 42,
 					message: 'Working',

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -76,10 +76,12 @@ vi.mock('@tauri-apps/api/core', () => ({
 				mockJobCounter += 1;
 				const jobId = `mock-job-${mockJobCounter}`;
 				emitTestEvent('processing-queue', {
+					operation_kind: 'processingBatch',
 					items: [{ input_index: 0, file_path: '/mock/path/chapter1.mp3' }],
 					max_concurrent: 2,
 				});
 				emitTestEvent('processing-progress', {
+					operation_kind: 'processingBatch',
 					stage: 'converting',
 					percentage: 40,
 					message: 'Converting audio',
@@ -89,6 +91,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 					input_index: 0,
 				});
 				emitTestEvent('processing-progress', {
+					operation_kind: 'processingBatch',
 					stage: 'completed',
 					percentage: 100,
 					message: 'Processing completed successfully!',
@@ -131,6 +134,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 					| undefined;
 				const items = args?.items ?? [];
 				emitTestEvent('processing-queue', {
+					operation_kind: 'metadataSave',
 					items: items.map((item, index) => ({
 						input_index: index,
 						file_path: item.filePath,
@@ -140,6 +144,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 				});
 				for (const [index, item] of items.entries()) {
 					emitTestEvent('processing-progress', {
+						operation_kind: 'metadataSave',
 						stage: 'writing',
 						percentage: 0,
 						message: `Saving metadata ${index + 1}/${items.length}`,
@@ -149,6 +154,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 						input_index: index,
 					});
 					emitTestEvent('processing-progress', {
+						operation_kind: 'metadataSave',
 						stage: 'completed',
 						percentage: 100,
 						message: `Saved metadata ${index + 1}/${items.length}`,
@@ -178,6 +184,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 			case 'cancel_processing': {
 				const args = _args as { jobId?: string | null } | undefined;
 				emitTestEvent('processing-progress', {
+					operation_kind: 'processingBatch',
 					stage: 'cancelled',
 					percentage: 0,
 					message: 'Cancelled by user',

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -18,10 +18,10 @@ import type {
 	OutputNamingConfig as GeneratedOutputNamingConfig,
 	PlannedOutput as GeneratedPlannedOutput,
 	PlannedOutputAction as GeneratedPlannedOutputAction,
+	OperationResultSummary as GeneratedOperationResultSummary,
 	ProcessCommandResult as GeneratedProcessCommandResult,
 	ProcessResultEntry as GeneratedProcessResultEntry,
 	ProcessResultStatus as GeneratedProcessResultStatus,
-	ProcessResultSummary as GeneratedProcessResultSummary,
 	ProcessPayload as GeneratedProcessPayload,
 	ProcessingPreflightPlan as GeneratedProcessingPreflightPlan,
 	SampleRateConfig as GeneratedSampleRateConfig,
@@ -80,7 +80,7 @@ export interface PreviewRequest {
 }
 
 export type ProcessResultStatus = GeneratedProcessResultStatus;
-export type ProcessResultSummary = NullToOptionalDeep<GeneratedProcessResultSummary>;
+export type ProcessResultSummary = NullToOptionalDeep<GeneratedOperationResultSummary>;
 export type ProcessResultError = AppErrorEnvelope;
 export type ProcessCommandJobResult = Omit<
 	NullToOptionalDeep<GeneratedProcessResultEntry>,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,5 +1,6 @@
 import type {
 	EventStage as GeneratedEventStage,
+	OperationKind as GeneratedOperationKind,
 	ProgressEvent as GeneratedProgressEvent,
 	QueueEvent as GeneratedQueueEvent,
 } from '../lib/generated/tauri';
@@ -19,6 +20,7 @@ export const EVENTS = {
 } as const;
 
 export type EventStage = GeneratedEventStage;
+export type OperationKind = GeneratedOperationKind;
 
 /**
  * Exhaustive value-level access to the generated progress stages.
@@ -35,6 +37,12 @@ export const STAGES: { readonly [K in EventStage]: K } = {
 	skipped: 'skipped',
 	failed: 'failed',
 	cancelled: 'cancelled',
+} as const;
+
+export const OPERATION_KINDS: { readonly [K in OperationKind]: K } = {
+	processingMerge: 'processingMerge',
+	processingBatch: 'processingBatch',
+	metadataSave: 'metadataSave',
 } as const;
 
 export type ProcessingProgressEvent = NullToOptionalDeep<GeneratedProgressEvent>;

--- a/src/ui/statusPanel/AGENTS.md
+++ b/src/ui/statusPanel/AGENTS.md
@@ -4,13 +4,20 @@
 
 ## Private Cluster
 - Files: `controller.ts`, `runtimeApi.ts`, `events.ts`, `feedback.ts`, `formatting.ts`, `preview.ts`, `processing.ts`, `processingConfig.ts`, `processingWorkflow.ts`, `processingWorkflowLive.ts`, `processingWorkflowServices.ts`, `processingCancellationWorkflow.ts`, `processingCancellationWorkflowLive.ts`, `processingCancellationWorkflowServices.ts`, `render.ts`, `state.ts`, `viewState.svelte.ts`, `viewTypes.ts`, `domain/`, `services/`, `__tests__/`, `StatusPanelIsland.svelte`.
-- The cluster owns progress events, queue snapshots, cancellation, terminal status truth, view-state derivation, status feedback, and processing request composition from panel Public API Strips.
+- The cluster consumes backend `OperationKind`, progress events, queue snapshots,
+  cancellation facts, and terminal results as a read model. It owns visible
+  status derivation, status feedback, controls, and processing request
+  composition from panel Public API Strips; it does not own backend lifecycle
+  vocabulary or terminal-summary truth.
 
 ## Allowed Agent Edits Without Escalation
 - Change internals when `bun run test -- src/ui/statusPanel/__tests__/runtime-api-contract.test.ts src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts src/ui/statusPanel/__tests__/statusPanel-island.test.ts` and `scripts/check-public-api-strips.sh` stay green.
 - Test visible status outcomes rather than private reducer shape when behavior is user-facing.
 - Keep direct view-state/controller/runtimeApi imports inside this cluster or tests.
 - Build `ProcessingRequestConfig` through `processingConfig.ts`; do not import encoder or output panel private state to assemble process payloads.
+- Use backend `operation_kind` from queue/progress events to classify merge,
+  batch, and metadata-save status behavior; do not infer operation identity only
+  from caller choreography.
 
 ## Breaking-Change Triggers
 - Adding, removing, or renaming any Public API Strip export.

--- a/src/ui/statusPanel/__tests__/progressAggregator.test.ts
+++ b/src/ui/statusPanel/__tests__/progressAggregator.test.ts
@@ -43,6 +43,7 @@ describe('StatusPanel aggregate progress', () => {
 	it('computes simple averages across active and completed jobs', () => {
 		const controller = new StatusPanelRuntime();
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -50,12 +51,14 @@ describe('StatusPanel aggregate progress', () => {
 			max_concurrent: 2,
 		};
 		const converting: ProcessingProgressEvent = {
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: 'converting',
 			percentage: 50,
 			message: 'Halfway',
 		};
 		const completed: ProcessingProgressEvent = {
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: 'completed',
 			percentage: 100,
@@ -83,6 +86,7 @@ describe('StatusPanel aggregate progress', () => {
 	it('counts queued jobs as zero-progress participants in batch averages', () => {
 		const controller = new StatusPanelRuntime();
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -92,6 +96,7 @@ describe('StatusPanel aggregate progress', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: 'completed',
 			percentage: 100,
@@ -128,6 +133,7 @@ describe('StatusPanel aggregate progress', () => {
 	])('does not leak stale currentFile/etaSeconds onto terminal aggregates for %s', (terminalStage) => {
 		const controller = new StatusPanelRuntime();
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [{ input_index: 0, file_path: '/books/alpha.m4b' }],
 			max_concurrent: 1,
 		};
@@ -138,6 +144,7 @@ describe('StatusPanel aggregate progress', () => {
 		// fields; a careless flushRender would preserve these onto the terminal
 		// status that follows.
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: 'converting',
 			percentage: 80,
@@ -147,6 +154,7 @@ describe('StatusPanel aggregate progress', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: terminalStage,
 			percentage: 100,

--- a/src/ui/statusPanel/__tests__/queueSnapshot.test.ts
+++ b/src/ui/statusPanel/__tests__/queueSnapshot.test.ts
@@ -41,6 +41,7 @@ describe('StatusPanel queue snapshot', () => {
 	it('initializes queued items in order', () => {
 		const controller = new StatusPanelRuntime();
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -66,12 +67,14 @@ describe('StatusPanel queue snapshot', () => {
 	it('applies queue snapshot order and labels after early progress arrives', async () => {
 		const controller = new StatusPanelRuntime();
 		const earlyProgress: ProcessingProgressEvent = {
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: 'converting',
 			percentage: 45,
 			message: 'working',
 		};
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 2, file_path: '/books/gamma.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },

--- a/src/ui/statusPanel/__tests__/resetToIdle.test.ts
+++ b/src/ui/statusPanel/__tests__/resetToIdle.test.ts
@@ -58,10 +58,12 @@ describe('StatusPanel resetToIdle', () => {
 		const mergeToggle = document.getElementById('merge-mode-toggle') as HTMLInputElement;
 		const maxConcurrent = document.getElementById('max-concurrent-select') as HTMLSelectElement;
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [{ input_index: 0, file_path: '/books/alpha.m4b' }],
 			max_concurrent: 1,
 		};
 		const progress: ProcessingProgressEvent = {
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: 'converting',
 			percentage: 25,

--- a/src/ui/statusPanel/__tests__/stateMachine.test.ts
+++ b/src/ui/statusPanel/__tests__/stateMachine.test.ts
@@ -30,6 +30,7 @@ describe('statusPanel state machine', () => {
 	it('builds queue snapshot ordering and preserves queue labels', () => {
 		const model = createStatusPanelModel();
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 2, file_path: '/books/c.m4b' },
 				{ input_index: 0, file_path: '/books/a.m4b' },
@@ -51,9 +52,31 @@ describe('statusPanel state machine', () => {
 		expect(next.currentStatus).not.toHaveProperty('etaSeconds');
 	});
 
+	it('uses backend operation identity to classify lifecycle work kind', () => {
+		const queuedMetadataSave: ProcessingQueueEvent = {
+			operation_kind: 'metadataSave',
+			items: [{ input_index: 0, file_path: '/books/a.m4b' }],
+			max_concurrent: 1,
+		};
+		const afterQueue = applyQueueSnapshot(createStatusPanelModel(), queuedMetadataSave, 1_000);
+
+		expect(afterQueue.model.currentWorkKind).toBe('metadataSave');
+
+		const mergeProgress: ProcessingProgressEvent = {
+			operation_kind: 'processingMerge',
+			stage: 'converting',
+			percentage: 25,
+			message: 'Merging',
+		};
+		const afterProgress = applyProgress(afterQueue.model, mergeProgress, 1_100);
+
+		expect(afterProgress.model.currentWorkKind).toBe('merge');
+	});
+
 	it('handles progress events that arrive before queue snapshot', () => {
 		const model = createStatusPanelModel();
 		const earlyProgress: ProcessingProgressEvent = {
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: 'converting',
 			percentage: 55,
@@ -64,6 +87,7 @@ describe('statusPanel state machine', () => {
 		expect(afterEarly.model.currentStatus.stage).toBe('converting');
 
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/a.m4b' },
 				{ input_index: 1, file_path: '/books/b.m4b' },
@@ -86,6 +110,7 @@ describe('statusPanel state machine', () => {
 
 	it('aggregates processing, completed, skipped, failed, and cancelled states', () => {
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/a.m4b' },
 				{ input_index: 1, file_path: '/books/b.m4b' },
@@ -96,11 +121,41 @@ describe('statusPanel state machine', () => {
 			max_concurrent: 2,
 		};
 		const progressEvents: ProcessingProgressEvent[] = [
-			{ input_index: 0, stage: 'converting', percentage: 50, message: 'Converting' },
-			{ input_index: 1, stage: 'completed', percentage: 100, message: 'Done' },
-			{ input_index: 2, stage: 'skipped', percentage: 100, message: 'Skipped' },
-			{ input_index: 3, stage: 'failed', percentage: 100, message: 'Failed' },
-			{ input_index: 4, stage: 'cancelled', percentage: 100, message: 'Cancelled' },
+			{
+				operation_kind: 'processingBatch',
+				input_index: 0,
+				stage: 'converting',
+				percentage: 50,
+				message: 'Converting',
+			},
+			{
+				operation_kind: 'processingBatch',
+				input_index: 1,
+				stage: 'completed',
+				percentage: 100,
+				message: 'Done',
+			},
+			{
+				operation_kind: 'processingBatch',
+				input_index: 2,
+				stage: 'skipped',
+				percentage: 100,
+				message: 'Skipped',
+			},
+			{
+				operation_kind: 'processingBatch',
+				input_index: 3,
+				stage: 'failed',
+				percentage: 100,
+				message: 'Failed',
+			},
+			{
+				operation_kind: 'processingBatch',
+				input_index: 4,
+				stage: 'cancelled',
+				percentage: 100,
+				message: 'Cancelled',
+			},
 		];
 		const result = progressEvents.reduce(
 			(state, event) => applyProgress(state.model, event, 1_000 + event.input_index! * 1000),
@@ -118,6 +173,7 @@ describe('statusPanel state machine', () => {
 
 	it('bypasses throttle for stage transitions while coalescing same-stage updates', () => {
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [{ input_index: 0, file_path: '/books/a.m4b' }],
 			max_concurrent: 1,
 		};
@@ -126,6 +182,7 @@ describe('statusPanel state machine', () => {
 		const initial = applyProgress(
 			base,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 0,
 				stage: 'analyzing',
 				percentage: 10,
@@ -136,6 +193,7 @@ describe('statusPanel state machine', () => {
 		const sameStageIgnored = applyProgress(
 			initial.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 0,
 				stage: 'analyzing',
 				percentage: 25,
@@ -147,6 +205,7 @@ describe('statusPanel state machine', () => {
 		const stageTransition = applyProgress(
 			sameStageIgnored.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 0,
 				stage: 'writing',
 				percentage: 35,
@@ -164,6 +223,7 @@ describe('statusPanel state machine', () => {
 		const result = applyProgress(
 			createStatusPanelModel(),
 			{
+				operation_kind: 'processingBatch',
 				job_id: 'job-single',
 				stage: 'completed',
 				percentage: 100,
@@ -189,6 +249,7 @@ describe('statusPanel state machine', () => {
 		const result = applyProgress(
 			createStatusPanelModel(),
 			{
+				operation_kind: 'processingBatch',
 				job_id: 'job-single',
 				stage: 'skipped',
 				percentage: 100,
@@ -220,6 +281,7 @@ describe('statusPanel state machine', () => {
 
 	it('emits a batch completion hold intent with final feedback classification', () => {
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/a.m4b' },
 				{ input_index: 1, file_path: '/books/b.m4b' },
@@ -234,6 +296,7 @@ describe('statusPanel state machine', () => {
 		result = applyProgress(
 			result.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 0,
 				stage: 'completed',
 				percentage: 100,
@@ -244,6 +307,7 @@ describe('statusPanel state machine', () => {
 		result = applyProgress(
 			result.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 1,
 				stage: 'cancelled',
 				percentage: 100,
@@ -299,6 +363,7 @@ describe('statusPanel state machine', () => {
 
 	it('marks active rows cancelled on cancellation when jobs are still running', () => {
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/a.m4b' },
 				{ input_index: 1, file_path: '/books/b.m4b' },
@@ -310,6 +375,7 @@ describe('statusPanel state machine', () => {
 		result = applyProgress(
 			result.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 0,
 				stage: 'converting',
 				percentage: 15,
@@ -320,6 +386,7 @@ describe('statusPanel state machine', () => {
 		result = applyProgress(
 			result.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 1,
 				stage: 'converting',
 				percentage: 20,
@@ -346,6 +413,7 @@ describe('statusPanel state machine', () => {
 
 	it('repairs rows from command results for skipped, cancelled, and failed terminal statuses', () => {
 		const snapshot: ProcessingQueueEvent = {
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/a.m4b' },
 				{ input_index: 1, file_path: '/books/b.m4b' },
@@ -357,6 +425,7 @@ describe('statusPanel state machine', () => {
 		result = applyProgress(
 			result.model,
 			{
+				operation_kind: 'processingBatch',
 				input_index: 0,
 				job_id: 'job-0',
 				stage: 'converting',

--- a/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
@@ -120,6 +120,7 @@ describe('StatusPanel lifecycle', () => {
 
 		const cancelRequest = controller.requestCancelAll();
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.writing,
 			percentage: 68,
@@ -187,6 +188,7 @@ describe('StatusPanel lifecycle', () => {
 		const showInfoSpy = vi.spyOn(feedback, 'showInfo');
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -195,12 +197,14 @@ describe('StatusPanel lifecycle', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: terminalStages[0],
 			percentage: 100,
 			message: 'terminal-0',
 		});
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: terminalStages[1],
 			percentage: 100,
@@ -290,6 +294,7 @@ describe('StatusPanel lifecycle', () => {
 		controller.setBatchCompletionMessage('Processed 1/2. Failed: beta.m4b');
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -298,12 +303,14 @@ describe('StatusPanel lifecycle', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.completed,
 			percentage: 100,
 			message: 'terminal-0',
 		});
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: STAGES.failed,
 			percentage: 100,
@@ -323,6 +330,7 @@ describe('StatusPanel lifecycle', () => {
 		const showInfoSpy = vi.spyOn(feedback, 'showInfo');
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -331,6 +339,7 @@ describe('StatusPanel lifecycle', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.completed,
 			percentage: 100,
@@ -369,6 +378,7 @@ describe('StatusPanel lifecycle', () => {
 		seedDisabledControls();
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -377,6 +387,7 @@ describe('StatusPanel lifecycle', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.skipped,
 			percentage: 100,
@@ -397,6 +408,7 @@ describe('StatusPanel lifecycle', () => {
 		controller.setBatchCompletionMessage('No files were processed successfully. Skipped: 2.');
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -405,12 +417,14 @@ describe('StatusPanel lifecycle', () => {
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.skipped,
 			percentage: 100,
 			message: 'Skipped existing output at /books/alpha.m4b',
 		});
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: STAGES.skipped,
 			percentage: 100,
@@ -456,6 +470,7 @@ describe('StatusPanel lifecycle', () => {
 		const showInfoSpy = vi.spyOn(feedback, 'showInfo');
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			job_id: 'job-1',
 			stage,
 			percentage: 100,
@@ -494,6 +509,7 @@ describe('StatusPanel lifecycle', () => {
 		seedDisabledControls();
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.completed,
 			percentage: 100,
@@ -504,6 +520,7 @@ describe('StatusPanel lifecycle', () => {
 		vi.advanceTimersByTime(1000);
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.completed,
 			percentage: 100,
@@ -530,6 +547,7 @@ describe('StatusPanel lifecycle', () => {
 		vi.spyOn(tauriClient, 'cancelProcessing').mockResolvedValue('cancel requested');
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -542,12 +560,14 @@ describe('StatusPanel lifecycle', () => {
 		expect(controller.getCurrentStatus().message).toBe('Cancellation requested…');
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.cancelled,
 			percentage: 100,
 			message: 'cancelled-0',
 		});
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: STAGES.cancelled,
 			percentage: 100,
@@ -572,6 +592,7 @@ describe('StatusPanel lifecycle', () => {
 		const showInfoSpy = vi.spyOn(feedback, 'showInfo');
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -598,6 +619,7 @@ describe('StatusPanel lifecycle', () => {
 		seedDisabledControls();
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -605,12 +627,14 @@ describe('StatusPanel lifecycle', () => {
 			max_concurrent: 2,
 		});
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: STAGES.completed,
 			percentage: 100,
 			message: 'terminal-0',
 		});
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 1,
 			stage: STAGES.completed,
 			percentage: 100,
@@ -631,11 +655,13 @@ describe('StatusPanel lifecycle', () => {
 		seedDisabledControls();
 
 		controller.applyQueueSnapshot({
+			operation_kind: 'processingBatch',
 			items: [{ input_index: 0, file_path: '/books/alpha.m4b' }],
 			max_concurrent: 1,
 		});
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: 'analyzing',
 			percentage: 10,
@@ -649,6 +675,7 @@ describe('StatusPanel lifecycle', () => {
 		// Prior to fix, shouldThrottleProgressUpdate dropped this update entirely and
 		// the stage transition never reached the UI until the next 1s tick.
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			input_index: 0,
 			stage: 'writing',
 			percentage: 60,
@@ -662,6 +689,7 @@ describe('StatusPanel lifecycle', () => {
 		const controller = new StatusPanelRuntime();
 
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			job_id: 'job-123',
 			stage: 'converting',
 			percentage: 35,
@@ -675,6 +703,7 @@ describe('StatusPanel lifecycle', () => {
 
 		const stepAfterReset = getStepText();
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			job_id: 'job-123',
 			stage: 'converting',
 			percentage: 50,
@@ -687,6 +716,7 @@ describe('StatusPanel lifecycle', () => {
 
 		controller.resetToIdle();
 		controller.applyProgress({
+			operation_kind: 'processingBatch',
 			job_id: 'job-456',
 			stage: 'converting',
 			percentage: 42,

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -42,6 +42,7 @@ import {
 	type StatusPanelCompletionFeedback,
 	type StatusPanelIntent,
 	type StatusPanelModel,
+	workKindFromOperationKind,
 } from './domain/stateMachine';
 
 export class StatusPanelRuntime {
@@ -233,7 +234,8 @@ export class StatusPanelRuntime {
 
 	private buildInferredProgressLabel(event: ProcessingProgressEvent): string {
 		const fileList = getCurrentFileList();
-		if (this.model.currentWorkKind === 'merge' && fileList?.files?.length) {
+		const workKind = workKindFromOperationKind(event.operation_kind);
+		if (workKind === 'merge' && fileList?.files?.length) {
 			const firstValidFile = fileList.files.find((file) => file.isValid);
 			if (firstValidFile?.path) {
 				return buildQueueLabels([firstValidFile.path])[0] ?? firstValidFile.path;

--- a/src/ui/statusPanel/domain/stateMachine.ts
+++ b/src/ui/statusPanel/domain/stateMachine.ts
@@ -30,6 +30,7 @@ import {
 	type StatusPanelIntent,
 	type StatusPanelModel,
 	type StatusPanelReducerResult,
+	workKindFromOperationKind,
 } from './stateMachineTypes';
 
 export {
@@ -38,6 +39,7 @@ export {
 	SINGLE_COMPLETION_HOLD_MS,
 	buildBatchCompletionFeedback,
 	isTerminalProgressStage,
+	workKindFromOperationKind,
 };
 export type { StatusPanelCompletionFeedback, StatusPanelIntent, StatusPanelModel };
 
@@ -88,7 +90,7 @@ export function applyQueueSnapshot(
 		lastProgressRenderByKey: new Map(),
 		currentStatus: model.currentStatus,
 		isProcessing: queueSnapshot.queueOrder.length > 0,
-		currentWorkKind: model.currentWorkKind,
+		currentWorkKind: workKindFromOperationKind(event.operation_kind),
 		latestProgressEvent: model.latestProgressEvent,
 		batchCompletionMessageOverride: model.batchCompletionMessageOverride,
 	};
@@ -120,6 +122,7 @@ export function applyProgress(
 	}
 
 	const next = cloneModel(model);
+	next.currentWorkKind = workKindFromOperationKind(event.operation_kind);
 	next.lastProgressRenderByKey.set(jobKey, now);
 
 	const label = options?.label ?? resolveProgressLabel(event, existing?.label);

--- a/src/ui/statusPanel/domain/stateMachineTypes.ts
+++ b/src/ui/statusPanel/domain/stateMachineTypes.ts
@@ -1,4 +1,4 @@
-import type { ProcessingProgressEvent, EventStage } from '../../../types/events';
+import type { ProcessingProgressEvent, EventStage, OperationKind } from '../../../types/events';
 import type { JobProgress, ProcessingStatus } from '../state';
 
 export const SINGLE_COMPLETION_HOLD_MS = 2000;
@@ -8,6 +8,17 @@ export const PROGRESS_THROTTLE_MS = 1000;
 
 export type CompletionFeedbackKind = 'success' | 'error' | 'info';
 export type StatusPanelWorkKind = 'merge' | 'batch' | 'metadataSave';
+
+export function workKindFromOperationKind(operationKind: OperationKind): StatusPanelWorkKind {
+	switch (operationKind) {
+		case 'processingMerge':
+			return 'merge';
+		case 'processingBatch':
+			return 'batch';
+		case 'metadataSave':
+			return 'metadataSave';
+	}
+}
 
 export interface StatusPanelCompletionFeedback {
 	kind: CompletionFeedbackKind;


### PR DESCRIPTION
## Summary

Implements the Operation Lifecycle Contract roadmap as a processing-owned Backend Lifecycle sub-owner, not a seventh Grey-Box Public API.

The PR makes operation lifecycle truth explicit across processing, metadata save, audio progress reporting, and Status Panel consumption without moving metadata policy, artifact commit truth, or status runtime ownership.

## Boundary Changes

- Adds `src-tauri/src/processing/lifecycle.rs` with `OperationKind` and `OperationResultSummary`.
- Carries `operation_kind` on `ProgressEvent` and `QueueEvent` for `processingMerge`, `processingBatch`, and `metadataSave`.
- Moves lifecycle event names, progress bands, and progress math out of `audio/constants.rs` into `processing/progress`.
- Keeps `audio/constants.rs` private to audio/media facts.
- Reuses processing lifecycle emit helpers from metadata batch save while keeping metadata write policy inside metadata-owned APIs.
- Keeps Status Panel as a consumer/read model; it now classifies work kind from backend `operation_kind` when queue/progress events arrive.

## Generated Contract Changes

- Regenerated `src/lib/generated/tauri.ts`.
- Generated queue/progress event payloads now include `operation_kind`.
- Generated result summaries now expose shared `OperationResultSummary`; the Rust `ProcessResultSummary` alias remains only as source-level processing readability.

## Docs And Boundary Assertions

- Updated processing, audio, job registry, backend, and Status Panel `AGENTS.md` guidance.
- Updated `docs/system-map.md`, `docs/ubiquitous-language.md`, and `docs/api-map.md` to reflect Backend Lifecycle as a processing sub-owner.
- Updated `scripts/check-public-api-strips.sh` so the lifecycle public strip is intentional and audio no longer advertises lifecycle constants.
- Refreshed the operation lifecycle roadmap/HTML artifact enough to mark the implemented direction.
- Fixed stale Remote Acquisition spec wording from “sixth/existing five” to “seventh/existing six.”

## Testing / Verification

- `scripts/checks.sh standard`
- `cargo check -p audiobook-boss`
- `bun run build`
- `bun run bindings:generate`
- `bun run bindings:check:local` after staging/commit
- `bash scripts/check-public-api-strips.sh`
- `bash scripts/check-no-bridge-imports.sh`
- `bash scripts/check-context-surface.sh`
- `bun run test -- src/ui/statusPanel/__tests__/stateMachine.test.ts src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts src/ui/statusPanel/__tests__/progressAggregator.test.ts src/ui/statusPanel/__tests__/queueSnapshot.test.ts src/lib/tauri-client.test.ts src/lib/behavior-contract.test.ts`
- `bun run test -- src/lib/tauri-client.generated-event-bindings.test.ts src/lib/tauri-public-api.contract.test.ts src/ui/statusPanel/__tests__/runtime-api-contract.test.ts src/ui/statusPanel/__tests__/statusPanel-island.test.ts src/ui/core/__tests__/metadataSaveWorkflow.test.ts src/ui/__tests__/metadata-save-pending-flow.test.ts`
- `cargo test -p audiobook-boss --lib processing::progress::emitter::tests::terminal_events_share_context_and_reset_progress -- --exact`
- `cargo test -p audiobook-boss --lib commands::metadata::save_batch::tests::metadata_batch_cancels_remaining_items_between_writes -- --exact`
- `cargo test -p audiobook-boss --lib commands::metadata::save_batch::tests::metadata_batch_returns_ordered_per_file_failures_without_aborting -- --exact`
- `cargo test -p audiobook-boss --lib processing::terminal_outcomes::tests::terminal_classification_distinguishes_cancelled_failed_and_mixed_results -- --exact`
- `cargo test -p audiobook-boss --lib processing::terminal_outcomes::tests::collect_batch_results_preserves_mixed_success_failure_and_cancelled_entries -- --exact`
- `cargo test -p audiobook-boss --lib processing::terminal_outcomes::tests::terminal_classification_preserves_post_commit_success_truth -- --exact`

## Testing Infra After-Action

No broad testing/proof-infra work is bundled here. Two observations are worth carrying forward to issue #323:

- `cargo test -p audiobook-boss processing::progress` compiled the crate and then sat in the library test binary long enough to look hung. Exact `--lib <test-name> -- --exact` commands produced the intended focused signal.
- `cargo test -p audiobook-boss -- --list | rg ...` still walked into unrelated integration binaries and stalled while listing `integration_path_validation`; this is part of the clumsy/noisy test-selection behavior, not lifecycle implementation scope.
- `bun run bindings:check:local` reports generated bindings as stale while intended generated-binding changes are still unstaged because the script regenerates and checks unstaged diff against `HEAD`. Staging or committing the regenerated binding makes the same check pass.

## Residual Risk

- Event payload shape changed, so downstream review should pay attention to any non-test consumers of `processing-progress` / `processing-queue` that assume the older payload. The generated bindings, tauri client tests, Status Panel tests, and full standard gate are green.
- The xHE-AAC fixture test remains ignored/manual because it requires `ABB_XHE_AAC_FIXTURE` and external FFmpeg with libfdk_aac; this PR does not change that test posture.
