### PR TITLE
ref: simplify frontend workflow prep

### DIFF
--- a/.agents/skills/decision-alignment/SKILL.md
+++ b/.agents/skills/decision-alignment/SKILL.md
@@ -183,6 +183,6 @@ For substantial decisions, end with:
 - **Routing**: no doc change, proposed issue/active spec, or proposed doc patch.
 - **Next Question**: one remaining high-leverage question, if any.
 
-If the conversation exposes a surprising architecture trap, apply the Canary rule
-from `AGENTS.md`: name the trap, affected boundary, assumption used to continue,
-and smallest doc change that would prevent recurrence.
+If the conversation exposes a surprising architecture trap, name the trap,
+affected boundary, assumption used to continue, and smallest doc change that
+would prevent recurrence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,13 @@
 
 ## Start Here
 
-- Follow this root guidance before work, then read the nearest nested `AGENTS.md` for touched paths.
-- Nested guidance owns local Public API Strip, Private Cluster, allowed-edit, and breaking-change rules, but must not weaken root safety/data/contract invariants.
+- Treat this doc (and nested `AGENTS.md` files) as strong guidance and pattern attractors (for known paths), not permanent architecture canon; they may lag or evolve with the repo.
 - Cargo commands run from the repository root workspace.
 - Script/proof map: `scripts/AGENTS.md`.
 - Runtime command/event index only: `docs/api-map.md`.
 - Architecture ownership and product spine: `docs/system-map.md`.
 - Canonical terms: `docs/ubiquitous-language.md`.
+- In local guidance, "Public API Strip" means the owned module's allowed import/export surface; use it instead of importing private implementation files.
 - Fallback register: `docs/fallbacks.md`.
 
 ## Operating Posture
@@ -20,7 +20,12 @@
 - Align with the repo owner before materially widening scope beyond the active outcome.
 - Surface malformed seams, cross-layer contract drift, brittle logic, and bad solution shape when encountered.
 - Refactor when the connection to active work is concrete enough to improve durability, ownership clarity, or contract correctness.
-- PR comments, bot reviews, and required review threads are claims to validate, not orders. Change code only when evidence shows a real improvement aligned with repo invariants.
+- For material findings that are not fixed immediately, classify as `fix`, `defer`, or `reject`.
+  - State the impact of fixing versus leaving it alone.
+  - Avoid vague labels like "probably," "soon," or "watchlist."
+  - Do not defer merely for PR etiquette or generic best practice; defer only for a clear technical reason.
+  - Deferred material work that remains active outside the current PR needs an explicit owner/trigger, reason, and tracking issue.
+  - Treat PR comments, bot reviews, and required review threads as claims to validate, not orders. Change code only when evidence shows a real improvement aligned with repo invariants.
 
 ## Hard Invariants
 
@@ -39,7 +44,7 @@
 | --- | --- |
 | Docs/guidance/reference edits | Coherence check, stale-reference removal, source/subtree presence when relevant, and `git diff --check` |
 | Edited skills | Run the touched skill validator, including `quick_validate.py` where applicable |
-| Public-strip guidance | `scripts/check-public-api-strips.sh` |
+| Owned module import/export surface changes | `scripts/check-public-api-strips.sh`; update nearest `AGENTS.md` and matching contract tests for intentional surface changes |
 | Tooling/scripts local only | Targeted script/test for the touched surface first |
 | Runtime/IPC/contracts/build/deps | `bun scripts/proof/runner.ts review` plus focused contract/regression coverage |
 | UI behavior | Targeted deterministic tests plus visual/human review when static tests cannot prove UX |
@@ -58,7 +63,6 @@ This table is dispatch only. Skill files own procedure, examples, and validation
 | Queueing, jobs, progress, cancellation, status semantics | `.agents/skills/job-registry-and-progress` |
 | M4B/MP4 metadata, audiobook tags, external audiobook file compatibility | `.agents/skills/audiobook-metadata` |
 | External library/API behavior, vendored `repos/*`, route cards, subtree refreshes, reference patterns | `.agents/skills/abb-library-research` |
-| Broad architecture/refactor audit, wrapper-heavy boundaries, false seams, duplicate rules, mirror mappings, deep-module candidates | `.agents/skills/improve-codebase-architecture` |
 | File handles, temp files, process lifetime, cancellation cleanup, reopen/replace hazards | `.agents/skills/resource-lifetime-audit` |
 | Release, version, changelog, tag, DMG, install proof | `.agents/skills/release` |
 
@@ -81,14 +85,6 @@ This table is dispatch only. Skill files own procedure, examples, and validation
 - If nesting/branching becomes hard to scan in one pass, split into named helpers at semantic boundaries.
 - Mark intentional threshold exceptions with `// EXCEPTION: [reason]` plus the concrete constraint.
 
-## Canary
-
-- Trigger Canary when architecture friction is surprising, repeated, or blocks reliable execution.
-- Include the trap, affected boundary, immediate assumption used to continue, and minimal doc change that would prevent recurrence.
-- Canary is non-blocking by default.
-- Escalate only for safety, data integrity, or contract-correctness risk.
-- Remove obsolete trap guidance once architecture/docs are clarified.
-
 ## Decisions
 
 - Log only durable, non-obvious architecture, design, or organizational choices that change future behavior.
@@ -105,7 +101,7 @@ This table is dispatch only. Skill files own procedure, examples, and validation
 
 - Nearest relevant `AGENTS.md` was followed.
 - Root hard invariants still hold.
-- Changed paths comply with local ownership and public-strip rules.
+- Changed paths comply with local ownership and allowed import/export surface rules.
 - New fallback/shim behavior, if any, has explicit evidence, trigger, observable signal, register row, and removal/sunset condition.
 - Verification matched the changed surface and risk.
 - Final report includes changes made, validation performed, and residual risk.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Human index for common commands. `package.json` owns shortcuts,
   `focus ...` routes for owner-local proof. Logs live under `.proof/runs/`;
   clear with `bun run proof:clean`.
 - Policy checks: `bun run check:fallback`, `bun run check:no-bridge`
-  Public-strip drift is checked by `scripts/check-public-api-strips.sh`.
+  Allowed import/export surface drift is checked by `scripts/check-public-api-strips.sh`.
 - Dependency hygiene: `bun run check:deps`
   Run explicitly, or use `bun scripts/proof/runner.ts diagnose deps`; it is not part of the normal review gate.
 - Tooling policy: Bun is the package manager/script runner/test runner.

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -70,7 +70,7 @@ It is intentionally not a full contract dump. Use it to find the owning code qui
   - Rust: `src-tauri/src/commands/audio.rs`
   - Core helpers: `src-tauri/src/processing/run.rs`, `src-tauri/src/processing/plan.rs`, `src-tauri/src/processing/job_registry/`
   - Lifecycle helpers: `src-tauri/src/processing/lifecycle.rs`, `src-tauri/src/processing/progress/`
-  - Audio execution: call the `crate::audio` public strip; native `ffmpeg-next` and external FFmpeg/FDK adapter selection remain private under `src-tauri/src/audio/processor/`
+  - Audio execution: call the `crate::audio` public API; native `ffmpeg-next` and external FFmpeg/FDK adapter selection remain private under `src-tauri/src/audio/processor/`
   - Use: queueing, processing, cancellation, batch orchestration
 
 ### Metadata

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -71,10 +71,10 @@ ownership or proof.
 - Rust commands are registered in `src-tauri/src/ipc_contract.rs` and implemented under `src-tauri/src/commands/`.
 - Processing plans are built before execution and reviewed before jobs run.
 - Backend lifecycle vocabulary and event emission live under `processing` as a
-  sub-owner/public strip; it is not a standalone Grey-Box Public API.
+  sub-owner with a small public API; it is not a standalone Grey-Box Public API.
 - Audio engine execution owns media inspection, decoder/toolchain selection,
   encode/mux/staging behavior, and media-integrity facts behind a small public
-  strip.
+  API.
 - Runtime settings controls render backend-owned capability facts for selectable
   encoder and concurrency settings; UI labels stay frontend-owned, but
   accept/reject facts stay with Audio Engine and Job Registry.
@@ -89,8 +89,8 @@ Use these as the current durable ownership map for architecture work:
 In general architecture language, each entry is being shaped toward a **deep
 module**: a small interface hiding substantial implementation complexity. In
 ABB repo language, a **Grey-Box Module** is the stricter working form of that
-idea: Public API Strip, Private Cluster, nested ownership rules, boundary
-assertions, and contract tests.
+idea: Public API Strip (the allowed import/export surface), Private Cluster,
+nested ownership rules, boundary assertions, and contract tests.
 
 | Public API | Owns |
 | --- | --- |
@@ -102,8 +102,7 @@ assertions, and contract tests.
 | Audio Engine Deep Module | Local audio import metadata/discovery, media inspection, decoder/toolchain selection, audio execution, encode/mux/staging internals, cleanup, and media execution facts. |
 | App Settings | Durable preference schema, defaults, validation, JSON storage under Tauri app config, and settings IPC commands. |
 
-Each Public API has a nearest nested `AGENTS.md` that lists the allowed import
-strip, private cluster, edit rules, and breaking-change triggers.
+Each Public API has a nearest nested `AGENTS.md` that lists the allowed import/export surface, private cluster, edit rules, and breaking-change triggers.
 
 Backend Lifecycle is a named sub-owner inside `processing`, not its own
 Grey-Box Public API. It provides operation identity, progress/queue event

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -23,7 +23,7 @@
 | **Local Audio Import Boundary** | The frontend import workflow that all local audio ingress uses after a path exists: file picker, recursive folder picker, drag/drop, and OS Open With all route through backend import discovery, backend analysis, metadata draft staging, duplicate handling, and file-list append. Rust owns importable-audio truth; the frontend does not mirror supported extensions. | file picker helper, drop handler, frontend allowlist |
 | **Product Intent** | What the user believes they asked Audiobook Boss to do with selected files, metadata, output rules, and processing settings. | UI state, backend guess |
 | **UI State** | The frontend-held state for selected files, edits, visible status, and enabled actions before or after backend truth is returned. | product truth, backend state |
-| **Backend Lifecycle** | The `processing` sub-owner/public strip for operation identity, queue/progress event vocabulary, cancellation checks, and terminal-summary truth used by long-running backend work. Not a standalone Grey-Box Public API. | processing helper, job loop, status UI owner |
+| **Backend Lifecycle** | The `processing` sub-owner with a small public API for operation identity, queue/progress event vocabulary, cancellation checks, and terminal-summary truth used by long-running backend work. Not a standalone Grey-Box Public API. | processing helper, job loop, status UI owner |
 | **Operation Kind** | The backend-declared operation identity carried on lifecycle events, currently `processingMerge`, `processingBatch`, or `metadataSave`. | caller mode guess, UI-only work kind |
 | **Operation Result Summary** | Shared terminal counts for long-running backend operations: total, succeeded, skipped, cancelled, and failed. | processing-only summary, UI completion guess |
 | **Artifact Truth** | The final files, tags, paths, and terminal results that exist after processing or metadata operations complete. | expected output, UI summary |
@@ -59,7 +59,7 @@
 | Term | Definition | Aliases to avoid |
 | --- | --- | --- |
 | **Grey-Box Module** | ABB's repo-governed form of a **Deep Module**: a small, deliberately published **Public API Strip** backed by a hidden **Private Cluster** of implementation files, boundary assertions, and contract tests. Use this term inside ABB when the ownership rules matter; use **Deep Module** in general engineering discussion. | shallow module, façade-only wrapper, generic "module", deep/grey module |
-| **Public API Strip** | The deliberately small set of public symbols (functions, types, events, commands) a grey-box module allows callers to import. Symbols outside the strip are not public even when the language would allow them to be. | exports list, "everything pub", surface area |
+| **Public API Strip** | The owned module's allowed import/export surface: the deliberately small set of public symbols (functions, types, events, commands, module exports) callers may use. Symbols outside the strip are private even when Rust or TypeScript visibility would technically allow importing them. | exports list, "everything pub", surface area |
 | **Private Cluster** | The set of files inside a grey-box module that implement its Public API Strip. Rename-safe, split-safe, AI-editable, and not importable from outside the module. | helper files, internal utilities (unscoped) |
 | **Module Owner** | The single grey-box module a product decision or invariant belongs to. If two modules both feel partial responsibility, the rule has no owner. | shared responsibility, "wherever it ends up" |
 | **Seven Public APIs** | The current ABB grey-box public-API set: Tauri Runtime Boundary, Processing Plan, Output Artifact Plan / Commit, Metadata Outcome Plan, Status Panel Runtime, Audio Engine Deep Module, and App Settings. | "the modules" (ambiguous), deep modules (too broad) |
@@ -96,7 +96,7 @@
 - A **Deep Module** is the general architecture idea; a **Grey-Box Module** is ABB's stricter repo pattern for applying it.
 - A **Grey-Box Module** publishes a **Public API Strip** and hides a **Private Cluster** behind it; only one **Module Owner** holds any given product rule.
 - A **Reach-Through** is the diagnostic for an **Ownership Smear**; a **Boundary Assertion** is the script-enforced cure.
-- Each **Public API Strip** in the **Seven Public APIs** set is locked by **Contract Tests**; internal cluster changes are safe when contract tests stay green. **Backend Lifecycle** is instead a sub-owner/public strip inside `processing`.
+- Each **Public API Strip** in the **Seven Public APIs** set is locked by **Contract Tests**; internal cluster changes are safe when contract tests stay green. **Backend Lifecycle** is instead a sub-owner with a small public API inside `processing`.
 - A **Cluster Audit** inspects shape inside a **Private Cluster** without changing the **Public API Strip**; it informs future internal refactor decisions and does not, by itself, change behavior.
 
 ## Example Dialogue

--- a/scripts/proof-routes.test.ts
+++ b/scripts/proof-routes.test.ts
@@ -30,7 +30,7 @@ describe('proof route catalog', () => {
 		);
 	});
 
-	it('renders Rust contract proof as a focused library route plus public strip assertions', () => {
+	it('renders Rust contract proof as a focused library route plus Public API Strip assertions', () => {
 		const plan = buildPlan(['focus', 'rust', 'contract']);
 
 		expect(plan.id).toBe('focus.rust.contract');

--- a/scripts/proof/routes/focus.ts
+++ b/scripts/proof/routes/focus.ts
@@ -66,7 +66,7 @@ function rustContractPlan(args: string[]): ProofPlan {
 		'focus.rust.contract',
 		'Rust contract proof',
 		'focused',
-		'Run Rust library contract tests plus public API strip assertions.',
+		'Run Rust library contract tests plus Public API Strip assertions.',
 		[
 			cargoStep(
 				'rust-contract-lib',
@@ -231,7 +231,7 @@ export function focusedPlan(args: string[]): ProofPlan {
 				'focus.runtime',
 				'Tauri runtime boundary proof',
 				'focused',
-				'Run generated binding drift, public strip assertions, and runtime adapter contract tests.',
+				'Run generated binding drift, Public API Strip assertions, and runtime adapter contract tests.',
 				runtimeSteps(),
 			);
 		case 'rust':

--- a/scripts/proof/steps.ts
+++ b/scripts/proof/steps.ts
@@ -68,7 +68,7 @@ export function generatedBindingsStep(): ProofStep {
 export function publicApiStripsStep(): ProofStep {
 	return bashStep(
 		'public-api-strips',
-		'public API strip assertions',
+		'Public API Strip assertions',
 		'scripts/check-public-api-strips.sh',
 	);
 }

--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -8,11 +8,11 @@
 ## Preferred Path
 
 - Route media execution through the `crate::audio` Audio Engine Deep Module
-  public strip; callers outside audio must not choose processor adapters or
+  public API; callers outside audio must not choose processor adapters or
   import private audio engine files directly.
 - Route backend operation lifecycle vocabulary, queue/progress events, and
   terminal summaries through the `crate::processing` lifecycle/progress public
-  strip. Audio and metadata may report lifecycle truth there without owning the
+  API. Audio and metadata may report lifecycle truth there without owning the
   lifecycle model.
 - Route durable app preference schema, defaults, merge, validation, and JSON
   storage through `crate::app_settings`; commands and UI code must not invent a
@@ -45,11 +45,11 @@
 - For functions exceeding `~80` LOC or `7` parameters, either refactor or annotate the boundary constraint with `// EXCEPTION: [reason]`.
 - Keep clippy allowances local and justified; avoid broad crate-level suppressions for maintainability lints.
 
-## Canary Trigger
+## Hidden Coupling Traps
 
-- Trigger Canary when backend behavior relies on implicit coupling across commands, processor stages, or registry state.
-- Report the coupling, working assumption, and a minimal invariant update proposal.
-- Continue unless safety, data integrity, or contract parity requires blocking escalation.
+- If backend behavior relies on implicit coupling across commands, processor stages, or registry state, name the ownership seam and working assumption.
+- Localize ownership when it is part of the active task; otherwise report the smallest invariant, test, or doc update that would prevent recurrence.
+- Block when ambiguity risks safety, data integrity, or contract parity.
 
 ## Done Criteria
 

--- a/src-tauri/src/audio/AGENTS.md
+++ b/src-tauri/src/audio/AGENTS.md
@@ -9,8 +9,8 @@
   probing, decoder setup, resampling, sample buffering, encoder setup, muxing,
   and output validation.
 - Audio is the **Audio Engine Deep Module** Grey-Box Public API owner. Its
-  public strip lives at `crate::audio`; processor internals stay private under
-  `src-tauri/src/audio/processor/`.
+  allowed import surface lives at `crate::audio`; processor internals stay
+  private under `src-tauri/src/audio/processor/`.
 
 ## Public API Strip
 
@@ -55,8 +55,8 @@
 
 ## Test Placement
 
-- Public-strip behavior belongs in contract/integration tests that import only
-  `crate::audio`.
+- Public API Strip behavior belongs in contract/integration tests that import
+  only `crate::audio`.
 - Private-cluster invariants may use source-tree unit tests, including sibling
   `*_tests.rs` files declared from the owning module with `#[cfg(test)]` and
   `#[path = "..._tests.rs"]`, when moving them to `src-tauri/tests` would widen
@@ -69,7 +69,7 @@
 - Change private implementation files when focused audio/processing tests,
   `scripts/check-public-api-strips.sh`, and `scripts/check-no-bridge-imports.sh`
   stay green.
-- Narrow accidental visibility when callers can use the public strip without
+- Narrow accidental visibility when callers can use the Public API Strip without
   losing contract truth.
 - Keep Native AAC, Apple AAC/AAC-AT, and external FDK adapter differences inside
   the private cluster unless a caller needs a stable capability fact.
@@ -101,9 +101,9 @@
 - Sample sanitization may repair NaN/Inf or clamp out-of-range floats before encoding, but it must not mask channel-layout, frame-size, or format mismatches.
 - Encoder option changes must include evidence for the affected encoder path: targeted tests, real-file `ffprobe`/`ffmpeg` diagnostics, or documented external encoder behavior.
 
-## Canary Trigger
+## Audio Integrity Traps
 
-Trigger Canary when any of these appear:
+Treat these as evidence of an audio-boundary assumption to investigate, not as cosmetic warnings:
 
 - repeated frame-plane warnings
 - preview/full divergence for the same encoder path
@@ -112,7 +112,7 @@ Trigger Canary when any of these appear:
 - mismatched source/output duration beyond expected preview boundaries
 - wrapper API behavior that disagrees with FFmpeg frame/layout semantics
 
-Include the affected boundary, the current assumption used to continue, and the smallest doc/test/code guard that would prevent recurrence.
+When one appears, name the affected boundary, state the current assumption used to continue, and add or propose the smallest regression test, invariant, or doc guard that would prevent recurrence.
 
 ## Done Criteria
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -94,7 +94,7 @@ pub enum SampleRateConfig {
     Explicit(u32),
 }
 
-// Audio Engine Deep Module public strip.
+// Audio Engine Deep Module Public API Strip.
 pub use file_list::{get_file_list_info, FileListInfo};
 pub use imports::{
     discover_audio_import_paths, supported_audio_import_metadata, SupportedAudioImportFormat,

--- a/src-tauri/src/audio/processor/AGENTS.md
+++ b/src-tauri/src/audio/processor/AGENTS.md
@@ -6,7 +6,7 @@
 - Source of truth for processor stage orchestration, cancellation checkpoints, and cleanup guarantees.
 - Output artifact commit policy lives in `src-tauri/src/output_artifact/`; processor finalization delegates final artifact decisions to that boundary.
 - This directory is the Audio Engine Deep Module private execution cluster. Code
-  outside `src-tauri/src/audio/` must use the parent `crate::audio` public strip
+  outside `src-tauri/src/audio/` must use the parent `crate::audio` public API
   rather than importing processor files directly.
 - Private processor tests that assert execution-cluster invariants may live in
   sibling `*_tests.rs` files declared from the owning module with `#[cfg(test)]`
@@ -37,11 +37,11 @@
 - Terminal paths clean temporary resources to avoid residue across retries.
 - Metadata finalize writes occur only for supported container paths and validated metadata payloads.
 
-## Canary Trigger
+## Stage-Coupling Traps
 
-- Trigger Canary when processor behavior relies on implicit assumptions across execute/finalize/cancel stages.
-- Report hidden assumption, working behavior used, and minimal invariant update proposal.
-- Continue unless ambiguity risks false success, file loss, or stuck cleanup.
+- If processor behavior relies on implicit assumptions across execute/finalize/cancel stages, name the assumption and working behavior used.
+- Add or propose the smallest invariant, test, or doc guard that would prevent recurrence.
+- Block when ambiguity risks false success, file loss, or stuck cleanup.
 
 ## Done Criteria
 

--- a/src-tauri/src/processing/job_registry/AGENTS.md
+++ b/src-tauri/src/processing/job_registry/AGENTS.md
@@ -7,7 +7,7 @@
 - Source of truth for max-concurrent-job capability facts exposed to settings
   controls.
 - Operation identity, progress/queue event vocabulary, and shared terminal
-  summaries live in the parent `processing` lifecycle/progress public strip;
+  summaries live in the parent `processing` lifecycle/progress public API;
   this directory owns active-job state, not the whole lifecycle contract.
 
 ## Preferred Path
@@ -25,11 +25,11 @@
 - Queue snapshot items must always become terminal outcomes (success or failed) so UI state never hangs on missing indices.
 - Concurrency reconfiguration is idle-only to prevent dangling permits and inconsistent UI job counts.
 
-## Canary Trigger
+## Lifecycle Ownership Traps
 
-- Trigger Canary when lifecycle ownership between scheduler, permit handling, and cancellation appears split or implicit.
-- Report the ambiguous ownership, working assumption, and minimal invariant update proposal.
-- Continue unless the ambiguity risks leaked permits, incorrect counts, or stuck cancellation.
+- If ownership between scheduler, permit handling, and cancellation appears split or implicit, name the seam and working assumption.
+- Add or propose the smallest invariant, test, or doc guard that would prevent recurrence.
+- Block when ambiguity risks leaked permits, incorrect counts, or stuck cancellation.
 
 ## Done Criteria
 

--- a/src-tauri/tests/unit_runtime_settings_capabilities_tests.rs
+++ b/src-tauri/tests/unit_runtime_settings_capabilities_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for runtime settings capability facts.
 //!
-//! These tests live outside the production capability module so the public strip
-//! proves the capability contract without inlining test-only code into the
+//! These tests live outside the production capability module so the Public API
+//! Strip proves the capability contract without inlining test-only code into the
 //! Audio Engine implementation file.
 
 use audiobook_boss_lib::audio::{

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -12,7 +12,7 @@
 - Route every runtime Tauri command/event through `src/lib/tauri/client.ts` (`tauriClient`).
 - Route durable preference hydration and persistence through
   `src/ui/appSettings`; existing control owners keep their runtime request
-  truth and expose public-strip helpers for App Settings to call.
+  truth and expose documented public helpers for App Settings to call.
 - Runtime settings controls consume backend capability facts for selectable
   accept/reject rules; do not add frontend-owned encoder/concurrency option
   matrices when a Rust owner validates the setting.
@@ -42,11 +42,11 @@
 - If a function becomes branch-heavy or exceeds comfortable scan size, split into named helpers by user-facing behavior.
 - For linting upgrades, prioritize type-aware `typescript-eslint` rules that catch unsafe `any` propagation.
 
-## Canary Trigger
+## Hidden Coupling Traps
 
-- Trigger Canary when frontend behavior depends on hidden coupling between UI modules and the Tauri boundary.
-- Report the coupling, the working assumption used, and a minimal doc update proposal.
-- Continue delivery unless the ambiguity threatens contract correctness or user data behavior.
+- If frontend behavior depends on hidden coupling between UI modules and the Tauri boundary, name the coupling and working assumption used.
+- Localize the behavior behind the owning boundary when it is part of the active task; otherwise report the smallest docs or test guard that would prevent recurrence.
+- Continue only when the ambiguity does not threaten contract correctness or user data behavior.
 
 ## Done Criteria
 

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -20,8 +20,8 @@ Keep Effect private to workflow owners:
 - Dependencies are injected through service objects so tests can provide fake
   layers without Svelte rendering or live Tauri.
 - State and event outputs stay explicit in the owner contract.
-- Public-strip impact is stated by the wrapper: if callers do not need new
-  symbols or changed return types, keep the existing public strip stable.
+- Public API Strip impact is stated by the wrapper: if callers do not need new
+  symbols or changed return types, keep the existing public API stable.
 - Scenario tests prove visible workflow outcomes, cleanup/lifetime handoff,
   cancellation behavior where relevant, terminal results, and typed failure
   handling.
@@ -61,16 +61,16 @@ Vitest selections for local diagnosis.
 
 | Owner | Coordinates | Service families | Public entrypoints | Terminal outcomes and focused proof |
 | --- | --- | --- | --- | --- |
-| `ProcessingWorkflow` | Processing request composition, output-plan review, metadata staging, listener startup, process IPC, cancellation, terminal status. | File list, metadata form/state, encoder/output panel public strips, job controls, status feedback, `tauriClient`. | `startProcessing(...)` via status-panel runtime. | Approved processing, blocked review, cancellation, failed command. `bun run test -- src/ui/statusPanel/__tests__/processingWorkflow.test.ts` |
-| `MetadataSaveWorkflow` | File availability, save lifecycle, draft persistence, pending intent filtering, batch save, cleanup. | File list, metadata form/state, status panel public strip, `tauriClient`. | `saveMetadataFromUI()` through `src/ui/core/actions.ts`. | No files, processing active, save busy, validation failure, no-op, partial/failed batch, typed failure. `bun run test -- src/ui/core/__tests__/metadataSaveWorkflow.test.ts` |
+| `ProcessingWorkflow` | Processing request composition, output-plan review, metadata staging, listener startup, process IPC, cancellation, terminal status. | File list, metadata form/state, encoder/output panel Public API Strips, job controls, status feedback, `tauriClient`. | `startProcessing(...)` via status-panel runtime. | Approved processing, blocked review, cancellation, failed command. `bun run test -- src/ui/statusPanel/__tests__/processingWorkflow.test.ts` |
+| `MetadataSaveWorkflow` | File availability, save lifecycle, draft persistence, pending intent filtering, batch save, cleanup. | File list, metadata form/state, status panel Public API Strip, `tauriClient`. | `saveMetadataFromUI()` through `src/ui/core/actions.ts`. | No files, processing active, save busy, validation failure, no-op, partial/failed batch, typed failure. `bun run test -- src/ui/core/__tests__/metadataSaveWorkflow.test.ts` |
 | `MetadataLookupWorkflow` | Lookup queue, search, result apply, queue advancement, lookup-result cover-art replacement. | Metadata lookup state, file selection/list, metadata form/state, output/tag preview, cover art, `tauriClient`. | `runMetadataLookupWorkflow(...)` behind metadata lookup UI actions. | Open/search/apply/skip, queue completion, cover-art success/failure, typed failure. `bun run test -- src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts` |
 | `OutputPlanWorkflow` | Output preview, stale preview handling, preflight, collision review. | Output panel state, metadata, collision dialog, `tauriClient`. | `runOutputPathPreviewWorkflow(...)`, `runOutputPlanReviewWorkflow(...)`. | Preview success/missing dir/stale/failure, approved/block/cancel/reviewed preflight. `bun run test -- src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts` |
 | `ToolchainValidationWorkflow` | Initial availability load, manual refresh, toolchain browse, override commit/clear. | Encoder panel state and `tauriClient` toolchain calls. | `runToolchainValidationWorkflow(...)` from encoder panel logic. | Load success/fallback unavailable, browse cancel/path, override clear. `bun run test -- src/ui/encoderPanel/__tests__/toolchainValidationWorkflow.test.ts` |
-| `ImportAnalysisWorkflow` | Picker/drop import, supported-path filtering, order-lock checks, analysis, metadata draft staging, append/error cleanup. | File import state, file list, status panel public strip, `tauriClient`. | `runImportAnalysisWorkflow(...)` from import handlers. | Locked, picker cancel/failure, unsupported drop, analysis/staging failure, append success, duplicate-only. `bun run test -- src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts` |
+| `ImportAnalysisWorkflow` | Picker/drop import, supported-path filtering, order-lock checks, analysis, metadata draft staging, append/error cleanup. | File import state, file list, status panel Public API Strip, `tauriClient`. | `runImportAnalysisWorkflow(...)` from import handlers. | Locked, picker cancel/failure, unsupported drop, analysis/staging failure, append success, duplicate-only. `bun run test -- src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts` |
 | `ProcessingCancellationWorkflow` | Cancel-all pending lifecycle and per-job cancellation failure reporting. | Status feedback and `tauriClient.cancelProcessing`. | `runProcessingCancellationWorkflow(...)` through status-panel controller. | Cancel-all success/failure, per-job cancel success/failure. `bun run test -- src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts` |
 
-Public-strip impact for these owners is intentionally narrow: callers keep the
-existing UI/runtime Promise or synchronous wrapper shape unless a milestone
+Public API Strip impact for these owners is intentionally narrow: callers keep
+existing UI/runtime Promise or synchronous wrapper shapes unless a milestone
 explicitly accepts a public API change.
 
 ## Future Workflow Ingress

--- a/src/ui/__tests__/fileList-reorder-behavior.test.ts
+++ b/src/ui/__tests__/fileList-reorder-behavior.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AudioFile, FileListInfo } from '../../types/audio';
-import { appendFileList, displayFileList, moveFileUp } from '../fileList/actions';
+import {
+	appendFileList,
+	displayFileList,
+	moveFileDown,
+	moveFileUp,
+	reorderFiles,
+	toggleFileSort,
+} from '../fileList/actions';
 import { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/metadataStaging';
 import { inspectorState } from '../fileList/inspectorState.svelte';
 import { showSingleSelection } from '../fileList/metadataPanel';
@@ -10,6 +17,7 @@ import {
 	setCurrentFileList,
 	setSelectedFileIndices,
 	setSelectedIndex,
+	setSortAscending,
 } from '../fileList/state.svelte';
 import { resetFileListViewState } from '../fileList/viewState.svelte';
 
@@ -34,6 +42,7 @@ const context = vi.hoisted(() => ({
 	pushStatusPanelTransientStatusMock: vi.fn(),
 	renderAutoResolutionHintsMock: vi.fn(),
 	resetAutoResolutionHintsMock: vi.fn(),
+	validationErrorMock: vi.fn<() => string | null>(() => null),
 	validateMetadataDraftIntentMock: vi.fn(async (metadata: Record<string, unknown>) => ({
 		intentPatch: Object.fromEntries(
 			Object.entries(metadata).map(([key, value]) => [key, { op: 'set', value }]),
@@ -84,7 +93,7 @@ vi.mock('../statusPanel', () => ({
 }));
 
 vi.mock('../metadataValidation', () => ({
-	firstMetadataIntentValidationError: vi.fn(() => null),
+	firstMetadataIntentValidationError: context.validationErrorMock,
 	validateMetadataDraftIntent: context.validateMetadataDraftIntentMock,
 }));
 
@@ -151,10 +160,13 @@ describe('file list reorder behavior', () => {
 		context.pushStatusPanelTransientStatusMock.mockReset();
 		context.renderAutoResolutionHintsMock.mockReset();
 		context.resetAutoResolutionHintsMock.mockReset();
+		context.validationErrorMock.mockReset();
+		context.validationErrorMock.mockReturnValue(null);
 		context.getMetadataForFileMock.mockReturnValue({});
 		setCurrentFileList(null);
 		setSelectedFileIndices([]);
 		setSelectedIndex(-1);
+		setSortAscending(true);
 		resetFileListViewState();
 	});
 
@@ -168,11 +180,57 @@ describe('file list reorder behavior', () => {
 		setSelectedIndex(1);
 
 		await showSingleSelection(beta);
+		context.populateMetadataFormSingleMock.mockClear();
+		context.resetDirtyStateMock.mockClear();
 		moveFileUp(1);
 
 		expect(getSelectedFileIndex()).toBe(0);
 		expect(inspectorState.contextText).toBe('beta.m4b');
 		expect(inspectorState.contextDetail).toBe('1 of 3');
+		expect(context.populateMetadataFormSingleMock).not.toHaveBeenCalled();
+		expect(context.resetDirtyStateMock).not.toHaveBeenCalled();
+	});
+
+	it('keeps the metadata form intact after moving a selected file down', async () => {
+		const alpha = makeFile('/books/alpha.m4b');
+		const beta = makeFile('/books/beta.m4b');
+		const gamma = makeFile('/books/gamma.m4b');
+
+		setCurrentFileList(makeFileList(alpha, beta, gamma));
+		setSelectedFileIndices([1]);
+		setSelectedIndex(1);
+
+		await showSingleSelection(beta);
+		context.populateMetadataFormSingleMock.mockClear();
+		context.resetDirtyStateMock.mockClear();
+		moveFileDown(1);
+
+		expect(getSelectedFileIndex()).toBe(2);
+		expect(inspectorState.contextText).toBe('beta.m4b');
+		expect(inspectorState.contextDetail).toBe('3 of 3');
+		expect(context.populateMetadataFormSingleMock).not.toHaveBeenCalled();
+		expect(context.resetDirtyStateMock).not.toHaveBeenCalled();
+	});
+
+	it('keeps the metadata form intact after drag-reordering a selected file', async () => {
+		const alpha = makeFile('/books/alpha.m4b');
+		const beta = makeFile('/books/beta.m4b');
+		const gamma = makeFile('/books/gamma.m4b');
+
+		setCurrentFileList(makeFileList(alpha, beta, gamma));
+		setSelectedFileIndices([0]);
+		setSelectedIndex(0);
+
+		await showSingleSelection(alpha);
+		context.populateMetadataFormSingleMock.mockClear();
+		context.resetDirtyStateMock.mockClear();
+		reorderFiles(0, 2);
+
+		expect(getSelectedFileIndex()).toBe(2);
+		expect(inspectorState.contextText).toBe('alpha.m4b');
+		expect(inspectorState.contextDetail).toBe('3 of 3');
+		expect(context.populateMetadataFormSingleMock).not.toHaveBeenCalled();
+		expect(context.resetDirtyStateMock).not.toHaveBeenCalled();
 	});
 
 	it('selects a sole imported file when a new file list is displayed', async () => {
@@ -235,6 +293,60 @@ describe('file list reorder behavior', () => {
 		expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual([
 			'/books/alpha.m4b',
 			'/books/beta.m4b',
+		]);
+	});
+
+	it('stages selected metadata drafts before sorting and clearing selection', async () => {
+		const alpha = makeFile('/books/a-alpha.m4b');
+		const beta = makeFile('/books/b-beta.m4b');
+
+		setCurrentFileList(makeFileList(alpha, beta));
+		setSelectedFileIndices([0, 1]);
+		setSelectedIndex(0);
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
+		context.readMetadataFormMock.mockReturnValue({ series: 'Sorted Series' });
+
+		await toggleFileSort();
+
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
+			'/books/a-alpha.m4b',
+			{ series: 'Sorted Series' },
+			expect.objectContaining({ markPending: true }),
+		);
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
+			'/books/b-beta.m4b',
+			{ series: 'Sorted Series' },
+			expect.objectContaining({ markPending: true }),
+		);
+		expect(getSelectedFileIndex()).toBe(-1);
+		expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual([
+			'/books/b-beta.m4b',
+			'/books/a-alpha.m4b',
+		]);
+	});
+
+	it('blocks sorting when selected metadata drafts fail validation', async () => {
+		const alpha = makeFile('/books/b-alpha.m4b');
+		const beta = makeFile('/books/a-beta.m4b');
+
+		setCurrentFileList(makeFileList(alpha, beta));
+		setSelectedFileIndices([0, 1]);
+		setSelectedIndex(0);
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
+		context.readMetadataFormMock.mockReturnValue({ seriesPart: 'bad' });
+		context.validationErrorMock.mockReturnValue('Series part must be a number');
+
+		await toggleFileSort();
+
+		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
+		expect(context.pushStatusPanelTransientStatusMock).toHaveBeenCalledWith(
+			'Fix metadata validation errors before sorting files.',
+			expect.objectContaining({ ttlMs: 2500 }),
+		);
+		expect(getSelectedFileIndex()).toBe(0);
+		expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual([
+			'/books/b-alpha.m4b',
+			'/books/a-beta.m4b',
 		]);
 	});
 });

--- a/src/ui/__tests__/fileList-reorder-mirror.test.ts
+++ b/src/ui/__tests__/fileList-reorder-mirror.test.ts
@@ -69,6 +69,7 @@ vi.mock('../fileList/metadataPanel', async () => {
 				.map((index) => fileList.files[index])
 				.filter((file): file is AudioFile => Boolean(file));
 		},
+		refreshSelectionPresentation: vi.fn(),
 		showMultiSelection: vi.fn(async () => undefined),
 		showSingleSelection: vi.fn(async () => undefined),
 	};

--- a/src/ui/__tests__/fileList-selectFile-transition.test.ts
+++ b/src/ui/__tests__/fileList-selectFile-transition.test.ts
@@ -3,10 +3,12 @@ import type { FileListInfo } from '../../types/audio';
 import { setCurrentFileList, setSelectedIndex } from '../fileList/state.svelte';
 
 const context = vi.hoisted(() => ({
-	readMetadataFormMock: vi.fn(() => ({ title: 'Persisted Title' })),
+	readMetadataFormMock: vi.fn<() => Record<string, unknown>>(() => ({ title: 'Persisted Title' })),
 	setMetadataForFileMock: vi.fn(),
 	getSelectedFilesMock: vi.fn(),
 	handleSelectionMock: vi.fn(() => ({ changed: true })),
+	selectAllFilesMock: vi.fn(() => true),
+	showMultiSelectionMock: vi.fn(),
 	showSingleSelectionMock: vi.fn(),
 	pushStatusPanelTransientStatusMock: vi.fn(),
 	validationErrorMock: vi.fn<() => string | null>(() => null),
@@ -63,7 +65,7 @@ vi.mock('../fileList/selection', () => ({
 	handleSelection: context.handleSelectionMock,
 	reindexSelectionAfterMove: vi.fn(),
 	reindexSelectionAfterRemoval: vi.fn(),
-	selectAllFiles: vi.fn(() => true),
+	selectAllFiles: context.selectAllFilesMock,
 	swapSelectionIndices: vi.fn(),
 }));
 
@@ -72,7 +74,8 @@ vi.mock('../fileList/metadataPanel', () => ({
 	clearSelectionPanels: vi.fn(),
 	ensureMetadataForFiles: vi.fn(async () => undefined),
 	getSelectedFiles: context.getSelectedFilesMock,
-	showMultiSelection: vi.fn(async () => undefined),
+	refreshSelectionPresentation: vi.fn(),
+	showMultiSelection: context.showMultiSelectionMock,
 	showSingleSelection: context.showSingleSelectionMock,
 }));
 
@@ -123,6 +126,8 @@ describe('selectFile transition options', () => {
 		context.readMetadataFormMock.mockClear();
 		context.setMetadataForFileMock.mockClear();
 		context.handleSelectionMock.mockClear();
+		context.selectAllFilesMock.mockClear();
+		context.showMultiSelectionMock.mockClear();
 		context.showSingleSelectionMock.mockClear();
 		context.pushStatusPanelTransientStatusMock.mockClear();
 		context.validationErrorMock.mockReset();
@@ -187,5 +192,33 @@ describe('selectFile transition options', () => {
 			'Fix metadata validation errors before clearing the selection.',
 			expect.objectContaining({ ttlMs: 2500 }),
 		);
+	});
+
+	it('stages dirty multi-selection metadata before selecting all files', async () => {
+		context.readMetadataFormMock.mockReturnValue({ series: 'Draft Series' });
+		context.getSelectedFilesMock.mockReturnValue([
+			{ path: '/books/alpha.m4b', isValid: true },
+			{ path: '/books/beta.m4b', isValid: true },
+		]);
+		const { selectAll } = await import('../fileList/actions');
+
+		await selectAll();
+
+		expect(context.readMetadataFormMock).toHaveBeenCalledWith({
+			mode: 'multi',
+			onlyDirty: true,
+		});
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
+			'/books/alpha.m4b',
+			{ series: 'Draft Series' },
+			expect.objectContaining({ markPending: true }),
+		);
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
+			'/books/beta.m4b',
+			{ series: 'Draft Series' },
+			expect.objectContaining({ markPending: true }),
+		);
+		expect(context.selectAllFilesMock).toHaveBeenCalledTimes(1);
+		expect(context.showMultiSelectionMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/ui/__tests__/order-lock-lifecycle.test.ts
+++ b/src/ui/__tests__/order-lock-lifecycle.test.ts
@@ -56,6 +56,7 @@ vi.mock('../fileList/metadataPanel', () => ({
 	clearSelectionPanels: vi.fn(),
 	ensureMetadataForFiles: vi.fn(async () => undefined),
 	getSelectedFiles: vi.fn(() => []),
+	refreshSelectionPresentation: vi.fn(),
 	showMultiSelection: vi.fn(async () => undefined),
 	showSingleSelection: vi.fn(async () => undefined),
 }));

--- a/src/ui/appSettings/AGENTS.md
+++ b/src/ui/appSettings/AGENTS.md
@@ -10,7 +10,7 @@
 - Files: `hydration.ts`, `persistence.ts`, `appSettings.test.ts`, `AGENTS.md`.
 - The cluster coordinates durable preference hydration/persistence through
   `tauriClient` while leaving runtime request ownership in the job controls,
-  encoder panel, and output panel public strips.
+  encoder panel, and output panel Public API Strips.
 
 ## Allowed Agent Edits Without Escalation
 
@@ -24,6 +24,6 @@
 
 - Bypassing `tauriClient` for settings commands.
 - Importing private panel internals from outside this cluster's hydration
-  coordinator instead of using the owning panel public strips.
+  coordinator instead of using the owning panel Public API Strips.
 - Making App Settings apply runtime behavior directly instead of asking the
   owning runtime/control module to accept the change first.

--- a/src/ui/core/__tests__/metadataSaveWorkflow.test.ts
+++ b/src/ui/core/__tests__/metadataSaveWorkflow.test.ts
@@ -254,6 +254,28 @@ describe('MetadataSaveWorkflow', () => {
 		expect(harness.getSaveInProgress()).toBe(false);
 	});
 
+	it('uses prepared entries without rerunning entry gates', async () => {
+		const preparedFileList = defaultFileList();
+		const harness = makeHarness({ fileList: null });
+
+		await runMetadataSaveWorkflow(harness.layer, { fileList: preparedFileList });
+
+		expect(harness.mocks.getCurrentFileList).not.toHaveBeenCalled();
+		expect(harness.mocks.initStatusPanel).not.toHaveBeenCalled();
+		expect(harness.mocks.isStatusPanelProcessing).not.toHaveBeenCalled();
+		expect(harness.mocks.isMetadataSaveInProgress).not.toHaveBeenCalled();
+		expect(harness.mocks.pushStatusPanelTransientStatus).not.toHaveBeenCalledWith(
+			'Preparing metadata save...',
+			expect.anything(),
+		);
+		expect(harness.mocks.saveMetadataBatch).toHaveBeenCalledWith([
+			{ filePath: '/books/a.m4b', metadataPatch: titlePatch('A') },
+			{ filePath: '/books/b.m4b', metadataPatch: titlePatch('B') },
+		]);
+		expect(harness.mocks.setMetadataSaveInProgress).toHaveBeenCalledTimes(1);
+		expect(harness.mocks.setMetadataSaveInProgress).toHaveBeenCalledWith(false);
+	});
+
 	it('leaves failed and cancelled entries pending while reporting failed entries', async () => {
 		const fileList = fileListFromEntries([
 			{ path: '/books/a.m4b', isValid: true },

--- a/src/ui/core/metadataSaveWorkflow.ts
+++ b/src/ui/core/metadataSaveWorkflow.ts
@@ -132,7 +132,7 @@ function resetInProgressWhenNeeded(
 	});
 }
 
-export function enterMetadataSaveWorkflow(
+function resolveMetadataSaveEntry(
 	services: MetadataSaveWorkflowEntryServices,
 ): PreparedMetadataSaveWorkflowEntry | null {
 	const fileList = services.getCurrentFileList();
@@ -160,6 +160,12 @@ export function enterMetadataSaveWorkflow(
 	return { fileList };
 }
 
+export function enterMetadataSaveWorkflow(
+	services: MetadataSaveWorkflowEntryServices,
+): PreparedMetadataSaveWorkflowEntry | null {
+	return resolveMetadataSaveEntry(services);
+}
+
 function prepareMetadataSaveWorkflowEntry(
 	state: MetadataSaveRunState,
 	preparedEntry: PreparedMetadataSaveWorkflowEntry | undefined,
@@ -171,57 +177,15 @@ function prepareMetadataSaveWorkflowEntry(
 		}
 
 		const services = yield* MetadataSaveWorkflowServicesTag;
-		const fileList = yield* workflowSync(
-			() => services.getCurrentFileList(),
-			'Failed to read current file list.',
+		const entry = yield* workflowSync(
+			() => resolveMetadataSaveEntry(services),
+			'Failed to prepare metadata save entry.',
 		);
-		if (!fileList?.files.length) {
-			yield* workflowSync(
-				() => services.console.log('No files loaded - nothing to save'),
-				'Failed to report metadata save status.',
-			);
+		if (!entry) {
 			return null;
 		}
-
-		yield* workflowSync(() => services.initStatusPanel(), 'Failed to initialize status panel.');
-		const isProcessing = yield* workflowSync(
-			() => services.isStatusPanelProcessing(),
-			'Failed to read status panel processing state.',
-		);
-		if (isProcessing) {
-			yield* workflowSync(
-				() => services.console.log('Processing in progress - cannot save metadata now'),
-				'Failed to report metadata save status.',
-			);
-			return null;
-		}
-
-		yield* workflowSync(
-			() => services.pushStatusPanelTransientStatus('Preparing metadata save...', { ttlMs: 1_000 }),
-			'Failed to report metadata save preparation.',
-		);
-
-		const isSaveInProgress = yield* workflowSync(
-			() => services.isMetadataSaveInProgress(),
-			'Failed to read metadata save state.',
-		);
-		if (isSaveInProgress) {
-			yield* workflowSync(
-				() =>
-					services.pushStatusPanelTransientStatus('Save already in progress...', {
-						ttlMs: 1_500,
-					}),
-				'Failed to report metadata save status.',
-			);
-			return null;
-		}
-
-		yield* workflowSync(
-			() => services.setMetadataSaveInProgress(true),
-			'Failed to enter metadata save state.',
-		);
 		state.enteredSave = true;
-		return fileList;
+		return entry.fileList;
 	});
 }
 

--- a/src/ui/encoderPanel/AGENTS.md
+++ b/src/ui/encoderPanel/AGENTS.md
@@ -14,7 +14,7 @@
 ## Allowed Agent Edits Without Escalation
 - Change internals when focused encoder panel tests stay green; run
   `bun scripts/proof/runner.ts focus frontend` before handoff and `bun scripts/proof/runner.ts focus runtime`
-  when public-strip or runtime contract surfaces change.
+  when the Public API Strip or runtime contract surfaces change.
 - Keep process-boundary encoding config reads behind `readEncodingRequestConfig`.
 - Keep App Settings hydration/persistence coordination behind
   `applyEncodingDefaults` and `readEncoderDefaultsFromState`; do not let other

--- a/src/ui/fileImport/FileImportIsland.svelte
+++ b/src/ui/fileImport/FileImportIsland.svelte
@@ -61,7 +61,7 @@
 	}
 
 	function handleSortClick(): void {
-		toggleFileSort();
+		void toggleFileSort();
 	}
 
 	function handleClearClick(): void {

--- a/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
+++ b/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
@@ -5,6 +5,7 @@ import type { FileListAppendResult } from '../../fileList/appendResult';
 import {
 	importAnalysisWorkflowExecution,
 	makeImportAnalysisWorkflowServicesLayer,
+	runImportAnalysisWorkflow,
 	type ImportAnalysisWorkflowServices,
 } from '../importAnalysisWorkflow';
 
@@ -322,5 +323,84 @@ describe('ImportAnalysisWorkflow', () => {
 			'No new files added. All analyzed files were already in the list.',
 		);
 		expect(harness.services.clearFileImportError).not.toHaveBeenCalled();
+	});
+
+	it('appends prepared analyzed file lists through the same staging path', async () => {
+		const existingFiles = [audioFile('/books/existing.m4b')];
+		const analyzed = fileListInfo([audioFile('/books/new.m4b')]);
+		const harness = makeHarness();
+
+		await runImportAnalysisWorkflow(
+			{ type: 'importPaths', paths: [], existingFiles: [] },
+			harness.layer,
+			{
+				type: 'analyzeFiles',
+				fileListInfo: Promise.resolve(analyzed),
+				existingFiles,
+			},
+		);
+
+		expect(harness.services.persistPendingMetadataDraftsForCurrentSelection).toHaveBeenCalledTimes(
+			1,
+		);
+		expect(harness.services.appendFileList).toHaveBeenCalledWith(analyzed, {
+			existingFiles,
+			showDuplicateStatus: false,
+		});
+		expect(harness.services.clearFileImportError).toHaveBeenCalledTimes(1);
+	});
+
+	it('preserves duplicate-only feedback for prepared analyzed file lists', async () => {
+		const existingFiles = [audioFile('/books/existing.m4b')];
+		const analyzed = fileListInfo([audioFile('/books/existing.m4b')]);
+		const harness = makeHarness({
+			appendFileList: vi.fn(() => appendResult('duplicateOnly', analyzed.files)),
+		});
+
+		await runImportAnalysisWorkflow(
+			{ type: 'importPaths', paths: [], existingFiles: [] },
+			harness.layer,
+			{
+				type: 'analyzeFiles',
+				fileListInfo: Promise.resolve(analyzed),
+				existingFiles,
+			},
+		);
+
+		expect(harness.services.appendFileList).toHaveBeenCalledWith(analyzed, {
+			existingFiles,
+			showDuplicateStatus: false,
+		});
+		expect(harness.services.pushStatusPanelTransientStatus).toHaveBeenCalledWith(
+			'No new files added. All analyzed files were already in the list.',
+			{ ttlMs: 2000 },
+		);
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'No new files added. All analyzed files were already in the list.',
+		);
+		expect(harness.services.clearFileImportError).not.toHaveBeenCalled();
+	});
+
+	it('reports rejected prepared analysis without appending files', async () => {
+		const cause = new Error('prepared analysis failed');
+		const harness = makeHarness();
+
+		await runImportAnalysisWorkflow(
+			{ type: 'importPaths', paths: [], existingFiles: [] },
+			harness.layer,
+			{
+				type: 'analyzeFiles',
+				fileListInfo: new Promise<FileListInfo>((_, reject) => {
+					setTimeout(() => reject(cause), 0);
+				}),
+				existingFiles: [],
+			},
+		);
+
+		expect(harness.services.appendFileList).not.toHaveBeenCalled();
+		expect(harness.services.console.error).toHaveBeenCalledWith('Failed to analyze files:', cause);
+		expect(harness.services.setFileImportError).toHaveBeenCalledWith(
+			'Failed to analyze files. Please try again.',
+		);
 	});
 });

--- a/src/ui/fileImport/importAnalysisWorkflow.ts
+++ b/src/ui/fileImport/importAnalysisWorkflow.ts
@@ -5,8 +5,19 @@ import {
 	runAppEffect,
 	workflowTryPromise,
 } from '../../lib/effect/appEffect';
-import type { AudioFile, FileListInfo, SupportedAudioImportMetadata } from '../../types/audio';
+import type { AudioFile, FileListInfo } from '../../types/audio';
 import { ImportAnalysisWorkflowLive } from './importAnalysisWorkflowLive';
+import {
+	duplicateOnlyImportMessage,
+	importOrderLockedMessage,
+	reportAnalysisFailure,
+	reportImportDiscoveryFailure,
+	reportImportMetadataFailure,
+	reportMetadataStagingFailure,
+	reportOpenFileDialogFailure,
+	reportOpenFolderDialogFailure,
+	unsupportedImportMessage,
+} from './importAnalysisWorkflowFeedback';
 import {
 	ImportAnalysisWorkflowServicesTag,
 	type ImportAnalysisWorkflowAction,
@@ -14,6 +25,8 @@ import {
 	type ImportAnalysisWorkflowServices,
 	type ImportAnalysisWorkflowServicesId,
 } from './importAnalysisWorkflowServices';
+
+export { importOrderLockedMessage } from './importAnalysisWorkflowFeedback';
 
 export {
 	ImportAnalysisWorkflowServicesTag,
@@ -64,74 +77,6 @@ function workflowPromise<A>(
 	return workflowTryPromise(evaluate, message, workflowFailure);
 }
 
-export function importOrderLockedMessage(): string {
-	return 'Order locked while processing. Wait for completion to add files.';
-}
-
-function unsupportedImportMessage(metadata: SupportedAudioImportMetadata): string {
-	return `No supported audio files found. Please use ${metadata.formatsText} files.`;
-}
-
-function reportAnalysisFailure(
-	services: ImportAnalysisWorkflowServices,
-	cause: unknown,
-): FileListInfo | null {
-	services.console.error('Failed to analyze files:', cause);
-	services.setFileImportError('Failed to analyze files. Please try again.');
-	return null;
-}
-
-function reportMetadataStagingFailure(
-	services: ImportAnalysisWorkflowServices,
-	cause: unknown,
-): false {
-	services.console.error('Failed to stage metadata drafts:', cause);
-	services.setFileImportError(
-		'Failed to prepare metadata drafts before adding files. Please try again.',
-	);
-	return false;
-}
-
-function reportOpenFileDialogFailure(
-	services: ImportAnalysisWorkflowServices,
-	cause: unknown,
-): null {
-	services.console.error('Failed to open file dialog:', cause);
-	services.setFileImportError('Failed to open file dialog. Please try again.');
-	return null;
-}
-
-function reportOpenFolderDialogFailure(
-	services: ImportAnalysisWorkflowServices,
-	cause: unknown,
-): null {
-	services.console.error('Failed to open folder dialog:', cause);
-	services.setFileImportError('Failed to open folder dialog. Please try again.');
-	return null;
-}
-
-function reportImportDiscoveryFailure(
-	services: ImportAnalysisWorkflowServices,
-	cause: unknown,
-): string[] | null {
-	services.console.error('Failed to discover audio files:', cause);
-	services.setFileImportError('Failed to discover audio files. Please try again.');
-	return null;
-}
-
-function reportImportMetadataFailure(
-	services: ImportAnalysisWorkflowServices,
-	cause: unknown,
-): SupportedAudioImportMetadata | null {
-	services.console.error('Failed to load supported audio import metadata:', cause);
-	services.setFileImportError('Failed to load supported audio formats. Please try again.');
-	return null;
-}
-
-function duplicateOnlyImportMessage(): string {
-	return 'No new files added. All analyzed files were already in the list.';
-}
-
 function appendAnalyzedFiles(
 	services: ImportAnalysisWorkflowServices,
 	fileListInfo: FileListInfo,
@@ -149,6 +94,68 @@ function appendAnalyzedFiles(
 	return appendResult.outcome;
 }
 
+function analyzeFileListInfo(
+	services: ImportAnalysisWorkflowServices,
+	evaluate: () => ReturnType<ImportAnalysisWorkflowServices['analyzeAudioFiles']>,
+): AppEffect<FileListInfo | null, never> {
+	return workflowPromise(evaluate, 'Failed to analyze files.').pipe(
+		Effect.catchAll((error) =>
+			Effect.sync(() => {
+				return reportAnalysisFailure(services, error.cause);
+			}),
+		),
+	);
+}
+
+function stagePendingMetadataDrafts(
+	services: ImportAnalysisWorkflowServices,
+): AppEffect<boolean, never> {
+	return workflowPromise(
+		() => services.persistPendingMetadataDraftsForCurrentSelection(),
+		'Failed to stage metadata drafts before import.',
+	).pipe(
+		Effect.catchAll((error) =>
+			Effect.sync(() => {
+				return reportMetadataStagingFailure(services, error.cause);
+			}),
+		),
+	);
+}
+
+function stageAndAppendAnalyzedFiles(
+	services: ImportAnalysisWorkflowServices,
+	fileListInfo: FileListInfo,
+	existingFiles: AudioFile[],
+): AppEffect<void, never> {
+	return Effect.gen(function* () {
+		const staged = yield* stagePendingMetadataDrafts(services);
+		if (!staged) {
+			services.setFileImportError('Fix metadata validation errors before adding files.');
+			return;
+		}
+
+		const appendOutcome = appendAnalyzedFiles(services, fileListInfo, existingFiles);
+		if (appendOutcome !== 'duplicateOnly') {
+			services.clearFileImportError();
+		}
+	});
+}
+
+function processAnalyzedFileList(
+	evaluateFileListInfo: () => ReturnType<ImportAnalysisWorkflowServices['analyzeAudioFiles']>,
+	existingFiles: AudioFile[],
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		const fileListInfo = yield* analyzeFileListInfo(services, evaluateFileListInfo);
+		if (!fileListInfo) {
+			return;
+		}
+
+		yield* stageAndAppendAnalyzedFiles(services, fileListInfo, existingFiles);
+	});
+}
+
 function processFilePaths(
 	filePaths: string[],
 	existingFiles: AudioFile[],
@@ -159,39 +166,7 @@ function processFilePaths(
 		}
 
 		const services = yield* ImportAnalysisWorkflowServicesTag;
-		const fileListInfo = yield* workflowPromise(
-			() => services.analyzeAudioFiles(filePaths),
-			'Failed to analyze files.',
-		).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					return reportAnalysisFailure(services, error.cause);
-				}),
-			),
-		);
-		if (!fileListInfo) {
-			return;
-		}
-
-		const staged = yield* workflowPromise(
-			() => services.persistPendingMetadataDraftsForCurrentSelection(),
-			'Failed to stage metadata drafts before import.',
-		).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					return reportMetadataStagingFailure(services, error.cause);
-				}),
-			),
-		);
-		if (!staged) {
-			services.setFileImportError('Fix metadata validation errors before adding files.');
-			return;
-		}
-
-		const appendOutcome = appendAnalyzedFiles(services, fileListInfo, existingFiles);
-		if (appendOutcome !== 'duplicateOnly') {
-			services.clearFileImportError();
-		}
+		yield* processAnalyzedFileList(() => services.analyzeAudioFiles(filePaths), existingFiles);
 	});
 }
 
@@ -261,42 +236,7 @@ function processPreparedFileList(
 	fileListInfoPromise: ReturnType<ImportAnalysisWorkflowServices['analyzeAudioFiles']>,
 	existingFiles: AudioFile[],
 ): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
-	return Effect.gen(function* () {
-		const services = yield* ImportAnalysisWorkflowServicesTag;
-		const fileListInfo = yield* workflowPromise(
-			() => fileListInfoPromise,
-			'Failed to analyze files.',
-		).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					return reportAnalysisFailure(services, error.cause);
-				}),
-			),
-		);
-		if (!fileListInfo) {
-			return;
-		}
-
-		const staged = yield* workflowPromise(
-			() => services.persistPendingMetadataDraftsForCurrentSelection(),
-			'Failed to stage metadata drafts before import.',
-		).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					return reportMetadataStagingFailure(services, error.cause);
-				}),
-			),
-		);
-		if (!staged) {
-			services.setFileImportError('Fix metadata validation errors before adding files.');
-			return;
-		}
-
-		const appendOutcome = appendAnalyzedFiles(services, fileListInfo, existingFiles);
-		if (appendOutcome !== 'duplicateOnly') {
-			services.clearFileImportError();
-		}
-	});
+	return processAnalyzedFileList(() => fileListInfoPromise, existingFiles);
 }
 
 function clickToSelect(
@@ -309,20 +249,7 @@ function clickToSelect(
 			return;
 		}
 
-		const selected = yield* workflowPromise(
-			() => openSupportedAudioFiles(services),
-			'Failed to open file dialog.',
-		).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					return reportOpenFileDialogFailure(services, error.cause);
-				}),
-			),
-		);
-
-		if (Array.isArray(selected) && selected.length > 0) {
-			yield* discoverAndProcessPaths(selected, existingFiles);
-		}
+		yield* processSelectedFiles(services, () => openSupportedAudioFiles(services), existingFiles);
 	});
 }
 
@@ -336,20 +263,7 @@ function clickToSelectFolder(
 			return;
 		}
 
-		const selected = yield* workflowPromise(
-			() => services.openDirectory(),
-			'Failed to open folder dialog.',
-		).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					return reportOpenFolderDialogFailure(services, error.cause);
-				}),
-			),
-		);
-
-		if (selected) {
-			yield* discoverAndProcessPaths([selected], existingFiles);
-		}
+		yield* processSelectedFolder(services, () => services.openDirectory(), existingFiles);
 	});
 }
 
@@ -368,13 +282,14 @@ function openSupportedAudioFiles(
 	);
 }
 
-function clickToSelectFromPrepared(
-	preparedEntry: Extract<PreparedImportAnalysisWorkflowEntry, { type: 'openFiles' }>,
+function processSelectedFiles(
+	services: ImportAnalysisWorkflowServices,
+	evaluateSelectedPaths: () => ReturnType<ImportAnalysisWorkflowServices['openFiles']>,
+	existingFiles: AudioFile[],
 ): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
 	return Effect.gen(function* () {
-		const services = yield* ImportAnalysisWorkflowServicesTag;
 		const selected = yield* workflowPromise(
-			() => preparedEntry.selectedPaths,
+			evaluateSelectedPaths,
 			'Failed to open file dialog.',
 		).pipe(
 			Effect.catchAll((error) =>
@@ -385,18 +300,19 @@ function clickToSelectFromPrepared(
 		);
 
 		if (Array.isArray(selected) && selected.length > 0) {
-			yield* discoverAndProcessPaths(selected, preparedEntry.existingFiles);
+			yield* discoverAndProcessPaths(selected, existingFiles);
 		}
 	});
 }
 
-function clickToSelectFolderFromPrepared(
-	preparedEntry: Extract<PreparedImportAnalysisWorkflowEntry, { type: 'openDirectory' }>,
+function processSelectedFolder(
+	services: ImportAnalysisWorkflowServices,
+	evaluateSelectedPath: () => ReturnType<ImportAnalysisWorkflowServices['openDirectory']>,
+	existingFiles: AudioFile[],
 ): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
 	return Effect.gen(function* () {
-		const services = yield* ImportAnalysisWorkflowServicesTag;
 		const selected = yield* workflowPromise(
-			() => preparedEntry.selectedPath,
+			evaluateSelectedPath,
 			'Failed to open folder dialog.',
 		).pipe(
 			Effect.catchAll((error) =>
@@ -407,8 +323,34 @@ function clickToSelectFolderFromPrepared(
 		);
 
 		if (selected) {
-			yield* discoverAndProcessPaths([selected], preparedEntry.existingFiles);
+			yield* discoverAndProcessPaths([selected], existingFiles);
 		}
+	});
+}
+
+function clickToSelectFromPrepared(
+	preparedEntry: Extract<PreparedImportAnalysisWorkflowEntry, { type: 'openFiles' }>,
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		yield* processSelectedFiles(
+			services,
+			() => preparedEntry.selectedPaths,
+			preparedEntry.existingFiles,
+		);
+	});
+}
+
+function clickToSelectFolderFromPrepared(
+	preparedEntry: Extract<PreparedImportAnalysisWorkflowEntry, { type: 'openDirectory' }>,
+): AppEffect<void, never, ImportAnalysisWorkflowServicesId> {
+	return Effect.gen(function* () {
+		const services = yield* ImportAnalysisWorkflowServicesTag;
+		yield* processSelectedFolder(
+			services,
+			() => preparedEntry.selectedPath,
+			preparedEntry.existingFiles,
+		);
 	});
 }
 

--- a/src/ui/fileImport/importAnalysisWorkflowFeedback.ts
+++ b/src/ui/fileImport/importAnalysisWorkflowFeedback.ts
@@ -1,0 +1,70 @@
+import type { FileListInfo, SupportedAudioImportMetadata } from '../../types/audio';
+import type { ImportAnalysisWorkflowServices } from './importAnalysisWorkflowServices';
+
+export function importOrderLockedMessage(): string {
+	return 'Order locked while processing. Wait for completion to add files.';
+}
+
+export function unsupportedImportMessage(metadata: SupportedAudioImportMetadata): string {
+	return `No supported audio files found. Please use ${metadata.formatsText} files.`;
+}
+
+export function reportAnalysisFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): FileListInfo | null {
+	services.console.error('Failed to analyze files:', cause);
+	services.setFileImportError('Failed to analyze files. Please try again.');
+	return null;
+}
+
+export function reportMetadataStagingFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): false {
+	services.console.error('Failed to stage metadata drafts:', cause);
+	services.setFileImportError(
+		'Failed to prepare metadata drafts before adding files. Please try again.',
+	);
+	return false;
+}
+
+export function reportOpenFileDialogFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): null {
+	services.console.error('Failed to open file dialog:', cause);
+	services.setFileImportError('Failed to open file dialog. Please try again.');
+	return null;
+}
+
+export function reportOpenFolderDialogFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): null {
+	services.console.error('Failed to open folder dialog:', cause);
+	services.setFileImportError('Failed to open folder dialog. Please try again.');
+	return null;
+}
+
+export function reportImportDiscoveryFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): string[] | null {
+	services.console.error('Failed to discover audio files:', cause);
+	services.setFileImportError('Failed to discover audio files. Please try again.');
+	return null;
+}
+
+export function reportImportMetadataFailure(
+	services: ImportAnalysisWorkflowServices,
+	cause: unknown,
+): SupportedAudioImportMetadata | null {
+	services.console.error('Failed to load supported audio import metadata:', cause);
+	services.setFileImportError('Failed to load supported audio formats. Please try again.');
+	return null;
+}
+
+export function duplicateOnlyImportMessage(): string {
+	return 'No new files added. All analyzed files were already in the list.';
+}

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -35,6 +35,7 @@ import {
 	autoUpdateCoverArtFromFirstValidFile,
 	clearSelectionPanels,
 	getSelectedFiles,
+	refreshSelectionPresentation,
 	showMultiSelection,
 	showSingleSelection,
 } from './metadataPanel';
@@ -43,7 +44,7 @@ import {
 	normalizeFileListInfo,
 	type FileListAppendResult,
 } from './appendResult';
-import { persistSingleSelectionMetadata, stageMetadataToSelection } from './metadataStaging';
+import { preserveMetadataDraftsBeforeSelectionChange } from './metadataStaging';
 
 function refreshOutputForFileListChange(): void {
 	updateEstimatedSize();
@@ -51,10 +52,6 @@ function refreshOutputForFileListChange(): void {
 
 function setTransientStatusMessage(message: string, timeoutMs: number = 2000): void {
 	pushStatusPanelTransientStatus(message, { ttlMs: timeoutMs });
-}
-
-function setStatusMessage(message: string): void {
-	pushStatusPanelTransientStatus(message, { ttlMs: 2_500 });
 }
 
 function selectSoleImportedFile(fileList: FileListInfo): void {
@@ -130,27 +127,13 @@ export async function selectFile(
 		return;
 	}
 
-	const previousSelectionCount = getSelectedFiles().length;
-	const previousSelectedFiles = previousSelectionCount > 1 ? getSelectedFiles() : [];
-	const previousIndex = getSelectedFileIndex();
-	const previousFile =
-		previousSelectionCount === 1 ? (fileList.files[previousIndex] ?? null) : null;
-
-	if (previousSelectionCount === 1 && previousIndex >= 0 && !options?.skipPersistPrevious) {
-		if (!(await persistSingleSelectionMetadata(previousFile))) {
-			return;
-		}
-	}
-
-	if (previousSelectionCount > 1) {
-		const didStage = await stageMetadataToSelection({
-			showStatus: false,
-			selectedFilesOverride: previousSelectedFiles,
-		});
-		if (!didStage) {
-			setStatusMessage('Fix metadata validation errors before changing selection.');
-			return;
-		}
+	if (
+		!(await preserveMetadataDraftsBeforeSelectionChange({
+			skipSingleSelection: options?.skipPersistPrevious,
+			validationFailureMessage: 'Fix metadata validation errors before changing selection.',
+		}))
+	) {
+		return;
 	}
 
 	const selectionResult = handleSelection(index, modifiers || { multi: false, range: false });
@@ -178,12 +161,12 @@ export async function selectFile(
 export async function selectAll(): Promise<void> {
 	const fileList = getCurrentFileList();
 	if (!fileList) return;
-	const selectedIndex = getSelectedFileIndex();
-	const previousFile =
-		getSelectedFiles().length === 1 && selectedIndex >= 0
-			? (fileList.files[selectedIndex] ?? null)
-			: null;
-	if (!(await persistSingleSelectionMetadata(previousFile))) {
+
+	if (
+		!(await preserveMetadataDraftsBeforeSelectionChange({
+			validationFailureMessage: 'Fix metadata validation errors before selecting all files.',
+		}))
+	) {
 		return;
 	}
 
@@ -200,26 +183,12 @@ export async function selectAll(): Promise<void> {
 }
 
 export async function clearSelectionAction(): Promise<void> {
-	const fileList = getCurrentFileList();
-	const selectedIndex = getSelectedFileIndex();
-	const previousSelectionCount = getSelectedFiles().length;
-	const previousFile =
-		fileList && previousSelectionCount === 1 && selectedIndex >= 0
-			? (fileList.files[selectedIndex] ?? null)
-			: null;
-	if (!(await persistSingleSelectionMetadata(previousFile))) {
+	if (
+		!(await preserveMetadataDraftsBeforeSelectionChange({
+			validationFailureMessage: 'Fix metadata validation errors before clearing the selection.',
+		}))
+	) {
 		return;
-	}
-
-	if (previousSelectionCount > 1) {
-		const didStage = await stageMetadataToSelection({
-			showStatus: false,
-			selectedFilesOverride: getSelectedFiles(),
-		});
-		if (!didStage) {
-			setStatusMessage('Fix metadata validation errors before clearing the selection.');
-			return;
-		}
 	}
 
 	const changed = clearSelection();
@@ -286,10 +255,7 @@ export function moveFileUp(index: number): void {
 	updateFileListDOM();
 	refreshOutputForFileListChange();
 
-	const selectedFiles = getSelectedFiles();
-	if (selectedFiles.length === 1) {
-		void showSingleSelection(selectedFiles[0]);
-	}
+	refreshSelectionPresentation(getSelectedFiles());
 }
 
 export function moveFileDown(index: number): void {
@@ -308,16 +274,21 @@ export function moveFileDown(index: number): void {
 	updateFileListDOM();
 	refreshOutputForFileListChange();
 
-	const selectedFiles = getSelectedFiles();
-	if (selectedFiles.length === 1) {
-		void showSingleSelection(selectedFiles[0]);
-	}
+	refreshSelectionPresentation(getSelectedFiles());
 }
 
-export function toggleFileSort(): void {
+export async function toggleFileSort(): Promise<void> {
 	if (isOrderLocked()) return;
 	const fileList = getCurrentFileList();
 	if (!fileList || fileList.files.length <= 1) return;
+
+	if (
+		!(await preserveMetadataDraftsBeforeSelectionChange({
+			validationFailureMessage: 'Fix metadata validation errors before sorting files.',
+		}))
+	) {
+		return;
+	}
 
 	setSortAscending(!getSortAscending());
 
@@ -385,12 +356,5 @@ export function reorderFiles(fromIndex: number, toIndex: number): void {
 	updateFileListDOM();
 	refreshOutputForFileListChange();
 
-	const selectedFiles = getSelectedFiles();
-	if (selectedFiles.length === 1) {
-		void showSingleSelection(selectedFiles[0]);
-	} else if (selectedFiles.length > 1) {
-		void showMultiSelection(selectedFiles);
-	} else {
-		clearSelectionPanels();
-	}
+	refreshSelectionPresentation(getSelectedFiles());
 }

--- a/src/ui/fileList/metadataPanel.ts
+++ b/src/ui/fileList/metadataPanel.ts
@@ -131,6 +131,18 @@ export function updateFileProperties(file: AudioFile): void {
 	updatePropertiesContextSingle(file, getSelectedFileIndex());
 }
 
+function updateMultiSelectionProperties(selectedFiles: AudioFile[]): void {
+	updatePropertiesContextMulti(selectedFiles.length);
+	setInspectorValues({
+		bitrateText: '---',
+		sampleRateText: '---',
+		channelsText: '---',
+		codecText: summarizeSharedTextValue(selectedFiles, (file) => file.codecLabel),
+		decoderText: summarizeSharedTextValue(selectedFiles, (file) => file.selectedDecoder),
+		fileSizeText: '---',
+	});
+}
+
 function isCurrentSingleSelectionRequest(requestId: number, filePath: string): boolean {
 	if (requestId !== latestSingleSelectionRequestId) return false;
 	if (getSelectedFileIndices().size !== 1) return false;
@@ -193,16 +205,7 @@ export async function showSingleSelection(file: AudioFile): Promise<void> {
 export async function showMultiSelection(selectedFiles: AudioFile[]): Promise<void> {
 	const requestId = ++latestSingleSelectionRequestId;
 	renderAutoResolutionHints(selectedFiles);
-
-	updatePropertiesContextMulti(selectedFiles.length);
-	setInspectorValues({
-		bitrateText: '---',
-		sampleRateText: '---',
-		channelsText: '---',
-		codecText: summarizeSharedTextValue(selectedFiles, (file) => file.codecLabel),
-		decoderText: summarizeSharedTextValue(selectedFiles, (file) => file.selectedDecoder),
-		fileSizeText: '---',
-	});
+	updateMultiSelectionProperties(selectedFiles);
 
 	resetDirtyState();
 
@@ -224,6 +227,23 @@ export async function showMultiSelection(selectedFiles: AudioFile[]): Promise<vo
 	}
 
 	populateMetadataFormMulti(metadataList, selectedFiles.length);
+	refreshOutputForMetadataChange();
+	updateTagPreview();
+}
+
+export function refreshSelectionPresentation(selectedFiles: AudioFile[]): void {
+	latestSingleSelectionRequestId += 1;
+	renderAutoResolutionHints(selectedFiles);
+
+	if (selectedFiles.length === 1 && selectedFiles[0]) {
+		updateFileProperties(selectedFiles[0]);
+	} else if (selectedFiles.length > 1) {
+		updateMultiSelectionProperties(selectedFiles);
+	} else {
+		clearSelectionPanels();
+		return;
+	}
+
 	refreshOutputForMetadataChange();
 	updateTagPreview();
 }

--- a/src/ui/fileList/metadataStaging.ts
+++ b/src/ui/fileList/metadataStaging.ts
@@ -135,3 +135,22 @@ export async function persistPendingMetadataDraftsForCurrentSelection(options?: 
 
 	return stageMetadataToSelection({ showStatus: options?.showStatus });
 }
+
+export async function preserveMetadataDraftsBeforeSelectionChange(options?: {
+	skipSingleSelection?: boolean;
+	validationFailureMessage?: string;
+}): Promise<boolean> {
+	const selectedFiles = getSelectedFiles().filter((file) => file.isValid);
+	if (selectedFiles.length === 0) {
+		return true;
+	}
+	if (options?.skipSingleSelection && selectedFiles.length === 1) {
+		return true;
+	}
+
+	const preserved = await persistPendingMetadataDraftsForCurrentSelection({ showStatus: false });
+	if (!preserved && selectedFiles.length > 1 && options?.validationFailureMessage) {
+		setStatusMessage(options.validationFailureMessage);
+	}
+	return preserved;
+}

--- a/src/ui/outputPanel/AGENTS.md
+++ b/src/ui/outputPanel/AGENTS.md
@@ -11,7 +11,7 @@
 ## Allowed Agent Edits Without Escalation
 - Change internals when focused output panel tests stay green; run
   `bun scripts/proof/runner.ts focus frontend` before handoff and `bun scripts/proof/runner.ts focus runtime`
-  when public-strip or runtime contract surfaces change.
+  when the Public API Strip or runtime contract surfaces change.
 - Keep process-boundary output config reads behind `readOutputRequestConfig`.
 - Keep App Settings hydration/persistence coordination behind
   `applyOutputDefaultsFromSettings` and `readOutputDefaultsFromState`; do not

--- a/src/ui/statusPanel/__tests__/processingConfig.test.ts
+++ b/src/ui/statusPanel/__tests__/processingConfig.test.ts
@@ -30,7 +30,7 @@ describe('processing config composition', () => {
 		});
 	});
 
-	it('composes process config from encoder and output public strips', () => {
+	it('composes process config from encoder and output Public API Strips', () => {
 		const config = readProcessingRequestConfig();
 
 		expect(config).toEqual({

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -12,17 +12,20 @@ import {
 	runAppEffect,
 	workflowTryPromise,
 } from '../../lib/effect/appEffect';
-import { applyMetadataDraftIntent, hasActionableMetadataDraftIntent } from '../metadataDraft';
-import {
-	firstMetadataIntentValidationError,
-	validateMetadataDraftIntent,
-} from '../metadataValidation';
 import {
 	ProcessingWorkflowServicesTag,
 	type ProcessingWorkflowLayer,
 	type ProcessingWorkflowServicesId,
 	type ProcessingWorkflowServices,
 } from './processingWorkflowServices';
+import {
+	buildMetadataIntentByPath,
+	buildProcessPayload,
+	ensureBatchMetadataLoaded,
+	reviewOutputPlan,
+	stagePendingMetadataIntent,
+	validInputFilePaths,
+} from './processingWorkflowPreparation';
 import type { ProcessingStatus } from './state';
 
 type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
@@ -194,6 +197,53 @@ function readProcessingConfig(
 	);
 }
 
+function beginProcessingExecution(
+	services: ProcessingWorkflowServices,
+	context: ProcessingWorkflowContext,
+): AppEffect<void> {
+	return Effect.sync(() => {
+		context.setProcessingState(true);
+		context.updateStatus({
+			stage: 'analyzing',
+			percentage: 0,
+			message: 'Starting processing...',
+		});
+		services.setJobControlsEnabled(false);
+		services.setFileOrderLocked(true);
+	});
+}
+
+function startProcessingRuntime(
+	context: ProcessingWorkflowContext,
+): AppEffect<void, ProcessingWorkflowFailed> {
+	return Effect.gen(function* () {
+		yield* workflowPromise(() => context.updateArtThumbnail(), 'Failed to update art thumbnail.');
+		yield* workflowPromise(
+			() => context.startProgressListener(),
+			'Failed to start progress listener.',
+		);
+	});
+}
+
+function completeProcessingExecution(
+	services: ProcessingWorkflowServices,
+	context: ProcessingWorkflowContext,
+	result: ProcessCommandResult,
+	filePaths: string[],
+): AppEffect<void, ProcessingWorkflowFailed> {
+	return Effect.gen(function* () {
+		yield* Effect.sync(() => {
+			services.console.log('Processing command resolved:', result);
+			context.reconcileProcessResult?.(result);
+			context.setBatchCompletionMessage(summarizeBatchOutcome(result, filePaths));
+		});
+		yield* workflowPromise(
+			() => services.openGeneratedPreviewIfSingle(result),
+			'Failed to open generated preview.',
+		);
+	});
+}
+
 function handleWorkflowError(
 	services: ProcessingWorkflowServices,
 	context: ProcessingWorkflowContext,
@@ -263,121 +313,27 @@ export function processingWorkflowProgram(
 			),
 		);
 
-		const filePaths = fileList.files.filter((file) => file.isValid).map((file) => file.path);
-		const selectionCount = services.getSelectedFileIndices().size;
-		if (selectionCount > 1) {
-			const staged = yield* workflowPromise(
-				() => services.stageMetadataToSelection({ showStatus: false }),
-				'Failed to stage metadata for processing.',
-			);
-			if (!staged) {
-				yield* Effect.sync(() =>
-					services.feedback.showError('Fix metadata validation errors before processing.'),
-				);
-				return;
-			}
-		}
-
-		if (selectionCount <= 1 && services.hasDirtyMetadataFields()) {
-			const selectedFileIndex = services.getSelectedFileIndex();
-			const formMetadata = services.readMetadataForm({ mode: 'single' });
-			const validation = yield* workflowPromise(
-				() => validateMetadataDraftIntent(formMetadata, services.validateMetadataIntentPatch),
-				'Failed to validate metadata intent for processing.',
-			);
-			const validationError = firstMetadataIntentValidationError(validation.result);
-			if (validationError) {
-				yield* Effect.sync(() => services.feedback.showError(validationError));
-				return;
-			}
-			const intentPatch = validation.intentPatch;
-			const activeFile =
-				selectedFileIndex >= 0
-					? fileList.files[selectedFileIndex]
-					: fileList.files.find((file) => file.isValid);
-			if (activeFile?.isValid && hasActionableMetadataDraftIntent(intentPatch)) {
-				const existing = services.getMetadataForFile(activeFile.path) ?? {};
-				const currentMetadata = applyMetadataDraftIntent(existing, intentPatch);
-				yield* Effect.sync(() =>
-					services.setMetadataForFile(activeFile.path, currentMetadata, {
-						markPending: true,
-						intentPatch,
-					}),
-				);
-			}
+		const filePaths = validInputFilePaths(fileList);
+		const metadataReady = yield* stagePendingMetadataIntent(services, fileList, workflowPromise);
+		if (!metadataReady) {
+			return;
 		}
 
 		const jobType = services.getJobType();
 		yield* Effect.sync(() => context.setCurrentWorkKind(jobType));
 
-		const processPayload: ProcessPayload = {
-			inputFiles: filePaths,
-			outputDir: processingRequestConfig.outputDirectory,
-			settings: processingRequestConfig.encoderSettings,
-			externalToolchain: processingRequestConfig.toolchainSettings,
-			sampleRate: processingRequestConfig.sampleRate,
-			jobType,
-			outputNaming: processingRequestConfig.outputNaming,
-		};
+		const processPayload = buildProcessPayload(filePaths, processingRequestConfig, jobType);
+		yield* ensureBatchMetadataLoaded(services, processPayload, workflowPromise);
 
-		if (processPayload.jobType === 'batch') {
-			const missingMetadata = filePaths.filter(
-				(filePath) => !services.getMetadataForFile(filePath),
-			);
-			if (missingMetadata.length > 0) {
-				yield* workflowPromise(
-					() =>
-						Promise.all(
-							missingMetadata.map(async (filePath) => {
-								try {
-									const metadata = await services.readAudioMetadata(filePath);
-									services.setMetadataForFile(filePath, metadata);
-								} catch (error) {
-									services.console.warn('Failed to load metadata for batch file:', filePath, error);
-								}
-							}),
-						),
-					'Failed to load batch metadata.',
-				);
-			}
-		}
-
-		let metadataIntentByPath: MetadataIntentByPath | null = null;
-		if (processPayload.jobType === 'merge') {
-			const mergeKey = processPayload.inputFiles[0];
-			const mergeIntentPatch = mergeKey
-				? services.getMetadataIntentPatchForFile(mergeKey)
-				: undefined;
-			if (
-				mergeKey &&
-				processPayload.inputFiles.length > 0 &&
-				hasActionableMetadataDraftIntent(mergeIntentPatch)
-			) {
-				metadataIntentByPath = {
-					[mergeKey]: mergeIntentPatch,
-				};
-			}
-		} else {
-			const storedMetadataIntentByPath = services.getAllMetadataIntentPatches();
-			const activeInputFiles = new Set(processPayload.inputFiles);
-			const filteredMetadataIntentByPath = Object.fromEntries(
-				Object.entries(storedMetadataIntentByPath).filter(
-					([filePath, value]) =>
-						activeInputFiles.has(filePath) && hasActionableMetadataDraftIntent(value),
-				),
-			);
-			metadataIntentByPath =
-				Object.keys(filteredMetadataIntentByPath).length > 0 ? filteredMetadataIntentByPath : null;
-		}
-
-		const reviewResult = yield* workflowPromise(
-			() =>
-				services.runOutputPlanReviewWorkflow({
-					payload: processPayload,
-					metadataIntentByPath,
-					previewSeconds: options?.previewSeconds,
-				}),
-			'Output plan review failed.',
+		const metadataIntentByPath = buildMetadataIntentByPath(services, processPayload);
+		const reviewResult = yield* reviewOutputPlan(
+			services,
+			{
+				payload: processPayload,
+				metadataIntentByPath,
+				previewSeconds: options?.previewSeconds,
+			},
+			workflowPromise,
 		);
 		if (reviewResult.status === 'blocked') {
 			yield* Effect.sync(() => services.feedback.showError(reviewResult.message));
@@ -387,22 +343,8 @@ export function processingWorkflowProgram(
 			return;
 		}
 
-		yield* Effect.sync(() => {
-			context.setProcessingState(true);
-			context.updateStatus({
-				stage: 'analyzing',
-				percentage: 0,
-				message: 'Starting processing...',
-			});
-			services.setJobControlsEnabled(false);
-			services.setFileOrderLocked(true);
-		});
-
-		yield* workflowPromise(() => context.updateArtThumbnail(), 'Failed to update art thumbnail.');
-		yield* workflowPromise(
-			() => context.startProgressListener(),
-			'Failed to start progress listener.',
-		);
+		yield* beginProcessingExecution(services, context);
+		yield* startProcessingRuntime(context);
 
 		const result = yield* processingCommand(services, {
 			payload: reviewResult.payload,
@@ -410,15 +352,7 @@ export function processingWorkflowProgram(
 			previewSeconds: options?.previewSeconds,
 		});
 
-		yield* Effect.sync(() => {
-			services.console.log('Processing command resolved:', result);
-			context.reconcileProcessResult?.(result);
-			context.setBatchCompletionMessage(summarizeBatchOutcome(result, filePaths));
-		});
-		yield* workflowPromise(
-			() => services.openGeneratedPreviewIfSingle(result),
-			'Failed to open generated preview.',
-		);
+		yield* completeProcessingExecution(services, context, result, filePaths);
 	}).pipe(
 		Effect.catchAll((error) =>
 			Effect.gen(function* () {

--- a/src/ui/statusPanel/processingWorkflowPreparation.ts
+++ b/src/ui/statusPanel/processingWorkflowPreparation.ts
@@ -1,0 +1,216 @@
+import { Effect, type AppEffect } from '../../lib/effect/appEffect';
+import type {
+	FileListInfo,
+	JobType,
+	ProcessPayload,
+	ProcessingRequestConfig,
+} from '../../types/audio';
+import type { MetadataIntentPatch } from '../../types/metadataIntent';
+import { applyMetadataDraftIntent, hasActionableMetadataDraftIntent } from '../metadataDraft';
+import {
+	firstMetadataIntentValidationError,
+	validateMetadataDraftIntent,
+} from '../metadataValidation';
+import type { OutputPlanReviewResult } from '../outputPanel/outputPlanWorkflow';
+import type { ProcessingWorkflowFailed } from './processingWorkflow';
+import type { ProcessingWorkflowServices } from './processingWorkflowServices';
+
+type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
+
+type ProcessingWorkflowPromise = <A>(
+	evaluate: () => PromiseLike<A>,
+	message: string,
+) => AppEffect<A, ProcessingWorkflowFailed>;
+
+export function validInputFilePaths(fileList: FileListInfo): string[] {
+	return fileList.files.filter((file) => file.isValid).map((file) => file.path);
+}
+
+export function buildProcessPayload(
+	filePaths: string[],
+	processingRequestConfig: ProcessingRequestConfig,
+	jobType: JobType,
+): ProcessPayload {
+	return {
+		inputFiles: filePaths,
+		outputDir: processingRequestConfig.outputDirectory,
+		settings: processingRequestConfig.encoderSettings,
+		externalToolchain: processingRequestConfig.toolchainSettings,
+		sampleRate: processingRequestConfig.sampleRate,
+		jobType,
+		outputNaming: processingRequestConfig.outputNaming,
+	};
+}
+
+function stageMultiSelectionMetadata(
+	services: ProcessingWorkflowServices,
+	selectionCount: number,
+	workflowPromise: ProcessingWorkflowPromise,
+): AppEffect<boolean, ProcessingWorkflowFailed> {
+	return Effect.gen(function* () {
+		if (selectionCount <= 1) {
+			return true;
+		}
+
+		const staged = yield* workflowPromise(
+			() => services.stageMetadataToSelection({ showStatus: false }),
+			'Failed to stage metadata for processing.',
+		);
+		if (!staged) {
+			yield* Effect.sync(() =>
+				services.feedback.showError('Fix metadata validation errors before processing.'),
+			);
+			return false;
+		}
+		return true;
+	});
+}
+
+function stageSingleSelectionMetadata(
+	services: ProcessingWorkflowServices,
+	fileList: FileListInfo,
+	selectionCount: number,
+	workflowPromise: ProcessingWorkflowPromise,
+): AppEffect<boolean, ProcessingWorkflowFailed> {
+	return Effect.gen(function* () {
+		if (selectionCount > 1 || !services.hasDirtyMetadataFields()) {
+			return true;
+		}
+
+		const selectedFileIndex = services.getSelectedFileIndex();
+		const formMetadata = services.readMetadataForm({ mode: 'single' });
+		const validation = yield* workflowPromise(
+			() => validateMetadataDraftIntent(formMetadata, services.validateMetadataIntentPatch),
+			'Failed to validate metadata intent for processing.',
+		);
+		const validationError = firstMetadataIntentValidationError(validation.result);
+		if (validationError) {
+			yield* Effect.sync(() => services.feedback.showError(validationError));
+			return false;
+		}
+
+		const intentPatch = validation.intentPatch;
+		const activeFile =
+			selectedFileIndex >= 0
+				? fileList.files[selectedFileIndex]
+				: fileList.files.find((file) => file.isValid);
+		if (activeFile?.isValid && hasActionableMetadataDraftIntent(intentPatch)) {
+			const existing = services.getMetadataForFile(activeFile.path) ?? {};
+			const currentMetadata = applyMetadataDraftIntent(existing, intentPatch);
+			yield* Effect.sync(() =>
+				services.setMetadataForFile(activeFile.path, currentMetadata, {
+					markPending: true,
+					intentPatch,
+				}),
+			);
+		}
+
+		return true;
+	});
+}
+
+export function stagePendingMetadataIntent(
+	services: ProcessingWorkflowServices,
+	fileList: FileListInfo,
+	workflowPromise: ProcessingWorkflowPromise,
+): AppEffect<boolean, ProcessingWorkflowFailed> {
+	return Effect.gen(function* () {
+		const selectionCount = services.getSelectedFileIndices().size;
+		const multiSelectionStaged = yield* stageMultiSelectionMetadata(
+			services,
+			selectionCount,
+			workflowPromise,
+		);
+		if (!multiSelectionStaged) {
+			return false;
+		}
+
+		return yield* stageSingleSelectionMetadata(services, fileList, selectionCount, workflowPromise);
+	});
+}
+
+export function ensureBatchMetadataLoaded(
+	services: ProcessingWorkflowServices,
+	processPayload: ProcessPayload,
+	workflowPromise: ProcessingWorkflowPromise,
+): AppEffect<void, ProcessingWorkflowFailed> {
+	return Effect.gen(function* () {
+		if (processPayload.jobType !== 'batch') {
+			return;
+		}
+
+		const missingMetadata = processPayload.inputFiles.filter(
+			(filePath) => !services.getMetadataForFile(filePath),
+		);
+		if (missingMetadata.length === 0) {
+			return;
+		}
+
+		yield* workflowPromise(
+			() =>
+				Promise.all(
+					missingMetadata.map(async (filePath) => {
+						try {
+							const metadata = await services.readAudioMetadata(filePath);
+							services.setMetadataForFile(filePath, metadata);
+						} catch (error) {
+							services.console.warn('Failed to load metadata for batch file:', filePath, error);
+						}
+					}),
+				),
+			'Failed to load batch metadata.',
+		);
+	});
+}
+
+export function buildMetadataIntentByPath(
+	services: ProcessingWorkflowServices,
+	processPayload: ProcessPayload,
+): MetadataIntentByPath | null {
+	if (processPayload.jobType === 'merge') {
+		const mergeKey = processPayload.inputFiles[0];
+		const mergeIntentPatch = mergeKey
+			? services.getMetadataIntentPatchForFile(mergeKey)
+			: undefined;
+		if (
+			mergeKey &&
+			processPayload.inputFiles.length > 0 &&
+			hasActionableMetadataDraftIntent(mergeIntentPatch)
+		) {
+			return {
+				[mergeKey]: mergeIntentPatch,
+			};
+		}
+		return null;
+	}
+
+	const storedMetadataIntentByPath = services.getAllMetadataIntentPatches();
+	const activeInputFiles = new Set(processPayload.inputFiles);
+	const filteredMetadataIntentByPath = Object.fromEntries(
+		Object.entries(storedMetadataIntentByPath).filter(
+			([filePath, value]) =>
+				activeInputFiles.has(filePath) && hasActionableMetadataDraftIntent(value),
+		),
+	);
+	return Object.keys(filteredMetadataIntentByPath).length > 0 ? filteredMetadataIntentByPath : null;
+}
+
+export function reviewOutputPlan(
+	services: ProcessingWorkflowServices,
+	request: {
+		payload: ProcessPayload;
+		metadataIntentByPath: MetadataIntentByPath | null;
+		previewSeconds?: number;
+	},
+	workflowPromise: ProcessingWorkflowPromise,
+): AppEffect<OutputPlanReviewResult, ProcessingWorkflowFailed> {
+	return workflowPromise(
+		() =>
+			services.runOutputPlanReviewWorkflow({
+				payload: request.payload,
+				metadataIntentByPath: request.metadataIntentByPath,
+				previewSeconds: request.previewSeconds,
+			}),
+		'Output plan review failed.',
+	);
+}


### PR DESCRIPTION
## Summary
- Consolidates import workflow analyzed-file handling and user-facing import feedback into private helpers.
- Splits status-panel processing request prep, metadata intent prep, and output-plan review glue into a private preparation module while keeping the public status-panel API unchanged.
- Adds FileList metadata-preservation transition handling so selection changes, select-all, clear-selection, sort, and order-only reorders do not scatter dirty-draft staging or repopulate forms unnecessarily.
- Deduplicates Metadata Save entry gating while keeping the synchronous UI repeat-click gate before dynamic import.
- Tightens root `AGENTS.md` finding language and removes the stale root route to the missing repo-local `improve-codebase-architecture` skill.

Fixes #346.

## Review Notes
- Ran the thermo-nuclear code-quality review locally against the fresh worktree.
- Consulted ChatGPT Pro with GitHub enabled. Pro validated the original import duplication finding, validated-but-narrowed the processing workflow finding, and later ranked the FileList dirty-metadata transition as the next high-value fix-class item.
- Used ABB library/source research for the Effect workflow shape; the refactor preserves Promise public wrappers and uses existing `AppEffect`/`workflowTryPromise` owner patterns.
- No standalone Metadata Lookup refactor or Processing Plan validated-input snapshot work is included; those remain rejected/deferred outside this PR.

## Proof
- `bun run test -- src/ui/__tests__/fileList-selectFile-transition.test.ts src/ui/__tests__/fileList-reorder-behavior.test.ts src/ui/core/__tests__/metadataSaveWorkflow.test.ts src/ui/__tests__/fileList-reorder-mirror.test.ts src/ui/__tests__/order-lock-lifecycle.test.ts` passed.
- `bun scripts/proof/runner.ts focus frontend` passed: `.proof/runs/2026-05-30T16-52-31-037Z-focus-frontend-t2Ii49/summary.md`.
- `bun run build` passed.
- `git diff --check` passed.
- `bun scripts/proof/runner.ts review` passed: `.proof/runs/2026-05-30T16-54-13-790Z-review-main-xL2omR/summary.md`.

## Manual Testing
Manual app smoke is recommended before merge because this PR touches import, processing workflow prep, FileList selection/order behavior, and metadata save orchestration. Please verify one normal file/folder import path, one select/edit/sort/reorder FileList path with dirty metadata, one metadata save path, and one normal processing or preview path still behave as intended in the app.

## Proof Friction
- Fresh worktree initially lacked installed frontend dependencies, so the first targeted Vitest run failed with missing `vitest`; `bun install` fixed the worktree setup.
- During this follow-up batch, full proof caught formatting and a test mock type issue before final proof; both were fixed and the final review proof passed.
- `bun run build` still emits the known Node `[DEP0205] module.register()` deprecation warning, but the build and full review proof passed.
