### PR TITLE
feat: add Work Runtime V1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@
 | Change | Verification |
 | --- | --- |
 | Docs/guidance/reference edits | Coherence check, stale-reference removal, source/subtree presence when relevant, and `git diff --check` |
-| Edited skills | Run the touched skill validator, including `quick_validate.py` where applicable |
+| Edited skills | Run the touched skill validator where one exists |
 | Owned module import/export surface changes | Update nearest `AGENTS.md` and matching contract tests for intentional surface changes |
 | Tooling/scripts local only | Targeted script/test for the touched surface first |
 | Runtime/IPC/contracts/build/deps | Owner-scoped command menu in `README.md`/`scripts/AGENTS.md`, plus focused contract/regression coverage |

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -20,6 +20,7 @@ Core crates must not depend on:
 
 ## Direct Tests
 
+- Audible: `cargo nextest run -p abb-audible-core`
 - Metadata: `cargo nextest run -p abb-metadata-core`
 - Media contract: `cargo nextest run -p abb-media-core`
 - Output Artifact: `cargo nextest run -p abb-output-artifact-core`

--- a/crates/abb-processing-core/src/lib.rs
+++ b/crates/abb-processing-core/src/lib.rs
@@ -6,6 +6,7 @@ pub enum OperationKind {
     ProcessingMerge,
     #[default]
     ProcessingBatch,
+    RemoteAcquisition,
     MetadataSave,
 }
 

--- a/docs/specs/work-runtime-v1.md
+++ b/docs/specs/work-runtime-v1.md
@@ -31,6 +31,10 @@ operation independently, and verify terminal summaries against disk truth.
   Status Panel ignores WorkRuntime-scoped legacy queue/progress events, Work
   Center terminal source cleanup is race-guarded, and retained remote-source
   sessions are purged when background submission fails after a deferred purge.
+- [x] 2026-06-06: Address manual cancellation cleanup feedback: output artifact
+  now tracks ABB-created final parent directories and prunes only empty created
+  parents after failed/cancelled processing; preexisting or non-empty output
+  directories are preserved.
 
 ## Surprises & Discoveries
 

--- a/docs/specs/work-runtime-v1.md
+++ b/docs/specs/work-runtime-v1.md
@@ -1,0 +1,189 @@
+# Work Runtime V1 — Active Spec
+
+Status: temporary active spec.
+Cleanup: delete or distill into canon after implementation, review, validation,
+docs alignment, and sync.
+
+## Purpose / Big Picture / North Star
+
+Outcome: Audiobook Boss can accept long-running work as immutable background
+operations, return the FileList to drafting immediately after backend
+acceptance, and show multiple batch/merge operations in a Work Center.
+
+Acceptance signal: the user can submit a batch encode, keep using FileList,
+compose and submit a merge while the batch is still running, cancel either
+operation independently, and verify terminal summaries against disk truth.
+
+## Progress
+
+- [x] 2026-06-06: Pro consultation synthesized; owner accepted FileList as
+  Draft Workspace, functional V1, and module-size guardrails.
+- [x] 2026-06-06: Add WorkRuntime pure state and runtime proof.
+- [x] 2026-06-06: Wire batch/merge processing through WorkRuntime.
+- [x] 2026-06-06: Add Work Center and draft-unlock workflow.
+- [x] 2026-06-06: Evaluate acquisition + Source Inbox in this PR; defer V1B
+  wiring because V1A already touches the processing runtime, status workflow,
+  IPC contract, and new Work Center UI, and acquisition needs its own remote
+  runtime/inbox UX slice to avoid leaking provider concerns or bloating the
+  existing modal.
+
+## Surprises & Discoveries
+
+- Observation: current processing and remote acquisition each own separate job
+  state, cancellation, and progress surfaces.
+  Evidence: `src-tauri/src/processing/job_registry/`,
+  `src-tauri/src/remote_source/mod.rs`, `src/ui/statusPanel/`,
+  `src/ui/remoteSource/RemoteSourceAcquireDialog.svelte`.
+- Observation: major likely touch points are already large.
+  Evidence: `remote_source/mod.rs` ~779 LOC, `processing/run.rs` ~837 LOC,
+  `RemoteSourceAcquireDialog.svelte` ~755 LOC, `statusPanel/controller.ts`
+  ~476 LOC at spec creation.
+
+## Decision Log
+
+- Decision: FileList is a Draft Workspace, not the queue.
+  Rationale: live FileList mutation must not affect accepted work; this is the
+  unlock that allows batch and merge workflows to coexist.
+  Date: 2026-06-06.
+- Decision: V1 is functional, not scaffolding-only.
+  Rationale: the owner needs a pressure-testable workflow before returning to
+  power use.
+  Date: 2026-06-06.
+- Decision: WorkRuntime owns operation truth; RemoteSourceRuntime keeps provider
+  truth.
+  Rationale: work orchestration needs one event/cancel/status model without
+  leaking provider secrets or Audible internals.
+  Date: 2026-06-06.
+- Decision: Source Inbox is the default remote-acquisition handoff model.
+  Rationale: acquisition completion should produce retained usable material,
+  not immediately mutate the current draft or purge useful staged files when the
+  draft is busy.
+  Date: 2026-06-06.
+
+## Context And Orientation
+
+- Current repo state checked on branch `feat/work-runtime-v1`.
+- Canon terms that matter:
+  - Runtime Boundary: frontend IPC routes through `tauriClient`.
+  - Backend Lifecycle: current processing sub-owner for operation identity,
+    queue/progress, cancellation, and terminal truth.
+  - RemoteSourceRuntime: provider-neutral remote acquisition surface; provider
+    secrets and raw payloads remain backend-private.
+  - Terminal Truth / Artifact Truth: Rust reports durable final state.
+- Canon surfaces this spec must not redefine:
+  - `docs/system-map.md`
+  - `docs/ubiquitous-language.md`
+  - `docs/api-map.md`
+  - nearest nested `AGENTS.md` files.
+
+## Scope And Constraints
+
+In scope:
+
+- Background processing operations for `processingBatch` and `processingMerge`.
+- Immutable work submissions accepted by backend before execution completes.
+- Work Center UI read model for multiple operations.
+- FileList draft unlock after accepted submit.
+- Per-operation cancellation.
+- Resource-lane vocabulary sufficient for encode CPU, output commit, and future
+  acquisition lanes.
+- Remote acquisition + Acquired Sources inbox if V1A stays stable enough.
+
+Out of scope:
+
+- Persistent operation history across app restart.
+- Pause/resume and priority editing.
+- Multi-instance orchestration.
+- External queue/service platforms.
+- Metadata save as a required first slice, though the operation model should not
+  prevent it.
+
+Constraints:
+
+- Do not make already-large modules larger except for narrow routing glue.
+- New backend work belongs in `src-tauri/src/work_runtime/`.
+- New frontend work belongs in `src/ui/workCenter/`.
+- Add local `AGENTS.md` files for new ownership surfaces.
+- `processing/run.rs` must not become WorkRuntime.
+- `remote_source/mod.rs` must not absorb WorkRuntime state or Work Center
+  concerns.
+- `RemoteSourceAcquireDialog.svelte` should shrink toward auth/selection UI if
+  acquisition is wired.
+- No reach-through imports into private clusters.
+- No silent fallback/shim behavior.
+
+## Plan Of Work
+
+- Edits:
+  - Create WorkRuntime public strip, runtime state, event types, commands, and
+    Tauri registration.
+  - Add pure operation-state tests and fake-executor runtime tests before real
+    processing wiring.
+  - Add processing adapter that submits immutable batch/merge work and drives
+    existing processing execution behind WorkRuntime.
+  - Add Work Center UI and update Status Panel / FileList integration.
+  - Add Source Inbox only after V1A is functional and reviewed locally.
+- Verification steps:
+  - Run focused Rust tests for new core/runtime state.
+  - Regenerate/check generated bindings.
+  - Run focused Tauri client and Work Center Vitest coverage.
+  - Run manual app smoke for batch + merge coexistence.
+  - Run GPT-5.5 xhigh read-only child-thread review before push.
+- Expected repo-visible outcome:
+  - A PR branch with functional V1A and either V1B acquisition/inbox or an
+    explicit active-spec remaining-work section.
+
+## Interfaces And Dependencies
+
+- New Rust owner: `src-tauri/src/work_runtime/`.
+- New frontend owner: `src/ui/workCenter/`.
+- Commands:
+  - submit processing operation.
+  - list/get work operations.
+  - cancel work operation.
+- Events:
+  - operation snapshot.
+  - operation list snapshot.
+  - resource snapshot if useful for UI.
+- Types:
+  - OperationId.
+  - OperationKind: `processingBatch`, `processingMerge`, `remoteAcquisition`,
+    `metadataSave`.
+  - OperationSnapshot.
+  - ChildJobSnapshot.
+  - ProgressSnapshot.
+  - OperationTerminalSummary.
+  - ResourceLane.
+
+## Verification Path and Checks
+
+Targeted checks:
+
+- `cargo nextest run -p abb-processing-core`
+- targeted `cargo nextest run -p audiobook-boss --lib <work-runtime tests>` as
+  available.
+- `bash scripts/check-generated-bindings.sh --mode local`
+- `bun scripts/check-tauri-runtime-boundary.ts`
+- `bun run test -- src/lib/tauri-public-api.contract.test.ts src/lib/tauri-client.test.ts src/lib/tauri-client.generated-event-bindings.test.ts`
+- focused Work Center / Status Panel / FileList Vitest selections.
+
+Manual evidence:
+
+- Batch operation accepted and FileList usable immediately afterward.
+- Merge operation accepted while batch operation still runs.
+- Work Center shows independent operation progress and terminal summaries.
+- Operation cancel does not cancel unrelated operation.
+- Output files and terminal summaries match disk truth.
+- Acquisition + Source Inbox scenarios if V1B lands.
+
+## Cleanup Trigger
+
+When this effort is implemented, rejected, or superseded:
+
+- Delete this spec.
+- Distill only enduring behavior into the smallest canon surfaces:
+  - `docs/system-map.md`
+  - `docs/ubiquitous-language.md`
+  - `docs/api-map.md`
+  - nearest nested `AGENTS.md`
+  - GitHub issue for explicit deferred V1B items, if needed.

--- a/docs/specs/work-runtime-v1.md
+++ b/docs/specs/work-runtime-v1.md
@@ -26,6 +26,11 @@ operation independently, and verify terminal summaries against disk truth.
   IPC contract, and new Work Center UI, and acquisition needs its own remote
   runtime/inbox UX slice to avoid leaking provider concerns or bloating the
   existing modal.
+- [x] 2026-06-06: Address PR review feedback for V1A overlap correctness:
+  operation-scoped WorkRuntime jobs no longer honor legacy global cancel,
+  Status Panel ignores WorkRuntime-scoped legacy queue/progress events, Work
+  Center terminal source cleanup is race-guarded, and retained remote-source
+  sessions are purged when background submission fails after a deferred purge.
 
 ## Surprises & Discoveries
 
@@ -38,6 +43,11 @@ operation independently, and verify terminal summaries against disk truth.
   Evidence: `remote_source/mod.rs` ~779 LOC, `processing/run.rs` ~837 LOC,
   `RemoteSourceAcquireDialog.svelte` ~755 LOC, `statusPanel/controller.ts`
   ~476 LOC at spec creation.
+- Observation: Work Center still consumes legacy progress events as an overlay
+  on backend operation snapshots.
+  Evidence: `src/ui/workCenter/model.ts` re-derives progress/child status from
+  `processing-progress` while WorkRuntime snapshots remain canonical terminal
+  truth.
 
 ## Decision Log
 
@@ -175,6 +185,20 @@ Manual evidence:
 - Operation cancel does not cancel unrelated operation.
 - Output files and terminal summaries match disk truth.
 - Acquisition + Source Inbox scenarios if V1B lands.
+
+## Deferred Triggers
+
+- Next WorkRuntime slice that changes progress semantics: move Work Center to
+  backend-authored operation snapshots only and delete the frontend legacy
+  progress reducer.
+- Next change to `processing/run.rs`: split by processing dispatch/cohesion
+  before adding new operation-kind behavior.
+- Next change to `processingWorkflow.ts`: split foreground preview execution
+  from background submit/retain/error mapping if either path grows again.
+- V1B acquisition/inbox: implement in a dedicated branch or PR unless a V1A
+  correctness dependency appears.
+- Feedback/review tooling: do not spawn sub-agents or child threads unless the
+  owner re-enables that route for a narrow, high-signal task.
 
 ## Cleanup Trigger
 

--- a/src-tauri/src/audio/AGENTS.md
+++ b/src-tauri/src/audio/AGENTS.md
@@ -44,10 +44,10 @@
 
 ## Private Cluster
 
-- Files: `buffer.rs`, `buffer_tests.rs`, `cleanup/`, `extensions.rs`,
-  `constants.rs`, `file_list.rs`, `imports.rs`, `metrics.rs`,
-  `path_validation.rs`, `processor/`, `settings.rs`, `settings_encoder.rs`,
-  and `toolchain.rs`.
+- Files: `buffer.rs`, `cleanup/`, `extensions.rs`,
+  `constants.rs`, `file_list.rs`, `imports.rs`, `imports_tests.rs`, `metrics.rs`,
+  `path_validation.rs`, `processor/`, `settings.rs`, `settings_capabilities.rs`,
+  `settings_encoder.rs`, and `toolchain.rs`.
 - The cluster owns local audio import metadata/discovery, decoder/toolchain
   selection, media inspection, decode/resample/encode/mux internals, staging,
   cleanup, and media execution facts. Processing owns lifecycle orchestration

--- a/src-tauri/src/commands/metadata/save_batch.rs
+++ b/src-tauri/src/commands/metadata/save_batch.rs
@@ -253,6 +253,7 @@ fn emit_metadata_save_queue(window: &tauri::Window, items: &[MetadataSaveRequest
 
 fn emit_metadata_save_progress(window: &tauri::Window, progress: MetadataSaveProgress) {
     let event = ProgressEvent {
+        operation_id: None,
         operation_kind: OperationKind::MetadataSave,
         stage: progress.stage,
         percentage: progress.percentage,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod metadata;
 pub mod metadata_lookup;
 pub mod remote_source;
 pub mod system;
+pub mod work_runtime;
 
 pub type CommandResult<T> = std::result::Result<T, crate::errors::AppErrorEnvelope>;
 
@@ -13,3 +14,4 @@ pub use metadata::*;
 pub use metadata_lookup::*;
 pub use remote_source::*;
 pub use system::*;
+pub use work_runtime::*;

--- a/src-tauri/src/commands/work_runtime.rs
+++ b/src-tauri/src/commands/work_runtime.rs
@@ -1,0 +1,62 @@
+use crate::audio;
+use crate::commands::CommandResult;
+use crate::errors::AppError;
+use crate::work_runtime::{
+    OperationId, OperationListSnapshot, OperationSnapshot, SubmitProcessingOperationRequest,
+    WorkSubmissionAccepted,
+};
+use tauri::Manager;
+
+#[tauri::command]
+#[specta::specta]
+pub async fn submit_processing_operation(
+    window: tauri::Window,
+    runtime: tauri::State<'_, crate::work_runtime::WorkRuntime>,
+    registry: tauri::State<'_, crate::ManagedJobRegistry>,
+    request: SubmitProcessingOperationRequest,
+) -> CommandResult<WorkSubmissionAccepted> {
+    if registry.is_global_cancelled() && registry.get_aggregate_status().await.total_jobs == 0 {
+        registry.reset_global_cancel();
+    }
+    let cache_dir = window
+        .app_handle()
+        .path()
+        .app_cache_dir()
+        .map_err(|error| {
+            AppError::General(format!(
+                "Failed to resolve processing workspace root: {error}"
+            ))
+        })?;
+    let workspace_root = audio::processing_workspace_root(&cache_dir);
+
+    Ok(runtime
+        .submit_processing_operation(window, registry.inner().clone(), workspace_root, request)
+        .await?)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn list_work_operations(
+    runtime: tauri::State<'_, crate::work_runtime::WorkRuntime>,
+) -> CommandResult<OperationListSnapshot> {
+    Ok(runtime.list_operations()?)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_work_operation(
+    runtime: tauri::State<'_, crate::work_runtime::WorkRuntime>,
+    operation_id: OperationId,
+) -> CommandResult<OperationSnapshot> {
+    Ok(runtime.get_operation(operation_id)?)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn cancel_work_operation(
+    window: tauri::Window,
+    runtime: tauri::State<'_, crate::work_runtime::WorkRuntime>,
+    operation_id: OperationId,
+) -> CommandResult<OperationSnapshot> {
+    Ok(runtime.cancel_operation(&window, operation_id)?)
+}

--- a/src-tauri/src/ipc_contract.rs
+++ b/src-tauri/src/ipc_contract.rs
@@ -43,11 +43,17 @@ pub fn builder() -> Builder<tauri::Wry> {
             crate::commands::set_max_concurrent_jobs,
             crate::commands::process_audiobook_files,
             crate::commands::cancel_processing,
+            crate::commands::submit_processing_operation,
+            crate::commands::list_work_operations,
+            crate::commands::get_work_operation,
+            crate::commands::cancel_work_operation,
         ])
         .events(tauri_specta::collect_events![
             crate::processing::ProgressEvent,
             crate::processing::QueueEvent,
-            crate::opened_audio::OpenedAudioFilesEvent
+            crate::opened_audio::OpenedAudioFilesEvent,
+            crate::work_runtime::WorkOperationSnapshotEvent,
+            crate::work_runtime::WorkOperationListSnapshotEvent
         ])
         .error_handling(ErrorHandlingMode::Result)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod opened_audio;
 pub mod output_artifact;
 pub mod processing;
 pub mod remote_source;
+pub mod work_runtime;
 // Re-export key public types needed by external integration tests without exposing full internal module structure
 pub use metadata::{
     add_cover_art_stream_pre_header as ffmpeg_add_cover_art_stream_pre_header,
@@ -113,6 +114,7 @@ pub fn run() {
 
     // Initialize job registry with auto-detected concurrency (num_cpus / 2)
     let job_registry: ManagedJobRegistry = Arc::new(processing::JobRegistry::auto());
+    let work_runtime = work_runtime::WorkRuntime::default();
     log::info!(
         "Job registry initialized: max_concurrent = {}",
         job_registry.max_concurrent()
@@ -124,6 +126,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(job_registry)
+        .manage(work_runtime)
         .manage(opened_audio::OpenedAudioFileQueue::default())
         .invoke_handler(specta_builder.invoke_handler())
         .setup(move |app| {

--- a/src-tauri/src/output_artifact/AGENTS.md
+++ b/src-tauri/src/output_artifact/AGENTS.md
@@ -1,14 +1,14 @@
 ## Public API Strip
 - Import from `crate::output_artifact`, not private child modules.
 - Functions: `build_output_path_preview`, `derive_output_artifact_path`, `build_output_path`, `action_requires_output_write`, `plan_is_hard_block`, `enforce_output_plan_review`, `ensure_output_parent_dirs`, `commit_output_artifact`, `finalized_output_success`, `commit_supplemental_output_asset`.
-- Types: `OutputCommitRequest`, `SupplementalOutputAssetCommitRequest`, `OutputPlanLedger`, `OutputPlanReview`, `OutputKind`, `CollisionPolicy`, `NamingPreset`, `OutputNamingConfig`, `PlannedOutput`, `PlannedOutputAction`, `OutputReviewRequirement`, `OutputCollisionInfo`, `OutputCollisionKind`, `OutputCollision`, `ResolvedOutputPlan`.
+- Types: `OutputCommitRequest`, `OutputParentDirCleanup`, `SupplementalOutputAssetCommitRequest`, `OutputPlanLedger`, `OutputPlanReview`, `OutputKind`, `CollisionPolicy`, `NamingPreset`, `OutputNamingConfig`, `PlannedOutput`, `PlannedOutputAction`, `OutputReviewRequirement`, `OutputCollisionInfo`, `OutputCollisionKind`, `OutputCollision`, `ResolvedOutputPlan`.
 - Pure naming/collision/review data facts are packaged in
   `abb-output-artifact-core`; `src-tauri/src/output_artifact` owns runtime file
   I/O and final commit behavior.
 
 ## Private Cluster
-- Files: `artifact.rs`, `collision.rs`, `commit.rs`, `commit_tests.rs`, `naming.rs`, `plan.rs`, `review.rs`, `supplemental.rs`, `types.rs`, `contract_tests.rs`.
-- The cluster owns artifact path derivation, collision detection, review signatures, parent-dir creation, final artifact commit behavior, destination-adjacent replacement temps, and final-sidecar Supplemental PDF commit behavior.
+- Files: `artifact.rs`, `collision.rs`, `commit.rs`, `commit_tests.rs`, `naming.rs`, `parent_dirs.rs`, `parent_dirs_tests.rs`, `plan.rs`, `review.rs`, `supplemental.rs`, `types.rs`, `contract_tests.rs`.
+- The cluster owns artifact path derivation, collision detection, review signatures, parent-dir creation and cleanup of ABB-created empty parent dirs, final artifact commit behavior, destination-adjacent replacement temps, and final-sidecar Supplemental PDF commit behavior.
 
 ## Allowed Agent Edits Without Escalation
 - Change pure output planning rules when `cargo nextest run -p abb-output-artifact-core` stays green.

--- a/src-tauri/src/output_artifact/contract_tests.rs
+++ b/src-tauri/src/output_artifact/contract_tests.rs
@@ -85,7 +85,8 @@ fn output_artifact_parent_dir_contract_only_creates_writable_destinations() {
         .expect("skip plan");
     skip_plan.action = PlannedOutputAction::SkipExisting;
 
-    ensure_output_parent_dirs([&write_plan, &skip_plan]).expect("ensure parents");
+    let _cleanup = ensure_output_parent_dirs(temp_dir.path(), [&write_plan, &skip_plan])
+        .expect("ensure parents");
 
     assert!(temp_dir.path().join("write").exists());
     assert!(!temp_dir.path().join("skip").exists());

--- a/src-tauri/src/output_artifact/mod.rs
+++ b/src-tauri/src/output_artifact/mod.rs
@@ -2,6 +2,7 @@ mod artifact;
 mod collision;
 mod commit;
 mod naming;
+mod parent_dirs;
 mod plan;
 mod review;
 mod supplemental;
@@ -17,9 +18,10 @@ pub(crate) use commit::{commit_output_artifact, finalized_output_success, Output
 #[cfg_attr(not(test), allow(unused_imports))]
 pub(crate) use naming::build_output_path;
 pub use naming::build_output_path_preview;
+pub(crate) use parent_dirs::{ensure_output_parent_dirs, OutputParentDirCleanup};
 #[allow(unused_imports)]
 pub(crate) use plan::{action_requires_output_write, plan_is_hard_block, OutputPlanLedger};
-pub(crate) use review::{enforce_output_plan_review, ensure_output_parent_dirs, OutputPlanReview};
+pub(crate) use review::{enforce_output_plan_review, OutputPlanReview};
 pub(crate) use supplemental::{
     commit_supplemental_output_asset, SupplementalOutputAssetCommitRequest,
 };

--- a/src-tauri/src/output_artifact/parent_dirs.rs
+++ b/src-tauri/src/output_artifact/parent_dirs.rs
@@ -1,0 +1,209 @@
+use super::plan::action_requires_output_write;
+use super::types::ResolvedOutputPlan;
+use crate::errors::{sanitize_path_for_display, AppError, Result};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub(crate) struct OutputParentDirCleanup {
+    output_root: PathBuf,
+    created_dirs: Vec<PathBuf>,
+    active: bool,
+}
+
+impl OutputParentDirCleanup {
+    fn new(output_root: PathBuf) -> Self {
+        Self {
+            output_root,
+            created_dirs: Vec::new(),
+            active: true,
+        }
+    }
+
+    fn add_created_dirs(&mut self, created_dirs: Vec<PathBuf>) {
+        self.created_dirs.extend(created_dirs);
+    }
+
+    pub(crate) fn release(mut self) {
+        self.active = false;
+        self.created_dirs.clear();
+    }
+
+    pub(crate) fn cleanup_now(mut self) -> Result<()> {
+        self.cleanup_active()
+    }
+
+    fn cleanup_active(&mut self) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        self.active = false;
+
+        let mut first_error = None;
+        for dir in std::mem::take(&mut self.created_dirs).into_iter().rev() {
+            if let Err(error) = remove_created_empty_dir(&self.output_root, &dir) {
+                log::warn!(
+                    "output_parent_cleanup status=err dir={} err={}",
+                    dir.display(),
+                    error
+                );
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for OutputParentDirCleanup {
+    fn drop(&mut self) {
+        if self.active && !self.created_dirs.is_empty() {
+            if let Err(error) = self.cleanup_active() {
+                log::warn!("output_parent_cleanup status=drop_err err={error}");
+            }
+        }
+    }
+}
+
+pub(crate) fn ensure_output_parent_dirs<'a>(
+    output_root: &Path,
+    outputs: impl IntoIterator<Item = &'a ResolvedOutputPlan>,
+) -> Result<OutputParentDirCleanup> {
+    let output_root = output_root.canonicalize().map_err(|error| {
+        AppError::FileValidation(format!(
+            "Cannot validate output root '{}': {}",
+            sanitize_path_for_display(output_root),
+            error
+        ))
+    })?;
+    let mut cleanup = OutputParentDirCleanup::new(output_root);
+
+    for output in outputs {
+        if !action_requires_output_write(output.action) {
+            continue;
+        }
+        if let Some(parent) = output.resolved_path.parent() {
+            ensure_output_parent_under_root(&cleanup.output_root, parent)?;
+            let created_dirs = create_missing_output_parent_dirs(parent)?;
+            cleanup.add_created_dirs(created_dirs);
+        }
+    }
+
+    Ok(cleanup)
+}
+
+fn create_missing_output_parent_dirs(parent: &Path) -> Result<Vec<PathBuf>> {
+    let mut missing_dirs = Vec::new();
+    let mut current = Some(parent);
+    while let Some(path) = current {
+        if path.try_exists().map_err(AppError::Io)? {
+            break;
+        }
+        missing_dirs.push(path.to_path_buf());
+        current = path.parent();
+    }
+
+    let mut created_dirs = Vec::new();
+    for dir in missing_dirs.into_iter().rev() {
+        match std::fs::create_dir(&dir) {
+            Ok(()) => created_dirs.push(dir),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists && dir.is_dir() => {}
+            Err(error) => {
+                return Err(AppError::FileValidation(format!(
+                    "Cannot create output directory '{}': {}",
+                    sanitize_path_for_display(&dir),
+                    error
+                )));
+            }
+        }
+    }
+
+    Ok(created_dirs)
+}
+
+fn ensure_output_parent_under_root(output_root: &Path, parent: &Path) -> Result<()> {
+    let Some(existing_ancestor) = nearest_existing_ancestor(parent)? else {
+        return Err(AppError::FileValidation(format!(
+            "Cannot validate output directory '{}'.",
+            sanitize_path_for_display(parent)
+        )));
+    };
+    let existing_ancestor = existing_ancestor.canonicalize().map_err(|error| {
+        AppError::FileValidation(format!(
+            "Cannot validate output directory '{}': {}",
+            sanitize_path_for_display(&existing_ancestor),
+            error
+        ))
+    })?;
+
+    if existing_ancestor.starts_with(output_root) {
+        return Ok(());
+    }
+
+    Err(AppError::FileValidation(format!(
+        "Output directory '{}' escapes the configured output root.",
+        sanitize_path_for_display(parent)
+    )))
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Result<Option<PathBuf>> {
+    let mut current = Some(path);
+    while let Some(path) = current {
+        if path.try_exists().map_err(AppError::Io)? {
+            return Ok(Some(path.to_path_buf()));
+        }
+        current = path.parent();
+    }
+    Ok(None)
+}
+
+fn remove_created_empty_dir(output_root: &Path, dir: &Path) -> Result<()> {
+    if !dir.try_exists().map_err(AppError::Io)? {
+        return Ok(());
+    }
+
+    let metadata = std::fs::symlink_metadata(dir).map_err(AppError::Io)?;
+    if metadata.file_type().is_symlink() {
+        return Err(AppError::ResourceCleanup(
+            "Refusing to cleanup symlinked output directory".to_string(),
+        ));
+    }
+
+    let canonical_dir = dir.canonicalize().map_err(|error| {
+        AppError::ResourceCleanup(format!("Invalid output cleanup directory: {error}"))
+    })?;
+    if canonical_dir == output_root || !canonical_dir.starts_with(output_root) {
+        return Err(AppError::ResourceCleanup(
+            "Refusing to cleanup output directory outside configured output root".to_string(),
+        ));
+    }
+
+    match std::fs::remove_dir(dir) {
+        Ok(()) => {
+            log::info!("output_parent_cleanup status=removed dir={}", dir.display());
+            Ok(())
+        }
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty
+            ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(AppError::ResourceCleanup(format!(
+            "Failed to remove output directory '{}': {}",
+            sanitize_path_for_display(dir),
+            error
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[path = "parent_dirs_tests.rs"]
+mod tests;

--- a/src-tauri/src/output_artifact/parent_dirs_tests.rs
+++ b/src-tauri/src/output_artifact/parent_dirs_tests.rs
@@ -1,0 +1,160 @@
+use super::*;
+use crate::output_artifact::{OutputKind, PlannedOutputAction, ResolvedOutputPlan};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn output_plan(action: PlannedOutputAction, path: impl Into<PathBuf>) -> ResolvedOutputPlan {
+    let path = path.into();
+    ResolvedOutputPlan {
+        kind: OutputKind::Final,
+        requested_path: path.clone(),
+        resolved_path: path,
+        rename_candidate: None,
+        collision: None,
+        action,
+    }
+}
+
+#[test]
+fn creates_parent_dirs_for_writable_outputs_only() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let writable = output_plan(
+        PlannedOutputAction::Write,
+        temp_dir.path().join("created").join("book.m4b"),
+    );
+    let skipped = output_plan(
+        PlannedOutputAction::SkipExisting,
+        temp_dir.path().join("skipped").join("book.m4b"),
+    );
+
+    let _cleanup =
+        ensure_output_parent_dirs(temp_dir.path(), [&writable, &skipped]).expect("parent dirs");
+
+    assert!(temp_dir.path().join("created").exists());
+    assert!(!temp_dir.path().join("skipped").exists());
+}
+
+#[test]
+fn cleanup_removes_newly_created_empty_output_parents() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let output = output_plan(
+        PlannedOutputAction::Write,
+        temp_dir
+            .path()
+            .join("author")
+            .join("title")
+            .join("book.m4b"),
+    );
+
+    let cleanup = ensure_output_parent_dirs(temp_dir.path(), [&output]).expect("parent dirs");
+
+    assert!(temp_dir.path().join("author").join("title").exists());
+
+    cleanup.cleanup_now().expect("cleanup output parents");
+
+    assert!(!temp_dir.path().join("author").join("title").exists());
+    assert!(!temp_dir.path().join("author").exists());
+    assert!(temp_dir.path().exists());
+}
+
+#[test]
+fn cleanup_preserves_preexisting_empty_output_parents() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let parent = temp_dir.path().join("author").join("title");
+    std::fs::create_dir_all(&parent).expect("precreate parent");
+    let output = output_plan(PlannedOutputAction::Write, parent.join("book.m4b"));
+
+    let cleanup = ensure_output_parent_dirs(temp_dir.path(), [&output]).expect("parent dirs");
+
+    cleanup.cleanup_now().expect("cleanup output parents");
+
+    assert!(parent.exists(), "preexisting parent should remain");
+}
+
+#[test]
+fn cleanup_preserves_non_empty_output_parents() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let parent = temp_dir.path().join("author").join("title");
+    let output = output_plan(PlannedOutputAction::Write, parent.join("book.m4b"));
+    let cleanup = ensure_output_parent_dirs(temp_dir.path(), [&output]).expect("parent dirs");
+
+    std::fs::write(parent.join("marker.txt"), b"keep").expect("write marker");
+
+    cleanup.cleanup_now().expect("cleanup output parents");
+
+    assert!(parent.exists(), "non-empty parent should remain");
+    assert!(
+        temp_dir.path().join("author").exists(),
+        "non-empty child should keep ancestor"
+    );
+}
+
+#[test]
+fn cleanup_preserves_successful_sibling_and_removes_cancelled_empty_sibling() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let successful_parent = temp_dir.path().join("author").join("success");
+    let cancelled_parent = temp_dir.path().join("author").join("cancelled");
+    let successful = output_plan(
+        PlannedOutputAction::Write,
+        successful_parent.join("book.m4b"),
+    );
+    let cancelled = output_plan(
+        PlannedOutputAction::Write,
+        cancelled_parent.join("book.m4b"),
+    );
+    let cleanup =
+        ensure_output_parent_dirs(temp_dir.path(), [&successful, &cancelled]).expect("parents");
+
+    std::fs::write(successful_parent.join("book.m4b"), b"committed")
+        .expect("write committed output");
+
+    cleanup.cleanup_now().expect("cleanup output parents");
+
+    assert!(
+        successful_parent.exists(),
+        "successful parent should remain"
+    );
+    assert!(
+        !cancelled_parent.exists(),
+        "empty cancelled parent should be removed"
+    );
+    assert!(temp_dir.path().join("author").exists());
+}
+
+#[test]
+fn rejects_output_parent_escape_from_output_root() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let escaped = temp_dir
+        .path()
+        .join("..")
+        .join("outside-output-root")
+        .join("book.m4b");
+    let output = output_plan(PlannedOutputAction::Write, escaped);
+
+    let err = ensure_output_parent_dirs(temp_dir.path(), [&output])
+        .expect_err("escaped parent should fail");
+
+    assert!(err
+        .to_string()
+        .contains("escapes the configured output root"));
+}
+
+#[cfg(unix)]
+#[test]
+fn cleanup_refuses_symlinked_output_parent() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let outside = TempDir::new().expect("outside dir");
+    let parent = temp_dir.path().join("author").join("title");
+    let output = output_plan(PlannedOutputAction::Write, parent.join("book.m4b"));
+    let cleanup = ensure_output_parent_dirs(temp_dir.path(), [&output]).expect("parent dirs");
+
+    std::fs::remove_dir(&parent).expect("remove created parent");
+    std::os::unix::fs::symlink(outside.path(), &parent).expect("swap symlink parent");
+
+    let err = cleanup
+        .cleanup_now()
+        .expect_err("symlinked parent cleanup should fail");
+
+    assert!(err.to_string().contains("symlinked output directory"));
+    assert!(outside.path().exists(), "outside target must remain");
+}

--- a/src-tauri/src/output_artifact/review.rs
+++ b/src-tauri/src/output_artifact/review.rs
@@ -1,4 +1,4 @@
-use super::plan::{action_requires_output_write, plan_is_hard_block};
+use super::plan::plan_is_hard_block;
 use super::types::{CollisionPolicy, OutputCollisionKind, PlannedOutputAction, ResolvedOutputPlan};
 use crate::errors::{sanitize_path_for_display, AppError, Result};
 
@@ -6,27 +6,6 @@ pub(crate) struct OutputPlanReview<'a> {
     pub(crate) expected_signature: Option<&'a str>,
     pub(crate) current_signature: &'a str,
     pub(crate) collision_policy: CollisionPolicy,
-}
-
-pub(crate) fn ensure_output_parent_dirs<'a>(
-    outputs: impl IntoIterator<Item = &'a ResolvedOutputPlan>,
-) -> Result<()> {
-    for output in outputs {
-        if !action_requires_output_write(output.action) {
-            continue;
-        }
-        if let Some(parent) = output.resolved_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|error| {
-                AppError::FileValidation(format!(
-                    "Cannot create output directory '{}': {}",
-                    sanitize_path_for_display(parent),
-                    error
-                ))
-            })?;
-        }
-    }
-
-    Ok(())
 }
 
 fn output_plan_review_message(output: &ResolvedOutputPlan) -> String {
@@ -224,23 +203,5 @@ mod tests {
         .expect_err("hard block should fail");
 
         assert!(err.to_string().contains("targets an input source file"));
-    }
-
-    #[test]
-    fn creates_parent_dirs_for_writable_outputs_only() {
-        let temp_dir = TempDir::new().expect("temp dir");
-        let writable = output_plan(
-            PlannedOutputAction::Write,
-            temp_dir.path().join("created").join("book.m4b"),
-        );
-        let skipped = output_plan(
-            PlannedOutputAction::SkipExisting,
-            temp_dir.path().join("skipped").join("book.m4b"),
-        );
-
-        ensure_output_parent_dirs([&writable, &skipped]).expect("parent dirs");
-
-        assert!(temp_dir.path().join("created").exists());
-        assert!(!temp_dir.path().join("skipped").exists());
     }
 }

--- a/src-tauri/src/processing.rs
+++ b/src-tauri/src/processing.rs
@@ -1,6 +1,7 @@
 pub mod context;
 pub mod job_registry;
 pub mod lifecycle;
+mod output_parent_cleanup;
 pub(crate) mod plan;
 pub mod preview_config;
 pub mod progress;

--- a/src-tauri/src/processing/AGENTS.md
+++ b/src-tauri/src/processing/AGENTS.md
@@ -1,7 +1,7 @@
 ## Public API Strip
 - Processing Plan: import from `crate::processing::plan`, not private helpers.
   Functions: `resolve_preflight_plan`, `prepare_execution_plan`. Types:
-  `ResolvedProcessingPlan`, `PlannedProcessingJob`.
+  `ExecutionProcessingPlan`, `ResolvedProcessingPlan`, `PlannedProcessingJob`.
 - Backend Lifecycle: import shared lifecycle vocabulary and event helpers from
   `crate::processing`, not `audio`, `commands`, or Status Panel internals.
   Types: `OperationKind`, `OperationResultSummary`, `EventStage`,
@@ -13,8 +13,8 @@
 
 ## Private Cluster
 - Files: `../processing.rs`, `plan.rs`, `run.rs`, `terminal_outcomes/`,
-  `lifecycle.rs`, `context/`, `job_registry/`, `progress/`,
-  `preview_config.rs`, `session.rs`, `contract_tests.rs`.
+  `lifecycle.rs`, `context/`, `job_registry/`, `output_parent_cleanup.rs`,
+  `progress/`, `preview_config.rs`, `session.rs`, `contract_tests.rs`.
 - The cluster owns preflight planning, execution-plan preparation, runner
   orchestration, processing context/session state, backend lifecycle
   vocabulary, job lifecycle, queue/progress event types, terminal result
@@ -25,7 +25,7 @@
   `cargo nextest run -p abb-processing-core` stays green.
 - Change planner or runner internals when targeted `audiobook-boss` Nextest and
   Public API Strip checks stay green.
-- Keep preflight side-effect-free; execution may create output dirs only after review enforcement.
+- Keep preflight side-effect-free; execution may create and track output dirs only after review enforcement.
 - Keep runner responsibilities to encoder request validation, job registration,
   scheduler dispatch, audio execution requests through `crate::audio`, and
   handoff to terminal outcome helpers. Toolchain selection stays audio-owned.

--- a/src-tauri/src/processing/AGENTS.md
+++ b/src-tauri/src/processing/AGENTS.md
@@ -14,7 +14,7 @@
 ## Private Cluster
 - Files: `../processing.rs`, `plan.rs`, `run.rs`, `terminal_outcomes/`,
   `lifecycle.rs`, `context/`, `job_registry/`, `output_parent_cleanup.rs`,
-  `progress/`, `preview_config.rs`, `session.rs`, `contract_tests.rs`.
+  `progress/`, `preview_config.rs`, `session.rs`, `types.rs`.
 - The cluster owns preflight planning, execution-plan preparation, runner
   orchestration, processing context/session state, backend lifecycle
   vocabulary, job lifecycle, queue/progress event types, terminal result

--- a/src-tauri/src/processing/context/processing.rs
+++ b/src-tauri/src/processing/context/processing.rs
@@ -99,6 +99,8 @@ pub struct ProcessingContext {
     pub preview: Option<PreviewConfig>,
     /// Optional job identifier for parallel batch processing
     pub job_id: Option<String>,
+    /// Optional WorkRuntime operation identifier
+    pub operation_id: Option<String>,
     /// Optional index of the input file in the original request
     pub input_index: Option<usize>,
     /// Backend operation family for lifecycle events emitted by this context
@@ -141,6 +143,7 @@ impl ProcessingContext {
             workspace_root,
             preview: None,
             job_id: None,
+            operation_id: None,
             input_index: None,
             operation_kind: OperationKind::ProcessingBatch,
         }
@@ -178,6 +181,7 @@ impl ProcessingContext {
             workspace_root,
             preview: None,
             job_id: None,
+            operation_id: None,
             input_index: None,
             operation_kind: OperationKind::ProcessingBatch,
         }
@@ -244,6 +248,7 @@ impl ProcessingContext {
             Some(window) => crate::processing::progress::ProgressEmitter::with_context(
                 window.clone(),
                 self.operation_kind,
+                self.operation_id.clone(),
                 self.job_id.clone(),
                 self.input_index,
             ),
@@ -280,6 +285,7 @@ pub struct ProcessingContextBuilder {
     output: Option<OutputConfig>,
     preview: Option<PreviewConfig>,
     job_id: Option<String>,
+    operation_id: Option<String>,
     input_index: Option<usize>,
     operation_kind: OperationKind,
     workspace_root: Option<PathBuf>,
@@ -330,6 +336,12 @@ impl ProcessingContextBuilder {
     /// Sets the job ID
     pub fn job_id(mut self, job_id: String) -> Self {
         self.job_id = Some(job_id);
+        self
+    }
+
+    /// Sets the WorkRuntime operation ID
+    pub fn operation_id(mut self, operation_id: String) -> Self {
+        self.operation_id = Some(operation_id);
         self
     }
 
@@ -398,6 +410,7 @@ impl ProcessingContextBuilder {
             workspace_root,
             preview: self.preview,
             job_id: self.job_id,
+            operation_id: self.operation_id,
             input_index: self.input_index,
             operation_kind: self.operation_kind,
         })

--- a/src-tauri/src/processing/job_registry/cancel.rs
+++ b/src-tauri/src/processing/job_registry/cancel.rs
@@ -8,17 +8,21 @@ pub struct CancellationChecker {
     pub(crate) job_flag: Arc<AtomicBool>,
     pub(crate) global_flag: Arc<AtomicBool>,
     pub(crate) operation_flag: Option<Arc<AtomicBool>>,
+    pub(crate) honor_global: bool,
 }
 
 impl CancellationChecker {
     pub fn with_operation_flag(mut self, flag: Option<Arc<AtomicBool>>) -> Self {
+        if flag.is_some() {
+            self.honor_global = false;
+        }
         self.operation_flag = flag;
         self
     }
 
     /// Checks if processing should be cancelled (job-specific OR global)
     pub fn is_cancelled(&self) -> bool {
-        self.global_flag.load(Ordering::Acquire)
+        (self.honor_global && self.global_flag.load(Ordering::Acquire))
             || self.job_flag.load(Ordering::Acquire)
             || self
                 .operation_flag

--- a/src-tauri/src/processing/job_registry/cancel.rs
+++ b/src-tauri/src/processing/job_registry/cancel.rs
@@ -7,11 +7,22 @@ use std::sync::Arc;
 pub struct CancellationChecker {
     pub(crate) job_flag: Arc<AtomicBool>,
     pub(crate) global_flag: Arc<AtomicBool>,
+    pub(crate) operation_flag: Option<Arc<AtomicBool>>,
 }
 
 impl CancellationChecker {
+    pub fn with_operation_flag(mut self, flag: Option<Arc<AtomicBool>>) -> Self {
+        self.operation_flag = flag;
+        self
+    }
+
     /// Checks if processing should be cancelled (job-specific OR global)
     pub fn is_cancelled(&self) -> bool {
-        self.global_flag.load(Ordering::Acquire) || self.job_flag.load(Ordering::Acquire)
+        self.global_flag.load(Ordering::Acquire)
+            || self.job_flag.load(Ordering::Acquire)
+            || self
+                .operation_flag
+                .as_ref()
+                .is_some_and(|flag| flag.load(Ordering::Acquire))
     }
 }

--- a/src-tauri/src/processing/job_registry/mod.rs
+++ b/src-tauri/src/processing/job_registry/mod.rs
@@ -4,6 +4,9 @@
 //! to limit simultaneous processing operations.
 
 mod cancel;
+mod permit;
+#[cfg(test)]
+mod tests;
 mod types;
 
 use crate::errors::{AppError, Result};
@@ -11,7 +14,7 @@ use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::sync::{RwLock, Semaphore};
 use tokio::task::{Id, JoinSet};
 use uuid::Uuid;
 
@@ -189,42 +192,6 @@ impl JobRegistry {
         BatchScheduler::new(self)
     }
 
-    /// Registers a new job and acquires a semaphore permit
-    ///
-    /// This method will block if max_concurrent jobs are already running.
-    /// Returns the JobId and an owned permit that must be held for the
-    /// duration of processing.
-    pub async fn register_job(&self) -> Result<(JobId, OwnedSemaphorePermit)> {
-        if self.global_cancel.load(Ordering::SeqCst) {
-            return Err(AppError::cancelled());
-        }
-
-        // Acquire semaphore permit (blocks if at capacity)
-        let semaphore = { self.semaphore.read().await.clone() };
-        let permit = semaphore
-            .acquire_owned()
-            .await
-            .map_err(|_| AppError::InvalidInput("Semaphore closed".to_string()))?;
-
-        if self.global_cancel.load(Ordering::SeqCst) {
-            drop(permit);
-            return Err(AppError::cancelled());
-        }
-
-        let job_id = JobId::new();
-        let mut job = Job::new(job_id);
-        job.state = JobState::Running;
-
-        // Insert job into registry
-        {
-            let mut jobs = self.jobs.write().await;
-            jobs.insert(job_id.0, job);
-        }
-
-        log::info!("Job {} registered and started", job_id);
-        Ok((job_id, permit))
-    }
-
     /// Gets the cancellation flag for a specific job
     pub async fn get_cancel_flag(&self, job_id: JobId) -> Arc<AtomicBool> {
         let jobs = self.jobs.read().await;
@@ -253,6 +220,7 @@ impl JobRegistry {
         CancellationChecker {
             job_flag,
             global_flag: self.global_cancel.clone(),
+            operation_flag: None,
         }
     }
 

--- a/src-tauri/src/processing/job_registry/mod.rs
+++ b/src-tauri/src/processing/job_registry/mod.rs
@@ -221,6 +221,7 @@ impl JobRegistry {
             job_flag,
             global_flag: self.global_cancel.clone(),
             operation_flag: None,
+            honor_global: true,
         }
     }
 

--- a/src-tauri/src/processing/job_registry/permit.rs
+++ b/src-tauri/src/processing/job_registry/permit.rs
@@ -21,16 +21,21 @@ impl JobRegistry {
         &self,
         external_cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(JobId, OwnedSemaphorePermit)> {
-        if self.global_cancel.load(Ordering::SeqCst) || external_cancelled(&external_cancel) {
+        let honor_global = external_cancel.is_none();
+        if (honor_global && self.global_cancel.load(Ordering::SeqCst))
+            || external_cancelled(&external_cancel)
+        {
             return Err(AppError::cancelled());
         }
 
         let semaphore = { self.semaphore.read().await.clone() };
         let permit = self
-            .acquire_permit_with_external_cancel(semaphore, external_cancel.clone())
+            .acquire_permit_with_external_cancel(semaphore, external_cancel.clone(), honor_global)
             .await?;
 
-        if self.global_cancel.load(Ordering::SeqCst) || external_cancelled(&external_cancel) {
+        if (honor_global && self.global_cancel.load(Ordering::SeqCst))
+            || external_cancelled(&external_cancel)
+        {
             drop(permit);
             return Err(AppError::cancelled());
         }
@@ -52,12 +57,15 @@ impl JobRegistry {
         &self,
         semaphore: Arc<Semaphore>,
         external_cancel: Option<Arc<AtomicBool>>,
+        honor_global: bool,
     ) -> Result<OwnedSemaphorePermit> {
         let acquire = semaphore.acquire_owned();
         tokio::pin!(acquire);
 
         loop {
-            if self.global_cancel.load(Ordering::SeqCst) || external_cancelled(&external_cancel) {
+            if (honor_global && self.global_cancel.load(Ordering::SeqCst))
+                || external_cancelled(&external_cancel)
+            {
                 return Err(AppError::cancelled());
             }
 

--- a/src-tauri/src/processing/job_registry/permit.rs
+++ b/src-tauri/src/processing/job_registry/permit.rs
@@ -1,0 +1,79 @@
+use super::{Job, JobId, JobRegistry, JobState};
+use crate::errors::{AppError, Result};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const PERMIT_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+impl JobRegistry {
+    /// Registers a new job and acquires a semaphore permit.
+    ///
+    /// This method will block if max_concurrent jobs are already running.
+    /// Returns the JobId and an owned permit that must be held for the
+    /// duration of processing.
+    pub async fn register_job(&self) -> Result<(JobId, OwnedSemaphorePermit)> {
+        self.register_job_with_external_cancel(None).await
+    }
+
+    pub async fn register_job_with_external_cancel(
+        &self,
+        external_cancel: Option<Arc<AtomicBool>>,
+    ) -> Result<(JobId, OwnedSemaphorePermit)> {
+        if self.global_cancel.load(Ordering::SeqCst) || external_cancelled(&external_cancel) {
+            return Err(AppError::cancelled());
+        }
+
+        let semaphore = { self.semaphore.read().await.clone() };
+        let permit = self
+            .acquire_permit_with_external_cancel(semaphore, external_cancel.clone())
+            .await?;
+
+        if self.global_cancel.load(Ordering::SeqCst) || external_cancelled(&external_cancel) {
+            drop(permit);
+            return Err(AppError::cancelled());
+        }
+
+        let job_id = JobId::new();
+        let mut job = Job::new(job_id);
+        job.state = JobState::Running;
+
+        {
+            let mut jobs = self.jobs.write().await;
+            jobs.insert(job_id.0, job);
+        }
+
+        log::info!("Job {} registered and started", job_id);
+        Ok((job_id, permit))
+    }
+
+    async fn acquire_permit_with_external_cancel(
+        &self,
+        semaphore: Arc<Semaphore>,
+        external_cancel: Option<Arc<AtomicBool>>,
+    ) -> Result<OwnedSemaphorePermit> {
+        let acquire = semaphore.acquire_owned();
+        tokio::pin!(acquire);
+
+        loop {
+            if self.global_cancel.load(Ordering::SeqCst) || external_cancelled(&external_cancel) {
+                return Err(AppError::cancelled());
+            }
+
+            tokio::select! {
+                permit = &mut acquire => {
+                    return permit
+                        .map_err(|_| AppError::InvalidInput("Semaphore closed".to_string()));
+                }
+                _ = tokio::time::sleep(PERMIT_CANCEL_POLL_INTERVAL) => {}
+            }
+        }
+    }
+}
+
+fn external_cancelled(external_cancel: &Option<Arc<AtomicBool>>) -> bool {
+    external_cancel
+        .as_ref()
+        .is_some_and(|flag| flag.load(Ordering::SeqCst))
+}

--- a/src-tauri/src/processing/job_registry/tests.rs
+++ b/src-tauri/src/processing/job_registry/tests.rs
@@ -28,3 +28,34 @@ async fn external_cancel_interrupts_waiting_permit_acquire() {
         AppError::Cancellation(_)
     ));
 }
+
+#[tokio::test]
+async fn operation_scoped_jobs_ignore_legacy_global_cancel() {
+    let registry = JobRegistry::new(1);
+    registry.cancel_all();
+    let operation_cancel = Arc::new(AtomicBool::new(false));
+
+    let (job_id, _permit) = registry
+        .register_job_with_external_cancel(Some(operation_cancel.clone()))
+        .await
+        .expect("operation scoped registration should not honor global cancel");
+    let cancellation = registry
+        .cancellation_checker(job_id)
+        .await
+        .with_operation_flag(Some(operation_cancel));
+
+    assert!(!cancellation.is_cancelled());
+}
+
+#[tokio::test]
+async fn legacy_jobs_honor_global_cancel() {
+    let registry = JobRegistry::new(1);
+    registry.cancel_all();
+
+    let result = registry.register_job().await;
+
+    assert!(matches!(
+        result.expect_err("legacy registration should be cancelled"),
+        AppError::Cancellation(_)
+    ));
+}

--- a/src-tauri/src/processing/job_registry/tests.rs
+++ b/src-tauri/src/processing/job_registry/tests.rs
@@ -1,0 +1,30 @@
+use super::JobRegistry;
+use crate::errors::AppError;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::{sleep, timeout};
+
+#[tokio::test]
+async fn external_cancel_interrupts_waiting_permit_acquire() {
+    let registry = JobRegistry::new(1);
+    let (_job_id, _held_permit) = registry.register_job().await.expect("first job");
+    let operation_cancel = Arc::new(AtomicBool::new(false));
+    let registration = registry.register_job_with_external_cancel(Some(operation_cancel.clone()));
+    tokio::pin!(registration);
+
+    tokio::select! {
+        result = &mut registration => panic!("registration completed before cancel: {result:?}"),
+        _ = sleep(Duration::from_millis(20)) => {}
+    }
+
+    operation_cancel.store(true, Ordering::SeqCst);
+    let result = timeout(Duration::from_millis(250), &mut registration)
+        .await
+        .expect("registration should observe cancellation promptly");
+
+    assert!(matches!(
+        result.expect_err("registration should be cancelled"),
+        AppError::Cancellation(_)
+    ));
+}

--- a/src-tauri/src/processing/output_parent_cleanup.rs
+++ b/src-tauri/src/processing/output_parent_cleanup.rs
@@ -1,0 +1,105 @@
+use crate::errors::Result;
+use crate::output_artifact::OutputParentDirCleanup;
+use crate::processing::{ProcessCommandResult, ProcessResultStatus};
+
+pub(super) fn finalize_output_parent_cleanup(
+    result: Result<ProcessCommandResult>,
+    cleanup: OutputParentDirCleanup,
+) -> Result<ProcessCommandResult> {
+    match result {
+        Ok(result) if result_releases_output_parent_cleanup(&result) => {
+            cleanup.release();
+            Ok(result)
+        }
+        Ok(result) => {
+            cleanup_output_parents_after_unsuccessful_result(cleanup);
+            Ok(result)
+        }
+        Err(error) => {
+            cleanup_output_parents_after_unsuccessful_result(cleanup);
+            Err(error)
+        }
+    }
+}
+
+fn result_releases_output_parent_cleanup(result: &ProcessCommandResult) -> bool {
+    result.results.iter().all(|entry| {
+        matches!(
+            entry.status,
+            ProcessResultStatus::Success | ProcessResultStatus::Skipped
+        )
+    })
+}
+
+fn cleanup_output_parents_after_unsuccessful_result(cleanup: OutputParentDirCleanup) {
+    if let Err(error) = cleanup.cleanup_now() {
+        log::warn!("output_parent_cleanup status=terminal_cleanup_err err={error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output_artifact::{
+        ensure_output_parent_dirs, OutputKind, PlannedOutputAction, ResolvedOutputPlan,
+    };
+    use crate::processing::{JobType, ProcessResultEntry};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn output_plan(path: impl Into<PathBuf>) -> ResolvedOutputPlan {
+        let path = path.into();
+        ResolvedOutputPlan {
+            kind: OutputKind::Final,
+            requested_path: path.clone(),
+            resolved_path: path,
+            rename_candidate: None,
+            collision: None,
+            action: PlannedOutputAction::Write,
+        }
+    }
+
+    fn result(status: ProcessResultStatus) -> ProcessCommandResult {
+        ProcessCommandResult::new(
+            JobType::Batch,
+            vec![ProcessResultEntry {
+                input_index: Some(0),
+                status,
+                message: "terminal".to_string(),
+                error: None,
+                preview_file_path: None,
+                preview_actual_seconds: None,
+                job_id: Some("job-1".to_string()),
+            }],
+        )
+    }
+
+    #[test]
+    fn successful_result_releases_output_parent_cleanup() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let parent = temp_dir.path().join("author").join("title");
+        let output = output_plan(parent.join("book.m4b"));
+        let cleanup = ensure_output_parent_dirs(temp_dir.path(), [&output]).expect("parent dirs");
+
+        finalize_output_parent_cleanup(Ok(result(ProcessResultStatus::Success)), cleanup)
+            .expect("finalize cleanup");
+
+        assert!(parent.exists(), "released cleanup should leave parent dirs");
+    }
+
+    #[test]
+    fn cancelled_result_cleans_empty_output_parent() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let parent = temp_dir.path().join("author").join("title");
+        let output = output_plan(parent.join("book.m4b"));
+        let cleanup = ensure_output_parent_dirs(temp_dir.path(), [&output]).expect("parent dirs");
+
+        finalize_output_parent_cleanup(Ok(result(ProcessResultStatus::Cancelled)), cleanup)
+            .expect("finalize cleanup");
+
+        assert!(
+            !parent.exists(),
+            "cancelled cleanup should prune empty parent dirs"
+        );
+    }
+}

--- a/src-tauri/src/processing/plan.rs
+++ b/src-tauri/src/processing/plan.rs
@@ -6,8 +6,8 @@ use crate::metadata::{
 };
 use crate::output_artifact::{
     build_output_path_preview, enforce_output_plan_review, ensure_output_parent_dirs,
-    CollisionPolicy, OutputKind, OutputPlanLedger, OutputPlanReview, PlannedOutputAction,
-    ResolvedOutputPlan,
+    CollisionPolicy, OutputKind, OutputParentDirCleanup, OutputPlanLedger, OutputPlanReview,
+    PlannedOutputAction, ResolvedOutputPlan,
 };
 use crate::processing::{JobType, OutputNamingConfig, ProcessPayload, ProcessingPreflightPlan};
 use std::collections::HashMap;
@@ -35,6 +35,11 @@ pub(crate) struct ResolvedProcessingPlan {
     pub(crate) collision_policy: CollisionPolicy,
     pub(crate) plan_signature: String,
     pub(crate) jobs: Vec<PlannedProcessingJob>,
+}
+
+pub(crate) struct ExecutionProcessingPlan {
+    pub(crate) plan: ResolvedProcessingPlan,
+    pub(crate) output_parent_cleanup: OutputParentDirCleanup,
 }
 
 fn resolve_output_dir(output_dir: &str, create_if_missing: bool) -> Result<PathBuf> {
@@ -248,7 +253,7 @@ pub(crate) fn prepare_execution_plan(
     payload: &ProcessPayload,
     metadata: Option<&HashMap<String, crate::metadata::MetadataIntentPatch>>,
     preview_seconds: Option<f64>,
-) -> Result<ResolvedProcessingPlan> {
+) -> Result<ExecutionProcessingPlan> {
     let inputs = build_processing_inputs(payload, true, preview_seconds)?;
     let plan = build_processing_plan(payload, metadata, &inputs)?;
     log_output_plan("process", payload, &plan);
@@ -260,8 +265,14 @@ pub(crate) fn prepare_execution_plan(
         },
         plan.jobs.iter().map(|job| &job.output),
     )?;
-    ensure_output_parent_dirs(plan.jobs.iter().map(|job| &job.output))?;
-    Ok(plan)
+    let output_parent_cleanup = ensure_output_parent_dirs(
+        &inputs.base_output_dir,
+        plan.jobs.iter().map(|job| &job.output),
+    )?;
+    Ok(ExecutionProcessingPlan {
+        plan,
+        output_parent_cleanup,
+    })
 }
 
 fn build_merge_processing_job(

--- a/src-tauri/src/processing/progress/emitter.rs
+++ b/src-tauri/src/processing/progress/emitter.rs
@@ -15,6 +15,8 @@ pub struct ProgressEmitter {
     operation_kind: OperationKind,
     /// Optional Tauri window for event emission (None in headless/test runs)
     window: Option<Window>,
+    /// Optional WorkRuntime operation identifier
+    operation_id: Option<String>,
     /// Optional job identifier for parallel batch processing
     job_id: Option<String>,
     /// Optional input index for batch processing
@@ -32,6 +34,7 @@ impl ProgressEmitter {
         Self {
             operation_kind,
             window: Some(window),
+            operation_id: None,
             job_id: None,
             input_index: None,
         }
@@ -42,6 +45,7 @@ impl ProgressEmitter {
         Self {
             operation_kind: OperationKind::ProcessingBatch,
             window: Some(window),
+            operation_id: None,
             job_id: Some(job_id),
             input_index: None,
         }
@@ -51,12 +55,14 @@ impl ProgressEmitter {
     pub fn with_context(
         window: Window,
         operation_kind: OperationKind,
+        operation_id: Option<String>,
         job_id: Option<String>,
         input_index: Option<usize>,
     ) -> Self {
         Self {
             operation_kind,
             window: Some(window),
+            operation_id,
             job_id,
             input_index,
         }
@@ -72,6 +78,7 @@ impl ProgressEmitter {
         Self {
             operation_kind,
             window: None,
+            operation_id: None,
             job_id: None,
             input_index: None,
         }
@@ -84,6 +91,7 @@ impl ProgressEmitter {
 
     fn terminal_event(&self, stage: EventStage, message: &str) -> ProgressEvent {
         ProgressEvent {
+            operation_id: self.operation_id.clone(),
             operation_kind: self.operation_kind,
             stage,
             percentage: if stage == EventStage::Skipped {
@@ -242,6 +250,7 @@ impl ProgressEmitter {
         eta_seconds: Option<f64>,
     ) {
         let event = ProgressEvent {
+            operation_id: self.operation_id.clone(),
             operation_kind: self.operation_kind,
             stage: EventStage::from(&stage),
             percentage,
@@ -267,6 +276,7 @@ mod tests {
         let emitter = ProgressEmitter {
             operation_kind: OperationKind::ProcessingBatch,
             window: None,
+            operation_id: Some("op-123".to_string()),
             job_id: Some("job-123".to_string()),
             input_index: Some(7),
         };
@@ -281,6 +291,9 @@ mod tests {
         assert_eq!(failed.operation_kind, OperationKind::ProcessingBatch);
         assert_eq!(cancelled.operation_kind, OperationKind::ProcessingBatch);
         assert_eq!(skipped.operation_kind, OperationKind::ProcessingBatch);
+        assert_eq!(failed.operation_id, Some("op-123".to_string()));
+        assert_eq!(cancelled.operation_id, Some("op-123".to_string()));
+        assert_eq!(skipped.operation_id, Some("op-123".to_string()));
         assert_eq!(failed.percentage, 0.0);
         assert_eq!(cancelled.percentage, 0.0);
         assert_eq!(skipped.percentage, 100.0);

--- a/src-tauri/src/processing/progress/mod.rs
+++ b/src-tauri/src/processing/progress/mod.rs
@@ -89,6 +89,9 @@ impl From<ProcessingStage> for EventStage {
 /// Progress event structure for frontend communication
 #[derive(Clone, Serialize, specta::Type)]
 pub struct ProgressEvent {
+    /// WorkRuntime operation identifier when this event belongs to accepted work
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
     /// Backend operation family that emitted this event
     pub operation_kind: OperationKind,
     /// Current processing stage
@@ -112,6 +115,8 @@ pub struct ProgressEvent {
 /// Batch queue snapshot for frontend communication
 #[derive(Clone, Serialize, specta::Type)]
 pub struct QueueEvent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
     pub operation_kind: OperationKind,
     pub items: Vec<QueueItem>,
     pub max_concurrent: usize,
@@ -139,10 +144,16 @@ impl QueueEvent {
         max_concurrent: usize,
     ) -> Self {
         Self {
+            operation_id: None,
             operation_kind,
             items,
             max_concurrent,
         }
+    }
+
+    pub fn with_operation_id(mut self, operation_id: Option<String>) -> Self {
+        self.operation_id = operation_id;
+        self
     }
 }
 

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -1,4 +1,7 @@
-use super::plan::{prepare_execution_plan, resolve_preflight_plan, ResolvedProcessingPlan};
+use super::output_parent_cleanup::finalize_output_parent_cleanup;
+use super::plan::{
+    prepare_execution_plan, resolve_preflight_plan, ExecutionProcessingPlan, ResolvedProcessingPlan,
+};
 use super::terminal_outcomes::{
     build_all_skipped_batch_result, classify_processing_error, collect_batch_results,
     emit_terminal_failed_event, emit_terminal_skipped_event, no_write_skipped_result,
@@ -110,14 +113,31 @@ impl ProcessingRun {
         validate_external_processing_contract(&payload)?;
         log_encoder_summary(&payload);
 
-        let plan = prepare_execution_plan(&payload, metadata.as_ref(), preview_seconds)?;
+        let execution_plan = prepare_execution_plan(&payload, metadata.as_ref(), preview_seconds)?;
+        let job_type = execution_plan.plan.job_type;
 
-        match plan.job_type {
+        match job_type {
             JobType::Merge => {
-                dispatch_merge_job(window, registry, workspace_root, &payload, plan, options).await
+                dispatch_merge_job(
+                    window,
+                    registry,
+                    workspace_root,
+                    &payload,
+                    execution_plan,
+                    options,
+                )
+                .await
             }
             JobType::Batch => {
-                dispatch_batch_jobs(window, registry, workspace_root, &payload, plan, options).await
+                dispatch_batch_jobs(
+                    window,
+                    registry,
+                    workspace_root,
+                    &payload,
+                    execution_plan,
+                    options,
+                )
+                .await
             }
         }
     }
@@ -223,6 +243,23 @@ async fn dispatch_merge_job(
     registry: crate::ManagedJobRegistry,
     workspace_root: PathBuf,
     payload: &ProcessPayload,
+    execution_plan: ExecutionProcessingPlan,
+    options: ProcessingRunOptions,
+) -> Result<ProcessCommandResult> {
+    let ExecutionProcessingPlan {
+        plan,
+        output_parent_cleanup,
+    } = execution_plan;
+    let result =
+        dispatch_merge_plan(window, registry, workspace_root, payload, plan, options).await;
+    finalize_output_parent_cleanup(result, output_parent_cleanup)
+}
+
+async fn dispatch_merge_plan(
+    window: tauri::Window,
+    registry: crate::ManagedJobRegistry,
+    workspace_root: PathBuf,
+    payload: &ProcessPayload,
     plan: ResolvedProcessingPlan,
     options: ProcessingRunOptions,
 ) -> Result<ProcessCommandResult> {
@@ -263,6 +300,23 @@ async fn dispatch_merge_job(
 }
 
 async fn dispatch_batch_jobs(
+    window: tauri::Window,
+    registry: crate::ManagedJobRegistry,
+    workspace_root: PathBuf,
+    payload: &ProcessPayload,
+    execution_plan: ExecutionProcessingPlan,
+    options: ProcessingRunOptions,
+) -> Result<ProcessCommandResult> {
+    let ExecutionProcessingPlan {
+        plan,
+        output_parent_cleanup,
+    } = execution_plan;
+    let result =
+        dispatch_batch_plan(window, registry, workspace_root, payload, plan, options).await;
+    finalize_output_parent_cleanup(result, output_parent_cleanup)
+}
+
+async fn dispatch_batch_plan(
     window: tauri::Window,
     registry: crate::ManagedJobRegistry,
     workspace_root: PathBuf,

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -27,9 +27,25 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tokio::sync::OwnedSemaphorePermit;
 
 pub(crate) struct ProcessingRun;
+
+#[derive(Clone, Default)]
+pub(crate) struct ProcessingRunOptions {
+    pub(crate) operation_id: Option<String>,
+    pub(crate) operation_cancel: Option<Arc<AtomicBool>>,
+}
+
+impl ProcessingRunOptions {
+    fn is_operation_cancelled(&self) -> bool {
+        self.operation_cancel
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Acquire))
+    }
+}
 
 pub(crate) async fn process_payload(
     window: tauri::Window,
@@ -39,6 +55,27 @@ pub(crate) async fn process_payload(
     metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
     preview_seconds: Option<f64>,
 ) -> Result<ProcessCommandResult> {
+    process_payload_with_options(
+        window,
+        registry,
+        workspace_root,
+        payload,
+        metadata,
+        preview_seconds,
+        ProcessingRunOptions::default(),
+    )
+    .await
+}
+
+pub(crate) async fn process_payload_with_options(
+    window: tauri::Window,
+    registry: crate::ManagedJobRegistry,
+    workspace_root: PathBuf,
+    payload: ProcessPayload,
+    metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
+    preview_seconds: Option<f64>,
+    options: ProcessingRunOptions,
+) -> Result<ProcessCommandResult> {
     ProcessingRun::execute(
         window,
         registry,
@@ -46,6 +83,7 @@ pub(crate) async fn process_payload(
         payload,
         metadata,
         preview_seconds,
+        options,
     )
     .await
 }
@@ -66,6 +104,7 @@ impl ProcessingRun {
         payload: ProcessPayload,
         metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
         preview_seconds: Option<f64>,
+        options: ProcessingRunOptions,
     ) -> Result<ProcessCommandResult> {
         validate_encoder_settings(&payload.settings)?;
         validate_external_processing_contract(&payload)?;
@@ -75,10 +114,10 @@ impl ProcessingRun {
 
         match plan.job_type {
             JobType::Merge => {
-                dispatch_merge_job(window, registry, workspace_root, &payload, plan).await
+                dispatch_merge_job(window, registry, workspace_root, &payload, plan, options).await
             }
             JobType::Batch => {
-                dispatch_batch_jobs(window, registry, workspace_root, &payload, plan).await
+                dispatch_batch_jobs(window, registry, workspace_root, &payload, plan, options).await
             }
         }
     }
@@ -135,6 +174,7 @@ fn emit_batch_queue_event(
     window: &tauri::Window,
     registry: &crate::ManagedJobRegistry,
     input_files: &[String],
+    operation_id: Option<&str>,
 ) {
     let queue_items: Vec<QueueItem> = input_files
         .iter()
@@ -148,7 +188,8 @@ fn emit_batch_queue_event(
         OperationKind::ProcessingBatch,
         queue_items,
         registry.max_concurrent(),
-    );
+    )
+    .with_operation_id(operation_id.map(|value| value.to_string()));
     emit_queue_event(window, &queue_event);
 }
 
@@ -156,6 +197,7 @@ fn finalize_batch_results(
     window: &tauri::Window,
     payload: &ProcessPayload,
     outcomes: Vec<Result<ProcessResultEntry>>,
+    operation_id: Option<&str>,
 ) -> Result<Vec<ProcessResultEntry>> {
     let finalized = collect_batch_results(payload.input_files.len(), outcomes)?;
     log::debug!(
@@ -166,6 +208,7 @@ fn finalize_batch_results(
         emit_terminal_failed_event(
             window,
             OperationKind::ProcessingBatch,
+            operation_id,
             event.input_index,
             event.job_id.as_deref(),
             &event.message,
@@ -181,7 +224,12 @@ async fn dispatch_merge_job(
     workspace_root: PathBuf,
     payload: &ProcessPayload,
     plan: ResolvedProcessingPlan,
+    options: ProcessingRunOptions,
 ) -> Result<ProcessCommandResult> {
+    if options.is_operation_cancelled() {
+        return Err(AppError::cancelled());
+    }
+
     let planned_job = plan.jobs.into_iter().next().ok_or_else(|| {
         AppError::InvalidInput("No output plan entries were built for merge processing".to_string())
     })?;
@@ -200,6 +248,8 @@ async fn dispatch_merge_job(
         sample_rate: resolve_sample_rate(payload)?,
         input_index: None,
         operation_kind: OperationKind::ProcessingMerge,
+        operation_id: options.operation_id.clone(),
+        operation_cancel: options.operation_cancel.clone(),
         output_plan: planned_job.output,
         file_info,
         metadata: planned_job.metadata,
@@ -218,6 +268,7 @@ async fn dispatch_batch_jobs(
     workspace_root: PathBuf,
     payload: &ProcessPayload,
     plan: ResolvedProcessingPlan,
+    options: ProcessingRunOptions,
 ) -> Result<ProcessCommandResult> {
     if payload.input_files.is_empty() {
         return Err(AppError::InvalidInput(
@@ -229,7 +280,12 @@ async fn dispatch_batch_jobs(
         return Ok(result);
     }
 
-    emit_batch_queue_event(&window, &registry, &payload.input_files);
+    emit_batch_queue_event(
+        &window,
+        &registry,
+        &payload.input_files,
+        options.operation_id.as_deref(),
+    );
 
     let mut scheduled_jobs: Vec<Pin<Box<dyn Future<Output = Result<ProcessResultEntry>> + Send>>> =
         Vec::new();
@@ -242,6 +298,7 @@ async fn dispatch_batch_jobs(
             emit_terminal_skipped_event(
                 &window,
                 OperationKind::ProcessingBatch,
+                options.operation_id.as_deref(),
                 skipped_entry.input_index,
                 skipped_entry.job_id.as_deref(),
                 &skipped_entry.message,
@@ -258,6 +315,8 @@ async fn dispatch_batch_jobs(
         let cover_art_passthrough = planned_job.cover_art_passthrough;
         let preview_cloned = preview_seconds;
         let workspace_root_cloned = workspace_root.clone();
+        let operation_id = options.operation_id.clone();
+        let operation_cancel = options.operation_cancel.clone();
         let input_index = planned_job.input_index;
         let output = planned_job.output.clone();
         let path = planned_job.input_path.clone().ok_or_else(|| {
@@ -266,6 +325,12 @@ async fn dispatch_batch_jobs(
         let supplemental_assets = supplemental_assets_for_input(payload, input_index);
 
         scheduled_jobs.push(Box::pin(async move {
+            if operation_cancel
+                .as_ref()
+                .is_some_and(|flag| flag.load(Ordering::Acquire))
+            {
+                return Err(AppError::cancelled());
+            }
             let file_info = audio::get_file_list_info(std::slice::from_ref(&path))?;
             run_processing_job(ProcessingJobRequest {
                 window: window_cloned,
@@ -275,6 +340,8 @@ async fn dispatch_batch_jobs(
                 sample_rate: sr_cloned,
                 input_index,
                 operation_kind: OperationKind::ProcessingBatch,
+                operation_id,
+                operation_cancel,
                 output_plan: output,
                 file_info,
                 metadata: md_cloned,
@@ -287,7 +354,8 @@ async fn dispatch_batch_jobs(
     }
 
     let outcomes = registry.scheduler().run_batch(scheduled_jobs).await;
-    let finalized_results = finalize_batch_results(&window, payload, outcomes)?;
+    let finalized_results =
+        finalize_batch_results(&window, payload, outcomes, options.operation_id.as_deref())?;
 
     Ok(ProcessCommandResult::new(JobType::Batch, finalized_results))
 }
@@ -300,6 +368,8 @@ struct ProcessingJobRequest {
     sample_rate: audio::SampleRateConfig,
     input_index: Option<usize>,
     operation_kind: OperationKind,
+    operation_id: Option<String>,
+    operation_cancel: Option<Arc<AtomicBool>>,
     output_plan: ResolvedOutputPlan,
     file_info: FileListInfo,
     metadata: Option<crate::metadata::AudiobookMetadata>,
@@ -309,9 +379,14 @@ struct ProcessingJobRequest {
 }
 
 async fn run_processing_job(request: ProcessingJobRequest) -> Result<ProcessResultEntry> {
-    let (job_id, _permit, cancellation_checker) =
-        register_job_and_validate_output(&request.registry, &request.output_plan.resolved_path)
-            .await?;
+    let (job_id, _permit, cancellation_checker) = register_job_and_validate_output(
+        &request.registry,
+        &request.output_plan.resolved_path,
+        request.operation_cancel.clone(),
+    )
+    .await?;
+    let cancellation_checker =
+        cancellation_checker.with_operation_flag(request.operation_cancel.clone());
 
     let (context, preview_seconds_resolved) = build_processing_context(ProcessingContextRequest {
         window: request.window,
@@ -321,6 +396,7 @@ async fn run_processing_job(request: ProcessingJobRequest) -> Result<ProcessResu
         sample_rate: request.sample_rate,
         input_index: request.input_index,
         operation_kind: request.operation_kind,
+        operation_id: request.operation_id.clone(),
         output_plan: request.output_plan.clone(),
         workspace_root: request.workspace_root,
         preview_seconds: request.preview_seconds,
@@ -453,8 +529,11 @@ fn commit_supplemental_assets_for_output(
 async fn register_job_and_validate_output(
     registry: &crate::ManagedJobRegistry,
     output_path: &Path,
+    operation_cancel: Option<Arc<AtomicBool>>,
 ) -> Result<(JobId, OwnedSemaphorePermit, CancellationChecker)> {
-    let (job_id, permit) = registry.register_job().await?;
+    let (job_id, permit) = registry
+        .register_job_with_external_cancel(operation_cancel)
+        .await?;
     log::info!(
         "Job {} started for output: {}",
         job_id,
@@ -478,6 +557,7 @@ struct ProcessingContextRequest {
     sample_rate: audio::SampleRateConfig,
     input_index: Option<usize>,
     operation_kind: OperationKind,
+    operation_id: Option<String>,
     output_plan: ResolvedOutputPlan,
     workspace_root: PathBuf,
     preview_seconds: Option<f64>,
@@ -497,6 +577,7 @@ fn build_processing_context(request: ProcessingContextRequest) -> (ProcessingCon
     context.job_id = Some(request.job_id.to_string());
     context.input_index = request.input_index;
     context.operation_kind = request.operation_kind;
+    context.operation_id = request.operation_id;
 
     let preview_seconds_resolved = request.preview_seconds;
     if let Some(seconds) = preview_seconds_resolved {
@@ -583,11 +664,11 @@ mod tests {
         let temp_dir = TempDir::new().expect("create temp dir");
         let invalid_output = temp_dir.path().join("output.mp3");
 
-        let error = match super::register_job_and_validate_output(&registry, &invalid_output).await
-        {
-            Ok(_) => panic!("invalid extension should fail validation"),
-            Err(error) => error,
-        };
+        let error =
+            match super::register_job_and_validate_output(&registry, &invalid_output, None).await {
+                Ok(_) => panic!("invalid extension should fail validation"),
+                Err(error) => error,
+            };
 
         assert!(
             error

--- a/src-tauri/src/processing/terminal_outcomes/events.rs
+++ b/src-tauri/src/processing/terminal_outcomes/events.rs
@@ -3,6 +3,7 @@ use crate::processing::{OperationKind, ProgressEmitter};
 pub(in crate::processing) fn emit_terminal_failed_event(
     window: &tauri::Window,
     operation_kind: OperationKind,
+    operation_id: Option<&str>,
     input_index: Option<usize>,
     job_id: Option<&str>,
     message: &str,
@@ -10,6 +11,7 @@ pub(in crate::processing) fn emit_terminal_failed_event(
     let emitter = ProgressEmitter::with_context(
         window.clone(),
         operation_kind,
+        operation_id.map(|value| value.to_string()),
         job_id.map(|value| value.to_string()),
         input_index,
     );
@@ -19,6 +21,7 @@ pub(in crate::processing) fn emit_terminal_failed_event(
 pub(in crate::processing) fn emit_terminal_skipped_event(
     window: &tauri::Window,
     operation_kind: OperationKind,
+    operation_id: Option<&str>,
     input_index: Option<usize>,
     job_id: Option<&str>,
     message: &str,
@@ -26,6 +29,7 @@ pub(in crate::processing) fn emit_terminal_skipped_event(
     let emitter = ProgressEmitter::with_context(
         window.clone(),
         operation_kind,
+        operation_id.map(|value| value.to_string()),
         job_id.map(|value| value.to_string()),
         input_index,
     );

--- a/src-tauri/src/processing/types.rs
+++ b/src-tauri/src/processing/types.rs
@@ -26,7 +26,7 @@ impl From<JobType> for OperationKind {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, specta::Type)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct ProcessPayload {
     pub input_files: Vec<String>,

--- a/src-tauri/src/work_runtime/AGENTS.md
+++ b/src-tauri/src/work_runtime/AGENTS.md
@@ -1,0 +1,26 @@
+# WorkRuntime
+
+## Public API Strip
+
+- `WorkRuntime`
+- `OperationId`
+- operation snapshot, child snapshot, progress, summary, lane, and submit request types
+- `WORK_OPERATION_SNAPSHOT_EVENT_NAME`
+- `WORK_OPERATION_LIST_SNAPSHOT_EVENT_NAME`
+
+## Ownership
+
+- Own operation identity, immutable accepted submissions, operation snapshots,
+  operation-scoped cancellation, and Work Center event truth.
+- Use `processing::run` as the processing executor boundary. Do not import audio
+  processor internals, output-artifact internals, or remote-source private
+  provider/materializer modules.
+- Keep Tauri command handlers in `src-tauri/src/commands/work_runtime.rs`.
+- Keep provider secrets, raw provider payloads, protected intermediates, and
+  remote staging mechanics inside `remote_source`.
+
+## Size Guardrails
+
+- Add new behavior inside this module before expanding existing large modules.
+- `mod.rs` is routing only. Split state, types, and runtime behavior when logic
+  grows past scan-friendly boundaries.

--- a/src-tauri/src/work_runtime/mod.rs
+++ b/src-tauri/src/work_runtime/mod.rs
@@ -1,0 +1,16 @@
+mod runtime;
+mod snapshot;
+mod state;
+#[cfg(test)]
+mod state_tests;
+mod terminal;
+mod types;
+
+pub use runtime::WorkRuntime;
+pub use types::{
+    ChildJobSnapshot, ChildJobStatus, OperationId, OperationListSnapshot, OperationSnapshot,
+    OperationTerminalSummary, ProgressSnapshot, ResourceLane, SubmitProcessingOperationRequest,
+    WorkOperationListSnapshotEvent, WorkOperationSnapshotEvent, WorkOperationStatus,
+    WorkProgressStage, WorkSubmissionAccepted, WORK_OPERATION_LIST_SNAPSHOT_EVENT_NAME,
+    WORK_OPERATION_SNAPSHOT_EVENT_NAME,
+};

--- a/src-tauri/src/work_runtime/runtime.rs
+++ b/src-tauri/src/work_runtime/runtime.rs
@@ -1,0 +1,251 @@
+use super::snapshot::new_processing_snapshot;
+use super::state::WorkRuntimeState;
+use super::types::{
+    OperationId, OperationListSnapshot, OperationSnapshot, SubmitProcessingOperationRequest,
+    WorkOperationListSnapshotEvent, WorkOperationSnapshotEvent, WorkSubmissionAccepted,
+};
+use crate::errors::{AppError, Result};
+use crate::processing::run::{
+    preflight_payload, process_payload_with_options, ProcessingRunOptions,
+};
+use crate::processing::JobType;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use tauri::Emitter;
+
+#[derive(Clone)]
+pub struct WorkRuntime {
+    inner: Arc<WorkRuntimeInner>,
+}
+
+struct WorkRuntimeInner {
+    state: Mutex<WorkRuntimeState>,
+    operation_cancel_flags: Mutex<HashMap<String, Arc<AtomicBool>>>,
+    sequence: AtomicU64,
+}
+
+impl Default for WorkRuntime {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(WorkRuntimeInner {
+                state: Mutex::new(WorkRuntimeState::default()),
+                operation_cancel_flags: Mutex::new(HashMap::new()),
+                sequence: AtomicU64::new(1),
+            }),
+        }
+    }
+}
+
+impl WorkRuntime {
+    pub async fn submit_processing_operation(
+        &self,
+        window: tauri::Window,
+        registry: crate::ManagedJobRegistry,
+        workspace_root: PathBuf,
+        request: SubmitProcessingOperationRequest,
+    ) -> Result<WorkSubmissionAccepted> {
+        preflight_payload(
+            request.payload.clone(),
+            request.metadata.clone(),
+            request.preview_seconds,
+        )?;
+
+        let operation_id = OperationId::new();
+        let sequence = self.inner.sequence.fetch_add(1, Ordering::SeqCst);
+        let kind = request.payload.job_type.unwrap_or(JobType::Batch).into();
+        let title = request
+            .title
+            .clone()
+            .unwrap_or_else(|| processing_operation_title(kind, request.payload.input_files.len()));
+        let input_ids = request.payload.input_ids.as_deref();
+        let snapshot = new_processing_snapshot(
+            operation_id.clone(),
+            sequence,
+            kind,
+            title,
+            &request.payload.input_files,
+            input_ids,
+            now_ms(),
+        );
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+
+        {
+            let mut state = lock_state(&self.inner.state)?;
+            state.insert_operation(snapshot.clone());
+        }
+        {
+            let mut flags = lock_cancel_flags(&self.inner.operation_cancel_flags)?;
+            flags.insert(operation_id.0.clone(), cancel_flag.clone());
+        }
+
+        self.emit_snapshot(&window, &snapshot);
+        self.emit_list(&window);
+
+        let runtime = self.clone();
+        let operation_id_for_task = operation_id.clone();
+        tokio::spawn(async move {
+            runtime.mark_running_and_emit(&window, &operation_id_for_task);
+            let result = process_payload_with_options(
+                window.clone(),
+                registry,
+                workspace_root,
+                request.payload,
+                request.metadata,
+                request.preview_seconds,
+                ProcessingRunOptions {
+                    operation_id: Some(operation_id_for_task.0.clone()),
+                    operation_cancel: Some(cancel_flag),
+                },
+            )
+            .await;
+            runtime.finish_processing_and_emit(&window, &operation_id_for_task, result);
+            runtime.remove_cancel_flag(&operation_id_for_task);
+        });
+
+        Ok(WorkSubmissionAccepted {
+            operation_id,
+            snapshot,
+        })
+    }
+
+    pub fn list_operations(&self) -> Result<OperationListSnapshot> {
+        Ok(lock_state(&self.inner.state)?.list())
+    }
+
+    pub fn get_operation(&self, operation_id: OperationId) -> Result<OperationSnapshot> {
+        lock_state(&self.inner.state)?.get(&operation_id)
+    }
+
+    pub fn cancel_operation(
+        &self,
+        window: &tauri::Window,
+        operation_id: OperationId,
+    ) -> Result<OperationSnapshot> {
+        if let Some(flag) = lock_cancel_flags(&self.inner.operation_cancel_flags)?
+            .get(operation_id.as_str())
+            .cloned()
+        {
+            flag.store(true, Ordering::Release);
+        }
+        let snapshot = lock_state(&self.inner.state)?.request_cancel(&operation_id, now_ms())?;
+        self.emit_snapshot(window, &snapshot);
+        self.emit_list(window);
+        Ok(snapshot)
+    }
+
+    fn mark_running_and_emit(&self, window: &tauri::Window, operation_id: &OperationId) {
+        match lock_state(&self.inner.state)
+            .and_then(|mut state| state.mark_running(operation_id, now_ms()))
+        {
+            Ok(snapshot) => {
+                self.emit_snapshot(window, &snapshot);
+                self.emit_list(window);
+            }
+            Err(error) => log::warn!("Failed to mark work operation running: {}", error),
+        }
+    }
+
+    fn finish_processing_and_emit(
+        &self,
+        window: &tauri::Window,
+        operation_id: &OperationId,
+        result: Result<crate::processing::ProcessCommandResult>,
+    ) {
+        let snapshot_result = match result {
+            Ok(result) => lock_state(&self.inner.state).and_then(|mut state| {
+                state.complete_from_process_result(operation_id, &result, now_ms())
+            }),
+            Err(AppError::Cancellation(message)) => lock_state(&self.inner.state)
+                .and_then(|mut state| state.cancel(operation_id, message, now_ms())),
+            Err(error) => {
+                let message = error.to_string();
+                lock_state(&self.inner.state)
+                    .and_then(|mut state| state.fail(operation_id, message, now_ms()))
+            }
+        };
+
+        match snapshot_result {
+            Ok(snapshot) => {
+                self.emit_snapshot(window, &snapshot);
+                self.emit_list(window);
+            }
+            Err(error) => log::warn!("Failed to terminalize work operation: {}", error),
+        }
+    }
+
+    fn remove_cancel_flag(&self, operation_id: &OperationId) {
+        if let Ok(mut flags) = lock_cancel_flags(&self.inner.operation_cancel_flags) {
+            flags.remove(operation_id.as_str());
+        }
+    }
+
+    fn emit_snapshot(&self, window: &tauri::Window, snapshot: &OperationSnapshot) {
+        let event = WorkOperationSnapshotEvent {
+            snapshot: snapshot.clone(),
+        };
+        if let Err(error) = window.emit(super::WORK_OPERATION_SNAPSHOT_EVENT_NAME, event) {
+            log::warn!("Failed to emit work operation snapshot: {}", error);
+        }
+    }
+
+    fn emit_list(&self, window: &tauri::Window) {
+        match self.list_operations() {
+            Ok(list) => {
+                let event = WorkOperationListSnapshotEvent {
+                    operations: list.operations,
+                };
+                if let Err(error) =
+                    window.emit(super::WORK_OPERATION_LIST_SNAPSHOT_EVENT_NAME, event)
+                {
+                    log::warn!("Failed to emit work operation list snapshot: {}", error);
+                }
+            }
+            Err(error) => log::warn!("Failed to build work operation list snapshot: {}", error),
+        }
+    }
+}
+
+fn processing_operation_title(kind: crate::processing::OperationKind, count: usize) -> String {
+    match kind {
+        crate::processing::OperationKind::ProcessingMerge => {
+            format!("Merge encode ({count} file{})", plural_suffix(count))
+        }
+        crate::processing::OperationKind::ProcessingBatch => {
+            format!("Batch encode ({count} file{})", plural_suffix(count))
+        }
+        crate::processing::OperationKind::RemoteAcquisition => {
+            format!("Remote acquisition ({count} title{})", plural_suffix(count))
+        }
+        crate::processing::OperationKind::MetadataSave => {
+            format!("Metadata save ({count} file{})", plural_suffix(count))
+        }
+    }
+}
+
+fn plural_suffix(count: usize) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn lock_state(state: &Mutex<WorkRuntimeState>) -> Result<MutexGuard<'_, WorkRuntimeState>> {
+    state
+        .lock()
+        .map_err(|_| AppError::General("Work runtime state lock failed".to_string()))
+}
+
+fn lock_cancel_flags(
+    flags: &Mutex<HashMap<String, Arc<AtomicBool>>>,
+) -> Result<MutexGuard<'_, HashMap<String, Arc<AtomicBool>>>> {
+    flags
+        .lock()
+        .map_err(|_| AppError::General("Work runtime cancellation lock failed".to_string()))
+}

--- a/src-tauri/src/work_runtime/snapshot.rs
+++ b/src-tauri/src/work_runtime/snapshot.rs
@@ -1,0 +1,127 @@
+use super::types::{
+    ChildJobSnapshot, OperationId, OperationSnapshot, ProgressSnapshot, ResourceLane,
+    WorkOperationStatus,
+};
+use crate::processing::OperationKind;
+use std::path::Path;
+
+pub(crate) fn new_processing_snapshot(
+    operation_id: OperationId,
+    sequence: u64,
+    kind: OperationKind,
+    title: String,
+    input_files: &[String],
+    input_ids: Option<&[Option<String>]>,
+    now_ms: i64,
+) -> OperationSnapshot {
+    let source_input_ids = input_ids
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|value| value.clone())
+        .collect();
+    let total_items = match kind {
+        OperationKind::ProcessingMerge => Some(1),
+        _ => Some(input_files.len()),
+    };
+    let children = match kind {
+        OperationKind::ProcessingMerge => vec![new_child(
+            &operation_id,
+            "merge-output".to_string(),
+            merge_label(input_files),
+            input_files.first().cloned(),
+            None,
+            None,
+            total_items,
+        )],
+        _ => input_files
+            .iter()
+            .enumerate()
+            .map(|(index, path)| {
+                new_child(
+                    &operation_id,
+                    format!("input-{index}"),
+                    basename(path),
+                    Some(path.clone()),
+                    Some(index),
+                    input_ids
+                        .and_then(|ids| ids.get(index))
+                        .and_then(|value| value.clone()),
+                    total_items,
+                )
+            })
+            .collect(),
+    };
+
+    OperationSnapshot {
+        operation_id,
+        sequence,
+        kind,
+        status: WorkOperationStatus::Accepted,
+        title,
+        created_at_ms: now_ms,
+        started_at_ms: None,
+        finished_at_ms: None,
+        cancellable: true,
+        cancel_requested: false,
+        lanes: vec![
+            ResourceLane::Analysis,
+            ResourceLane::EncodeCpu,
+            ResourceLane::OutputCommit,
+        ],
+        source_input_ids,
+        progress: ProgressSnapshot::pending("Accepted for background processing.", total_items),
+        children,
+        terminal_summary: None,
+        warnings: Vec::new(),
+        errors: Vec::new(),
+    }
+}
+
+fn new_child(
+    operation_id: &OperationId,
+    child_job_id: String,
+    label: String,
+    source_path: Option<String>,
+    input_index: Option<usize>,
+    input_id: Option<String>,
+    total_items: Option<usize>,
+) -> ChildJobSnapshot {
+    ChildJobSnapshot {
+        child_job_id,
+        operation_id: operation_id.clone(),
+        label,
+        status: super::ChildJobStatus::Queued,
+        lane: ResourceLane::EncodeCpu,
+        progress: ProgressSnapshot::pending("Queued.", total_items),
+        source_path,
+        input_index,
+        input_id,
+        job_id: None,
+        cancellable: false,
+        cancel_requested: false,
+        message: None,
+    }
+}
+
+fn basename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn merge_label(input_files: &[String]) -> String {
+    match input_files.first() {
+        Some(first) if input_files.len() > 1 => {
+            format!(
+                "Merge: {} + {} more",
+                basename(first),
+                input_files.len() - 1
+            )
+        }
+        Some(first) => format!("Merge: {}", basename(first)),
+        None => "Merge output".to_string(),
+    }
+}

--- a/src-tauri/src/work_runtime/snapshot.rs
+++ b/src-tauri/src/work_runtime/snapshot.rs
@@ -106,10 +106,9 @@ fn new_child(
 fn basename(path: &str) -> String {
     Path::new(path)
         .file_name()
-        .and_then(|value| value.to_str())
+        .map(|value| value.to_string_lossy().into_owned())
         .filter(|value| !value.is_empty())
-        .unwrap_or(path)
-        .to_string()
+        .unwrap_or_else(|| path.to_string())
 }
 
 fn merge_label(input_files: &[String]) -> String {

--- a/src-tauri/src/work_runtime/state.rs
+++ b/src-tauri/src/work_runtime/state.rs
@@ -1,0 +1,193 @@
+use super::types::{
+    ChildJobStatus, OperationId, OperationListSnapshot, OperationSnapshot,
+    OperationTerminalSummary, WorkOperationStatus, WorkProgressStage,
+};
+use crate::errors::{AppError, Result};
+use crate::processing::ProcessCommandResult;
+use std::collections::BTreeMap;
+
+use super::terminal::{
+    child_status_from_result_status, is_terminal, stage_from_child_status, stage_from_status,
+    status_from_terminal_summary, terminal_summary_from_process_result,
+};
+
+#[derive(Default)]
+pub(crate) struct WorkRuntimeState {
+    operations: BTreeMap<String, OperationSnapshot>,
+}
+
+impl WorkRuntimeState {
+    pub(crate) fn insert_operation(&mut self, snapshot: OperationSnapshot) {
+        self.operations
+            .insert(snapshot.operation_id.0.clone(), snapshot);
+    }
+
+    pub(crate) fn list(&self) -> OperationListSnapshot {
+        let mut operations = self.operations.values().cloned().collect::<Vec<_>>();
+        operations.sort_by(|left, right| right.sequence.cmp(&left.sequence));
+        OperationListSnapshot { operations }
+    }
+
+    pub(crate) fn get(&self, operation_id: &OperationId) -> Result<OperationSnapshot> {
+        self.operations
+            .get(operation_id.as_str())
+            .cloned()
+            .ok_or_else(|| AppError::InvalidInput("Work operation was not found.".to_string()))
+    }
+
+    pub(crate) fn mark_running(
+        &mut self,
+        operation_id: &OperationId,
+        now_ms: i64,
+    ) -> Result<OperationSnapshot> {
+        let snapshot = self.snapshot_mut(operation_id)?;
+        if !is_terminal(snapshot.status) {
+            snapshot.started_at_ms.get_or_insert(now_ms);
+            if snapshot.cancel_requested || snapshot.status == WorkOperationStatus::Cancelling {
+                return Ok(snapshot.clone());
+            }
+            snapshot.status = WorkOperationStatus::Running;
+            snapshot.progress.stage = WorkProgressStage::Analyzing;
+            snapshot.progress.message = "Processing started.".to_string();
+            for child in &mut snapshot.children {
+                if child.status == ChildJobStatus::Queued {
+                    child.cancellable = true;
+                }
+            }
+        }
+        Ok(snapshot.clone())
+    }
+
+    pub(crate) fn request_cancel(
+        &mut self,
+        operation_id: &OperationId,
+        now_ms: i64,
+    ) -> Result<OperationSnapshot> {
+        let snapshot = self.snapshot_mut(operation_id)?;
+        if !is_terminal(snapshot.status) {
+            snapshot.status = WorkOperationStatus::Cancelling;
+            snapshot.cancel_requested = true;
+            snapshot.cancellable = false;
+            snapshot.progress.message = "Cancellation requested.".to_string();
+            snapshot.progress.stage = WorkProgressStage::Cleaning;
+            for child in &mut snapshot.children {
+                child.cancel_requested = true;
+                child.cancellable = false;
+            }
+        } else {
+            snapshot.finished_at_ms.get_or_insert(now_ms);
+        }
+        Ok(snapshot.clone())
+    }
+
+    pub(crate) fn complete_from_process_result(
+        &mut self,
+        operation_id: &OperationId,
+        result: &ProcessCommandResult,
+        now_ms: i64,
+    ) -> Result<OperationSnapshot> {
+        let snapshot = self.snapshot_mut(operation_id)?;
+        let summary = terminal_summary_from_process_result(result);
+        snapshot.status = status_from_terminal_summary(&summary);
+        snapshot.finished_at_ms = Some(now_ms);
+        snapshot.cancellable = false;
+        snapshot.progress.stage = stage_from_status(snapshot.status);
+        snapshot.progress.percentage = 100.0;
+        snapshot.progress.message = summary.message.clone();
+        snapshot.terminal_summary = Some(summary);
+
+        for entry in &result.results {
+            let target_index = entry.input_index.unwrap_or(0);
+            if let Some(child) = snapshot
+                .children
+                .iter_mut()
+                .find(|child| child.input_index.unwrap_or(0) == target_index)
+            {
+                child.status = child_status_from_result_status(entry.status);
+                child.progress.stage = stage_from_child_status(child.status);
+                child.progress.percentage = 100.0;
+                child.progress.message = entry.message.clone();
+                child.job_id = entry.job_id.clone();
+                child.cancellable = false;
+                child.message = Some(entry.message.clone());
+            }
+        }
+
+        Ok(snapshot.clone())
+    }
+
+    pub(crate) fn fail(
+        &mut self,
+        operation_id: &OperationId,
+        message: String,
+        now_ms: i64,
+    ) -> Result<OperationSnapshot> {
+        let snapshot = self.snapshot_mut(operation_id)?;
+        snapshot.status = WorkOperationStatus::Failed;
+        snapshot.finished_at_ms = Some(now_ms);
+        snapshot.cancellable = false;
+        snapshot.progress.stage = WorkProgressStage::Failed;
+        snapshot.progress.percentage = 100.0;
+        snapshot.progress.message = message.clone();
+        snapshot.errors.push(message.clone());
+        snapshot.terminal_summary = Some(OperationTerminalSummary {
+            total: snapshot.children.len(),
+            succeeded: 0,
+            skipped: 0,
+            cancelled: 0,
+            failed: snapshot.children.len().max(1),
+            message,
+        });
+        for child in &mut snapshot.children {
+            if !matches!(
+                child.status,
+                ChildJobStatus::Completed | ChildJobStatus::Skipped | ChildJobStatus::Cancelled
+            ) {
+                child.status = ChildJobStatus::Failed;
+                child.cancellable = false;
+            }
+        }
+        Ok(snapshot.clone())
+    }
+
+    pub(crate) fn cancel(
+        &mut self,
+        operation_id: &OperationId,
+        message: String,
+        now_ms: i64,
+    ) -> Result<OperationSnapshot> {
+        let snapshot = self.snapshot_mut(operation_id)?;
+        snapshot.status = WorkOperationStatus::Cancelled;
+        snapshot.finished_at_ms = Some(now_ms);
+        snapshot.cancel_requested = true;
+        snapshot.cancellable = false;
+        snapshot.progress.stage = WorkProgressStage::Cancelled;
+        snapshot.progress.percentage = 100.0;
+        snapshot.progress.message = message.clone();
+        snapshot.terminal_summary = Some(OperationTerminalSummary {
+            total: snapshot.children.len(),
+            succeeded: 0,
+            skipped: 0,
+            cancelled: snapshot.children.len().max(1),
+            failed: 0,
+            message,
+        });
+        for child in &mut snapshot.children {
+            if !matches!(
+                child.status,
+                ChildJobStatus::Completed | ChildJobStatus::Skipped
+            ) {
+                child.status = ChildJobStatus::Cancelled;
+                child.cancellable = false;
+                child.cancel_requested = true;
+            }
+        }
+        Ok(snapshot.clone())
+    }
+
+    fn snapshot_mut(&mut self, operation_id: &OperationId) -> Result<&mut OperationSnapshot> {
+        self.operations
+            .get_mut(operation_id.as_str())
+            .ok_or_else(|| AppError::InvalidInput("Work operation was not found.".to_string()))
+    }
+}

--- a/src-tauri/src/work_runtime/state_tests.rs
+++ b/src-tauri/src/work_runtime/state_tests.rs
@@ -1,0 +1,102 @@
+use super::snapshot::new_processing_snapshot;
+use super::state::WorkRuntimeState;
+use super::{ChildJobStatus, OperationId, WorkOperationStatus};
+use crate::processing::{
+    JobType, OperationKind, ProcessCommandResult, ProcessResultEntry, ProcessResultStatus,
+};
+
+fn accepted_state() -> (WorkRuntimeState, OperationId) {
+    let mut state = WorkRuntimeState::default();
+    let operation_id = OperationId("op-1".to_string());
+    state.insert_operation(new_processing_snapshot(
+        operation_id.clone(),
+        1,
+        OperationKind::ProcessingBatch,
+        "Batch encode (2 files)".to_string(),
+        &["/tmp/first.m4b".to_string(), "/tmp/second.m4b".to_string()],
+        Some(&[Some("input-1".to_string()), Some("input-2".to_string())]),
+        100,
+    ));
+    (state, operation_id)
+}
+
+#[test]
+fn accepted_operation_preserves_immutable_child_identity() {
+    let (state, operation_id) = accepted_state();
+    let snapshot = state.get(&operation_id).expect("snapshot");
+
+    assert_eq!(snapshot.status, WorkOperationStatus::Accepted);
+    assert_eq!(snapshot.source_input_ids, ["input-1", "input-2"]);
+    assert_eq!(snapshot.children.len(), 2);
+    assert_eq!(snapshot.children[0].input_id.as_deref(), Some("input-1"));
+    assert_eq!(snapshot.children[0].label, "first.m4b");
+}
+
+#[test]
+fn request_cancel_marks_operation_and_children_without_terminalizing() {
+    let (mut state, operation_id) = accepted_state();
+    let snapshot = state
+        .request_cancel(&operation_id, 200)
+        .expect("request cancel");
+
+    assert_eq!(snapshot.status, WorkOperationStatus::Cancelling);
+    assert!(snapshot.cancel_requested);
+    assert!(snapshot.children.iter().all(|child| child.cancel_requested));
+    assert!(snapshot.finished_at_ms.is_none());
+}
+
+#[test]
+fn mark_running_does_not_overwrite_pending_cancellation() {
+    let (mut state, operation_id) = accepted_state();
+    state
+        .request_cancel(&operation_id, 200)
+        .expect("request cancel");
+    let snapshot = state.mark_running(&operation_id, 250).expect("running");
+
+    assert_eq!(snapshot.status, WorkOperationStatus::Cancelling);
+    assert!(snapshot.cancel_requested);
+    assert_eq!(snapshot.progress.message, "Cancellation requested.");
+    assert_eq!(snapshot.started_at_ms, Some(250));
+}
+
+#[test]
+fn terminal_result_updates_summary_and_child_rows_in_input_order() {
+    let (mut state, operation_id) = accepted_state();
+    state.mark_running(&operation_id, 150).expect("running");
+    let result = ProcessCommandResult::new(
+        JobType::Batch,
+        vec![
+            ProcessResultEntry {
+                input_index: Some(0),
+                status: ProcessResultStatus::Success,
+                message: "first ok".to_string(),
+                error: None,
+                preview_file_path: None,
+                preview_actual_seconds: None,
+                job_id: Some("job-1".to_string()),
+            },
+            ProcessResultEntry {
+                input_index: Some(1),
+                status: ProcessResultStatus::Failed,
+                message: "second failed".to_string(),
+                error: None,
+                preview_file_path: None,
+                preview_actual_seconds: None,
+                job_id: Some("job-2".to_string()),
+            },
+        ],
+    );
+
+    let snapshot = state
+        .complete_from_process_result(&operation_id, &result, 300)
+        .expect("complete");
+
+    assert_eq!(snapshot.status, WorkOperationStatus::Mixed);
+    assert_eq!(
+        snapshot.terminal_summary.as_ref().expect("summary").failed,
+        1
+    );
+    assert_eq!(snapshot.children[0].status, ChildJobStatus::Completed);
+    assert_eq!(snapshot.children[1].status, ChildJobStatus::Failed);
+    assert_eq!(snapshot.children[1].job_id.as_deref(), Some("job-2"));
+}

--- a/src-tauri/src/work_runtime/terminal.rs
+++ b/src-tauri/src/work_runtime/terminal.rs
@@ -1,0 +1,96 @@
+use super::types::{
+    ChildJobStatus, OperationTerminalSummary, WorkOperationStatus, WorkProgressStage,
+};
+use crate::processing::{OperationResultSummary, ProcessCommandResult, ProcessResultStatus};
+
+pub(crate) fn terminal_summary_from_process_result(
+    result: &ProcessCommandResult,
+) -> OperationTerminalSummary {
+    let summary = &result.summary;
+    OperationTerminalSummary {
+        total: summary.total,
+        succeeded: summary.succeeded,
+        skipped: summary.skipped,
+        cancelled: summary.cancelled,
+        failed: summary.failed,
+        message: terminal_message(summary),
+    }
+}
+
+pub(crate) fn status_from_terminal_summary(
+    summary: &OperationTerminalSummary,
+) -> WorkOperationStatus {
+    if summary.failed > 0 && (summary.succeeded > 0 || summary.skipped > 0 || summary.cancelled > 0)
+    {
+        return WorkOperationStatus::Mixed;
+    }
+    if summary.failed > 0 {
+        return WorkOperationStatus::Failed;
+    }
+    if summary.cancelled > 0 && (summary.succeeded > 0 || summary.skipped > 0) {
+        return WorkOperationStatus::Mixed;
+    }
+    if summary.cancelled > 0 {
+        return WorkOperationStatus::Cancelled;
+    }
+    WorkOperationStatus::Completed
+}
+
+pub(crate) fn child_status_from_result_status(status: ProcessResultStatus) -> ChildJobStatus {
+    match status {
+        ProcessResultStatus::Success => ChildJobStatus::Completed,
+        ProcessResultStatus::Skipped => ChildJobStatus::Skipped,
+        ProcessResultStatus::Cancelled => ChildJobStatus::Cancelled,
+        ProcessResultStatus::Failed => ChildJobStatus::Failed,
+    }
+}
+
+pub(crate) fn stage_from_status(status: WorkOperationStatus) -> WorkProgressStage {
+    match status {
+        WorkOperationStatus::Completed | WorkOperationStatus::Mixed => WorkProgressStage::Complete,
+        WorkOperationStatus::Cancelled => WorkProgressStage::Cancelled,
+        WorkOperationStatus::Failed => WorkProgressStage::Failed,
+        WorkOperationStatus::Accepted => WorkProgressStage::Pending,
+        WorkOperationStatus::Running => WorkProgressStage::Converting,
+        WorkOperationStatus::Cancelling => WorkProgressStage::Cleaning,
+    }
+}
+
+pub(crate) fn stage_from_child_status(status: ChildJobStatus) -> WorkProgressStage {
+    match status {
+        ChildJobStatus::Completed | ChildJobStatus::Skipped => WorkProgressStage::Complete,
+        ChildJobStatus::Cancelled => WorkProgressStage::Cancelled,
+        ChildJobStatus::Failed => WorkProgressStage::Failed,
+        ChildJobStatus::Queued => WorkProgressStage::Pending,
+        ChildJobStatus::Running => WorkProgressStage::Converting,
+    }
+}
+
+pub(crate) fn is_terminal(status: WorkOperationStatus) -> bool {
+    matches!(
+        status,
+        WorkOperationStatus::Completed
+            | WorkOperationStatus::Cancelled
+            | WorkOperationStatus::Failed
+            | WorkOperationStatus::Mixed
+    )
+}
+
+fn terminal_message(summary: &OperationResultSummary) -> String {
+    if summary.failed > 0 {
+        return format!(
+            "Finished with {} succeeded, {} failed, {} skipped, {} cancelled.",
+            summary.succeeded, summary.failed, summary.skipped, summary.cancelled
+        );
+    }
+    if summary.cancelled > 0 {
+        return format!(
+            "Finished with {} succeeded and {} cancelled.",
+            summary.succeeded, summary.cancelled
+        );
+    }
+    if summary.skipped > 0 && summary.succeeded == 0 {
+        return format!("Skipped {} item(s).", summary.skipped);
+    }
+    format!("Completed {} item(s).", summary.succeeded + summary.skipped)
+}

--- a/src-tauri/src/work_runtime/types.rs
+++ b/src-tauri/src/work_runtime/types.rs
@@ -1,0 +1,203 @@
+use crate::processing::{OperationKind, ProcessPayload};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub const WORK_OPERATION_SNAPSHOT_EVENT_NAME: &str = "work-operation-snapshot";
+pub const WORK_OPERATION_LIST_SNAPSHOT_EVENT_NAME: &str = "work-operation-list-snapshot";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, specta::Type)]
+#[serde(transparent)]
+pub struct OperationId(pub String);
+
+impl OperationId {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for OperationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for OperationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkOperationStatus {
+    Accepted,
+    Running,
+    Cancelling,
+    Completed,
+    Cancelled,
+    Failed,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ChildJobStatus {
+    Queued,
+    Running,
+    Completed,
+    Skipped,
+    Cancelled,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkProgressStage {
+    Pending,
+    Analyzing,
+    Converting,
+    Writing,
+    Downloading,
+    Decrypting,
+    Committing,
+    Cleaning,
+    Complete,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ResourceLane {
+    EncodeCpu,
+    NetworkDownload,
+    HelperMaterializer,
+    MetadataWrite,
+    OutputCommit,
+    Analysis,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressSnapshot {
+    pub stage: WorkProgressStage,
+    pub percentage: f32,
+    pub message: String,
+    pub current_item_index: Option<usize>,
+    pub total_items: Option<usize>,
+    pub bytes_downloaded: Option<u64>,
+    pub bytes_total: Option<u64>,
+    pub eta_seconds: Option<f64>,
+}
+
+impl ProgressSnapshot {
+    pub fn pending(message: impl Into<String>, total_items: Option<usize>) -> Self {
+        Self {
+            stage: WorkProgressStage::Pending,
+            percentage: 0.0,
+            message: message.into(),
+            current_item_index: None,
+            total_items,
+            bytes_downloaded: None,
+            bytes_total: None,
+            eta_seconds: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ChildJobSnapshot {
+    pub child_job_id: String,
+    pub operation_id: OperationId,
+    pub label: String,
+    pub status: ChildJobStatus,
+    pub lane: ResourceLane,
+    pub progress: ProgressSnapshot,
+    pub source_path: Option<String>,
+    pub input_index: Option<usize>,
+    pub input_id: Option<String>,
+    pub job_id: Option<String>,
+    pub cancellable: bool,
+    pub cancel_requested: bool,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationTerminalSummary {
+    pub total: usize,
+    pub succeeded: usize,
+    pub skipped: usize,
+    pub cancelled: usize,
+    pub failed: usize,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSnapshot {
+    pub operation_id: OperationId,
+    pub sequence: u64,
+    pub kind: OperationKind,
+    pub status: WorkOperationStatus,
+    pub title: String,
+    pub created_at_ms: i64,
+    pub started_at_ms: Option<i64>,
+    pub finished_at_ms: Option<i64>,
+    pub cancellable: bool,
+    pub cancel_requested: bool,
+    pub lanes: Vec<ResourceLane>,
+    pub source_input_ids: Vec<String>,
+    pub progress: ProgressSnapshot,
+    pub children: Vec<ChildJobSnapshot>,
+    pub terminal_summary: Option<OperationTerminalSummary>,
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationListSnapshot {
+    pub operations: Vec<OperationSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkSubmissionAccepted {
+    pub operation_id: OperationId,
+    pub snapshot: OperationSnapshot,
+}
+
+#[derive(Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitProcessingOperationRequest {
+    pub payload: ProcessPayload,
+    pub metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
+    pub preview_seconds: Option<f64>,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkOperationSnapshotEvent {
+    pub snapshot: OperationSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkOperationListSnapshotEvent {
+    pub operations: Vec<OperationSnapshot>,
+}
+
+impl tauri_specta::Event for WorkOperationSnapshotEvent {
+    const NAME: &'static str = WORK_OPERATION_SNAPSHOT_EVENT_NAME;
+}
+
+impl tauri_specta::Event for WorkOperationListSnapshotEvent {
+    const NAME: &'static str = WORK_OPERATION_LIST_SNAPSHOT_EVENT_NAME;
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
 	import EncoderPanelIsland from './ui/encoderPanel/EncoderPanelIsland.svelte';
 	import OutputPanelIsland from './ui/outputPanel/OutputPanelIsland.svelte';
 	import StatusPanelIsland from './ui/statusPanel/StatusPanelIsland.svelte';
+	import { WorkCenterIsland } from './ui/workCenter';
 	import {
 		onClearCoverArt,
 		onLoadCoverArtFromFilePicker,
@@ -153,6 +154,7 @@
 		</div>
 
 		<StatusPanelIsland />
+		<WorkCenterIsland />
 	</div>
 </div>
 <MetadataLookupIsland />

--- a/src/lib/behavior-contract.test.ts
+++ b/src/lib/behavior-contract.test.ts
@@ -13,6 +13,7 @@ const EXPECTED_COMMAND_NAMES = [
 	'analyze_audio_files',
 	'cancel_processing',
 	'cancel_remote_source_acquisition',
+	'cancel_work_operation',
 	'complete_remote_source_auth',
 	'discover_audio_import_paths',
 	'echo',
@@ -22,7 +23,9 @@ const EXPECTED_COMMAND_NAMES = [
 	'get_remote_source_acquisition_status',
 	'get_runtime_settings_capabilities',
 	'get_supported_audio_import_metadata',
+	'get_work_operation',
 	'list_remote_source_providers',
+	'list_work_operations',
 	'load_cover_art_file',
 	'load_cover_art_from_url',
 	'load_remote_source_library',
@@ -41,6 +44,7 @@ const EXPECTED_COMMAND_NAMES = [
 	'set_max_concurrent_jobs',
 	'start_remote_source_acquisition',
 	'start_remote_source_auth',
+	'submit_processing_operation',
 	'take_opened_audio_files',
 	'update_app_settings',
 	'validate_encoder_settings',
@@ -73,6 +77,8 @@ describe('compatibility guards', () => {
 			EVENTS.PROGRESS,
 			EVENTS.QUEUE,
 			EVENTS.OPENED_AUDIO_FILES,
+			EVENTS.WORK_OPERATION_SNAPSHOT,
+			EVENTS.WORK_OPERATION_LIST_SNAPSHOT,
 		]);
 	});
 });

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -123,6 +123,10 @@ export const commands = {
 	 *  Sets the global cancellation flag in the job registry
 	 */
 	cancelProcessing: (jobId: string | null) => typedError<string, AppErrorEnvelope>(__TAURI_INVOKE("cancel_processing", { jobId })),
+	submitProcessingOperation: (request: SubmitProcessingOperationRequest) => typedError<WorkSubmissionAccepted, AppErrorEnvelope>(__TAURI_INVOKE("submit_processing_operation", { request })),
+	listWorkOperations: () => typedError<OperationListSnapshot, AppErrorEnvelope>(__TAURI_INVOKE("list_work_operations")),
+	getWorkOperation: (operationId: OperationId) => typedError<OperationSnapshot, AppErrorEnvelope>(__TAURI_INVOKE("get_work_operation", { operationId })),
+	cancelWorkOperation: (operationId: OperationId) => typedError<OperationSnapshot, AppErrorEnvelope>(__TAURI_INVOKE("cancel_work_operation", { operationId })),
 };
 
 /** Events */
@@ -130,6 +134,8 @@ export const events = {
 	openedAudioFiles: makeEvent<OpenedAudioFilesEvent>("opened-audio-files"),
 	processingProgress: makeEvent<ProgressEvent>("processing-progress"),
 	processingQueue: makeEvent<QueueEvent>("processing-queue"),
+	workOperationListSnapshot: makeEvent<WorkOperationListSnapshotEvent>("work-operation-list-snapshot"),
+	workOperationSnapshot: makeEvent<WorkOperationSnapshotEvent>("work-operation-snapshot"),
 };
 
 /* Types */
@@ -253,6 +259,24 @@ export type BitrateModeKind = "cbr" | "cvbr" | "vbr";
 
 // Channel selection strategy
 export type ChannelConfig = "auto" | "mono" | "stereo";
+
+export type ChildJobSnapshot = {
+	childJobId: string,
+	operationId: OperationId,
+	label: string,
+	status: ChildJobStatus,
+	lane: ResourceLane,
+	progress: ProgressSnapshot,
+	sourcePath: string | null,
+	inputIndex: number | null,
+	inputId: string | null,
+	jobId: string | null,
+	cancellable: boolean,
+	cancelRequested: boolean,
+	message: string | null,
+};
+
+export type ChildJobStatus = "queued" | "running" | "completed" | "skipped" | "cancelled" | "failed";
 
 export type CollisionPolicy = "fail" | "replace_existing" | "rename_new" | "skip_existing";
 
@@ -462,7 +486,13 @@ export type OnlineMetadataResult = {
 
 export type OpenedAudioFilesEvent = Record<string, never>;
 
-export type OperationKind = "processingMerge" | "processingBatch" | "metadataSave";
+export type OperationId = string;
+
+export type OperationKind = "processingMerge" | "processingBatch" | "remoteAcquisition" | "metadataSave";
+
+export type OperationListSnapshot = {
+	operations: OperationSnapshot[],
+};
 
 export type OperationResultSummary = {
 	total: number,
@@ -470,6 +500,35 @@ export type OperationResultSummary = {
 	skipped: number,
 	cancelled: number,
 	failed: number,
+};
+
+export type OperationSnapshot = {
+	operationId: OperationId,
+	sequence: number,
+	kind: OperationKind,
+	status: WorkOperationStatus,
+	title: string,
+	createdAtMs: number,
+	startedAtMs: number | null,
+	finishedAtMs: number | null,
+	cancellable: boolean,
+	cancelRequested: boolean,
+	lanes: ResourceLane[],
+	sourceInputIds: string[],
+	progress: ProgressSnapshot,
+	children: ChildJobSnapshot[],
+	terminalSummary: OperationTerminalSummary | null,
+	warnings: string[],
+	errors: string[],
+};
+
+export type OperationTerminalSummary = {
+	total: number,
+	succeeded: number,
+	skipped: number,
+	cancelled: number,
+	failed: number,
+	message: string,
 };
 
 export type OutputCollisionInfo = {
@@ -570,6 +629,8 @@ export type ProgressEvent = ProgressEvent_Serialize | ProgressEvent_Deserialize;
 
 // Progress event structure for frontend communication
 export type ProgressEvent_Deserialize = {
+	// WorkRuntime operation identifier when this event belongs to accepted work
+	operation_id: string | null,
 	// Backend operation family that emitted this event
 	operation_kind: OperationKind,
 	// Current processing stage
@@ -590,6 +651,8 @@ export type ProgressEvent_Deserialize = {
 
 // Progress event structure for frontend communication
 export type ProgressEvent_Serialize = {
+	// WorkRuntime operation identifier when this event belongs to accepted work
+	operation_id?: string | null,
 	// Backend operation family that emitted this event
 	operation_kind: OperationKind,
 	// Current processing stage
@@ -608,10 +671,33 @@ export type ProgressEvent_Serialize = {
 	input_index?: number | null,
 };
 
+export type ProgressSnapshot = {
+	stage: WorkProgressStage,
+	percentage: number,
+	message: string,
+	currentItemIndex: number | null,
+	totalItems: number | null,
+	bytesDownloaded: number | null,
+	bytesTotal: number | null,
+	etaSeconds: number | null,
+};
+
 export type ProviderId = "audible";
 
 // Batch queue snapshot for frontend communication
-export type QueueEvent = {
+export type QueueEvent = QueueEvent_Serialize | QueueEvent_Deserialize;
+
+// Batch queue snapshot for frontend communication
+export type QueueEvent_Deserialize = {
+	operation_id: string | null,
+	operation_kind: OperationKind,
+	items: QueueItem[],
+	max_concurrent: number,
+};
+
+// Batch queue snapshot for frontend communication
+export type QueueEvent_Serialize = {
+	operation_id?: string | null,
 	operation_kind: OperationKind,
 	items: QueueItem[],
 	max_concurrent: number,
@@ -699,6 +785,8 @@ export type RemoteTitleAvailability = {
 
 export type RemoteTitleAvailabilityStatus = "available" | "catalogOnly" | "revoked" | "providerUnavailable";
 
+export type ResourceLane = "encodeCpu" | "networkDownload" | "helperMaterializer" | "metadataWrite" | "outputCommit" | "analysis";
+
 export type RuntimeSettingsCapabilities = {
 	encoder: EncoderSettingsCapabilities,
 	maxConcurrentJobs: MaxConcurrentJobsCapabilities,
@@ -710,6 +798,13 @@ export type SampleRateConfig =
 "auto" |
 // Explicit sample rate in Hz
 { explicit: number };
+
+export type SubmitProcessingOperationRequest = {
+	payload: ProcessPayload,
+	metadata: { [key in string]: MetadataIntentPatch } | null,
+	previewSeconds: number | null,
+	title: string | null,
+};
 
 export type SupplementalAsset = {
 	assetId: string,
@@ -751,6 +846,23 @@ export type ThreadSetting =
 { mode: "off" } |
 // Fixed number of threads
 { mode: "fixed"; value: number };
+
+export type WorkOperationListSnapshotEvent = {
+	operations: OperationSnapshot[],
+};
+
+export type WorkOperationSnapshotEvent = {
+	snapshot: OperationSnapshot,
+};
+
+export type WorkOperationStatus = "accepted" | "running" | "cancelling" | "completed" | "cancelled" | "failed" | "mixed";
+
+export type WorkProgressStage = "pending" | "analyzing" | "converting" | "writing" | "downloading" | "decrypting" | "committing" | "cleaning" | "complete" | "failed" | "cancelled";
+
+export type WorkSubmissionAccepted = {
+	operationId: OperationId,
+	snapshot: OperationSnapshot,
+};
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {

--- a/src/lib/tauri-client.generated-event-bindings.test.ts
+++ b/src/lib/tauri-client.generated-event-bindings.test.ts
@@ -23,10 +23,22 @@ describe('tauriClient generated event bindings', () => {
 		await tauriClient.listen(EVENTS.OPENED_AUDIO_FILES, () => {
 			/* no-op */
 		});
+		await tauriClient.listen(EVENTS.WORK_OPERATION_SNAPSHOT, () => {
+			/* no-op */
+		});
+		await tauriClient.listen(EVENTS.WORK_OPERATION_LIST_SNAPSHOT, () => {
+			/* no-op */
+		});
 
 		expect(tauriListen).toHaveBeenNthCalledWith(1, EVENTS.PROGRESS, expect.any(Function));
 		expect(tauriListen).toHaveBeenNthCalledWith(2, EVENTS.QUEUE, expect.any(Function));
 		expect(tauriListen).toHaveBeenNthCalledWith(3, EVENTS.OPENED_AUDIO_FILES, expect.any(Function));
-		expect(tauriListen).toHaveBeenCalledTimes(3);
+		expect(tauriListen).toHaveBeenNthCalledWith(4, EVENTS.WORK_OPERATION_SNAPSHOT, expect.any(Function));
+		expect(tauriListen).toHaveBeenNthCalledWith(
+			5,
+			EVENTS.WORK_OPERATION_LIST_SNAPSHOT,
+			expect.any(Function),
+		);
+		expect(tauriListen).toHaveBeenCalledTimes(5);
 	});
 });

--- a/src/lib/tauri-public-api.contract.test.ts
+++ b/src/lib/tauri-public-api.contract.test.ts
@@ -6,6 +6,7 @@ const EXPECTED_TAURI_CLIENT_METHODS = [
 	'analyzeAudioFiles',
 	'cancelProcessing',
 	'cancelRemoteSourceAcquisition',
+	'cancelWorkOperation',
 	'completeRemoteSourceAuth',
 	'discoverAudioImportPaths',
 	'echo',
@@ -15,8 +16,10 @@ const EXPECTED_TAURI_CLIENT_METHODS = [
 	'getRemoteSourceAcquisitionStatus',
 	'getRuntimeSettingsCapabilities',
 	'getSupportedAudioImportMetadata',
+	'getWorkOperation',
 	'listen',
 	'listRemoteSourceProviders',
+	'listWorkOperations',
 	'loadCoverArtFile',
 	'loadCoverArtFromUrl',
 	'loadRemoteSourceLibrary',
@@ -41,6 +44,7 @@ const EXPECTED_TAURI_CLIENT_METHODS = [
 	'setMaxConcurrentJobs',
 	'startRemoteSourceAcquisition',
 	'startRemoteSourceAuth',
+	'submitProcessingOperation',
 	'takeOpenedAudioFiles',
 	'updateAppSettings',
 	'validateEncoderSettings',
@@ -68,10 +72,16 @@ describe('Tauri Runtime Boundary public API contract', () => {
 		expect(TAURI_COMMAND_NAMES).toContain('take_opened_audio_files');
 		expect(TAURI_COMMAND_NAMES).toContain('list_remote_source_providers');
 		expect(TAURI_COMMAND_NAMES).toContain('start_remote_source_acquisition');
+		expect(TAURI_COMMAND_NAMES).toContain('submit_processing_operation');
+		expect(TAURI_COMMAND_NAMES).toContain('list_work_operations');
+		expect(TAURI_COMMAND_NAMES).toContain('get_work_operation');
+		expect(TAURI_COMMAND_NAMES).toContain('cancel_work_operation');
 		expect([...TAURI_APP_EVENT_NAMES]).toEqual([
 			'processing-progress',
 			'processing-queue',
 			'opened-audio-files',
+			'work-operation-snapshot',
+			'work-operation-list-snapshot',
 		]);
 	});
 });

--- a/src/lib/tauri/client.ts
+++ b/src/lib/tauri/client.ts
@@ -14,6 +14,8 @@ import {
 	type OpenedAudioFilesEvent,
 	type ProcessingProgressEvent,
 	type ProcessingQueueEvent,
+	type WorkOperationListSnapshotEvent,
+	type WorkOperationSnapshotEvent,
 } from '../../types/events';
 import type {
 	EncoderSettings,
@@ -40,8 +42,20 @@ import type {
 	RemoteSourceAccountState,
 	RemoteSourceProviderCapabilities,
 } from '../../types/remoteSource';
+import type {
+	OperationId,
+	OperationListSnapshot,
+	OperationSnapshot,
+	SubmitProcessingOperationRequest,
+	WorkSubmissionAccepted,
+} from '../../types/workRuntime';
 import { commandSpecs, type CommandResult, type TauriCommand } from './commands';
-import { normalizeProgressEvent, normalizeQueueEvent } from './normalizers';
+import {
+	normalizeOperationListSnapshot,
+	normalizeOperationSnapshot,
+	normalizeProgressEvent,
+	normalizeQueueEvent,
+} from './normalizers';
 
 type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
 type AppEventName = (typeof TAURI_APP_EVENT_NAMES)[number];
@@ -49,6 +63,10 @@ type RuntimeEventName = Exclude<EventName, AppEventName>;
 type ProgressEventHandler = (event: { payload: ProcessingProgressEvent }) => void;
 type QueueEventHandler = (event: { payload: ProcessingQueueEvent }) => void;
 type OpenedAudioFilesHandler = (event: { payload: OpenedAudioFilesEvent }) => void;
+type WorkOperationSnapshotHandler = (event: { payload: WorkOperationSnapshotEvent }) => void;
+type WorkOperationListSnapshotHandler = (event: {
+	payload: WorkOperationListSnapshotEvent;
+}) => void;
 type DialogOptions = Omit<OpenDialogOptions, 'multiple' | 'directory'>;
 
 async function listenProcessingProgress(handler: ProgressEventHandler): Promise<UnlistenFn> {
@@ -69,11 +87,37 @@ async function listenOpenedAudioFiles(handler: OpenedAudioFilesHandler): Promise
 	});
 }
 
+async function listenWorkOperationSnapshot(
+	handler: WorkOperationSnapshotHandler,
+): Promise<UnlistenFn> {
+	return generatedEvents.workOperationSnapshot.listen((event) => {
+		handler({ payload: { snapshot: normalizeOperationSnapshot(event.payload.snapshot) } });
+	});
+}
+
+async function listenWorkOperationListSnapshot(
+	handler: WorkOperationListSnapshotHandler,
+): Promise<UnlistenFn> {
+	return generatedEvents.workOperationListSnapshot.listen((event) => {
+		handler({
+			payload: normalizeOperationListSnapshot({ operations: event.payload.operations }),
+		});
+	});
+}
+
 function listen(event: typeof EVENTS.PROGRESS, handler: ProgressEventHandler): Promise<UnlistenFn>;
 function listen(event: typeof EVENTS.QUEUE, handler: QueueEventHandler): Promise<UnlistenFn>;
 function listen(
 	event: typeof EVENTS.OPENED_AUDIO_FILES,
 	handler: OpenedAudioFilesHandler,
+): Promise<UnlistenFn>;
+function listen(
+	event: typeof EVENTS.WORK_OPERATION_SNAPSHOT,
+	handler: WorkOperationSnapshotHandler,
+): Promise<UnlistenFn>;
+function listen(
+	event: typeof EVENTS.WORK_OPERATION_LIST_SNAPSHOT,
+	handler: WorkOperationListSnapshotHandler,
 ): Promise<UnlistenFn>;
 function listen<E extends RuntimeEventName>(
 	event: E,
@@ -85,6 +129,8 @@ function listen(
 		| ProgressEventHandler
 		| QueueEventHandler
 		| OpenedAudioFilesHandler
+		| WorkOperationSnapshotHandler
+		| WorkOperationListSnapshotHandler
 		| ((event: { payload: ApplicationEvents[RuntimeEventName] }) => void),
 ): Promise<UnlistenFn> {
 	if (event === EVENTS.PROGRESS) {
@@ -97,6 +143,14 @@ function listen(
 
 	if (event === EVENTS.OPENED_AUDIO_FILES) {
 		return listenOpenedAudioFiles(handler as OpenedAudioFilesHandler);
+	}
+
+	if (event === EVENTS.WORK_OPERATION_SNAPSHOT) {
+		return listenWorkOperationSnapshot(handler as WorkOperationSnapshotHandler);
+	}
+
+	if (event === EVENTS.WORK_OPERATION_LIST_SNAPSHOT) {
+		return listenWorkOperationListSnapshot(handler as WorkOperationListSnapshotHandler);
 	}
 
 	return tauriListen(
@@ -227,6 +281,14 @@ export const tauriClient = {
 		metadataIntent?: MetadataIntentByPath | null;
 		previewSeconds?: number | null;
 	}): Promise<ProcessCommandResult> => commandSpecs.process_audiobook_files(args),
+	submitProcessingOperation: (
+		args: SubmitProcessingOperationRequest,
+	): Promise<WorkSubmissionAccepted> => commandSpecs.submit_processing_operation(args),
+	listWorkOperations: (): Promise<OperationListSnapshot> => commandSpecs.list_work_operations(),
+	getWorkOperation: (operationId: OperationId): Promise<OperationSnapshot> =>
+		commandSpecs.get_work_operation({ operationId }),
+	cancelWorkOperation: (operationId: OperationId): Promise<OperationSnapshot> =>
+		commandSpecs.cancel_work_operation({ operationId }),
 	cancelProcessing: (jobId?: string | null): Promise<CommandResult<'cancel_processing'>> =>
 		jobId === undefined
 			? commandSpecs.cancel_processing()
@@ -248,6 +310,8 @@ export const TAURI_APP_EVENT_NAMES = Object.freeze([
 	'processing-progress',
 	'processing-queue',
 	'opened-audio-files',
+	'work-operation-snapshot',
+	'work-operation-list-snapshot',
 ] as const);
 
 export type { TauriCommand };

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -22,6 +22,7 @@ import type {
 	ProviderId,
 	RemoteAuthCompletionRequest,
 } from '../../types/remoteSource';
+import type { OperationId, SubmitProcessingOperationRequest } from '../../types/workRuntime';
 import { normalizeAppError, unwrapGeneratedResult } from './appError';
 import {
 	denormalizeMetadata,
@@ -32,8 +33,11 @@ import {
 	normalizeMetadata,
 	normalizeMetadataSaveBatchResult,
 	normalizeNullish,
+	normalizeOperationListSnapshot,
+	normalizeOperationSnapshot,
 	normalizeProcessResult,
 	normalizeRuntimeSettingsCapabilities,
+	normalizeWorkSubmissionAccepted,
 } from './normalizers';
 
 type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
@@ -290,6 +294,28 @@ export const commandSpecs = {
 				args.previewSeconds ?? null,
 			),
 			normalizeProcessResult,
+		),
+	submit_processing_operation: (args: SubmitProcessingOperationRequest) =>
+		runGeneratedCommand(
+			generatedCommands.submitProcessingOperation({
+				payload: denormalizeProcessPayload(args.payload),
+				metadata: compileMetadataIntentMap(args.metadataIntent),
+				previewSeconds: args.previewSeconds ?? null,
+				title: args.title ?? null,
+			}),
+			normalizeWorkSubmissionAccepted,
+		),
+	list_work_operations: (_args?: undefined) =>
+		runGeneratedCommand(generatedCommands.listWorkOperations(), normalizeOperationListSnapshot),
+	get_work_operation: (args: { operationId: OperationId }) =>
+		runGeneratedCommand(
+			generatedCommands.getWorkOperation(args.operationId),
+			normalizeOperationSnapshot,
+		),
+	cancel_work_operation: (args: { operationId: OperationId }) =>
+		runGeneratedCommand(
+			generatedCommands.cancelWorkOperation(args.operationId),
+			normalizeOperationSnapshot,
 		),
 	cancel_processing: (args?: { job_id?: string | null }) =>
 		runGeneratedCommand(generatedCommands.cancelProcessing(args?.job_id ?? null)),

--- a/src/lib/tauri/normalizers.ts
+++ b/src/lib/tauri/normalizers.ts
@@ -25,6 +25,9 @@ import type {
 	ProgressEvent as GeneratedProgressEvent,
 	QueueEvent as GeneratedQueueEvent,
 	RuntimeSettingsCapabilities as GeneratedRuntimeSettingsCapabilities,
+	OperationListSnapshot as GeneratedOperationListSnapshot,
+	OperationSnapshot as GeneratedOperationSnapshot,
+	WorkSubmissionAccepted as GeneratedWorkSubmissionAccepted,
 } from '../generated/tauri';
 import type {
 	EncoderAvailability,
@@ -41,6 +44,11 @@ import type {
 } from '../../types/metadata';
 import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
 import type { NullToOptionalDeep } from '../../types/ipc';
+import type {
+	OperationListSnapshot,
+	OperationSnapshot,
+	WorkSubmissionAccepted,
+} from '../../types/workRuntime';
 import { normalizeAppError } from './appError';
 
 type PlainRecord = Record<string, unknown>;
@@ -249,4 +257,26 @@ export function normalizeProgressEvent(payload: GeneratedProgressEvent): Process
 
 export function normalizeQueueEvent(payload: GeneratedQueueEvent): ProcessingQueueEvent {
 	return normalizeNullish(payload);
+}
+
+export function normalizeOperationSnapshot(
+	payload: GeneratedOperationSnapshot,
+): OperationSnapshot {
+	return normalizeNullish(payload) as OperationSnapshot;
+}
+
+export function normalizeOperationListSnapshot(
+	payload: GeneratedOperationListSnapshot,
+): OperationListSnapshot {
+	return normalizeNullish(payload) as OperationListSnapshot;
+}
+
+export function normalizeWorkSubmissionAccepted(
+	payload: GeneratedWorkSubmissionAccepted,
+): WorkSubmissionAccepted {
+	const normalized = normalizeNullish(payload) as WorkSubmissionAccepted;
+	return {
+		...normalized,
+		snapshot: normalizeOperationSnapshot(payload.snapshot),
+	};
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -12,6 +12,10 @@ import { afterEach, beforeEach, vi } from 'vitest';
 import { runtimeSettingsCapabilitiesFixture } from './fixtures/runtimeSettingsCapabilities';
 
 type TestEventHandler = (event: { event: string; id: number; payload: unknown }) => void;
+type ProcessPayloadForTest = {
+	inputFiles?: string[];
+	jobType?: 'batch' | 'merge' | null;
+};
 const eventListeners = new Map<string, Set<TestEventHandler>>();
 let mockJobCounter = 0;
 
@@ -21,6 +25,67 @@ function emitTestEvent(event: string, payload: unknown): void {
 	for (const handler of handlers) {
 		handler({ event, id: Date.now(), payload });
 	}
+}
+
+function mockOperationSnapshot(
+	operationId: string,
+	kind: 'processingBatch' | 'processingMerge',
+	inputFiles: string[],
+) {
+	return {
+		operationId,
+		sequence: mockJobCounter,
+		kind,
+		status: 'accepted',
+		title:
+			kind === 'processingMerge'
+				? `Merge encode (${inputFiles.length} files)`
+				: `Batch encode (${inputFiles.length} files)`,
+		createdAtMs: Date.now(),
+		startedAtMs: null,
+		finishedAtMs: null,
+		cancellable: true,
+		cancelRequested: false,
+		lanes: ['analysis', 'encodeCpu', 'outputCommit'],
+		sourceInputIds: [],
+		progress: {
+			stage: 'pending',
+			percentage: 0,
+			message: 'Accepted.',
+			currentItemIndex: null,
+			totalItems: inputFiles.length,
+			bytesDownloaded: null,
+			bytesTotal: null,
+			etaSeconds: null,
+		},
+		children: inputFiles.map((path, index) => ({
+			childJobId: `input-${index}`,
+			operationId,
+			label: path.split(/[\\/]/).pop() || path,
+			status: 'queued',
+			lane: 'encodeCpu',
+			progress: {
+				stage: 'pending',
+				percentage: 0,
+				message: 'Queued.',
+				currentItemIndex: null,
+				totalItems: inputFiles.length,
+				bytesDownloaded: null,
+				bytesTotal: null,
+				etaSeconds: null,
+			},
+			sourcePath: path,
+			inputIndex: index,
+			inputId: null,
+			jobId: null,
+			cancellable: false,
+			cancelRequested: false,
+			message: null,
+		})),
+		terminalSummary: null,
+		warnings: [],
+		errors: [],
+	};
 }
 
 // Mock Tauri's invoke API
@@ -148,6 +213,40 @@ vi.mock('@tauri-apps/api/core', () => ({
 							previewActualSeconds: null,
 						},
 					],
+				});
+			}
+			case 'submit_processing_operation': {
+				const args = _args as
+					| {
+							request?: {
+								payload?: ProcessPayloadForTest;
+							};
+					  }
+					| undefined;
+				const operationId = `mock-operation-${++mockJobCounter}`;
+				const inputFiles = args?.request?.payload?.inputFiles ?? [];
+				const kind =
+					args?.request?.payload?.jobType === 'merge' ? 'processingMerge' : 'processingBatch';
+				const snapshot = mockOperationSnapshot(operationId, kind, inputFiles);
+				emitTestEvent('work-operation-snapshot', { snapshot });
+				emitTestEvent('work-operation-list-snapshot', { operations: [snapshot] });
+				return Promise.resolve({ operationId, snapshot });
+			}
+			case 'list_work_operations':
+				return Promise.resolve({ operations: [] });
+			case 'get_work_operation': {
+				const args = _args as { operationId?: string } | undefined;
+				const operationId = args?.operationId ?? 'mock-operation';
+				return Promise.resolve(mockOperationSnapshot(operationId, 'processingBatch', []));
+			}
+			case 'cancel_work_operation': {
+				const args = _args as { operationId?: string } | undefined;
+				const operationId = args?.operationId ?? 'mock-operation';
+				return Promise.resolve({
+					...mockOperationSnapshot(operationId, 'processingBatch', []),
+					status: 'cancelling',
+					cancelRequested: true,
+					cancellable: false,
 				});
 			}
 			case 'save_metadata_batch': {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -4,6 +4,8 @@ import type {
 	OpenedAudioFilesEvent as GeneratedOpenedAudioFilesEvent,
 	ProgressEvent as GeneratedProgressEvent,
 	QueueEvent as GeneratedQueueEvent,
+	WorkOperationListSnapshotEvent as GeneratedWorkOperationListSnapshotEvent,
+	WorkOperationSnapshotEvent as GeneratedWorkOperationSnapshotEvent,
 } from '../lib/generated/tauri';
 import type { NullToOptionalDeep } from './ipc';
 
@@ -19,6 +21,8 @@ export const EVENTS = {
 	PROGRESS: 'processing-progress',
 	QUEUE: 'processing-queue',
 	OPENED_AUDIO_FILES: 'opened-audio-files',
+	WORK_OPERATION_SNAPSHOT: 'work-operation-snapshot',
+	WORK_OPERATION_LIST_SNAPSHOT: 'work-operation-list-snapshot',
 } as const;
 
 export type EventStage = GeneratedEventStage;
@@ -44,6 +48,7 @@ export const STAGES: { readonly [K in EventStage]: K } = {
 export const OPERATION_KINDS: { readonly [K in OperationKind]: K } = {
 	processingMerge: 'processingMerge',
 	processingBatch: 'processingBatch',
+	remoteAcquisition: 'remoteAcquisition',
 	metadataSave: 'metadataSave',
 } as const;
 
@@ -51,6 +56,10 @@ export type ProcessingProgressEvent = NullToOptionalDeep<GeneratedProgressEvent>
 export type ProcessingQueueItem = NullToOptionalDeep<GeneratedQueueEvent>['items'][number];
 export type ProcessingQueueEvent = NullToOptionalDeep<GeneratedQueueEvent>;
 export type OpenedAudioFilesEvent = NullToOptionalDeep<GeneratedOpenedAudioFilesEvent>;
+export type WorkOperationSnapshotEvent =
+	NullToOptionalDeep<GeneratedWorkOperationSnapshotEvent>;
+export type WorkOperationListSnapshotEvent =
+	NullToOptionalDeep<GeneratedWorkOperationListSnapshotEvent>;
 
 export interface TauriFileDropEvents {
 	'tauri://drag-drop': { paths: string[]; position: { x: number; y: number } };
@@ -63,6 +72,8 @@ export interface ApplicationEvents extends TauriFileDropEvents {
 	[EVENTS.PROGRESS]: ProcessingProgressEvent;
 	[EVENTS.QUEUE]: ProcessingQueueEvent;
 	[EVENTS.OPENED_AUDIO_FILES]: OpenedAudioFilesEvent;
+	[EVENTS.WORK_OPERATION_SNAPSHOT]: WorkOperationSnapshotEvent;
+	[EVENTS.WORK_OPERATION_LIST_SNAPSHOT]: WorkOperationListSnapshotEvent;
 }
 
 export type EventName = keyof ApplicationEvents;

--- a/src/types/workRuntime.ts
+++ b/src/types/workRuntime.ts
@@ -1,0 +1,59 @@
+import type {
+	ChildJobSnapshot as GeneratedChildJobSnapshot,
+	ChildJobStatus as GeneratedChildJobStatus,
+	OperationId as GeneratedOperationId,
+	OperationKind as GeneratedOperationKind,
+	OperationListSnapshot as GeneratedOperationListSnapshot,
+	OperationSnapshot as GeneratedOperationSnapshot,
+	OperationTerminalSummary as GeneratedOperationTerminalSummary,
+	ProgressSnapshot as GeneratedProgressSnapshot,
+	ResourceLane as GeneratedResourceLane,
+	SubmitProcessingOperationRequest as GeneratedSubmitProcessingOperationRequest,
+	WorkOperationStatus as GeneratedWorkOperationStatus,
+	WorkProgressStage as GeneratedWorkProgressStage,
+	WorkSubmissionAccepted as GeneratedWorkSubmissionAccepted,
+} from '../lib/generated/tauri';
+import type { ProcessPayload } from './audio';
+import type { NullToOptionalDeep } from './ipc';
+import type { MetadataIntentPatch } from './metadataIntent';
+
+export type OperationId = GeneratedOperationId;
+export type OperationKind = GeneratedOperationKind;
+export type WorkOperationStatus = GeneratedWorkOperationStatus;
+export type ChildJobStatus = GeneratedChildJobStatus;
+export type WorkProgressStage = GeneratedWorkProgressStage;
+export type ResourceLane = GeneratedResourceLane;
+
+export type ProgressSnapshot = NullToOptionalDeep<GeneratedProgressSnapshot>;
+export type ChildJobSnapshot = NullToOptionalDeep<GeneratedChildJobSnapshot>;
+export type OperationTerminalSummary = NullToOptionalDeep<GeneratedOperationTerminalSummary>;
+export type OperationSnapshot = Omit<
+	NullToOptionalDeep<GeneratedOperationSnapshot>,
+	'children'
+> & {
+	children: ChildJobSnapshot[];
+};
+export type OperationListSnapshot = Omit<
+	NullToOptionalDeep<GeneratedOperationListSnapshot>,
+	'operations'
+> & {
+	operations: OperationSnapshot[];
+};
+export type WorkSubmissionAccepted = Omit<
+	NullToOptionalDeep<GeneratedWorkSubmissionAccepted>,
+	'snapshot'
+> & {
+	snapshot: OperationSnapshot;
+};
+
+export type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
+
+export type SubmitProcessingOperationRequest = Omit<
+	NullToOptionalDeep<GeneratedSubmitProcessingOperationRequest>,
+	'payload' | 'metadata'
+> & {
+	payload: ProcessPayload;
+	metadataIntent?: MetadataIntentByPath | null;
+	title?: string | null;
+	previewSeconds?: number | null;
+};

--- a/src/ui/__tests__/metadata-save-pending-flow.test.ts
+++ b/src/ui/__tests__/metadata-save-pending-flow.test.ts
@@ -40,6 +40,10 @@ vi.mock('../../lib/tauri/client', () => ({
 			invalidCount: 0,
 		})),
 		readAudioMetadata: vi.fn(async () => ({})),
+		listWorkOperations: vi.fn(async () => ({ operations: [] })),
+		getWorkOperation: vi.fn(),
+		cancelWorkOperation: vi.fn(),
+		submitProcessingOperation: vi.fn(),
 	},
 }));
 

--- a/src/ui/remoteSource/sessionAssets.svelte.ts
+++ b/src/ui/remoteSource/sessionAssets.svelte.ts
@@ -6,6 +6,8 @@ import type { AcquisitionJob, SupplementalAsset } from '../../types/remoteSource
 
 let supplementalAssetsByInputId = $state<Record<string, SupplementalProcessingAsset[]>>({});
 let jobIdsByInputId = $state<Record<string, string>>({});
+let retainedInputIdCounts = $state<Record<string, number>>({});
+let pendingPurgeInputIds = $state<Record<string, true>>({});
 
 export type CompanionAssetSummary = {
 	text: string;
@@ -80,6 +82,45 @@ export function hasSupplementalAssetsForInputId(inputId: string | undefined): bo
 	return supplementalAssetsForInputId(inputId).length > 0;
 }
 
+function uniqueInputIds(inputIds: readonly (string | undefined)[]): string[] {
+	return Array.from(new Set(inputIds.filter((inputId): inputId is string => Boolean(inputId))));
+}
+
+export function retainRemoteSourceSessionsForInputIds(
+	inputIds: readonly (string | undefined)[],
+): void {
+	const next = { ...retainedInputIdCounts };
+	for (const inputId of uniqueInputIds(inputIds)) {
+		next[inputId] = (next[inputId] ?? 0) + 1;
+	}
+	retainedInputIdCounts = next;
+}
+
+export function releaseRemoteSourceSessionRetainers(
+	inputIds: readonly (string | undefined)[],
+): string[] {
+	const next = { ...retainedInputIdCounts };
+	const pendingToPurge: string[] = [];
+	const nextPending = { ...pendingPurgeInputIds };
+
+	for (const inputId of uniqueInputIds(inputIds)) {
+		const count = (next[inputId] ?? 0) - 1;
+		if (count > 0) {
+			next[inputId] = count;
+			continue;
+		}
+		delete next[inputId];
+		if (nextPending[inputId]) {
+			pendingToPurge.push(inputId);
+			delete nextPending[inputId];
+		}
+	}
+
+	retainedInputIdCounts = next;
+	pendingPurgeInputIds = nextPending;
+	return pendingToPurge;
+}
+
 export function companionSummaryForInputIds(
 	inputIds: readonly (string | undefined)[],
 ): CompanionAssetSummary {
@@ -120,14 +161,20 @@ export function removeRemoteSourceSupplementalAssets(
 ): void {
 	const next = { ...supplementalAssetsByInputId };
 	const nextJobs = { ...jobIdsByInputId };
+	const nextRetained = { ...retainedInputIdCounts };
+	const nextPending = { ...pendingPurgeInputIds };
 	for (const inputId of inputIds) {
 		if (inputId) {
 			delete next[inputId];
 			delete nextJobs[inputId];
+			delete nextRetained[inputId];
+			delete nextPending[inputId];
 		}
 	}
 	supplementalAssetsByInputId = next;
 	jobIdsByInputId = nextJobs;
+	retainedInputIdCounts = nextRetained;
+	pendingPurgeInputIds = nextPending;
 }
 
 function registeredInputIdsForJob(jobId: string): string[] {
@@ -147,13 +194,23 @@ function jobIsReadyForSessionPurge(jobId: string, inputIdsToRemove: Set<string>)
 export async function purgeRemoteSourceSessionsForInputIds(
 	inputIds: readonly (string | undefined)[],
 ): Promise<void> {
-	const ids = Array.from(
-		new Set(inputIds.filter((inputId): inputId is string => Boolean(inputId))),
-	);
-	const idsToRemove = new Set(ids);
+	const ids = uniqueInputIds(inputIds);
+	const purgeableIds: string[] = [];
+	const nextPending = { ...pendingPurgeInputIds };
+	for (const inputId of ids) {
+		if ((retainedInputIdCounts[inputId] ?? 0) > 0) {
+			nextPending[inputId] = true;
+		} else {
+			purgeableIds.push(inputId);
+		}
+	}
+	pendingPurgeInputIds = nextPending;
+	if (purgeableIds.length === 0) return;
+
+	const purgeableIdsToRemove = new Set(purgeableIds);
 	const jobIds = Array.from(
-		new Set(ids.flatMap((inputId) => jobIdsByInputId[inputId] ?? [])),
-	).filter((jobId) => jobIsReadyForSessionPurge(jobId, idsToRemove));
+		new Set(purgeableIds.flatMap((inputId) => jobIdsByInputId[inputId] ?? [])),
+	).filter((jobId) => jobIsReadyForSessionPurge(jobId, purgeableIdsToRemove));
 	for (const jobId of jobIds) {
 		try {
 			await tauriClient.purgeRemoteSourceSession(jobId);
@@ -164,7 +221,7 @@ export async function purgeRemoteSourceSessionsForInputIds(
 			);
 		}
 	}
-	removeRemoteSourceSupplementalAssets(ids);
+	removeRemoteSourceSupplementalAssets(purgeableIds);
 }
 
 export async function purgeSuccessfulRemoteSourceSessions(

--- a/src/ui/remoteSource/sessionAssets.test.ts
+++ b/src/ui/remoteSource/sessionAssets.test.ts
@@ -216,6 +216,43 @@ describe('remote source session assets', () => {
 		expect(module.supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
 	});
 
+	it('defers draft cleanup purge while an accepted work operation retains the input', async () => {
+		const module = await import('./sessionAssets.svelte');
+		module.registerRemoteSourceSupplementalAssets(acquisitionJob(), fileList());
+		module.retainRemoteSourceSessionsForInputIds(['current-input-1']);
+
+		await module.purgeRemoteSourceSessionsForInputIds(['current-input-1']);
+
+		expect(purgeRemoteSourceSessionMock).not.toHaveBeenCalled();
+		expect(module.supplementalAssetsForInputIds(['current-input-1'])).toBeDefined();
+
+		const pendingPurgeInputIds = module.releaseRemoteSourceSessionRetainers(['current-input-1']);
+		await module.purgeRemoteSourceSessionsForInputIds(pendingPurgeInputIds);
+
+		expect(purgeRemoteSourceSessionMock).toHaveBeenCalledWith('remote-job-1');
+		expect(module.supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
+	});
+
+	it('does not purge a shared acquired session while a retained sibling remains in flight', async () => {
+		const module = await import('./sessionAssets.svelte');
+		module.registerRemoteSourceSupplementalAssets(multiTitleAcquisitionJob(), multiTitleFileList());
+		module.retainRemoteSourceSessionsForInputIds(['current-input-1', 'current-input-2']);
+
+		await module.purgeRemoteSourceSessionsForInputIds(['current-input-1', 'current-input-2']);
+		const firstPendingPurge = module.releaseRemoteSourceSessionRetainers(['current-input-1']);
+		await module.purgeRemoteSourceSessionsForInputIds(firstPendingPurge);
+
+		expect(purgeRemoteSourceSessionMock).not.toHaveBeenCalled();
+		expect(module.supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
+		expect(module.supplementalAssetsForInputIds(['current-input-2'])).toBeDefined();
+
+		const secondPendingPurge = module.releaseRemoteSourceSessionRetainers(['current-input-2']);
+		await module.purgeRemoteSourceSessionsForInputIds(secondPendingPurge);
+
+		expect(purgeRemoteSourceSessionMock).toHaveBeenCalledWith('remote-job-1');
+		expect(module.supplementalAssetsForInputIds(['current-input-2'])).toBeUndefined();
+	});
+
 	it('waits to purge shared acquisition sessions until every registered input is removable', async () => {
 		const module = await import('./sessionAssets.svelte');
 		module.registerRemoteSourceSupplementalAssets(multiTitleAcquisitionJob(), multiTitleFileList());

--- a/src/ui/statusPanel/AGENTS.md
+++ b/src/ui/statusPanel/AGENTS.md
@@ -3,7 +3,7 @@
 - Exports: `beginMetadataSaveInStatusPanel`, `completeMetadataSaveInStatusPanel`, `failMetadataSaveInStatusPanel`, `initStatusPanel`, `isStatusPanelProcessing`, `pushStatusPanelTransientStatus`, `triggerCancelAllFromStatusPanel`, `triggerProcessFromStatusPanel`, `updateStatusPanelConcurrencyStatus`, `StatusPanelIsland`.
 
 ## Private Cluster
-- Files: `controller.ts`, `runtimeApi.ts`, `events.ts`, `feedback.ts`, `formatting.ts`, `preview.ts`, `processing.ts`, `processingConfig.ts`, `processingWorkflow.ts`, `processingWorkflowLive.ts`, `processingWorkflowServices.ts`, `processingCancellationWorkflow.ts`, `processingCancellationWorkflowLive.ts`, `processingCancellationWorkflowServices.ts`, `render.ts`, `state.ts`, `viewState.svelte.ts`, `viewTypes.ts`, `domain/`, `services/`, `__tests__/`, `StatusPanelIsland.svelte`.
+- Files: `controller.ts`, `runtimeApi.ts`, `events.ts`, `feedback.ts`, `metadataSaveFeedback.ts`, `formatting.ts`, `preview.ts`, `processing.ts`, `processingConfig.ts`, `processingWorkflow.ts`, `processingWorkflowPreparation.ts`, `processingWorkflowLive.ts`, `processingWorkflowServices.ts`, `processingCancellationWorkflow.ts`, `processingCancellationWorkflowLive.ts`, `processingCancellationWorkflowServices.ts`, `render.ts`, `state.ts`, `viewState.svelte.ts`, `viewTypes.ts`, `domain/`, `services/`, `__tests__/`, `StatusPanelIsland.svelte`.
 - The cluster consumes backend `OperationKind`, progress events, queue snapshots,
   cancellation facts, and terminal results as a read model. It owns visible
   status derivation, status feedback, controls, and processing request

--- a/src/ui/statusPanel/StatusPanelIsland.svelte
+++ b/src/ui/statusPanel/StatusPanelIsland.svelte
@@ -69,10 +69,14 @@
 		return `${activeItems.length} ${label}`;
 	}
 
-	function handleCancelJob(item: (typeof statusPanelViewState.jobItems)[number]): void {
-		if (!item.canCancel || !item.cancelId || !item.onCancel) return;
-		item.onCancel(item.cancelId);
-	}
+    function handleCancelJob(item: (typeof statusPanelViewState.jobItems)[number]): void {
+      if (!item.canCancel || !item.cancelId || !item.onCancel) return;
+      item.onCancel(item.cancelId);
+    }
+
+    function hasCancellableForegroundJob(): boolean {
+      return statusPanelViewState.jobItems.some((item) => item.canCancel && item.cancelId);
+    }
 </script>
 
 <div class="panel status-panel">
@@ -179,7 +183,11 @@
       <button
         id="cancel-all-button"
         class="btn-pill btn-pill-secondary"
-        disabled={statusPanelViewState.cancelAllPending || !statusPanelViewState.isProcessing}
+        disabled={
+          statusPanelViewState.cancelAllPending ||
+          !statusPanelViewState.isProcessing ||
+          !hasCancellableForegroundJob()
+        }
         onclick={handleCancelAllClick}
       >
         Cancel

--- a/src/ui/statusPanel/StatusPanelIsland.svelte
+++ b/src/ui/statusPanel/StatusPanelIsland.svelte
@@ -179,7 +179,7 @@
       <button
         id="cancel-all-button"
         class="btn-pill btn-pill-secondary"
-        disabled={statusPanelViewState.cancelAllPending}
+        disabled={statusPanelViewState.cancelAllPending || !statusPanelViewState.isProcessing}
         onclick={handleCancelAllClick}
       >
         Cancel

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -7,6 +7,7 @@ import * as feedback from '../feedback';
 const context = vi.hoisted(() => ({
 	preflightProcessingPlanMock: vi.fn(),
 	processAudiobookFilesMock: vi.fn(),
+	submitProcessingOperationMock: vi.fn(),
 	validateMetadataIntentPatchMock: vi.fn(async () => ({
 		isValid: true,
 		metadataPatch: {},
@@ -35,6 +36,7 @@ vi.mock('../../../lib/tauri/client', () => ({
 	tauriClient: {
 		preflightProcessingPlan: context.preflightProcessingPlanMock,
 		processAudiobookFiles: context.processAudiobookFilesMock,
+		submitProcessingOperation: context.submitProcessingOperationMock,
 		validateMetadataIntentPatch: context.validateMetadataIntentPatchMock,
 		readAudioMetadata: context.readAudioMetadataMock,
 		openPath: context.openPathMock,
@@ -119,6 +121,7 @@ describe('startProcessing metadata staging', () => {
 	beforeEach(() => {
 		context.preflightProcessingPlanMock.mockReset();
 		context.processAudiobookFilesMock.mockReset();
+		context.submitProcessingOperationMock.mockReset();
 		context.validateMetadataIntentPatchMock.mockClear();
 		context.readAudioMetadataMock.mockReset();
 		context.openPathMock.mockReset();
@@ -178,6 +181,37 @@ describe('startProcessing metadata staging', () => {
 			summary: { total: 1, succeeded: 1, skipped: 0, cancelled: 0, failed: 0 },
 			results: [{ inputIndex: 0, status: 'success', message: 'ok', jobId: 'job-1' }],
 		});
+		context.submitProcessingOperationMock.mockResolvedValue({
+			operationId: 'operation-1',
+			snapshot: {
+				operationId: 'operation-1',
+				sequence: 1,
+				kind: 'processingMerge',
+				status: 'accepted',
+				title: 'Merge encode (2 files)',
+				createdAtMs: 1,
+				startedAtMs: undefined,
+				finishedAtMs: undefined,
+				cancellable: true,
+				cancelRequested: false,
+				lanes: ['analysis', 'encodeCpu', 'outputCommit'],
+				sourceInputIds: ['input-1', 'input-2'],
+				progress: {
+					stage: 'pending',
+					percentage: 0,
+					message: 'Accepted.',
+					currentItemIndex: undefined,
+					totalItems: 1,
+					bytesDownloaded: undefined,
+					bytesTotal: undefined,
+					etaSeconds: undefined,
+				},
+				children: [],
+				terminalSummary: undefined,
+				warnings: [],
+				errors: [],
+			},
+		});
 		context.readAudioMetadataMock.mockResolvedValue({});
 		context.seriesPartValidationErrorMock.mockReturnValue(null);
 		context.subseriesPartValidationErrorMock.mockReturnValue(null);
@@ -191,7 +225,7 @@ describe('startProcessing metadata staging', () => {
 
 		expect(context.readMetadataFormMock).not.toHaveBeenCalled();
 		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: null,
 			}),
@@ -219,7 +253,7 @@ describe('startProcessing metadata staging', () => {
 				markPending: true,
 			},
 		);
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: {
 					'/books/a.m4b': { title: { op: 'set', value: 'Edited Title' } },
@@ -237,7 +271,7 @@ describe('startProcessing metadata staging', () => {
 		expect(context.stageMetadataToSelectionMock).toHaveBeenCalledWith({
 			showStatus: false,
 		});
-		expect(context.processAudiobookFilesMock).not.toHaveBeenCalled();
+		expect(context.submitProcessingOperationMock).not.toHaveBeenCalled();
 		expect(feedback.showError).toHaveBeenCalledWith(
 			'Fix metadata validation errors before processing.',
 		);
@@ -254,7 +288,7 @@ describe('startProcessing metadata staging', () => {
 			expect.objectContaining({ isValid: true }),
 		);
 		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
-		expect(context.processAudiobookFilesMock).not.toHaveBeenCalled();
+		expect(context.submitProcessingOperationMock).not.toHaveBeenCalled();
 		expect(feedback.showError).toHaveBeenCalledWith('Series part must be a number');
 	});
 
@@ -275,7 +309,7 @@ describe('startProcessing metadata staging', () => {
 				markPending: true,
 			},
 		);
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: {
 					'/books/a.m4b': { title: { op: 'clear' } },
@@ -301,7 +335,7 @@ describe('startProcessing metadata staging', () => {
 				markPending: true,
 			},
 		);
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: {
 					'/books/a.m4b': { cover_art: { op: 'clear' } },
@@ -321,7 +355,7 @@ describe('startProcessing metadata staging', () => {
 
 		await startProcessing(processingContext());
 
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: {
 					'/books/a.m4b': { title: { op: 'clear' } },
@@ -331,7 +365,7 @@ describe('startProcessing metadata staging', () => {
 		);
 	});
 
-	it('summarizes structured batch failures from error envelopes', async () => {
+	it('does not build a synchronous batch failure summary after background submission', async () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
@@ -361,12 +395,10 @@ describe('startProcessing metadata staging', () => {
 
 		await startProcessing(ctx);
 
-		expect(ctx.setBatchCompletionMessage).toHaveBeenCalledWith(
-			'No files were processed successfully. Failed: decoder unavailable',
-		);
+		expect(ctx.setBatchCompletionMessage).toHaveBeenCalledWith(null);
 	});
 
-	it('summarizes mixed batch success and cancellation truthfully', async () => {
+	it('does not build a synchronous mixed batch summary after background submission', async () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
@@ -405,7 +437,7 @@ describe('startProcessing metadata staging', () => {
 
 		await startProcessing(ctx);
 
-		expect(ctx.setBatchCompletionMessage).toHaveBeenCalledWith('Processed 1/2. Cancelled: 1.');
+		expect(ctx.setBatchCompletionMessage).toHaveBeenCalledWith(null);
 	});
 
 	it('treats structured cancellation errors as cancellation instead of failures', async () => {
@@ -413,7 +445,7 @@ describe('startProcessing metadata staging', () => {
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
 		context.getAllMetadataIntentPatchesMock.mockReturnValue({});
-		context.processAudiobookFilesMock.mockRejectedValueOnce({
+		context.submitProcessingOperationMock.mockRejectedValueOnce({
 			code: 'cancelled',
 			category: 'cancellation',
 			message: 'Processing was cancelled.',
@@ -442,7 +474,7 @@ describe('startProcessing metadata staging', () => {
 
 		await startProcessing(processingContext());
 
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: {
 					'/books/a.m4b': { title: { op: 'set', value: 'Active A' } },
@@ -463,7 +495,7 @@ describe('startProcessing metadata staging', () => {
 
 		await startProcessing(processingContext());
 
-		expect(context.processAudiobookFilesMock).toHaveBeenCalledWith(
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: null,
 			}),

--- a/src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingCancellationWorkflow.test.ts
@@ -38,12 +38,14 @@ describe('ProcessingCancellationWorkflow', () => {
 		await runAppEffect(
 			processingCancellationWorkflowExecution({
 				type: 'cancelAll',
+				jobIds: ['job-1', 'job-2'],
 				getCurrentStatus: activeStatus,
 				updateStatus,
 			}).pipe(Effect.provide(harness.layer)),
 		);
 
-		expect(harness.services.cancelProcessing).toHaveBeenCalledWith();
+		expect(harness.services.cancelProcessing).toHaveBeenCalledWith('job-1');
+		expect(harness.services.cancelProcessing).toHaveBeenCalledWith('job-2');
 		expect(harness.services.setCancelAllButtonPending).toHaveBeenNthCalledWith(1, true);
 		expect(harness.services.setCancelAllButtonPending).toHaveBeenLastCalledWith(false);
 		expect(updateStatus).toHaveBeenCalledWith({
@@ -65,6 +67,7 @@ describe('ProcessingCancellationWorkflow', () => {
 		await runAppEffect(
 			processingCancellationWorkflowExecution({
 				type: 'cancelAll',
+				jobIds: ['job-1'],
 				getCurrentStatus: activeStatus,
 				updateStatus,
 			}).pipe(Effect.provide(harness.layer)),

--- a/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { tauriClient } from '../../../lib/tauri/client';
 import {
 	makeProcessingWorkflowServicesLayer,
 	startProcessing,
@@ -19,8 +20,10 @@ import type { AcquisitionJob } from '../../../types/remoteSource';
 import type { WorkSubmissionAccepted } from '../../../types/workRuntime';
 import type { OutputPlanReviewResult } from '../../outputPanel/outputPlanWorkflow';
 import {
+	purgeRemoteSourceSessionsForInputIds,
 	registerRemoteSourceSupplementalAssets,
 	removeRemoteSourceSupplementalAssets,
+	supplementalAssetsForInputIds,
 } from '../../remoteSource/sessionAssets.svelte';
 
 function audioFile(path: string, overrides: Partial<AudioFile> = {}): AudioFile {
@@ -385,5 +388,38 @@ describe('ProcessingWorkflow', () => {
 		expect(feedback.showError).toHaveBeenCalledWith('Processing failed: Decoder unavailable.');
 		expect(ctx.resetToIdle).toHaveBeenCalledTimes(1);
 		expect(services.updateOutputPath).toHaveBeenLastCalledWith('final');
+	});
+
+	it('purges retained remote-source sessions that were pending purge when submission fails', async () => {
+		const currentFileList: FileListInfo = {
+			files: [audioFile('/session/book.m4b', { inputId: 'current-input-1' })],
+			selectedDecoders: [null],
+			totalDuration: 1,
+			totalSize: 1,
+			validCount: 1,
+			invalidCount: 0,
+		};
+		registerRemoteSourceSupplementalAssets(acquisitionJobWithPdf(), currentFileList);
+		const purgeSpy = vi.spyOn(tauriClient, 'purgeRemoteSourceSession').mockResolvedValue(undefined);
+		const ctx = workflowContext();
+		const { services, feedback } = workflowServices({
+			getCurrentFileList: vi.fn(() => currentFileList),
+			getJobType: vi.fn((): JobType => 'batch'),
+			submitProcessingOperation: vi.fn(async () => {
+				await purgeRemoteSourceSessionsForInputIds(['current-input-1']);
+				throw {
+					code: 'decoder_unavailable',
+					category: 'toolchain',
+					message: 'Decoder unavailable.',
+					detail: null,
+				};
+			}),
+		});
+
+		await runWithServices(ctx, services);
+
+		expect(feedback.showError).toHaveBeenCalledWith('Processing failed: Decoder unavailable.');
+		expect(purgeSpy).toHaveBeenCalledWith('remote-job-1');
+		expect(supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
 	});
 });

--- a/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
@@ -16,6 +16,7 @@ import {
 	type JobType,
 } from '../../../types/audio';
 import type { AcquisitionJob } from '../../../types/remoteSource';
+import type { WorkSubmissionAccepted } from '../../../types/workRuntime';
 import type { OutputPlanReviewResult } from '../../outputPanel/outputPlanWorkflow';
 import {
 	registerRemoteSourceSupplementalAssets,
@@ -94,6 +95,40 @@ function successResult(jobType: ProcessCommandResult['jobType'] = 'merge'): Proc
 				previewActualSeconds: undefined,
 			},
 		],
+	};
+}
+
+function acceptedSubmission(jobType: JobType = 'merge'): WorkSubmissionAccepted {
+	return {
+		operationId: 'operation-1',
+		snapshot: {
+			operationId: 'operation-1',
+			sequence: 1,
+			kind: jobType === 'batch' ? 'processingBatch' : 'processingMerge',
+			status: 'accepted',
+			title: jobType === 'batch' ? 'Batch encode (1 file)' : 'Merge encode (1 file)',
+			createdAtMs: 1,
+			startedAtMs: undefined,
+			finishedAtMs: undefined,
+			cancellable: true,
+			cancelRequested: false,
+			lanes: ['analysis', 'encodeCpu', 'outputCommit'],
+			sourceInputIds: ['current-input-1'],
+			progress: {
+				stage: 'pending',
+				percentage: 0,
+				message: 'Accepted.',
+				currentItemIndex: undefined,
+				totalItems: 1,
+				bytesDownloaded: undefined,
+				bytesTotal: undefined,
+				etaSeconds: undefined,
+			},
+			children: [],
+			terminalSummary: undefined,
+			warnings: [],
+			errors: [],
+		},
 	};
 }
 
@@ -185,6 +220,7 @@ function workflowServices(overrides: Partial<ProcessingWorkflowServices> = {}) {
 		})),
 		readAudioMetadata: vi.fn(async () => ({})),
 		processAudiobookFiles: vi.fn(async () => successResult()),
+		submitProcessingOperation: vi.fn(async () => acceptedSubmission(getJobTypeMock())),
 		runOutputPlanReviewWorkflow: runOutputPlanReviewWorkflowMock,
 		openGeneratedPreviewIfSingle: vi.fn(async () => undefined),
 		feedback,
@@ -227,8 +263,8 @@ describe('ProcessingWorkflow', () => {
 		expect(services.setJobControlsEnabled).toHaveBeenCalledWith(false);
 		expect(services.setFileOrderLocked).toHaveBeenCalledWith(true);
 		expect(ctx.updateArtThumbnail).toHaveBeenCalledTimes(1);
-		expect(ctx.startProgressListener).toHaveBeenCalledTimes(1);
-		expect(services.processAudiobookFiles).toHaveBeenCalledWith({
+		expect(ctx.startProgressListener).not.toHaveBeenCalled();
+		expect(services.submitProcessingOperation).toHaveBeenCalledWith({
 			payload: expect.objectContaining({
 				inputFiles: ['/books/a.m4b'],
 				preflightSignature: 'preflight-approved',
@@ -236,7 +272,11 @@ describe('ProcessingWorkflow', () => {
 			metadataIntent: null,
 			previewSeconds: undefined,
 		});
-		expect(ctx.reconcileProcessResult).toHaveBeenCalledWith(successResult());
+		expect(services.processAudiobookFiles).not.toHaveBeenCalled();
+		expect(ctx.reconcileProcessResult).not.toHaveBeenCalled();
+		expect(ctx.setProcessingState).toHaveBeenLastCalledWith(false);
+		expect(services.setJobControlsEnabled).toHaveBeenLastCalledWith(true);
+		expect(services.setFileOrderLocked).toHaveBeenLastCalledWith(false);
 		expect(ctx.setBatchCompletionMessage).toHaveBeenLastCalledWith(null);
 		expect(services.updateOutputPath).toHaveBeenLastCalledWith('final');
 	});
@@ -259,7 +299,7 @@ describe('ProcessingWorkflow', () => {
 
 		await runWithServices(ctx, services);
 
-		expect(services.processAudiobookFiles).toHaveBeenCalledWith({
+		expect(services.submitProcessingOperation).toHaveBeenCalledWith({
 			payload: expect.objectContaining({
 				inputFiles: ['/session/book.m4b'],
 				inputIds: ['current-input-1'],
@@ -301,13 +341,14 @@ describe('ProcessingWorkflow', () => {
 		expect(ctx.setProcessingState).not.toHaveBeenCalled();
 		expect(ctx.startProgressListener).not.toHaveBeenCalled();
 		expect(services.processAudiobookFiles).not.toHaveBeenCalled();
+		expect(services.submitProcessingOperation).not.toHaveBeenCalled();
 		expect(services.updateOutputPath).toHaveBeenLastCalledWith('final');
 	});
 
 	it('routes structured cancellation failures to cancellation handling instead of error reset', async () => {
 		const ctx = workflowContext();
 		const { services, feedback } = workflowServices({
-			processAudiobookFiles: vi.fn(async () => {
+			submitProcessingOperation: vi.fn(async () => {
 				throw {
 					code: 'cancelled',
 					category: 'cancellation',
@@ -328,7 +369,7 @@ describe('ProcessingWorkflow', () => {
 	it('surfaces failed processing commands through typed workflow failure handling', async () => {
 		const ctx = workflowContext();
 		const { services, feedback } = workflowServices({
-			processAudiobookFiles: vi.fn(async () => {
+			submitProcessingOperation: vi.fn(async () => {
 				throw {
 					code: 'decoder_unavailable',
 					category: 'toolchain',

--- a/src/ui/statusPanel/__tests__/stateMachine.test.ts
+++ b/src/ui/statusPanel/__tests__/stateMachine.test.ts
@@ -52,7 +52,7 @@ describe('statusPanel state machine', () => {
 		expect(next.currentStatus).not.toHaveProperty('etaSeconds');
 	});
 
-	it('uses backend operation identity to classify lifecycle work kind', () => {
+    it('uses backend operation identity to classify lifecycle work kind', () => {
 		const queuedMetadataSave: ProcessingQueueEvent = {
 			operation_kind: 'metadataSave',
 			items: [{ input_index: 0, file_path: '/books/a.m4b' }],
@@ -73,7 +73,36 @@ describe('statusPanel state machine', () => {
 		expect(afterProgress.model.currentWorkKind).toBe('merge');
 	});
 
-	it('handles progress events that arrive before queue snapshot', () => {
+	it('ignores WorkRuntime-scoped queue and progress events', () => {
+		const model = createStatusPanelModel();
+		const backgroundQueue: ProcessingQueueEvent = {
+			operation_id: 'op-1',
+			operation_kind: 'processingBatch',
+			items: [{ input_index: 0, file_path: '/books/background.m4b' }],
+			max_concurrent: 1,
+		};
+		const afterQueue = applyQueueSnapshot(model, backgroundQueue, 1_000);
+
+		expect(afterQueue.model).toBe(model);
+		expect(afterQueue.model.jobProgress.size).toBe(0);
+
+		const backgroundProgress: ProcessingProgressEvent = {
+			operation_id: 'op-1',
+			operation_kind: 'processingBatch',
+			input_index: 0,
+			job_id: 'job-1',
+			stage: 'converting',
+			percentage: 50,
+			message: 'Background operation progress',
+		};
+		const afterProgress = applyProgress(model, backgroundProgress, 1_100);
+
+		expect(afterProgress.model).toBe(model);
+		expect(afterProgress.model.jobProgress.size).toBe(0);
+		expect(afterProgress.intents).toEqual([]);
+	});
+
+    it('handles progress events that arrive before queue snapshot', () => {
 		const model = createStatusPanelModel();
 		const earlyProgress: ProcessingProgressEvent = {
 			operation_kind: 'processingBatch',

--- a/src/ui/statusPanel/__tests__/statusPanel-island.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-island.test.ts
@@ -46,11 +46,23 @@ describe('StatusPanel island mount', () => {
 		expect(initStatusPanelLogicMock).toHaveBeenCalledTimes(1);
 	});
 
-	it('wires process and cancel buttons to status-panel actions', () => {
-		render(StatusPanelIsland);
+    it('wires process and cancel buttons to status-panel actions', async () => {
+        render(StatusPanelIsland);
+        statusPanelViewState.isProcessing = true;
+        statusPanelViewState.jobItems = [
+            {
+                key: 'processing',
+                label: 'Book.m4b',
+                status: 'processing',
+                statusText: 'Converting',
+                canCancel: true,
+                cancelId: 'job-1',
+            },
+        ];
+        await tick();
 
-		const processButton = document.getElementById('process-button');
-		const cancelButton = document.getElementById('cancel-all-button');
+        const processButton = document.getElementById('process-button');
+        const cancelButton = document.getElementById('cancel-all-button');
 
 		processButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 		cancelButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
@@ -86,20 +86,27 @@ describe('StatusPanel lifecycle', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('disables cancel-all while cancel request is in flight and restores on success', async () => {
-		const controller = new StatusPanelRuntime();
+        it('disables cancel-all while cancel request is in flight and restores on success', async () => {
+            const controller = new StatusPanelRuntime();
 
 		let resolveCancel!: (value: string) => void;
 		const inFlightCancel = new Promise<string>((resolve) => {
 			resolveCancel = resolve;
 		});
-		const cancelSpy = vi
-			.spyOn(tauriClient, 'cancelProcessing')
-			.mockImplementation(() => inFlightCancel);
+            const cancelSpy = vi
+                .spyOn(tauriClient, 'cancelProcessing')
+                .mockImplementation(() => inFlightCancel);
+            controller.applyProgress({
+                operation_kind: 'processingBatch',
+                job_id: 'job-1',
+                stage: STAGES.converting,
+                percentage: 25,
+                message: 'Converting...',
+            });
 
-		const cancelRequest = controller.requestCancelAll();
-		expect(cancelSpy).toHaveBeenCalledTimes(1);
-		expect(statusPanelViewState.cancelAllPending).toBe(true);
+            const cancelRequest = controller.requestCancelAll();
+            expect(cancelSpy).toHaveBeenCalledWith('job-1');
+            expect(statusPanelViewState.cancelAllPending).toBe(true);
 
 		resolveCancel('cancel requested');
 		await cancelRequest;
@@ -109,22 +116,29 @@ describe('StatusPanel lifecycle', () => {
 		expect(getStepText()).toContain('Cancellation requested…');
 	});
 
-	it('preserves latest progress when cancel-all resolves after progress advances', async () => {
-		const controller = new StatusPanelRuntime();
+        it('preserves latest progress when cancel-all resolves after progress advances', async () => {
+            const controller = new StatusPanelRuntime();
 
 		let resolveCancel!: (value: string) => void;
 		const inFlightCancel = new Promise<string>((resolve) => {
 			resolveCancel = resolve;
-		});
-		vi.spyOn(tauriClient, 'cancelProcessing').mockImplementation(() => inFlightCancel);
+            });
+            vi.spyOn(tauriClient, 'cancelProcessing').mockImplementation(() => inFlightCancel);
+            controller.applyProgress({
+                operation_kind: 'processingBatch',
+                job_id: 'job-1',
+                stage: STAGES.converting,
+                percentage: 25,
+                message: 'Converting...',
+            });
 
-		const cancelRequest = controller.requestCancelAll();
-		controller.applyProgress({
-			operation_kind: 'processingBatch',
-			input_index: 0,
-			stage: STAGES.writing,
-			percentage: 68,
-			message: 'Writing metadata',
+            const cancelRequest = controller.requestCancelAll();
+            controller.applyProgress({
+                operation_kind: 'processingBatch',
+                job_id: 'job-1',
+                stage: STAGES.writing,
+                percentage: 68,
+                message: 'Writing metadata',
 		});
 
 		resolveCancel('cancel requested');
@@ -141,11 +155,18 @@ describe('StatusPanel lifecycle', () => {
 	it('restores cancel-all enabled state and surfaces explicit error on cancel failure', async () => {
 		const controller = new StatusPanelRuntime();
 		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-		vi.spyOn(tauriClient, 'cancelProcessing').mockRejectedValue(
-			new Error('tauriClient cancellation failed'),
-		);
+            vi.spyOn(tauriClient, 'cancelProcessing').mockRejectedValue(
+                new Error('tauriClient cancellation failed'),
+            );
+            controller.applyProgress({
+                operation_kind: 'processingBatch',
+                job_id: 'job-1',
+                stage: STAGES.converting,
+                percentage: 25,
+                message: 'Converting...',
+            });
 
-		await controller.requestCancelAll();
+            await controller.requestCancelAll();
 
 		expect(statusPanelViewState.cancelAllPending).toBe(false);
 		expect(getStepText()).toBe('Error: Failed to cancel processing. Please try again.');
@@ -187,8 +208,8 @@ describe('StatusPanel lifecycle', () => {
 		const showErrorSpy = vi.spyOn(feedback, 'showError');
 		const showInfoSpy = vi.spyOn(feedback, 'showInfo');
 
-		controller.applyQueueSnapshot({
-			operation_kind: 'processingBatch',
+            controller.applyQueueSnapshot({
+                operation_kind: 'processingBatch',
 			items: [
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
@@ -552,10 +573,26 @@ describe('StatusPanel lifecycle', () => {
 				{ input_index: 0, file_path: '/books/alpha.m4b' },
 				{ input_index: 1, file_path: '/books/beta.m4b' },
 			],
-			max_concurrent: 2,
-		});
+                max_concurrent: 2,
+            });
+            controller.applyProgress({
+                operation_kind: 'processingBatch',
+                input_index: 0,
+                job_id: 'job-0',
+                stage: STAGES.converting,
+                percentage: 25,
+                message: 'Converting alpha',
+            });
+            controller.applyProgress({
+                operation_kind: 'processingBatch',
+                input_index: 1,
+                job_id: 'job-1',
+                stage: STAGES.converting,
+                percentage: 25,
+                message: 'Converting beta',
+            });
 
-		await controller.requestCancelAll();
+            await controller.requestCancelAll();
 		expect(getStepText()).toContain('Cancellation requested…');
 		expect(controller.getCurrentStatus().message).toBe('Cancellation requested…');
 

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -163,12 +163,18 @@ export class StatusPanelRuntime {
 	}
 
 	public async requestCancelAll(): Promise<void> {
+		const jobIds = this.cancellableForegroundJobIds();
+		if (jobIds.length === 0) {
+			return;
+		}
 		const preparedCancelAll = enterCancelAllCancellationWorkflow(
 			liveProcessingCancellationWorkflowServices,
+			jobIds,
 		);
 		await runProcessingCancellationWorkflow(
 			{
 				type: 'cancelAll',
+				jobIds,
 				getCurrentStatus: () => this.model.currentStatus,
 				updateStatus: (status) => this.updateStatus(status),
 			},
@@ -258,6 +264,16 @@ export class StatusPanelRuntime {
 		}
 
 		return 'Processing';
+	}
+
+	private cancellableForegroundJobIds(): string[] {
+		return Array.from(
+			new Set(
+				Array.from(this.model.jobProgress.values())
+					.filter((job) => job.status === 'processing' && job.jobId)
+					.map((job) => job.jobId as string),
+			),
+		);
 	}
 
 	private buildMergeOutputLabel(): string {

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -443,31 +443,25 @@ export function initStatusPanel(): StatusPanelRuntime {
 	}
 	return statusPanelInstance;
 }
-
 export function isStatusPanelProcessing(): boolean {
 	return Boolean(statusPanelInstance?.isCurrentlyProcessing);
 }
-
 export function triggerProcessFromStatusPanel(options?: { previewSeconds?: number }): void {
 	void initStatusPanel().startProcessing(options);
 }
-
 export function triggerCancelAllFromStatusPanel(): void {
+	if (!statusPanelInstance?.isCurrentlyProcessing) return;
 	void statusPanelInstance?.requestCancelAll();
 }
-
 export function beginMetadataSaveInStatusPanel(): Promise<void> {
 	return initStatusPanel().beginMetadataSave();
 }
-
 export function completeMetadataSaveInStatusPanel(result: MetadataSaveBatchResult): void {
 	initStatusPanel().completeMetadataSave(result);
 }
-
 export function failMetadataSaveInStatusPanel(message?: string): void {
 	initStatusPanel().failMetadataSave(message);
 }
-
 export function pushStatusPanelTransientStatus(
 	message: string,
 	options?: { ttlMs?: number },

--- a/src/ui/statusPanel/domain/stateMachine.ts
+++ b/src/ui/statusPanel/domain/stateMachine.ts
@@ -82,6 +82,10 @@ export function applyQueueSnapshot(
 	event: ProcessingQueueEvent,
 	now: number,
 ): StatusPanelReducerResult {
+	if (event.operation_id) {
+		return { model, intents: [] };
+	}
+
 	const queueSnapshot = buildQueueSnapshotState(event.items, now);
 	const next: StatusPanelModel = {
 		jobProgress: new Map(queueSnapshot.jobProgress),
@@ -105,6 +109,10 @@ export function applyProgress(
 	now: number,
 	options?: { label?: string },
 ): StatusPanelReducerResult {
+	if (event.operation_id) {
+		return { model, intents: [] };
+	}
+
 	const jobKey = buildJobKey(
 		typeof event.input_index === 'number' ? event.input_index : undefined,
 		event.job_id,

--- a/src/ui/statusPanel/domain/stateMachineTypes.ts
+++ b/src/ui/statusPanel/domain/stateMachineTypes.ts
@@ -7,7 +7,7 @@ export const MERGE_SKIP_HOLD_MS = 1500;
 export const PROGRESS_THROTTLE_MS = 1000;
 
 export type CompletionFeedbackKind = 'success' | 'error' | 'info';
-export type StatusPanelWorkKind = 'merge' | 'batch' | 'metadataSave';
+export type StatusPanelWorkKind = 'merge' | 'batch' | 'remoteAcquisition' | 'metadataSave';
 
 export function workKindFromOperationKind(operationKind: OperationKind): StatusPanelWorkKind {
 	switch (operationKind) {
@@ -15,6 +15,8 @@ export function workKindFromOperationKind(operationKind: OperationKind): StatusP
 			return 'merge';
 		case 'processingBatch':
 			return 'batch';
+		case 'remoteAcquisition':
+			return 'remoteAcquisition';
 		case 'metadataSave':
 			return 'metadataSave';
 	}

--- a/src/ui/statusPanel/feedback.ts
+++ b/src/ui/statusPanel/feedback.ts
@@ -5,6 +5,7 @@ import {
 	setStatusPanelConcurrencyText,
 	setStatusPanelCoverArtDataUrl,
 	setStatusPanelJobItems,
+	setStatusPanelIsProcessing,
 	setStatusPanelProgressPercentage,
 	setStatusPanelStatusText,
 	setStatusPanelStepColor,
@@ -33,8 +34,8 @@ export function updateConcurrencyStatus(message: string): void {
 	setStatusPanelConcurrencyText(message);
 }
 
-export function updateProcessButton(_isProcessing: boolean): void {
-	// Process button label/style are static in the island.
+export function updateProcessButton(isProcessing: boolean): void {
+	setStatusPanelIsProcessing(isProcessing);
 }
 
 export function displayCoverArt(dataUrl: string): void {

--- a/src/ui/statusPanel/processingCancellationWorkflow.ts
+++ b/src/ui/statusPanel/processingCancellationWorkflow.ts
@@ -22,12 +22,13 @@ export {
 } from './processingCancellationWorkflowServices';
 
 export interface PreparedCancelAllRequest {
-	readonly request: ReturnType<ProcessingCancellationWorkflowServices['cancelProcessing']>;
+	readonly request: Promise<readonly unknown[]>;
 }
 
 export type ProcessingCancellationWorkflowAction =
 	| {
 			type: 'cancelAll';
+			jobIds: readonly string[];
 			getCurrentStatus: () => ProcessingStatus;
 			updateStatus: (status: ProcessingStatus) => void;
 	  }
@@ -72,11 +73,16 @@ function cancelAll(
 ): AppEffect<void, never, ProcessingCancellationWorkflowServicesId> {
 	return Effect.gen(function* () {
 		const services = yield* ProcessingCancellationWorkflowServicesTag;
+		if (action.jobIds.length === 0) {
+			return;
+		}
 		if (!preparedRequest) {
 			services.setCancelAllButtonPending(true);
 		}
 		yield* workflowPromise(
-			() => preparedRequest?.request ?? services.cancelProcessing(),
+			() =>
+				preparedRequest?.request ??
+				Promise.all(action.jobIds.map((jobId) => services.cancelProcessing(jobId))),
 			'Failed to cancel processing.',
 		).pipe(
 			Effect.tap(() =>
@@ -128,12 +134,13 @@ function processingCancellationWorkflowBody(
 
 export function enterCancelAllCancellationWorkflow(
 	services: ProcessingCancellationWorkflowServices,
+	jobIds: readonly string[],
 ): PreparedCancelAllRequest {
 	services.setCancelAllButtonPending(true);
 	try {
-		return { request: services.cancelProcessing() };
+		return { request: Promise.all(jobIds.map((jobId) => services.cancelProcessing(jobId))) };
 	} catch (cause) {
-		return { request: Promise.reject(cause) as ReturnType<typeof services.cancelProcessing> };
+		return { request: Promise.reject(cause) };
 	}
 }
 

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -30,7 +30,6 @@ import {
 } from './processingWorkflowPreparation';
 import {
 	purgeRemoteSourceSessionsForInputIds,
-	purgeSuccessfulRemoteSourceSessions,
 	releaseRemoteSourceSessionRetainers,
 	retainRemoteSourceSessionsForInputIds,
 } from '../remoteSource/sessionAssets.svelte';
@@ -288,8 +287,6 @@ function completeProcessingExecution(
 	context: ProcessingWorkflowContext,
 	result: ProcessCommandResult,
 	filePaths: string[],
-	inputIds: readonly (string | undefined)[],
-	shouldPurgeRemoteSessions: boolean,
 ): AppEffect<void, ProcessingWorkflowFailed> {
 	return Effect.gen(function* () {
 		yield* Effect.sync(() => {
@@ -301,12 +298,6 @@ function completeProcessingExecution(
 			() => services.openGeneratedPreviewIfSingle(result),
 			'Failed to open generated preview.',
 		);
-		if (shouldPurgeRemoteSessions) {
-			yield* workflowPromise(
-				() => purgeSuccessfulRemoteSourceSessions(result, inputIds),
-				'Failed to purge remote source session.',
-			);
-		}
 	});
 }
 
@@ -444,7 +435,7 @@ export function processingWorkflowProgram(
 				previewSeconds: options.previewSeconds,
 			});
 
-			yield* completeProcessingExecution(services, context, result, filePaths, inputIds, false);
+			yield* completeProcessingExecution(services, context, result, filePaths);
 			return;
 		}
 

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -29,6 +29,7 @@ import {
 	validInputFilePaths,
 } from './processingWorkflowPreparation';
 import {
+	purgeRemoteSourceSessionsForInputIds,
 	purgeSuccessfulRemoteSourceSessions,
 	releaseRemoteSourceSessionRetainers,
 	retainRemoteSourceSessionsForInputIds,
@@ -153,6 +154,23 @@ function workflowPromise<A>(
 	return workflowTryPromise(evaluate, message, workflowFailure);
 }
 
+function toProcessingWorkflowError(cause: unknown): ProcessingWorkflowError {
+	const normalized = normalizeAppError(cause);
+	const wasCancelled =
+		isAppErrorCategory(cause, 'cancellation') ||
+		normalized.message.toLowerCase().includes('cancelled');
+	if (wasCancelled) {
+		return new ProcessingWorkflowCancelled({
+			message: normalized.message,
+			cause,
+		});
+	}
+	return new ProcessingWorkflowFailed({
+		message: normalized.message,
+		cause,
+	});
+}
+
 function processingCommand(
 	services: ProcessingWorkflowServices,
 	request: {
@@ -168,22 +186,7 @@ function processingCommand(
 				metadataIntent: request.metadataIntentByPath,
 				previewSeconds: request.previewSeconds,
 			}),
-		catch: (cause) => {
-			const normalized = normalizeAppError(cause);
-			const wasCancelled =
-				isAppErrorCategory(cause, 'cancellation') ||
-				normalized.message.toLowerCase().includes('cancelled');
-			if (wasCancelled) {
-				return new ProcessingWorkflowCancelled({
-					message: normalized.message,
-					cause,
-				});
-			}
-			return new ProcessingWorkflowFailed({
-				message: normalized.message,
-				cause,
-			});
-		},
+		catch: toProcessingWorkflowError,
 	});
 }
 
@@ -202,22 +205,7 @@ function submitProcessingCommand(
 				metadataIntent: request.metadataIntentByPath,
 				previewSeconds: request.previewSeconds,
 			}),
-		catch: (cause) => {
-			const normalized = normalizeAppError(cause);
-			const wasCancelled =
-				isAppErrorCategory(cause, 'cancellation') ||
-				normalized.message.toLowerCase().includes('cancelled');
-			if (wasCancelled) {
-				return new ProcessingWorkflowCancelled({
-					message: normalized.message,
-					cause,
-				});
-			}
-			return new ProcessingWorkflowFailed({
-				message: normalized.message,
-				cause,
-			});
-		},
+		catch: toProcessingWorkflowError,
 	});
 }
 
@@ -233,9 +221,18 @@ function submitRetainedProcessingCommand(
 		yield* Effect.sync(() => retainRemoteSourceSessionsForInputIds(request.inputIds));
 		return yield* submitProcessingCommand(services, request).pipe(
 			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					releaseRemoteSourceSessionRetainers(request.inputIds);
-				}).pipe(Effect.flatMap(() => Effect.fail(error))),
+				Effect.tryPromise({
+					try: async () => {
+						const pendingPurgeInputIds = releaseRemoteSourceSessionRetainers(request.inputIds);
+						if (pendingPurgeInputIds.length > 0) {
+							await purgeRemoteSourceSessionsForInputIds(pendingPurgeInputIds);
+						}
+					},
+					catch: () => undefined,
+				}).pipe(
+					Effect.catchAll(() => Effect.succeed(undefined)),
+					Effect.flatMap(() => Effect.fail(error)),
+				),
 			),
 		);
 	});

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -3,6 +3,7 @@ import type {
 	ProcessPayload,
 	ProcessingRequestConfig,
 } from '../../types/audio';
+import type { WorkSubmissionAccepted } from '../../types/workRuntime';
 import type { MetadataIntentPatch } from '../../types/metadataIntent';
 import { isAppErrorCategory, normalizeAppError } from '../../lib/tauri/appError';
 import {
@@ -27,7 +28,11 @@ import {
 	validInputIds,
 	validInputFilePaths,
 } from './processingWorkflowPreparation';
-import { purgeSuccessfulRemoteSourceSessions } from '../remoteSource/sessionAssets.svelte';
+import {
+	purgeSuccessfulRemoteSourceSessions,
+	releaseRemoteSourceSessionRetainers,
+	retainRemoteSourceSessionsForInputIds,
+} from '../remoteSource/sessionAssets.svelte';
 import type { ProcessingStatus } from './state';
 
 type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
@@ -182,6 +187,60 @@ function processingCommand(
 	});
 }
 
+function submitProcessingCommand(
+	services: ProcessingWorkflowServices,
+	request: {
+		payload: ProcessPayload;
+		metadataIntentByPath: MetadataIntentByPath | null;
+		previewSeconds?: number;
+	},
+): AppEffect<WorkSubmissionAccepted, ProcessingWorkflowError> {
+	return Effect.tryPromise({
+		try: () =>
+			services.submitProcessingOperation({
+				payload: request.payload,
+				metadataIntent: request.metadataIntentByPath,
+				previewSeconds: request.previewSeconds,
+			}),
+		catch: (cause) => {
+			const normalized = normalizeAppError(cause);
+			const wasCancelled =
+				isAppErrorCategory(cause, 'cancellation') ||
+				normalized.message.toLowerCase().includes('cancelled');
+			if (wasCancelled) {
+				return new ProcessingWorkflowCancelled({
+					message: normalized.message,
+					cause,
+				});
+			}
+			return new ProcessingWorkflowFailed({
+				message: normalized.message,
+				cause,
+			});
+		},
+	});
+}
+
+function submitRetainedProcessingCommand(
+	services: ProcessingWorkflowServices,
+	request: {
+		payload: ProcessPayload;
+		metadataIntentByPath: MetadataIntentByPath | null;
+		inputIds: readonly (string | undefined)[];
+	},
+): AppEffect<WorkSubmissionAccepted, ProcessingWorkflowError> {
+	return Effect.gen(function* () {
+		yield* Effect.sync(() => retainRemoteSourceSessionsForInputIds(request.inputIds));
+		return yield* submitProcessingCommand(services, request).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					releaseRemoteSourceSessionRetainers(request.inputIds);
+				}).pipe(Effect.flatMap(() => Effect.fail(error))),
+			),
+		);
+	});
+}
+
 function readProcessingConfig(
 	services: ProcessingWorkflowServices,
 ): AppEffect<ProcessingRequestConfig | null> {
@@ -251,6 +310,25 @@ function completeProcessingExecution(
 				'Failed to purge remote source session.',
 			);
 		}
+	});
+}
+
+function completeAcceptedSubmission(
+	services: ProcessingWorkflowServices,
+	context: ProcessingWorkflowContext,
+	accepted: WorkSubmissionAccepted,
+): AppEffect<void> {
+	return Effect.sync(() => {
+		services.console.log('Processing operation accepted:', accepted);
+		context.setProcessingState(false);
+		context.updateStatus({
+			stage: 'completed',
+			percentage: 100,
+			message: 'Submitted to Work Center.',
+		});
+		services.setJobControlsEnabled(true);
+		services.setFileOrderLocked(false);
+		context.setBatchCompletionMessage(null);
 	});
 }
 
@@ -360,22 +438,26 @@ export function processingWorkflowProgram(
 		}
 
 		yield* beginProcessingExecution(services, context);
-		yield* startProcessingRuntime(context);
 
-		const result = yield* processingCommand(services, {
+		if (options?.previewSeconds != null) {
+			yield* startProcessingRuntime(context);
+			const result = yield* processingCommand(services, {
+				payload: reviewResult.payload,
+				metadataIntentByPath,
+				previewSeconds: options.previewSeconds,
+			});
+
+			yield* completeProcessingExecution(services, context, result, filePaths, inputIds, false);
+			return;
+		}
+
+		yield* workflowPromise(() => context.updateArtThumbnail(), 'Failed to update art thumbnail.');
+		const accepted = yield* submitRetainedProcessingCommand(services, {
 			payload: reviewResult.payload,
-			metadataIntentByPath,
-			previewSeconds: options?.previewSeconds,
+			metadataIntentByPath: metadataIntentByPath,
+			inputIds: inputIds,
 		});
-
-		yield* completeProcessingExecution(
-			services,
-			context,
-			result,
-			filePaths,
-			inputIds,
-			options?.previewSeconds == null,
-		);
+		yield* completeAcceptedSubmission(services, context, accepted);
 	}).pipe(
 		Effect.catchAll((error) =>
 			Effect.gen(function* () {

--- a/src/ui/statusPanel/processingWorkflowLive.ts
+++ b/src/ui/statusPanel/processingWorkflowLive.ts
@@ -43,6 +43,7 @@ const liveProcessingWorkflowServices: ProcessingWorkflowServices = {
 	validateMetadataIntentPatch: tauriClient.validateMetadataIntentPatch,
 	readAudioMetadata: tauriClient.readAudioMetadata,
 	processAudiobookFiles: tauriClient.processAudiobookFiles,
+	submitProcessingOperation: tauriClient.submitProcessingOperation,
 	runOutputPlanReviewWorkflow,
 	openGeneratedPreviewIfSingle,
 	feedback,

--- a/src/ui/statusPanel/processingWorkflowServices.ts
+++ b/src/ui/statusPanel/processingWorkflowServices.ts
@@ -44,6 +44,7 @@ export interface ProcessingWorkflowServices {
 	validateMetadataIntentPatch: typeof tauriClient.validateMetadataIntentPatch;
 	readAudioMetadata: typeof tauriClient.readAudioMetadata;
 	processAudiobookFiles: typeof tauriClient.processAudiobookFiles;
+	submitProcessingOperation: typeof tauriClient.submitProcessingOperation;
 	runOutputPlanReviewWorkflow: typeof runOutputPlanReviewWorkflow;
 	openGeneratedPreviewIfSingle: typeof openGeneratedPreviewIfSingle;
 	feedback: Pick<typeof feedback, 'showError'>;

--- a/src/ui/statusPanel/viewState.svelte.ts
+++ b/src/ui/statusPanel/viewState.svelte.ts
@@ -9,6 +9,7 @@ type StatusPanelViewState = {
 	stepText: string;
 	stepColor: string;
 	concurrencyText: string;
+	isProcessing: boolean;
 	cancelAllPending: boolean;
 };
 
@@ -21,6 +22,7 @@ const DEFAULT_STATUS_PANEL_VIEW_STATE: StatusPanelViewState = {
 	stepText: 'Current Step: Waiting for files...',
 	stepColor: 'var(--text-primary)',
 	concurrencyText: '',
+	isProcessing: false,
 	cancelAllPending: false,
 };
 
@@ -120,6 +122,10 @@ export function setStatusPanelConcurrencyText(value: string): void {
 	statusPanelViewState.concurrencyText = value;
 }
 
+export function setStatusPanelIsProcessing(isProcessing: boolean): void {
+	statusPanelViewState.isProcessing = isProcessing;
+}
+
 export function setStatusPanelCancelAllPending(isPending: boolean): void {
 	statusPanelViewState.cancelAllPending = isPending;
 }
@@ -134,6 +140,7 @@ export function resetStatusPanelViewState(): void {
 	statusPanelViewState.stepText = DEFAULT_STATUS_PANEL_VIEW_STATE.stepText;
 	statusPanelViewState.stepColor = DEFAULT_STATUS_PANEL_VIEW_STATE.stepColor;
 	statusPanelViewState.concurrencyText = DEFAULT_STATUS_PANEL_VIEW_STATE.concurrencyText;
+	statusPanelViewState.isProcessing = DEFAULT_STATUS_PANEL_VIEW_STATE.isProcessing;
 	statusPanelViewState.cancelAllPending = DEFAULT_STATUS_PANEL_VIEW_STATE.cancelAllPending;
 
 	if (statusMessageLockTimeoutId !== null) {

--- a/src/ui/workCenter/AGENTS.md
+++ b/src/ui/workCenter/AGENTS.md
@@ -1,0 +1,21 @@
+# Work Center
+
+## Public API Strip
+
+- `WorkCenterIsland`
+- `initializeWorkCenter`
+- `workCenterState`
+
+## Ownership
+
+- Own the frontend read model for WorkRuntime operations, operation-level cancel
+  actions, and source actions.
+- Consume Tauri only through `src/lib/tauri/client.ts`.
+- Do not own processing submission preparation, metadata staging, output plan
+  review, provider auth, or remote materializer details.
+
+## Guardrails
+
+- Keep multi-operation state in `model.ts`/`state.svelte.ts`; the Svelte
+  component should render and dispatch actions only.
+- Do not push singleton queue logic back into StatusPanel.

--- a/src/ui/workCenter/WorkCenterIsland.svelte
+++ b/src/ui/workCenter/WorkCenterIsland.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { ChildJobSnapshot, OperationSnapshot } from '../../types/workRuntime';
+	import {
+		cancelWorkOperation,
+		initializeWorkCenter,
+		openChildSource,
+		workCenterState,
+	} from './state.svelte';
+
+	onMount(() => {
+		void initializeWorkCenter();
+	});
+
+	function operationStatusLabel(status: OperationSnapshot['status']): string {
+		if (status === 'accepted') return 'Accepted';
+		if (status === 'running') return 'Running';
+		if (status === 'cancelling') return 'Cancelling';
+		if (status === 'completed') return 'Completed';
+		if (status === 'cancelled') return 'Cancelled';
+		if (status === 'failed') return 'Failed';
+		return 'Mixed';
+	}
+
+	function operationKindLabel(kind: OperationSnapshot['kind']): string {
+		if (kind === 'processingBatch') return 'Batch';
+		if (kind === 'processingMerge') return 'Merge';
+		if (kind === 'remoteAcquisition') return 'Acquisition';
+		return 'Metadata';
+	}
+
+	function childStatusLabel(status: ChildJobSnapshot['status']): string {
+		if (status === 'queued') return 'Queued';
+		if (status === 'running') return 'Running';
+		if (status === 'completed') return 'Done';
+		if (status === 'skipped') return 'Skipped';
+		if (status === 'cancelled') return 'Cancelled';
+		return 'Failed';
+	}
+
+	function canCancel(operation: OperationSnapshot): boolean {
+		return operation.cancellable && !operation.cancelRequested;
+	}
+
+	function summaryText(operation: OperationSnapshot): string {
+		if (operation.terminalSummary) return operation.terminalSummary.message;
+		return operation.progress.message;
+	}
+</script>
+
+<div class="panel work-center" aria-label="Work Center">
+	<div class="work-center-header">
+		<div>
+			<h3>Work Center</h3>
+			<p>{workCenterState.operations.length} operation{workCenterState.operations.length === 1 ? '' : 's'}</p>
+		</div>
+	</div>
+
+	{#if workCenterState.errorMessage}
+		<div class="work-center-error">{workCenterState.errorMessage}</div>
+	{/if}
+
+	{#if workCenterState.operations.length === 0}
+		<div class="work-center-empty">No background work.</div>
+	{:else}
+		<div class="work-operation-list">
+			{#each workCenterState.operations as operation (operation.operationId)}
+				<section class={`work-operation is-${operation.status}`}>
+					<div class="work-operation-topline">
+						<div class="work-operation-title-group">
+							<span class="work-kind">{operationKindLabel(operation.kind)}</span>
+							<span class="work-title" title={operation.title}>{operation.title}</span>
+						</div>
+						<div class="work-operation-actions">
+							<span class={`work-status is-${operation.status}`}>
+								{operationStatusLabel(operation.status)}
+							</span>
+							<button
+								class="work-action-button"
+								disabled={
+									!canCancel(operation) ||
+									Boolean(workCenterState.cancelPendingByOperationId[operation.operationId])
+								}
+								onclick={() => void cancelWorkOperation(operation.operationId)}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+
+					<div class="work-progress-row">
+						<div class="work-progress-track">
+							<div
+								class="work-progress-fill"
+								style={`width: ${Math.min(100, Math.max(0, operation.progress.percentage))}%`}
+							></div>
+						</div>
+						<span class="work-progress-value">{operation.progress.percentage.toFixed(0)}%</span>
+					</div>
+
+					<div class="work-summary" title={summaryText(operation)}>{summaryText(operation)}</div>
+
+					<div class="work-child-list">
+						{#each operation.children as child (child.childJobId)}
+							<div class={`work-child-row is-${child.status}`}>
+								<span class="work-child-label" title={child.sourcePath ?? child.label}>{child.label}</span>
+								<span class="work-child-status">{childStatusLabel(child.status)}</span>
+								{#if child.sourcePath}
+									<button
+										class="work-child-source"
+										title="Open source file"
+										onclick={() => void openChildSource(child)}
+									>
+										Source
+									</button>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				</section>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.work-center {
+		flex-shrink: 0;
+		gap: 0.5rem;
+		padding: 0.625rem 0.75rem;
+	}
+
+	.work-center-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.work-center-header h3 {
+		margin: 0;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+	}
+
+	.work-center-header p {
+		margin: 0.125rem 0 0;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	.work-center-empty,
+	.work-center-error,
+	.work-summary {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	.work-center-error {
+		color: var(--text-error);
+	}
+
+	.work-operation-list {
+		display: flex;
+		max-height: 14rem;
+		flex-direction: column;
+		gap: 0.5rem;
+		overflow-y: auto;
+		padding-right: 0.125rem;
+	}
+
+	.work-operation {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		padding: 0.5rem;
+		border: 1px solid var(--border-primary);
+		border-radius: 0.375rem;
+		background: var(--bg-input);
+	}
+
+	.work-operation-topline,
+	.work-operation-actions,
+	.work-operation-title-group,
+	.work-progress-row,
+	.work-child-row {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+	}
+
+	.work-operation-topline {
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.work-operation-title-group {
+		gap: 0.375rem;
+	}
+
+	.work-kind,
+	.work-status {
+		flex-shrink: 0;
+		border-radius: 9999px;
+		padding: 0.125rem 0.375rem;
+		font-size: 0.6875rem;
+		font-weight: 700;
+		line-height: 1.2;
+	}
+
+	.work-kind {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+
+	.work-title,
+	.work-child-label,
+	.work-summary {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.work-title {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.work-operation-actions {
+		flex-shrink: 0;
+		gap: 0.375rem;
+	}
+
+	.work-status.is-running,
+	.work-status.is-accepted,
+	.work-status.is-cancelling {
+		background: rgba(59, 130, 246, 0.12);
+		color: var(--accent-primary);
+	}
+
+	.work-status.is-completed {
+		background: rgba(16, 185, 129, 0.12);
+		color: var(--text-success);
+	}
+
+	.work-status.is-failed,
+	.work-status.is-mixed,
+	.work-status.is-cancelled {
+		background: rgba(239, 68, 68, 0.12);
+		color: var(--text-error);
+	}
+
+	.work-action-button,
+	.work-child-source {
+		margin-top: 0;
+		border: 1px solid var(--border-secondary);
+		border-radius: 0.25rem;
+		background: var(--bg-panel);
+		color: var(--text-secondary);
+		font-size: 0.6875rem;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	.work-action-button {
+		padding: 0.25rem 0.5rem;
+	}
+
+	.work-child-source {
+		padding: 0.1875rem 0.375rem;
+	}
+
+	.work-action-button:disabled {
+		cursor: not-allowed;
+		opacity: 0.45;
+	}
+
+	.work-progress-row {
+		gap: 0.5rem;
+	}
+
+	.work-progress-track {
+		position: relative;
+		height: 0.375rem;
+		flex: 1 1 auto;
+		overflow: hidden;
+		border-radius: 9999px;
+		background: var(--progress-bg);
+	}
+
+	.work-progress-fill {
+		height: 100%;
+		border-radius: inherit;
+		background: var(--progress-fg);
+		transition: width 0.2s ease;
+	}
+
+	.work-progress-value {
+		width: 2.5rem;
+		flex-shrink: 0;
+		text-align: right;
+		font-size: 0.6875rem;
+		color: var(--text-muted);
+	}
+
+	.work-child-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.work-child-row {
+		gap: 0.375rem;
+		border-top: 1px solid var(--border-primary);
+		padding-top: 0.25rem;
+		font-size: 0.75rem;
+	}
+
+	.work-child-label {
+		flex: 1 1 auto;
+		color: var(--text-secondary);
+	}
+
+	.work-child-status {
+		width: 4.5rem;
+		flex-shrink: 0;
+		text-align: right;
+		color: var(--text-muted);
+	}
+</style>

--- a/src/ui/workCenter/__tests__/model.test.ts
+++ b/src/ui/workCenter/__tests__/model.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { OperationSnapshot } from '../../../types/workRuntime';
+import { applyProgress, upsertOperation, type WorkCenterModel } from '../model';
+
+function operation(
+	id: string,
+	sequence: number,
+	title: string,
+	childCount = 1,
+): OperationSnapshot {
+	const children = Array.from({ length: childCount }, (_, index) => ({
+		childJobId: `${id}-child-${index}`,
+		operationId: id,
+		label: `${title} ${index + 1}`,
+		status: 'queued' as const,
+		lane: 'encodeCpu' as const,
+		progress: {
+			stage: 'pending' as const,
+			percentage: 0,
+			message: 'Queued.',
+			currentItemIndex: undefined,
+			totalItems: childCount,
+			bytesDownloaded: undefined,
+			bytesTotal: undefined,
+			etaSeconds: undefined,
+		},
+		sourcePath: `/tmp/${id}-${index}.m4b`,
+		inputIndex: index,
+		inputId: `${id}-${index}`,
+		jobId: undefined,
+		cancellable: false,
+		cancelRequested: false,
+		message: undefined,
+	}));
+	return {
+		operationId: id,
+		sequence,
+		kind: 'processingBatch',
+		status: 'accepted',
+		title,
+		createdAtMs: sequence,
+		startedAtMs: undefined,
+		finishedAtMs: undefined,
+		cancellable: true,
+		cancelRequested: false,
+		lanes: ['analysis', 'encodeCpu'],
+		sourceInputIds: [id],
+		progress: {
+			stage: 'pending',
+			percentage: 0,
+			message: 'Accepted.',
+			currentItemIndex: undefined,
+			totalItems: 1,
+			bytesDownloaded: undefined,
+			bytesTotal: undefined,
+			etaSeconds: undefined,
+		},
+		children,
+		terminalSummary: undefined,
+		warnings: [],
+		errors: [],
+	};
+}
+
+describe('Work Center model', () => {
+	it('upserts one operation without erasing existing operations', () => {
+		let model: WorkCenterModel = { operations: [] };
+		model = upsertOperation(model, operation('op-1', 1, 'First'));
+		model = upsertOperation(model, operation('op-2', 2, 'Second'));
+
+		expect(model.operations.map((item) => item.operationId)).toEqual(['op-2', 'op-1']);
+	});
+
+	it('applies progress only to the matching operation id', () => {
+		let model: WorkCenterModel = { operations: [] };
+		model = upsertOperation(model, operation('op-1', 1, 'First'));
+		model = upsertOperation(model, operation('op-2', 2, 'Second'));
+
+		const updated = applyProgress(model, {
+			operation_id: 'op-1',
+			operation_kind: 'processingBatch',
+			stage: 'converting',
+			percentage: 42,
+			message: 'Converting.',
+			current_file: undefined,
+			eta_seconds: undefined,
+			job_id: 'job-1',
+			input_index: 0,
+		});
+
+		expect(updated.operations.find((item) => item.operationId === 'op-1')?.progress.percentage).toBe(42);
+		expect(updated.operations.find((item) => item.operationId === 'op-2')?.progress.percentage).toBe(0);
+	});
+
+	it('aggregates child-scoped batch progress instead of marking the whole operation complete', () => {
+		let model: WorkCenterModel = { operations: [] };
+		model = upsertOperation(model, operation('op-1', 1, 'Batch', 2));
+
+		const updated = applyProgress(model, {
+			operation_id: 'op-1',
+			operation_kind: 'processingBatch',
+			stage: 'completed',
+			percentage: 100,
+			message: 'First item complete.',
+			current_file: undefined,
+			eta_seconds: undefined,
+			job_id: 'job-1',
+			input_index: 0,
+		});
+		const updatedOperation = updated.operations[0];
+
+		expect(updatedOperation.status).toBe('running');
+		expect(updatedOperation.progress.stage).toBe('converting');
+		expect(updatedOperation.progress.percentage).toBe(50);
+		expect(updatedOperation.children[0].status).toBe('completed');
+		expect(updatedOperation.children[1].status).toBe('queued');
+	});
+});

--- a/src/ui/workCenter/__tests__/state.test.ts
+++ b/src/ui/workCenter/__tests__/state.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tauriClient } from '../../../lib/tauri/client';
+import type { OperationSnapshot } from '../../../types/workRuntime';
+
+const { purgeMock, releaseMock } = vi.hoisted(() => ({
+    purgeMock: vi.fn(),
+    releaseMock: vi.fn(),
+}));
+
+vi.mock('../../remoteSource/sessionAssets.svelte', () => ({
+    purgeRemoteSourceSessionsForInputIds: purgeMock,
+    releaseRemoteSourceSessionRetainers: releaseMock,
+}));
+
+import { applyOperationSnapshot, disposeWorkCenter, initializeWorkCenter } from '../state.svelte';
+
+function completedMergeOperation(operationId: string): OperationSnapshot {
+    return {
+        operationId,
+        sequence: 1,
+        kind: 'processingMerge',
+        status: 'completed',
+        title: 'Merge encode',
+        createdAtMs: 1,
+        startedAtMs: 2,
+        finishedAtMs: 3,
+        cancellable: false,
+        cancelRequested: false,
+        lanes: ['analysis', 'encodeCpu', 'outputCommit'],
+        sourceInputIds: ['input-1', 'input-2'],
+        progress: {
+            stage: 'complete',
+            percentage: 100,
+            message: 'Complete.',
+            currentItemIndex: undefined,
+            totalItems: 1,
+            bytesDownloaded: undefined,
+            bytesTotal: undefined,
+            etaSeconds: undefined,
+        },
+        children: [
+            {
+                childJobId: `${operationId}-child`,
+                operationId,
+                label: 'Merge output',
+                status: 'completed',
+                lane: 'encodeCpu',
+                progress: {
+                    stage: 'complete',
+                    percentage: 100,
+                    message: 'Complete.',
+                    currentItemIndex: undefined,
+                    totalItems: 1,
+                    bytesDownloaded: undefined,
+                    bytesTotal: undefined,
+                    etaSeconds: undefined,
+                },
+                sourcePath: undefined,
+                inputIndex: undefined,
+                inputId: undefined,
+                jobId: 'job-1',
+                cancellable: false,
+                cancelRequested: false,
+                message: 'Complete.',
+            },
+        ],
+        terminalSummary: {
+            total: 1,
+            succeeded: 1,
+            skipped: 0,
+            cancelled: 0,
+            failed: 0,
+            message: 'Completed 1/1.',
+        },
+        warnings: [],
+        errors: [],
+    };
+}
+
+describe('Work Center state', () => {
+    beforeEach(() => {
+        purgeMock.mockReset();
+        purgeMock.mockResolvedValue(undefined);
+        releaseMock.mockReset();
+        releaseMock.mockReturnValue([]);
+        disposeWorkCenter();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = undefined;
+        disposeWorkCenter();
+    });
+
+    it('disposes registered listeners when initial operation listing fails', async () => {
+        (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+        const snapshotUnlisten = vi.fn();
+        const listUnlisten = vi.fn();
+        const progressUnlisten = vi.fn();
+        vi.spyOn(tauriClient, 'listen')
+            .mockResolvedValueOnce(snapshotUnlisten)
+            .mockResolvedValueOnce(listUnlisten)
+            .mockResolvedValueOnce(progressUnlisten);
+        vi.spyOn(tauriClient, 'listWorkOperations').mockRejectedValueOnce(new Error('list failed'));
+
+        await expect(initializeWorkCenter()).rejects.toThrow('list failed');
+
+        expect(snapshotUnlisten).toHaveBeenCalledTimes(1);
+        expect(listUnlisten).toHaveBeenCalledTimes(1);
+        expect(progressUnlisten).toHaveBeenCalledTimes(1);
+    });
+
+    it('purges completed merge operation source ids even when the merge child has no input id', async () => {
+        applyOperationSnapshot(completedMergeOperation('op-merge-purge'));
+        await Promise.resolve();
+
+        expect(releaseMock).toHaveBeenCalledWith(['input-1', 'input-2']);
+        expect(purgeMock).toHaveBeenCalledWith(['input-1', 'input-2']);
+    });
+
+    it('claims terminal operation purge before awaiting so duplicate terminal snapshots do not race', async () => {
+        let resolvePurge!: () => void;
+        purgeMock.mockReturnValueOnce(
+            new Promise<void>((resolve) => {
+                resolvePurge = resolve;
+            }),
+        );
+        const snapshot = completedMergeOperation('op-merge-race');
+
+        applyOperationSnapshot(snapshot);
+        applyOperationSnapshot(snapshot);
+        await Promise.resolve();
+
+        expect(releaseMock).toHaveBeenCalledTimes(1);
+        expect(purgeMock).toHaveBeenCalledTimes(1);
+        resolvePurge();
+    });
+});

--- a/src/ui/workCenter/index.ts
+++ b/src/ui/workCenter/index.ts
@@ -1,0 +1,2 @@
+export { default as WorkCenterIsland } from './WorkCenterIsland.svelte';
+export { initializeWorkCenter, workCenterState } from './state.svelte';

--- a/src/ui/workCenter/model.ts
+++ b/src/ui/workCenter/model.ts
@@ -1,0 +1,193 @@
+import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
+import type {
+	ChildJobSnapshot,
+	ChildJobStatus,
+	OperationListSnapshot,
+	OperationSnapshot,
+	WorkOperationStatus,
+	WorkProgressStage,
+} from '../../types/workRuntime';
+
+export interface WorkCenterModel {
+	operations: OperationSnapshot[];
+}
+
+const TERMINAL_OPERATION_STATUSES = new Set<WorkOperationStatus>([
+	'completed',
+	'cancelled',
+	'failed',
+	'mixed',
+]);
+const TERMINAL_CHILD_STATUSES = new Set<ChildJobStatus>([
+	'completed',
+	'skipped',
+	'cancelled',
+	'failed',
+]);
+
+export function isTerminalOperationStatus(status: WorkOperationStatus): boolean {
+	return TERMINAL_OPERATION_STATUSES.has(status);
+}
+
+export function replaceOperations(_model: WorkCenterModel, list: OperationListSnapshot): WorkCenterModel {
+	return {
+		operations: [...list.operations].sort(sortBySequenceDesc),
+	};
+}
+
+export function upsertOperation(model: WorkCenterModel, snapshot: OperationSnapshot): WorkCenterModel {
+	const next = model.operations.filter(
+		(operation) => operation.operationId !== snapshot.operationId,
+	);
+	next.push(snapshot);
+	next.sort(sortBySequenceDesc);
+	return { operations: next };
+}
+
+export function applyProgress(model: WorkCenterModel, event: ProcessingProgressEvent): WorkCenterModel {
+	const operationId = event.operation_id;
+	if (!operationId) return model;
+
+	let changed = false;
+	const operations = model.operations.map((operation) => {
+		if (operation.operationId !== operationId) return operation;
+		changed = true;
+		return applyProgressToOperation(operation, event);
+	});
+	return changed ? { operations } : model;
+}
+
+export function applyQueue(model: WorkCenterModel, event: ProcessingQueueEvent): WorkCenterModel {
+	const operationId = event.operation_id;
+	if (!operationId) return model;
+
+	let changed = false;
+	const operations = model.operations.map((operation) => {
+		if (operation.operationId !== operationId) return operation;
+		changed = true;
+		const children = operation.children.map((child) => {
+			if (typeof child.inputIndex !== 'number') return child;
+			const queueItem = event.items.find((item) => item.input_index === child.inputIndex);
+			if (!queueItem) return child;
+			return {
+				...child,
+				label: basename(queueItem.file_path),
+				status: child.status === 'queued' ? child.status : child.status,
+			};
+		});
+		return { ...operation, children };
+	});
+	return changed ? { operations } : model;
+}
+
+function applyProgressToOperation(
+	operation: OperationSnapshot,
+	event: ProcessingProgressEvent,
+): OperationSnapshot {
+	const childScopedBatchEvent =
+		operation.children.length > 1 && typeof event.input_index === 'number';
+	const children = operation.children.map((child) => {
+		if (!progressMatchesChild(child, event, operation.children.length)) {
+			return child;
+		}
+		const status = childStatusFromEvent(event.stage);
+		return {
+			...child,
+			status,
+			jobId: event.job_id ?? child.jobId,
+			progress: {
+				...child.progress,
+				stage: workStageFromEvent(event.stage),
+				percentage: event.percentage,
+				message: event.message,
+				etaSeconds: event.eta_seconds,
+			},
+			cancellable: status === 'running' && Boolean(event.job_id),
+			message: event.message,
+		};
+	});
+	const nextStatus = operationStatusFromEvent(
+		event,
+		operation.status,
+		childScopedBatchEvent,
+	);
+	const nextProgress = {
+		...operation.progress,
+		stage: childScopedBatchEvent ? inFlightStage(operation.progress.stage) : workStageFromEvent(event.stage),
+		percentage: childScopedBatchEvent
+			? aggregateChildProgress(children)
+			: event.percentage,
+		message: event.message,
+		etaSeconds: event.eta_seconds,
+	};
+
+	return {
+		...operation,
+		status: nextStatus,
+		progress: nextProgress,
+		children,
+	};
+}
+
+function progressMatchesChild(
+	child: ChildJobSnapshot,
+	event: ProcessingProgressEvent,
+	childCount: number,
+): boolean {
+	if (event.job_id && child.jobId === event.job_id) return true;
+	if (typeof event.input_index === 'number') {
+		return child.inputIndex === event.input_index;
+	}
+	return childCount === 1;
+}
+
+function operationStatusFromEvent(
+	event: ProcessingProgressEvent,
+	current: WorkOperationStatus,
+	childScopedBatchEvent: boolean,
+): WorkOperationStatus {
+	if (isTerminalOperationStatus(current)) return current;
+	if (childScopedBatchEvent) return 'running';
+	if (event.stage === 'failed') return 'failed';
+	if (event.stage === 'cancelled') return 'cancelled';
+	return 'running';
+}
+
+function childStatusFromEvent(stage: ProcessingProgressEvent['stage']): ChildJobStatus {
+	if (stage === 'completed') return 'completed';
+	if (stage === 'skipped') return 'skipped';
+	if (stage === 'failed') return 'failed';
+	if (stage === 'cancelled') return 'cancelled';
+	return 'running';
+}
+
+function workStageFromEvent(stage: ProcessingProgressEvent['stage']): WorkProgressStage {
+	if (stage === 'analyzing') return 'analyzing';
+	if (stage === 'converting') return 'converting';
+	if (stage === 'writing') return 'writing';
+	if (stage === 'completed' || stage === 'skipped') return 'complete';
+	if (stage === 'failed') return 'failed';
+	return 'cancelled';
+}
+
+function inFlightStage(current: WorkProgressStage): WorkProgressStage {
+	if (current === 'pending' || current === 'analyzing') return 'converting';
+	return current;
+}
+
+function aggregateChildProgress(children: ChildJobSnapshot[]): number {
+	if (children.length === 0) return 0;
+	const total = children.reduce((sum, child) => {
+		const percentage = TERMINAL_CHILD_STATUSES.has(child.status) ? 100 : child.progress.percentage;
+		return sum + Math.min(100, Math.max(0, percentage));
+	}, 0);
+	return total / children.length;
+}
+
+function sortBySequenceDesc(left: OperationSnapshot, right: OperationSnapshot): number {
+	return right.sequence - left.sequence;
+}
+
+function basename(path: string): string {
+	return path.split(/[\\/]/).pop() || path;
+}

--- a/src/ui/workCenter/model.ts
+++ b/src/ui/workCenter/model.ts
@@ -1,4 +1,4 @@
-import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
+import type { ProcessingProgressEvent } from '../../types/events';
 import type {
 	ChildJobSnapshot,
 	ChildJobStatus,
@@ -29,13 +29,19 @@ export function isTerminalOperationStatus(status: WorkOperationStatus): boolean 
 	return TERMINAL_OPERATION_STATUSES.has(status);
 }
 
-export function replaceOperations(_model: WorkCenterModel, list: OperationListSnapshot): WorkCenterModel {
+export function replaceOperations(
+	_model: WorkCenterModel,
+	list: OperationListSnapshot,
+): WorkCenterModel {
 	return {
 		operations: [...list.operations].sort(sortBySequenceDesc),
 	};
 }
 
-export function upsertOperation(model: WorkCenterModel, snapshot: OperationSnapshot): WorkCenterModel {
+export function upsertOperation(
+	model: WorkCenterModel,
+	snapshot: OperationSnapshot,
+): WorkCenterModel {
 	const next = model.operations.filter(
 		(operation) => operation.operationId !== snapshot.operationId,
 	);
@@ -44,7 +50,10 @@ export function upsertOperation(model: WorkCenterModel, snapshot: OperationSnaps
 	return { operations: next };
 }
 
-export function applyProgress(model: WorkCenterModel, event: ProcessingProgressEvent): WorkCenterModel {
+export function applyProgress(
+	model: WorkCenterModel,
+	event: ProcessingProgressEvent,
+): WorkCenterModel {
 	const operationId = event.operation_id;
 	if (!operationId) return model;
 
@@ -53,29 +62,6 @@ export function applyProgress(model: WorkCenterModel, event: ProcessingProgressE
 		if (operation.operationId !== operationId) return operation;
 		changed = true;
 		return applyProgressToOperation(operation, event);
-	});
-	return changed ? { operations } : model;
-}
-
-export function applyQueue(model: WorkCenterModel, event: ProcessingQueueEvent): WorkCenterModel {
-	const operationId = event.operation_id;
-	if (!operationId) return model;
-
-	let changed = false;
-	const operations = model.operations.map((operation) => {
-		if (operation.operationId !== operationId) return operation;
-		changed = true;
-		const children = operation.children.map((child) => {
-			if (typeof child.inputIndex !== 'number') return child;
-			const queueItem = event.items.find((item) => item.input_index === child.inputIndex);
-			if (!queueItem) return child;
-			return {
-				...child,
-				label: basename(queueItem.file_path),
-				status: child.status === 'queued' ? child.status : child.status,
-			};
-		});
-		return { ...operation, children };
 	});
 	return changed ? { operations } : model;
 }
@@ -106,17 +92,13 @@ function applyProgressToOperation(
 			message: event.message,
 		};
 	});
-	const nextStatus = operationStatusFromEvent(
-		event,
-		operation.status,
-		childScopedBatchEvent,
-	);
+	const nextStatus = operationStatusFromEvent(event, operation.status, childScopedBatchEvent);
 	const nextProgress = {
 		...operation.progress,
-		stage: childScopedBatchEvent ? inFlightStage(operation.progress.stage) : workStageFromEvent(event.stage),
-		percentage: childScopedBatchEvent
-			? aggregateChildProgress(children)
-			: event.percentage,
+		stage: childScopedBatchEvent
+			? inFlightStage(operation.progress.stage)
+			: workStageFromEvent(event.stage),
+		percentage: childScopedBatchEvent ? aggregateChildProgress(children) : event.percentage,
 		message: event.message,
 		etaSeconds: event.eta_seconds,
 	};
@@ -186,8 +168,4 @@ function aggregateChildProgress(children: ChildJobSnapshot[]): number {
 
 function sortBySequenceDesc(left: OperationSnapshot, right: OperationSnapshot): number {
 	return right.sequence - left.sequence;
-}
-
-function basename(path: string): string {
-	return path.split(/[\\/]/).pop() || path;
 }

--- a/src/ui/workCenter/state.svelte.ts
+++ b/src/ui/workCenter/state.svelte.ts
@@ -1,5 +1,5 @@
 import { tauriClient } from '../../lib/tauri/client';
-import { EVENTS, type ProcessingProgressEvent, type ProcessingQueueEvent } from '../../types/events';
+import { EVENTS, type ProcessingProgressEvent } from '../../types/events';
 import type { OperationId, OperationSnapshot } from '../../types/workRuntime';
 import {
 	purgeRemoteSourceSessionsForInputIds,
@@ -7,7 +7,6 @@ import {
 } from '../remoteSource/sessionAssets.svelte';
 import {
 	applyProgress,
-	applyQueue,
 	isTerminalOperationStatus,
 	replaceOperations,
 	upsertOperation,
@@ -42,31 +41,41 @@ export function initializeWorkCenter(): Promise<void> {
 	}
 
 	initializationPromise = (async () => {
-		const [snapshotUnlisten, listUnlisten, progressUnlisten, queueUnlisten] = await Promise.all([
-			tauriClient.listen(EVENTS.WORK_OPERATION_SNAPSHOT, ({ payload }) => {
-				applyOperationSnapshot(payload.snapshot);
-			}),
-			tauriClient.listen(EVENTS.WORK_OPERATION_LIST_SNAPSHOT, ({ payload }) => {
-				const model = replaceOperations(workCenterState, { operations: payload.operations });
-				workCenterState.operations = model.operations;
-				for (const operation of workCenterState.operations) {
-					void purgeRemoteSessionsForTerminalOperation(operation);
-				}
-			}),
-			tauriClient.listen(EVENTS.PROGRESS, ({ payload }) => {
-				applyProcessingProgress(payload);
-			}),
-			tauriClient.listen(EVENTS.QUEUE, ({ payload }) => {
-				applyProcessingQueue(payload);
-			}),
-		]);
-		unlisteners = [snapshotUnlisten, listUnlisten, progressUnlisten, queueUnlisten];
+		const nextUnlisteners: Unlisten[] = [];
+		try {
+			nextUnlisteners.push(
+				await tauriClient.listen(EVENTS.WORK_OPERATION_SNAPSHOT, ({ payload }) => {
+					applyOperationSnapshot(payload.snapshot);
+				}),
+			);
+			nextUnlisteners.push(
+				await tauriClient.listen(EVENTS.WORK_OPERATION_LIST_SNAPSHOT, ({ payload }) => {
+					const model = replaceOperations(workCenterState, { operations: payload.operations });
+					workCenterState.operations = model.operations;
+					for (const operation of workCenterState.operations) {
+						void purgeRemoteSessionsForTerminalOperation(operation);
+					}
+				}),
+			);
+			nextUnlisteners.push(
+				await tauriClient.listen(EVENTS.PROGRESS, ({ payload }) => {
+					applyProcessingProgress(payload);
+				}),
+			);
+			unlisteners = nextUnlisteners;
 
-		const list = await tauriClient.listWorkOperations();
-		const model = replaceOperations(workCenterState, list);
-		workCenterState.operations = model.operations;
-		workCenterState.initialized = true;
-		workCenterState.errorMessage = null;
+			const list = await tauriClient.listWorkOperations();
+			const model = replaceOperations(workCenterState, list);
+			workCenterState.operations = model.operations;
+			workCenterState.initialized = true;
+			workCenterState.errorMessage = null;
+		} catch (error) {
+			disposeUnlisteners(nextUnlisteners);
+			if (unlisteners === nextUnlisteners) {
+				unlisteners = [];
+			}
+			throw error;
+		}
 	})().catch((error) => {
 		workCenterState.errorMessage = `Failed to initialize Work Center: ${String(error)}`;
 		initializationPromise = null;
@@ -85,9 +94,7 @@ function isTauriRuntimeAvailable(): boolean {
 }
 
 export function disposeWorkCenter(): void {
-	for (const unlisten of unlisteners) {
-		unlisten();
-	}
+	disposeUnlisteners(unlisteners);
 	unlisteners = [];
 	initializationPromise = null;
 	workCenterState.initialized = false;
@@ -101,11 +108,6 @@ export function applyOperationSnapshot(snapshot: OperationSnapshot): void {
 
 export function applyProcessingProgress(event: ProcessingProgressEvent): void {
 	const model = applyProgress(workCenterState, event);
-	workCenterState.operations = model.operations;
-}
-
-export function applyProcessingQueue(event: ProcessingQueueEvent): void {
-	const model = applyQueue(workCenterState, event);
 	workCenterState.operations = model.operations;
 }
 
@@ -136,6 +138,7 @@ async function purgeRemoteSessionsForTerminalOperation(
 ): Promise<void> {
 	if (!isTerminalOperationStatus(operation.status)) return;
 	if (purgedOperationIds.has(operation.operationId)) return;
+	purgedOperationIds.add(operation.operationId);
 
 	const operationInputIds =
 		operation.sourceInputIds.length > 0
@@ -144,16 +147,23 @@ async function purgeRemoteSessionsForTerminalOperation(
 					.map((child) => child.inputId)
 					.filter((inputId): inputId is string => Boolean(inputId));
 	const pendingPurgeInputIds = releaseRemoteSourceSessionRetainers(operationInputIds);
-	const completedInputIds = operation.children
-		.filter((child) => child.status === 'completed')
-		.map((child) => child.inputId)
-		.filter((inputId): inputId is string => Boolean(inputId));
+	const completedInputIds =
+		operation.status === 'completed'
+			? operationInputIds
+			: operation.children
+					.filter((child) => child.status === 'completed')
+					.map((child) => child.inputId)
+					.filter((inputId): inputId is string => Boolean(inputId));
 	const purgeInputIds = Array.from(new Set([...completedInputIds, ...pendingPurgeInputIds]));
 	if (purgeInputIds.length === 0) {
-		purgedOperationIds.add(operation.operationId);
 		return;
 	}
 
 	await purgeRemoteSourceSessionsForInputIds(purgeInputIds);
-	purgedOperationIds.add(operation.operationId);
+}
+
+function disposeUnlisteners(listeners: Unlisten[]): void {
+	for (const unlisten of listeners.splice(0)) {
+		unlisten();
+	}
 }

--- a/src/ui/workCenter/state.svelte.ts
+++ b/src/ui/workCenter/state.svelte.ts
@@ -1,0 +1,159 @@
+import { tauriClient } from '../../lib/tauri/client';
+import { EVENTS, type ProcessingProgressEvent, type ProcessingQueueEvent } from '../../types/events';
+import type { OperationId, OperationSnapshot } from '../../types/workRuntime';
+import {
+	purgeRemoteSourceSessionsForInputIds,
+	releaseRemoteSourceSessionRetainers,
+} from '../remoteSource/sessionAssets.svelte';
+import {
+	applyProgress,
+	applyQueue,
+	isTerminalOperationStatus,
+	replaceOperations,
+	upsertOperation,
+	type WorkCenterModel,
+} from './model';
+
+type Unlisten = () => void;
+
+interface WorkCenterState extends WorkCenterModel {
+	initialized: boolean;
+	cancelPendingByOperationId: Record<string, boolean>;
+	errorMessage: string | null;
+}
+
+export const workCenterState = $state<WorkCenterState>({
+	initialized: false,
+	operations: [],
+	cancelPendingByOperationId: {},
+	errorMessage: null,
+});
+
+let initializationPromise: Promise<void> | null = null;
+let unlisteners: Unlisten[] = [];
+const purgedOperationIds = new Set<string>();
+
+export function initializeWorkCenter(): Promise<void> {
+	if (initializationPromise) return initializationPromise;
+	if (!isTauriRuntimeAvailable()) {
+		workCenterState.initialized = true;
+		workCenterState.errorMessage = null;
+		return Promise.resolve();
+	}
+
+	initializationPromise = (async () => {
+		const [snapshotUnlisten, listUnlisten, progressUnlisten, queueUnlisten] = await Promise.all([
+			tauriClient.listen(EVENTS.WORK_OPERATION_SNAPSHOT, ({ payload }) => {
+				applyOperationSnapshot(payload.snapshot);
+			}),
+			tauriClient.listen(EVENTS.WORK_OPERATION_LIST_SNAPSHOT, ({ payload }) => {
+				const model = replaceOperations(workCenterState, { operations: payload.operations });
+				workCenterState.operations = model.operations;
+				for (const operation of workCenterState.operations) {
+					void purgeRemoteSessionsForTerminalOperation(operation);
+				}
+			}),
+			tauriClient.listen(EVENTS.PROGRESS, ({ payload }) => {
+				applyProcessingProgress(payload);
+			}),
+			tauriClient.listen(EVENTS.QUEUE, ({ payload }) => {
+				applyProcessingQueue(payload);
+			}),
+		]);
+		unlisteners = [snapshotUnlisten, listUnlisten, progressUnlisten, queueUnlisten];
+
+		const list = await tauriClient.listWorkOperations();
+		const model = replaceOperations(workCenterState, list);
+		workCenterState.operations = model.operations;
+		workCenterState.initialized = true;
+		workCenterState.errorMessage = null;
+	})().catch((error) => {
+		workCenterState.errorMessage = `Failed to initialize Work Center: ${String(error)}`;
+		initializationPromise = null;
+		throw error;
+	});
+
+	return initializationPromise;
+}
+
+function isTauriRuntimeAvailable(): boolean {
+	return (
+		typeof window === 'undefined' ||
+		typeof (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ !==
+			'undefined'
+	);
+}
+
+export function disposeWorkCenter(): void {
+	for (const unlisten of unlisteners) {
+		unlisten();
+	}
+	unlisteners = [];
+	initializationPromise = null;
+	workCenterState.initialized = false;
+}
+
+export function applyOperationSnapshot(snapshot: OperationSnapshot): void {
+	const model = upsertOperation(workCenterState, snapshot);
+	workCenterState.operations = model.operations;
+	void purgeRemoteSessionsForTerminalOperation(snapshot);
+}
+
+export function applyProcessingProgress(event: ProcessingProgressEvent): void {
+	const model = applyProgress(workCenterState, event);
+	workCenterState.operations = model.operations;
+}
+
+export function applyProcessingQueue(event: ProcessingQueueEvent): void {
+	const model = applyQueue(workCenterState, event);
+	workCenterState.operations = model.operations;
+}
+
+export async function cancelWorkOperation(operationId: OperationId): Promise<void> {
+	workCenterState.cancelPendingByOperationId = {
+		...workCenterState.cancelPendingByOperationId,
+		[operationId]: true,
+	};
+	try {
+		const snapshot = await tauriClient.cancelWorkOperation(operationId);
+		applyOperationSnapshot(snapshot);
+	} catch (error) {
+		workCenterState.errorMessage = `Failed to cancel operation: ${String(error)}`;
+	} finally {
+		const next = { ...workCenterState.cancelPendingByOperationId };
+		delete next[operationId];
+		workCenterState.cancelPendingByOperationId = next;
+	}
+}
+
+export async function openChildSource(child: { sourcePath?: string | null }): Promise<void> {
+	if (!child.sourcePath) return;
+	await tauriClient.openPath(child.sourcePath);
+}
+
+async function purgeRemoteSessionsForTerminalOperation(
+	operation: OperationSnapshot,
+): Promise<void> {
+	if (!isTerminalOperationStatus(operation.status)) return;
+	if (purgedOperationIds.has(operation.operationId)) return;
+
+	const operationInputIds =
+		operation.sourceInputIds.length > 0
+			? operation.sourceInputIds
+			: operation.children
+					.map((child) => child.inputId)
+					.filter((inputId): inputId is string => Boolean(inputId));
+	const pendingPurgeInputIds = releaseRemoteSourceSessionRetainers(operationInputIds);
+	const completedInputIds = operation.children
+		.filter((child) => child.status === 'completed')
+		.map((child) => child.inputId)
+		.filter((inputId): inputId is string => Boolean(inputId));
+	const purgeInputIds = Array.from(new Set([...completedInputIds, ...pendingPurgeInputIds]));
+	if (purgeInputIds.length === 0) {
+		purgedOperationIds.add(operation.operationId);
+		return;
+	}
+
+	await purgeRemoteSourceSessionsForInputIds(purgeInputIds);
+	purgedOperationIds.add(operation.operationId);
+}


### PR DESCRIPTION
## Summary

- Adds WorkRuntime as the backend owner for accepted operation identity, operation snapshots, terminal summaries, and operation-scoped cancellation.
- Routes final batch/merge processing through accepted background submissions so FileList unlocks after backend acceptance.
- Adds Work Center UI for multiple background operations, child rows, progress, operation cancel, terminal summaries, and source actions.
- Keeps preview processing on the legacy foreground path so preview auto-open behavior stays intact.
- Retains acquired remote-source sessions while accepted processing operations are in flight so FileList cleanup cannot purge source/PDF assets out from under background work.

## Scope Notes

- This PR lands the functional V1A processing slice: batch/merge operations can coexist, and operation cancel is isolated from the old singleton/global cancel path.
- V1B remote acquisition + Acquired Sources inbox is deliberately deferred. The operation vocabulary includes `remoteAcquisition`, but provider secrets/materializer details remain inside RemoteSourceRuntime.
- `docs/specs/work-runtime-v1.md` is a temporary active spec for this workblock and should be deleted or distilled after review/sync.

## Review And Manual-Test Fixes

- WorkRuntime operation-scoped jobs now ignore legacy global cancel, including while waiting for encode permits.
- Status Panel now ignores WorkRuntime-scoped legacy queue/progress events and its Cancel action fans out only to visible foreground job IDs.
- Work Center no longer consumes the redundant queue reducer path; accepted snapshots own child labels/order and progress events only overlay active progress.
- Work Center initialization cleans up registered listeners if initial operation listing fails.
- Terminal remote-source cleanup is race-guarded, includes merge `sourceInputIds`, and purges deferred remote-source sessions if background submission fails after retain.
- Manual cancellation cleanup now tracks ABB-created final output parent dirs and prunes only empty created dirs after failed/cancelled processing; preexisting or non-empty output dirs are preserved.
- Removed the dead Status Panel foreground purge branch left after final processing moved to WorkRuntime/Work Center terminal cleanup.
- Path basename handling now uses `to_string_lossy()` for non-UTF-8 path components.
- Duplicate processing workflow cancellation/failure mapping was collapsed into one helper.
- The active spec now names deferred triggers for deleting the legacy frontend progress reducer and splitting large modules on the next relevant change.

## Verification

- `cargo test -p audiobook-boss output_artifact --lib` (41 passed)
- `cargo test -p audiobook-boss processing::output_parent_cleanup --lib` (2 passed)
- `bun run test -- src/ui/statusPanel/__tests__/processingWorkflow.test.ts` (6 passed)
- `cargo test -p audiobook-boss --lib` (277 passed, 4 ignored)
- `cargo test -p abb-processing-core` (3 passed)
- `bun run test` (78 files, 490 tests)
- `bash scripts/check-generated-bindings.sh --mode local`
- `bun scripts/check-tauri-runtime-boundary.ts`
- `bun run build`
- `git diff --check`
- Visual/manual smoke from local app testing: batch, acquisition-derived batch, merge, Work Center coexistence, independent cancellation, and disk output verification.

## Manual Pressure-Test Targets

- Submit batch processing and immediately edit/import/reorder a new draft.
- Submit a merge operation while a batch operation is running.
- Cancel one operation while another continues.
- Confirm cancelled processing does not leave empty ABB-created final output parent folders.
- Run foreground preview or metadata save while a background operation is running; Status Panel progress/cancel should remain foreground-only.
- Verify Work Center progress/children/terminal summaries match final disk output.
- Verify remote-source Supplemental PDF sessions survive FileList unlock and purge only after terminal processing handoff.
