### PR TITLE
Runtime capability ownership + security hardening

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,10 +21,10 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site
       - id: deploy
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/src/ui/__tests__/jobControls-info.test.ts
+++ b/src/ui/__tests__/jobControls-info.test.ts
@@ -188,7 +188,10 @@ describe('Job controls merge toggle', () => {
 	it('applies a hydrated fixed max concurrency preference and updates indicator + status text', async () => {
 		setMaxConcurrentJobsMock.mockResolvedValueOnce(3);
 
-		await applyMaxConcurrentPreference({ mode: 'fixed', value: 3 });
+		await applyMaxConcurrentPreference(
+			{ mode: 'fixed', value: 3 },
+			runtimeSettingsCapabilitiesFixture().maxConcurrentJobs,
+		);
 		await flushAsync();
 
 		expect(getMaxConcurrentSelect().value).toBe('3');

--- a/src/ui/__tests__/metadataLookup-island.test.ts
+++ b/src/ui/__tests__/metadataLookup-island.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import MetadataLookupIsland from '../metadataLookup/MetadataLookupIsland.svelte';
 
 vi.mock('../../lib/tauri/client', () => ({
@@ -46,6 +46,7 @@ vi.mock('../metadataState', () => ({
 }));
 
 import { initMetadataLookup } from '../metadataLookup';
+import { metadataLookupState } from '../metadataLookup/state.svelte';
 
 describe('MetadataLookup island mount', () => {
 	beforeEach(() => {
@@ -61,5 +62,52 @@ describe('MetadataLookup island mount', () => {
 		expect(document.getElementById('metadata-lookup-modal')).toBeTruthy();
 		expect(document.getElementById('metadata-lookup-search-btn')).toBeTruthy();
 		expect(document.getElementById('metadata-lookup-skip-btn')).toBeTruthy();
+	});
+
+	it('does not render provider cover URLs as image sources', async () => {
+		initMetadataLookup();
+		metadataLookupState.results = [
+			{
+				source: 'audnexus',
+				sourceId: 'audnexus:private',
+				title: 'Private Cover',
+				authors: ['Author One'],
+				narrators: ['Narrator One'],
+				series: undefined,
+				seriesPart: undefined,
+				subseries: undefined,
+				subseriesPart: undefined,
+				description: 'Description',
+				publishedDate: '2020-07',
+				durationSeconds: 3600,
+				audibleOnly: false,
+				coverUrl: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+			},
+			{
+				source: 'openlibrary',
+				sourceId: 'openlibrary:loopback',
+				title: 'Loopback Cover',
+				authors: ['Author Two'],
+				narrators: ['Narrator Two'],
+				series: undefined,
+				seriesPart: undefined,
+				subseries: undefined,
+				subseriesPart: undefined,
+				description: 'Description',
+				publishedDate: '2021-08',
+				durationSeconds: 7200,
+				audibleOnly: false,
+				coverUrl: 'http://127.0.0.1:8080/private-cover.jpg',
+			},
+		];
+
+		await waitFor(() => {
+			expect(
+				document.querySelectorAll('[data-testid="metadata-lookup-cover-available"]'),
+			).toHaveLength(2);
+		});
+		expect(document.querySelectorAll('#metadata-lookup-results img')).toHaveLength(0);
+		expect(document.querySelector('[src*="169.254.169.254"]')).toBeNull();
+		expect(document.querySelector('[src*="127.0.0.1"]')).toBeNull();
 	});
 });

--- a/src/ui/__tests__/runtimeSettingsCapabilities.test.ts
+++ b/src/ui/__tests__/runtimeSettingsCapabilities.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-	hydrateRuntimeSettingsCapabilities,
+	invalidateRuntimeSettingsCapabilities,
+	loadRuntimeSettingsCapabilities,
+	refreshRuntimeSettingsCapabilities,
 	runtimeSettingsCapabilitiesState,
 	setRuntimeSettingsCapabilities,
 } from '../runtimeSettingsCapabilities.svelte';
@@ -16,19 +18,18 @@ vi.mock('../../lib/tauri/client', () => ({
 	},
 }));
 
-describe('runtime settings capability hydration', () => {
+describe('runtime settings capability loading', () => {
 	beforeEach(() => {
 		context.getRuntimeSettingsCapabilitiesMock.mockReset();
-		setRuntimeSettingsCapabilities(null);
-		runtimeSettingsCapabilitiesState.loading = false;
+		invalidateRuntimeSettingsCapabilities();
 	});
 
 	it('deduplicates concurrent auto-detection loads', async () => {
 		const capabilities = runtimeSettingsCapabilitiesFixture();
 		context.getRuntimeSettingsCapabilitiesMock.mockResolvedValue(capabilities);
 
-		const first = hydrateRuntimeSettingsCapabilities();
-		const second = hydrateRuntimeSettingsCapabilities();
+		const first = loadRuntimeSettingsCapabilities();
+		const second = loadRuntimeSettingsCapabilities();
 
 		await expect(first).resolves.toBe(capabilities);
 		await expect(second).resolves.toBe(capabilities);
@@ -40,39 +41,104 @@ describe('runtime settings capability hydration', () => {
 		const automatic = runtimeSettingsCapabilitiesFixture();
 		context.getRuntimeSettingsCapabilitiesMock.mockResolvedValueOnce(automatic);
 
-		await hydrateRuntimeSettingsCapabilities();
+		await loadRuntimeSettingsCapabilities();
 
 		expect(context.getRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(1);
 		expect(context.getRuntimeSettingsCapabilitiesMock).toHaveBeenCalledWith();
 	});
 
-	it('stores capabilities in shared state after successful hydration', async () => {
+	it('stores capabilities in shared state after successful load', async () => {
 		const capabilities = runtimeSettingsCapabilitiesFixture();
 		context.getRuntimeSettingsCapabilitiesMock.mockResolvedValue(capabilities);
 
-		await hydrateRuntimeSettingsCapabilities();
+		await loadRuntimeSettingsCapabilities();
 
 		expect(runtimeSettingsCapabilitiesState.capabilities).toStrictEqual(capabilities);
 		expect(runtimeSettingsCapabilitiesState.loadError).toBeNull();
 		expect(runtimeSettingsCapabilitiesState.loading).toBe(false);
 	});
 
-	it('reuses a successful hydration result for later consumers', async () => {
+	it('reuses a successful load result for later consumers', async () => {
 		const capabilities = runtimeSettingsCapabilitiesFixture();
 		context.getRuntimeSettingsCapabilitiesMock.mockResolvedValue(capabilities);
 
-		await hydrateRuntimeSettingsCapabilities();
-		await hydrateRuntimeSettingsCapabilities();
+		await loadRuntimeSettingsCapabilities();
+		await loadRuntimeSettingsCapabilities();
 
 		expect(context.getRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(1);
 		expect(runtimeSettingsCapabilitiesState.capabilities).toStrictEqual(capabilities);
+	});
+
+	it('refreshes by bypassing a cached successful load', async () => {
+		const cached = runtimeSettingsCapabilitiesFixture({
+			maxConcurrentJobs: { fixedOptions: [1, 2] },
+		});
+		const refreshed = runtimeSettingsCapabilitiesFixture({
+			maxConcurrentJobs: { fixedOptions: [1, 2, 3, 4] },
+		});
+		context.getRuntimeSettingsCapabilitiesMock
+			.mockResolvedValueOnce(cached)
+			.mockResolvedValueOnce(refreshed);
+
+		await loadRuntimeSettingsCapabilities();
+		await refreshRuntimeSettingsCapabilities();
+
+		expect(context.getRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(2);
+		expect(runtimeSettingsCapabilitiesState.capabilities).toStrictEqual(refreshed);
+	});
+
+	it('deduplicates concurrent refresh loads', async () => {
+		const refreshed = runtimeSettingsCapabilitiesFixture();
+		context.getRuntimeSettingsCapabilitiesMock.mockResolvedValue(refreshed);
+
+		const first = refreshRuntimeSettingsCapabilities();
+		const second = refreshRuntimeSettingsCapabilities();
+
+		await expect(first).resolves.toBe(refreshed);
+		await expect(second).resolves.toBe(refreshed);
+		expect(context.getRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('joins an in-flight refresh instead of returning stale cached capabilities', async () => {
+		const cached = runtimeSettingsCapabilitiesFixture({
+			maxConcurrentJobs: { fixedOptions: [1, 2] },
+		});
+		const refreshed = runtimeSettingsCapabilitiesFixture({
+			maxConcurrentJobs: { fixedOptions: [1, 2, 3, 4] },
+		});
+		context.getRuntimeSettingsCapabilitiesMock
+			.mockResolvedValueOnce(cached)
+			.mockResolvedValueOnce(refreshed);
+
+		await loadRuntimeSettingsCapabilities();
+		const refresh = refreshRuntimeSettingsCapabilities();
+		const joined = loadRuntimeSettingsCapabilities();
+
+		await expect(refresh).resolves.toBe(refreshed);
+		await expect(joined).resolves.toBe(refreshed);
+		expect(context.getRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('invalidates cached capabilities and load state', async () => {
+		const capabilities = runtimeSettingsCapabilitiesFixture();
+		context.getRuntimeSettingsCapabilitiesMock.mockResolvedValue(capabilities);
+
+		await loadRuntimeSettingsCapabilities();
+		runtimeSettingsCapabilitiesState.loadError = new Error('stale');
+		runtimeSettingsCapabilitiesState.loading = true;
+
+		invalidateRuntimeSettingsCapabilities();
+
+		expect(runtimeSettingsCapabilitiesState.capabilities).toBeNull();
+		expect(runtimeSettingsCapabilitiesState.loadError).toBeNull();
+		expect(runtimeSettingsCapabilitiesState.loading).toBe(false);
 	});
 
 	it('sets error state on failed load and clears capabilities', async () => {
 		const failure = new Error('backend unavailable');
 		context.getRuntimeSettingsCapabilitiesMock.mockRejectedValue(failure);
 
-		await hydrateRuntimeSettingsCapabilities();
+		await loadRuntimeSettingsCapabilities();
 
 		expect(runtimeSettingsCapabilitiesState.capabilities).toBeNull();
 		expect(runtimeSettingsCapabilitiesState.loadError).toBe(failure);

--- a/src/ui/appSettings/appSettings.test.ts
+++ b/src/ui/appSettings/appSettings.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppSettings } from '../../types/appSettings';
+import { runtimeSettingsCapabilitiesFixture } from '../../test/fixtures/runtimeSettingsCapabilities';
 
 const context = vi.hoisted(() => ({
 	getAppSettingsMock: vi.fn(),
@@ -7,6 +8,7 @@ const context = vi.hoisted(() => ({
 	applyEncodingDefaultsMock: vi.fn(),
 	applyOutputDefaultsFromSettingsMock: vi.fn(),
 	applyMaxConcurrentPreferenceMock: vi.fn(),
+	loadRuntimeSettingsCapabilitiesMock: vi.fn(),
 }));
 
 vi.mock('../../lib/tauri/client', () => ({
@@ -26,6 +28,10 @@ vi.mock('../outputPanel', () => ({
 
 vi.mock('../jobControls', () => ({
 	applyMaxConcurrentPreference: context.applyMaxConcurrentPreferenceMock,
+}));
+
+vi.mock('../runtimeSettingsCapabilities.svelte', () => ({
+	loadRuntimeSettingsCapabilities: context.loadRuntimeSettingsCapabilitiesMock,
 }));
 
 const settingsFixture = (): AppSettings => ({
@@ -56,21 +62,33 @@ describe('app settings control plane', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		context.updateAppSettingsMock.mockResolvedValue(settingsFixture());
+		context.loadRuntimeSettingsCapabilitiesMock.mockResolvedValue(
+			runtimeSettingsCapabilitiesFixture(),
+		);
 	});
 
 	it('hydrates existing control owners from backend App Settings', async () => {
 		const settings = settingsFixture();
+		const capabilities = runtimeSettingsCapabilitiesFixture({
+			maxConcurrentJobs: { fixedOptions: [1, 2, 3] },
+		});
 		context.getAppSettingsMock.mockResolvedValueOnce(settings);
+		context.loadRuntimeSettingsCapabilitiesMock.mockResolvedValueOnce(capabilities);
 
 		const { hydrateAppSettings } = await import('./hydration');
 		await hydrateAppSettings();
 
-		expect(context.applyEncodingDefaultsMock).toHaveBeenCalledWith(settings.encoderDefaults);
+		expect(context.loadRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(1);
+		expect(context.applyEncodingDefaultsMock).toHaveBeenCalledWith(
+			settings.encoderDefaults,
+			capabilities.encoder,
+		);
 		expect(context.applyOutputDefaultsFromSettingsMock).toHaveBeenCalledWith(
 			settings.outputDefaults,
 		);
 		expect(context.applyMaxConcurrentPreferenceMock).toHaveBeenCalledWith(
 			settings.maxConcurrentJobs,
+			capabilities.maxConcurrentJobs,
 		);
 	});
 
@@ -82,12 +100,33 @@ describe('app settings control plane', () => {
 		const { hydrateAppSettings } = await import('./hydration');
 		await hydrateAppSettings();
 
-		expect(context.applyEncodingDefaultsMock).toHaveBeenCalledWith(settings.encoderDefaults);
+		expect(context.loadRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(1);
+		expect(context.applyEncodingDefaultsMock).toHaveBeenCalledWith(
+			settings.encoderDefaults,
+			expect.any(Object),
+		);
 		expect(context.applyOutputDefaultsFromSettingsMock).toHaveBeenCalledWith(
 			settings.outputDefaults,
 		);
 		expect(context.applyMaxConcurrentPreferenceMock).toHaveBeenCalledWith(
 			settings.maxConcurrentJobs,
+			expect.any(Object),
+		);
+	});
+
+	it('delegates null capability slices when runtime capability loading fails', async () => {
+		const settings = settingsFixture();
+		context.getAppSettingsMock.mockResolvedValueOnce(settings);
+		context.loadRuntimeSettingsCapabilitiesMock.mockResolvedValueOnce(null);
+
+		const { hydrateAppSettings } = await import('./hydration');
+		await hydrateAppSettings();
+
+		expect(context.loadRuntimeSettingsCapabilitiesMock).toHaveBeenCalledTimes(1);
+		expect(context.applyEncodingDefaultsMock).toHaveBeenCalledWith(settings.encoderDefaults, null);
+		expect(context.applyMaxConcurrentPreferenceMock).toHaveBeenCalledWith(
+			settings.maxConcurrentJobs,
+			null,
 		);
 	});
 

--- a/src/ui/appSettings/hydration.ts
+++ b/src/ui/appSettings/hydration.ts
@@ -3,6 +3,7 @@ import type { AppSettings } from '../../types/appSettings';
 import { applyEncodingDefaults } from '../encoderPanel';
 import { applyMaxConcurrentPreference } from '../jobControls';
 import { applyOutputDefaultsFromSettings } from '../outputPanel';
+import { loadRuntimeSettingsCapabilities } from '../runtimeSettingsCapabilities.svelte';
 
 let hydrationPromise: Promise<void> | null = null;
 
@@ -21,8 +22,10 @@ async function hydrateOnce(): Promise<void> {
 		return;
 	}
 
+	const capabilities = await loadRuntimeSettingsCapabilities();
+
 	try {
-		await applyEncodingDefaults(settings.encoderDefaults);
+		await applyEncodingDefaults(settings.encoderDefaults, capabilities?.encoder ?? null);
 	} catch (error) {
 		console.warn('Failed to hydrate encoding defaults:', error);
 	}
@@ -34,7 +37,10 @@ async function hydrateOnce(): Promise<void> {
 	}
 
 	try {
-		await applyMaxConcurrentPreference(settings.maxConcurrentJobs);
+		await applyMaxConcurrentPreference(
+			settings.maxConcurrentJobs,
+			capabilities?.maxConcurrentJobs ?? null,
+		);
 	} catch (error) {
 		console.warn('Failed to hydrate max concurrency preference:', error);
 	}

--- a/src/ui/encoderPanel/AGENTS.md
+++ b/src/ui/encoderPanel/AGENTS.md
@@ -4,6 +4,8 @@
 - Import encoder request configuration from `src/ui/encoderPanel`.
 - Exports: `applyEncodingDefaults`, `readEncoderDefaultsFromState`,
   `readEncodingRequestConfig`.
+- `applyEncodingDefaults(defaults, capabilities)` accepts an already-loaded
+  Runtime Settings Capabilities encoder slice from App Settings hydration.
 - Composition-only UI shells may import `EncoderWorkbenchIsland.svelte`; do not
   use the main encoder index for renderer exports because it must stay
   side-effect-light for config consumers.

--- a/src/ui/encoderPanel/index.ts
+++ b/src/ui/encoderPanel/index.ts
@@ -1,12 +1,12 @@
 import type { EncoderDefaults } from '../../types/appSettings';
+import type { EncoderSettingsCapabilities } from '../../types/audio';
 
-export async function applyEncodingDefaults(defaults: EncoderDefaults): Promise<void> {
-	const [{ hydrateRuntimeSettingsCapabilities }, logic] = await Promise.all([
-		import('../runtimeSettingsCapabilities.svelte'),
-		import('./logic'),
-	]);
-	const capabilities = await hydrateRuntimeSettingsCapabilities();
-	logic.setRuntimeEncoderSettingsCapabilities(capabilities?.encoder ?? null);
+export async function applyEncodingDefaults(
+	defaults: EncoderDefaults,
+	capabilities: EncoderSettingsCapabilities | null,
+): Promise<void> {
+	const logic = await import('./logic');
+	logic.setRuntimeEncoderSettingsCapabilities(capabilities);
 	logic.applyEncodingDefaults(defaults);
 }
 

--- a/src/ui/encoderPanel/logic.ts
+++ b/src/ui/encoderPanel/logic.ts
@@ -12,7 +12,7 @@ import type { EncoderAvailability, EncoderSettingsCapabilities } from '../../typ
 import type { EncoderDefaults } from '../../types/appSettings';
 import { resetAutoResolutionHints } from './autoResolutionHints';
 import { persistEncoderDefaults } from '../appSettings/persistence';
-import { hydrateRuntimeSettingsCapabilities } from '../runtimeSettingsCapabilities.svelte';
+import { loadRuntimeSettingsCapabilities } from '../runtimeSettingsCapabilities.svelte';
 
 const DEBUG = import.meta.env.DEV;
 const debugLog = (...args: unknown[]): void => {
@@ -287,7 +287,7 @@ export const setRuntimeEncoderSettingsCapabilities = (
 };
 
 const hydrateEncoderAvailability = async (): Promise<void> => {
-	const capabilities = await hydrateRuntimeSettingsCapabilities();
+	const capabilities = await loadRuntimeSettingsCapabilities();
 	setRuntimeEncoderSettingsCapabilities(capabilities?.encoder ?? null);
 };
 

--- a/src/ui/jobControls/index.ts
+++ b/src/ui/jobControls/index.ts
@@ -1,11 +1,11 @@
 import { tauriClient } from '../../lib/tauri/client';
 import type { ConcurrencyPreference } from '../../types/appSettings';
-import type { JobType } from '../../types/audio';
+import type { JobType, MaxConcurrentJobsCapabilities } from '../../types/audio';
 import { flushSync } from 'svelte';
 import { jobControlsState } from './state.svelte';
 import { updateOutputPath } from '../outputPanel';
 import { updateStatusPanelConcurrencyStatus } from '../statusPanel';
-import { hydrateRuntimeSettingsCapabilities } from '../runtimeSettingsCapabilities.svelte';
+import { loadRuntimeSettingsCapabilities } from '../runtimeSettingsCapabilities.svelte';
 
 export function initJobControls(): void {
 	void initializeRuntimeCapabilities();
@@ -13,7 +13,7 @@ export function initJobControls(): void {
 }
 
 async function initializeRuntimeCapabilities(): Promise<void> {
-	const capabilities = await hydrateRuntimeSettingsCapabilities();
+	const capabilities = await loadRuntimeSettingsCapabilities();
 	jobControlsState.maxConcurrentCapabilities = capabilities?.maxConcurrentJobs ?? null;
 }
 
@@ -59,8 +59,9 @@ export function getMaxConcurrentStatus(): {
 
 export async function applyMaxConcurrentPreference(
 	preference: ConcurrencyPreference,
+	capabilities: MaxConcurrentJobsCapabilities | null,
 ): Promise<void> {
-	await initializeRuntimeCapabilities();
+	jobControlsState.maxConcurrentCapabilities = capabilities;
 	const selection = preference.mode === 'fixed' ? String(preference.value) : 'auto';
 	const previousSelection = jobControlsState.maxConcurrentSelection;
 	jobControlsState.maxConcurrentSelection = selection;

--- a/src/ui/metadataLookup/MetadataLookupIsland.svelte
+++ b/src/ui/metadataLookup/MetadataLookupIsland.svelte
@@ -195,7 +195,7 @@
 					<div class="app-modal-result">
 						<div class="metadata-lookup-cover">
 							{#if result.coverUrl}
-								<img src={result.coverUrl} alt={`${result.title} cover art`} loading="lazy" />
+								<span data-testid="metadata-lookup-cover-available">Art Available</span>
 							{:else}
 								<span>No Art</span>
 							{/if}
@@ -260,12 +260,6 @@
 		color: var(--text-muted);
 		font-size: 0.7rem;
 		text-align: center;
-	}
-
-	.metadata-lookup-cover img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
 	}
 
 	.metadata-lookup-details {

--- a/src/ui/runtimeSettingsCapabilities.svelte.ts
+++ b/src/ui/runtimeSettingsCapabilities.svelte.ts
@@ -7,39 +7,54 @@ export const runtimeSettingsCapabilitiesState = $state({
 	loading: false,
 });
 
-const pendingLoads = new Map<string, Promise<RuntimeSettingsCapabilities | null>>();
-let latestLoadKey: string | null = null;
+let pendingLoad: Promise<RuntimeSettingsCapabilities | null> | null = null;
+let latestLoadId = 0;
 
 export function setRuntimeSettingsCapabilities(
 	capabilities: RuntimeSettingsCapabilities | null,
 ): void {
 	runtimeSettingsCapabilitiesState.capabilities = capabilities;
 	runtimeSettingsCapabilitiesState.loadError = null;
+	runtimeSettingsCapabilitiesState.loading = false;
 }
 
-export async function hydrateRuntimeSettingsCapabilities(): Promise<RuntimeSettingsCapabilities | null> {
-	const key = 'auto-detect';
-	const existing = pendingLoads.get(key);
-	if (existing) {
-		return existing;
+export function invalidateRuntimeSettingsCapabilities(): void {
+	latestLoadId += 1;
+	pendingLoad = null;
+	runtimeSettingsCapabilitiesState.capabilities = null;
+	runtimeSettingsCapabilitiesState.loadError = null;
+	runtimeSettingsCapabilitiesState.loading = false;
+}
+
+export function refreshRuntimeSettingsCapabilities(): Promise<RuntimeSettingsCapabilities | null> {
+	return loadRuntimeSettingsCapabilities({ refresh: true });
+}
+
+export async function loadRuntimeSettingsCapabilities(
+	options: { refresh?: boolean } = {},
+): Promise<RuntimeSettingsCapabilities | null> {
+	const refresh = options.refresh === true;
+	if (pendingLoad) {
+		return pendingLoad;
 	}
 
-	if (runtimeSettingsCapabilitiesState.capabilities) {
+	if (!refresh && runtimeSettingsCapabilitiesState.capabilities) {
 		return runtimeSettingsCapabilitiesState.capabilities;
 	}
 
-	latestLoadKey = key;
+	const loadId = latestLoadId + 1;
+	latestLoadId = loadId;
 	runtimeSettingsCapabilitiesState.loading = true;
-	const promise = tauriClient
+	pendingLoad = tauriClient
 		.getRuntimeSettingsCapabilities()
 		.then((capabilities) => {
-			if (latestLoadKey === key) {
+			if (latestLoadId === loadId) {
 				setRuntimeSettingsCapabilities(capabilities);
 			}
 			return capabilities;
 		})
 		.catch((error: unknown) => {
-			if (latestLoadKey === key) {
+			if (latestLoadId === loadId) {
 				runtimeSettingsCapabilitiesState.capabilities = null;
 				runtimeSettingsCapabilitiesState.loadError = error;
 			}
@@ -47,12 +62,11 @@ export async function hydrateRuntimeSettingsCapabilities(): Promise<RuntimeSetti
 			return null;
 		})
 		.finally(() => {
-			pendingLoads.delete(key);
-			if (latestLoadKey === key) {
+			if (latestLoadId === loadId) {
+				pendingLoad = null;
 				runtimeSettingsCapabilitiesState.loading = false;
 			}
 		});
 
-	pendingLoads.set(key, promise);
-	return promise;
+	return pendingLoad;
 }


### PR DESCRIPTION
## Summary

- Make runtime capability loading explicit through `loadRuntimeSettingsCapabilities`, `refreshRuntimeSettingsCapabilities`, and `invalidateRuntimeSettingsCapabilities`.
- Have App Settings hydration load one runtime capability snapshot and pass encoder/max-concurrency slices into the owning UI modules.
- Stop rendering provider-controlled metadata lookup cover URLs directly as image sources while keeping selected-cover application on the backend-validated `loadCoverArtFromUrl` path.
- Pin Pages workflow actions to full commit SHAs with retained version comments.
- Add a temporary active spec for this workblock.

Closes #302.
Closes #348.
Refs #298, #321, #331, #338, #341, #359.

## Validation

- `bun run test -- src/ui/__tests__/runtimeSettingsCapabilities.test.ts`
- `bun run test -- src/ui/appSettings/appSettings.test.ts src/ui/__tests__/encoderPanel-behavior.test.ts src/ui/__tests__/jobControls-info.test.ts`
- `bun run test -- src/ui/__tests__/metadataLookup-island.test.ts src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts`
- `bun run test -- src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts src/ui/core/__tests__/metadataSaveWorkflow.test.ts src/ui/__tests__/metadata-save-pending-flow.test.ts src/ui/statusPanel/__tests__/stateMachine.test.ts`
- `cargo nextest run -p audiobook-boss --lib discover_audio_import_paths`
- Review auditor reran the focused suites above plus `cargo nextest run -p audiobook-boss --lib validate_cover_art_url resolver_rejects_localhost resolver_allows_public_ip_literal`
- `bun run typecheck`
- `git diff --check`

Skipped generated binding check because no IPC/generated/Rust production contract files changed.
