### PR TITLE
fix: mode-keyed cover art ownership and safe lookup previews

### DIFF
--- a/src/ui/__tests__/coverArt-island.test.ts
+++ b/src/ui/__tests__/coverArt-island.test.ts
@@ -4,13 +4,15 @@ import CoverArtIsland from '../coverArt/CoverArtIsland.svelte';
 import {
 	applyCoverArtDrop,
 	COVER_ART_IMAGE_EXTENSION_HINTS,
-	getCurrentCoverArt,
-	isCoverArtRemovalRequested,
 	onClearCoverArt,
 	onLoadCoverArtFromFilePicker,
 	onLoadCoverArtFromInput,
-	setCoverArt,
+	setCustomCoverArt,
+	getCurrentCoverArt,
+	isCoverArtRemovalRequested,
 } from '../coverArt';
+import { setCurrentFileList, setSelectedFileIndices, setSelectedIndex } from '../fileList/state.svelte';
+import type { AudioFile, FileListInfo } from '../../types/audio';
 
 const { openFileMock, loadCoverArtFileMock, loadCoverArtFromUrlMock } = vi.hoisted(() => ({
 	openFileMock: vi.fn(),
@@ -41,7 +43,17 @@ describe('CoverArt island mount + clear behavior', () => {
 	});
 
 	it('mounts from root and clears cover art through UI action', () => {
-		setCoverArt([0x89, 0x50, 0x4e, 0x47]);
+		setCurrentFileList({
+			files: [{ path: '/books/a.m4b', isValid: true, inputId: 'a' } as AudioFile],
+			validCount: 1,
+			invalidCount: 0,
+			totalDuration: 0,
+			totalSize: 0,
+		} as FileListInfo);
+		setSelectedFileIndices([0]);
+		setSelectedIndex(0);
+
+		setCustomCoverArt([0x89, 0x50, 0x4e, 0x47]);
 
 		const clearButton = document.getElementById('cover-art-clear-btn') as HTMLButtonElement | null;
 		expect(clearButton).toBeTruthy();

--- a/src/ui/__tests__/coverArt-owner-integration.test.ts
+++ b/src/ui/__tests__/coverArt-owner-integration.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AudioFile, FileListInfo } from '../../types/audio';
-import { getCurrentCoverArt, refreshCoverArtDisplay, setCustomCoverArt } from '../coverArt';
+import {
+	clearCoverArt,
+	getCurrentCoverArt,
+	getHasCustomCoverArt,
+	refreshCoverArtDisplay,
+	setCustomCoverArt,
+} from '../coverArt';
 import { jobControlsState } from '../jobControls/state.svelte';
 import {
 	setCurrentFileList,
@@ -56,6 +62,18 @@ describe('coverArt owner integration', () => {
 		expect(getCurrentCoverArt()).toEqual([4, 5, 6]);
 	});
 
+	it('ignores custom cover art commits in batch multi-select', () => {
+		setSelectedFileIndices([0, 1]);
+		setSelectedIndex(0);
+
+		setCustomCoverArt([7, 8, 9]);
+
+		expect(getMetadataIntentPatchForFile('/books/a.m4b')?.cover_art).toBeUndefined();
+		expect(getMetadataIntentPatchForFile('/books/b.m4b')?.cover_art).toBeUndefined();
+		expect(getCurrentCoverArt()).toBeNull();
+		expect(getHasCustomCoverArt()).toBe(false);
+	});
+
 	it('commits merge cover art to the first valid file regardless of selection', () => {
 		jobControlsState.jobType = 'merge';
 		setSelectedFileIndices([1]);
@@ -68,6 +86,24 @@ describe('coverArt owner integration', () => {
 			value: [1, 2, 3],
 		});
 		expect(getMetadataIntentPatchForFile('/books/b.m4b')?.cover_art).toBeUndefined();
+	});
+
+	it('does not clear staged merge cover art during non-explicit panel resets', () => {
+		jobControlsState.jobType = 'merge';
+
+		setCustomCoverArt([9, 8, 7]);
+		clearCoverArt();
+
+		expect(getMetadataIntentPatchForFile('/books/a.m4b')?.cover_art).toEqual({
+			op: 'set',
+			value: [9, 8, 7],
+		});
+		expect(getCurrentCoverArt()).toEqual([9, 8, 7]);
+
+		clearCoverArt({ markRemoval: true });
+		expect(getMetadataIntentPatchForFile('/books/a.m4b')?.cover_art).toEqual({
+			op: 'clear',
+		});
 	});
 
 	it('refreshes batch preview when cycling selected files', () => {

--- a/src/ui/__tests__/coverArt-owner-integration.test.ts
+++ b/src/ui/__tests__/coverArt-owner-integration.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../types/audio';
+import { getCurrentCoverArt, refreshCoverArtDisplay, setCustomCoverArt } from '../coverArt';
+import { jobControlsState } from '../jobControls/state.svelte';
+import {
+	setCurrentFileList,
+	setSelectedFileIndices,
+	setSelectedIndex,
+} from '../fileList/state.svelte';
+import {
+	clearMetadataState,
+	getMetadataIntentPatchForFile,
+	setMetadataForFile,
+} from '../metadataState';
+
+vi.mock('../../lib/tauri/client', () => ({
+	tauriClient: {
+		listen: vi.fn(),
+	},
+}));
+
+function makeFile(path: string): AudioFile {
+	return { path, isValid: true, inputId: path } as AudioFile;
+}
+
+function makeFileList(files: AudioFile[]): FileListInfo {
+	return {
+		files,
+		validCount: files.length,
+		invalidCount: 0,
+		totalDuration: 0,
+		totalSize: 0,
+	} as FileListInfo;
+}
+
+describe('coverArt owner integration', () => {
+	beforeEach(() => {
+		clearMetadataState();
+		jobControlsState.jobType = 'batch';
+		setCurrentFileList(makeFileList([makeFile('/books/a.m4b'), makeFile('/books/b.m4b')]));
+		setSelectedFileIndices([0]);
+		setSelectedIndex(0);
+	});
+
+	it('commits custom cover art to the selected batch file only', () => {
+		setSelectedFileIndices([1]);
+		setSelectedIndex(1);
+
+		setCustomCoverArt([4, 5, 6]);
+
+		expect(getMetadataIntentPatchForFile('/books/b.m4b')?.cover_art).toEqual({
+			op: 'set',
+			value: [4, 5, 6],
+		});
+		expect(getMetadataIntentPatchForFile('/books/a.m4b')?.cover_art).toBeUndefined();
+		expect(getCurrentCoverArt()).toEqual([4, 5, 6]);
+	});
+
+	it('commits merge cover art to the first valid file regardless of selection', () => {
+		jobControlsState.jobType = 'merge';
+		setSelectedFileIndices([1]);
+		setSelectedIndex(1);
+
+		setCustomCoverArt([1, 2, 3]);
+
+		expect(getMetadataIntentPatchForFile('/books/a.m4b')?.cover_art).toEqual({
+			op: 'set',
+			value: [1, 2, 3],
+		});
+		expect(getMetadataIntentPatchForFile('/books/b.m4b')?.cover_art).toBeUndefined();
+	});
+
+	it('refreshes batch preview when cycling selected files', () => {
+		setMetadataForFile('/books/a.m4b', { cover_art: [1] });
+		setMetadataForFile('/books/b.m4b', { cover_art: [2] });
+
+		setSelectedFileIndices([0]);
+		setSelectedIndex(0);
+		refreshCoverArtDisplay();
+		expect(getCurrentCoverArt()).toEqual([1]);
+
+		setSelectedFileIndices([1]);
+		setSelectedIndex(1);
+		refreshCoverArtDisplay();
+		expect(getCurrentCoverArt()).toEqual([2]);
+	});
+});

--- a/src/ui/__tests__/fileList-reorder-behavior.test.ts
+++ b/src/ui/__tests__/fileList-reorder-behavior.test.ts
@@ -38,6 +38,7 @@ const context = vi.hoisted(() => ({
 	updateTagPreviewMock: vi.fn(),
 	clearCoverArtMock: vi.fn(),
 	getHasCustomCoverArtMock: vi.fn(() => false),
+	refreshCoverArtDisplayMock: vi.fn(),
 	setCoverArtMock: vi.fn(),
 	pushStatusPanelTransientStatusMock: vi.fn(),
 	renderAutoResolutionHintsMock: vi.fn(),
@@ -85,6 +86,7 @@ vi.mock('../tagPreview', () => ({
 vi.mock('../coverArt', () => ({
 	clearCoverArt: context.clearCoverArtMock,
 	getHasCustomCoverArt: context.getHasCustomCoverArtMock,
+	refreshCoverArtDisplay: context.refreshCoverArtDisplayMock,
 	setCoverArt: context.setCoverArtMock,
 }));
 
@@ -156,6 +158,7 @@ describe('file list reorder behavior', () => {
 		context.clearCoverArtMock.mockReset();
 		context.getHasCustomCoverArtMock.mockReset();
 		context.getHasCustomCoverArtMock.mockReturnValue(false);
+		context.refreshCoverArtDisplayMock.mockReset();
 		context.setCoverArtMock.mockReset();
 		context.pushStatusPanelTransientStatusMock.mockReset();
 		context.renderAutoResolutionHintsMock.mockReset();

--- a/src/ui/__tests__/metadataLookup-island.test.ts
+++ b/src/ui/__tests__/metadataLookup-island.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import MetadataLookupIsland from '../metadataLookup/MetadataLookupIsland.svelte';
 
 const { loadCoverArtFromUrlMock } = vi.hoisted(() => ({
@@ -117,14 +117,17 @@ describe('MetadataLookup island mount', () => {
 
 		await tick();
 
+		const coverAreas = document.querySelectorAll('.metadata-lookup-cover');
+		expect(coverAreas.length).toBe(2);
+		expect(loadCoverArtFromUrlMock).not.toHaveBeenCalled();
+
+		await fireEvent.mouseEnter(coverAreas[0]);
+
 		await waitFor(() => {
 			expect(loadCoverArtFromUrlMock).toHaveBeenCalledWith(
 				'https://covers.example.com/private-cover.jpg',
 			);
 		});
-
-		const coverAreas = document.querySelectorAll('.metadata-lookup-cover');
-		expect(coverAreas.length).toBe(2);
 
 		await waitFor(() => {
 			expect(document.querySelector('[data-testid="metadata-lookup-cover-image"]')).toBeTruthy();

--- a/src/ui/__tests__/metadataLookup-island.test.ts
+++ b/src/ui/__tests__/metadataLookup-island.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event';
 import MetadataLookupIsland from '../metadataLookup/MetadataLookupIsland.svelte';
 
 const { loadCoverArtFromUrlMock } = vi.hoisted(() => ({
@@ -118,16 +117,14 @@ describe('MetadataLookup island mount', () => {
 
 		await tick();
 
-		const coverAreas = document.querySelectorAll('.metadata-lookup-cover');
-		expect(coverAreas.length).toBe(2);
-
-		await userEvent.hover(coverAreas[0] as Element);
-
 		await waitFor(() => {
 			expect(loadCoverArtFromUrlMock).toHaveBeenCalledWith(
 				'https://covers.example.com/private-cover.jpg',
 			);
 		});
+
+		const coverAreas = document.querySelectorAll('.metadata-lookup-cover');
+		expect(coverAreas.length).toBe(2);
 
 		await waitFor(() => {
 			expect(document.querySelector('[data-testid="metadata-lookup-cover-image"]')).toBeTruthy();

--- a/src/ui/__tests__/metadataLookup-island.test.ts
+++ b/src/ui/__tests__/metadataLookup-island.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import MetadataLookupIsland from '../metadataLookup/MetadataLookupIsland.svelte';
+
+const { loadCoverArtFromUrlMock } = vi.hoisted(() => ({
+	loadCoverArtFromUrlMock: vi.fn(),
+}));
 
 vi.mock('../../lib/tauri/client', () => ({
 	tauriClient: {
 		searchOnlineMetadata: vi.fn(),
-		loadCoverArtFromUrl: vi.fn(),
+		loadCoverArtFromUrl: loadCoverArtFromUrlMock,
 	},
 }));
 
@@ -38,6 +43,9 @@ vi.mock('../coverArt', () => ({
 	clearCoverArt: vi.fn(),
 	setCoverArt: vi.fn(),
 	setCustomCoverArt: vi.fn(),
+	refreshCoverArtDisplay: vi.fn(),
+	coverArtBytesToDataUrl: (bytes: number[]) =>
+		`data:image/jpeg;base64,${btoa(String.fromCharCode(...bytes))}`,
 }));
 
 vi.mock('../metadataState', () => ({
@@ -45,11 +53,16 @@ vi.mock('../metadataState', () => ({
 	setMetadataForFile: vi.fn(),
 }));
 
+import { tick } from 'svelte';
 import { initMetadataLookup } from '../metadataLookup';
 import { metadataLookupState } from '../metadataLookup/state.svelte';
+import { clearMetadataLookupCoverPreviewCache } from '../metadataLookup/metadataLookupCoverPreview.svelte';
 
 describe('MetadataLookup island mount', () => {
 	beforeEach(() => {
+		clearMetadataLookupCoverPreviewCache();
+		loadCoverArtFromUrlMock.mockReset();
+		loadCoverArtFromUrlMock.mockResolvedValue([0xff, 0xd8, 0xff]);
 		document.body.innerHTML = `
       <button id="metadata-lookup-btn">Open</button>
     `;
@@ -64,8 +77,10 @@ describe('MetadataLookup island mount', () => {
 		expect(document.getElementById('metadata-lookup-skip-btn')).toBeTruthy();
 	});
 
-	it('does not render provider cover URLs as image sources', async () => {
+	it('loads cover previews through the backend without exposing provider URLs', async () => {
 		initMetadataLookup();
+		metadataLookupState.isOpen = true;
+		metadataLookupState.hasSearched = true;
 		metadataLookupState.results = [
 			{
 				source: 'audnexus',
@@ -81,7 +96,7 @@ describe('MetadataLookup island mount', () => {
 				publishedDate: '2020-07',
 				durationSeconds: 3600,
 				audibleOnly: false,
-				coverUrl: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+				coverUrl: 'https://covers.example.com/private-cover.jpg',
 			},
 			{
 				source: 'openlibrary',
@@ -97,16 +112,32 @@ describe('MetadataLookup island mount', () => {
 				publishedDate: '2021-08',
 				durationSeconds: 7200,
 				audibleOnly: false,
-				coverUrl: 'http://127.0.0.1:8080/private-cover.jpg',
+				coverUrl: 'https://covers.example.com/loopback-cover.jpg',
 			},
 		];
 
+		await tick();
+
+		const coverAreas = document.querySelectorAll('.metadata-lookup-cover');
+		expect(coverAreas.length).toBe(2);
+
+		await userEvent.hover(coverAreas[0] as Element);
+
 		await waitFor(() => {
-			expect(
-				document.querySelectorAll('[data-testid="metadata-lookup-cover-available"]'),
-			).toHaveLength(2);
+			expect(loadCoverArtFromUrlMock).toHaveBeenCalledWith(
+				'https://covers.example.com/private-cover.jpg',
+			);
 		});
-		expect(document.querySelectorAll('#metadata-lookup-results img')).toHaveLength(0);
+
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="metadata-lookup-cover-image"]')).toBeTruthy();
+		});
+
+		const image = document.querySelector(
+			'[data-testid="metadata-lookup-cover-image"]',
+		) as HTMLImageElement | null;
+		expect(image?.src.startsWith('data:image/jpeg;base64,')).toBe(true);
+		expect(image?.src).not.toContain('covers.example.com');
 		expect(document.querySelector('[src*="169.254.169.254"]')).toBeNull();
 		expect(document.querySelector('[src*="127.0.0.1"]')).toBeNull();
 	});

--- a/src/ui/__tests__/metadataLookup-queue-cover-art.test.ts
+++ b/src/ui/__tests__/metadataLookup-queue-cover-art.test.ts
@@ -12,6 +12,7 @@ const context = vi.hoisted(() => ({
 	applyMetadataToFormMock: vi.fn(),
 	setCustomCoverArtMock: vi.fn(),
 	clearCoverArtMock: vi.fn(),
+	refreshCoverArtDisplayMock: vi.fn(),
 	setCoverArtMock: vi.fn(),
 	updateOutputPathMock: vi.fn(),
 	updateEstimatedSizeMock: vi.fn(),
@@ -66,6 +67,7 @@ vi.mock('../metadataForm', () => ({
 
 vi.mock('../coverArt', () => ({
 	clearCoverArt: context.clearCoverArtMock,
+	refreshCoverArtDisplay: context.refreshCoverArtDisplayMock,
 	setCoverArt: context.setCoverArtMock,
 	setCustomCoverArt: context.setCustomCoverArtMock,
 }));
@@ -278,7 +280,7 @@ describe('metadata lookup queue cover art isolation', () => {
 			expect.objectContaining({ cover_art: [2, 2, 2] }),
 		);
 		expect(context.loadCoverArtFromUrlMock).toHaveBeenCalledTimes(1);
-		expect(context.setCoverArtMock).toHaveBeenLastCalledWith([2, 2, 2]);
+		expect(context.refreshCoverArtDisplayMock).toHaveBeenCalled();
 	});
 
 	it('does not mutate metadata when skipping queue item', async () => {

--- a/src/ui/__tests__/metadataPanel-race.test.ts
+++ b/src/ui/__tests__/metadataPanel-race.test.ts
@@ -11,6 +11,7 @@ import {
 	setSelectedFileIndices,
 	setSelectedIndex,
 } from '../fileList/state.svelte';
+import { jobControlsState } from '../jobControls/state.svelte';
 
 type Deferred<T> = {
 	promise: Promise<T>;
@@ -124,9 +125,13 @@ describe('metadata panel race guards', () => {
 		context.getHasCustomCoverArtMock.mockReset();
 		context.getHasCustomCoverArtMock.mockReturnValue(false);
 		context.setCoverArtMock.mockReset();
+		context.refreshCoverArtDisplayMock.mockReset();
+		context.getMetadataIntentPatchForFileMock.mockReset();
+		context.getMetadataIntentPatchForFileMock.mockReturnValue(undefined);
 		context.renderAutoResolutionHintsMock.mockReset();
 		context.resetAutoResolutionHintsMock.mockReset();
 		context.getMetadataForFileMock.mockReturnValue(undefined);
+		jobControlsState.jobType = 'merge';
 		setCurrentFileList(null);
 		setSelectedFileIndices([]);
 		setSelectedIndex(-1);
@@ -234,5 +239,22 @@ describe('metadata panel race guards', () => {
 		await pending;
 
 		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
+	});
+
+	it('auto-loads cover art for the selected batch file when it is not first valid', async () => {
+		const alpha = makeFile('/books/alpha.m4b');
+		const beta = makeFile('/books/beta.m4b');
+		jobControlsState.jobType = 'batch';
+		context.readAudioMetadataMock.mockResolvedValue({ cover_art: [4, 5, 6] });
+		setCurrentFileList(makeFileList(alpha, beta));
+		setSelectedFileIndices([1]);
+		setSelectedIndex(1);
+
+		await autoUpdateCoverArtFromFirstValidFile();
+
+		expect(context.readAudioMetadataMock).toHaveBeenCalledWith('/books/beta.m4b');
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith('/books/beta.m4b', {
+			cover_art: [4, 5, 6],
+		});
 	});
 });

--- a/src/ui/__tests__/metadataPanel-race.test.ts
+++ b/src/ui/__tests__/metadataPanel-race.test.ts
@@ -29,8 +29,10 @@ const context = vi.hoisted(() => ({
 	updateOutputPathMock: vi.fn(),
 	updateTagPreviewMock: vi.fn(),
 	clearCoverArtMock: vi.fn(),
+	refreshCoverArtDisplayMock: vi.fn(),
 	getHasCustomCoverArtMock: vi.fn(() => false),
 	setCoverArtMock: vi.fn(),
+	getMetadataIntentPatchForFileMock: vi.fn(),
 	renderAutoResolutionHintsMock: vi.fn(),
 	resetAutoResolutionHintsMock: vi.fn(),
 }));
@@ -44,6 +46,7 @@ vi.mock('../../lib/tauri/client', () => ({
 vi.mock('../metadataState', () => ({
 	getMetadataForFile: context.getMetadataForFileMock,
 	setMetadataForFile: context.setMetadataForFileMock,
+	getMetadataIntentPatchForFile: context.getMetadataIntentPatchForFileMock,
 }));
 
 vi.mock('../metadataForm', () => ({
@@ -65,6 +68,7 @@ vi.mock('../coverArt', () => ({
 	clearCoverArt: context.clearCoverArtMock,
 	getHasCustomCoverArt: context.getHasCustomCoverArtMock,
 	setCoverArt: context.setCoverArtMock,
+	refreshCoverArtDisplay: context.refreshCoverArtDisplayMock,
 }));
 
 vi.mock('../encoderPanel/autoResolutionHints', () => ({
@@ -212,7 +216,7 @@ describe('metadata panel race guards', () => {
 		coverRequest.resolve({ cover_art: [1, 2, 3] });
 		await pending;
 
-		expect(context.setCoverArtMock).not.toHaveBeenCalled();
+		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
 	});
 
 	it('drops auto-cover results from an outdated file list generation', async () => {
@@ -229,6 +233,6 @@ describe('metadata panel race guards', () => {
 		coverRequest.resolve({ cover_art: [9, 9, 9] });
 		await pending;
 
-		expect(context.setCoverArtMock).not.toHaveBeenCalled();
+		expect(context.setMetadataForFileMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/ui/coverArt.ts
+++ b/src/ui/coverArt.ts
@@ -1,5 +1,16 @@
 import { tauriClient } from '../lib/tauri/client';
 import { normalizeAppError } from '../lib/tauri/appError';
+import type { MetadataIntentPatch } from '../types/metadataIntent';
+import { jobControlsState } from './jobControls/state.svelte';
+import { getSelectedFiles } from './fileList/state.svelte';
+import { getCurrentFileList } from './fileList/state.svelte';
+import { applyMetadataDraftIntent } from './metadataDraft';
+import { getMetadataForFile, setMetadataForFile } from './metadataState';
+import {
+	effectiveCoverForFile,
+	resolveCoverDisplayPath,
+	resolveCoverOwnerPaths,
+} from './coverArt/coverOwner';
 import {
 	clearCoverArtMessageState,
 	clearCoverArtSession,
@@ -17,11 +28,59 @@ import {
 
 let coverArtMessageTimeoutId: number | null = null;
 
+function readJobType() {
+	return jobControlsState.jobType;
+}
+
 export const COVER_ART_IMAGE_EXTENSION_HINTS = ['jpg', 'jpeg', 'png', 'webp'] as const;
 const COVER_ART_IMAGE_EXTENSION_HINT_PATTERN = new RegExp(
 	`\\.(${COVER_ART_IMAGE_EXTENSION_HINTS.join('|')})$`,
 	'i',
 );
+
+function buildCoverArtIntentPatch(
+	coverArtBytes: number[] | null,
+	markRemoval: boolean,
+): MetadataIntentPatch {
+	if (markRemoval || !coverArtBytes || coverArtBytes.length === 0) {
+		return { cover_art: { op: 'clear' } };
+	}
+	return { cover_art: { op: 'set', value: [...coverArtBytes] } };
+}
+
+function commitCoverArtToOwners(coverArtBytes: number[] | null, markRemoval: boolean): void {
+	const ownerPaths = resolveCoverOwnerPaths(
+		readJobType(),
+		getCurrentFileList(),
+		getSelectedFiles(),
+	);
+	if (ownerPaths.length === 0) {
+		return;
+	}
+
+	const intentPatch = buildCoverArtIntentPatch(coverArtBytes, markRemoval);
+	for (const filePath of ownerPaths) {
+		const existing = getMetadataForFile(filePath) ?? {};
+		const merged = applyMetadataDraftIntent(existing, intentPatch);
+		setMetadataForFile(filePath, merged, {
+			markPending: true,
+			intentPatch,
+		});
+	}
+}
+
+export function refreshCoverArtDisplay(): void {
+	const displayPath = resolveCoverDisplayPath(
+		readJobType(),
+		getCurrentFileList(),
+		getSelectedFiles(),
+	);
+	if (!displayPath) {
+		displayCoverArt(null);
+		return;
+	}
+	displayCoverArt(effectiveCoverForFile(displayPath));
+}
 
 /**
  * Handles the Clear Cover Art action
@@ -113,14 +172,10 @@ async function loadCoverArtFromUrl(url: string): Promise<void> {
 }
 
 function applyLoadedCoverArt(imageData: number[]): void {
-	setCoverArtSession(imageData);
-	setHasCustomCoverArt(true);
-	setCoverArtRemovalRequested(false);
-
-	displayCoverArt(imageData);
+	setCustomCoverArt(imageData);
 }
 
-function coverArtBytesToDataUrl(coverArtBytes: number[]): string {
+export function coverArtBytesToDataUrl(coverArtBytes: number[]): string {
 	const uint8Array = new Uint8Array(coverArtBytes);
 	const chunkSize = 0x8000;
 	let binary = '';
@@ -227,9 +282,16 @@ function parseCoverArtUrl(raw: string): URL | null {
 	}
 }
 
-// Global Exports
 export function getCurrentCoverArt(): number[] | null {
-	return coverArtSessionState.currentCoverArt;
+	const displayPath = resolveCoverDisplayPath(
+		readJobType(),
+		getCurrentFileList(),
+		getSelectedFiles(),
+	);
+	if (!displayPath) {
+		return null;
+	}
+	return effectiveCoverForFile(displayPath);
 }
 
 export function getHasCustomCoverArt(): boolean {
@@ -249,20 +311,31 @@ export function setCoverArt(coverArtBytes: number[] | null): void {
 }
 
 export function setCustomCoverArt(coverArtBytes: number[] | null): void {
+	if (!coverArtBytes || coverArtBytes.length === 0) {
+		clearCoverArt({ markRemoval: true });
+		return;
+	}
+
+	commitCoverArtToOwners(coverArtBytes, false);
 	setCoverArtSession(coverArtBytes);
-	setHasCustomCoverArt(Boolean(coverArtBytes && coverArtBytes.length > 0));
+	setHasCustomCoverArt(true);
 	setCoverArtRemovalRequested(false);
-	displayCoverArt(coverArtBytes);
+	refreshCoverArtDisplay();
 }
 
 export function clearCoverArt(options?: { markRemoval?: boolean }): void {
 	const markRemoval = options?.markRemoval ?? false;
+
+	if (markRemoval || coverArtSessionState.hasCustomCoverArt) {
+		commitCoverArtToOwners(null, markRemoval);
+	}
+
 	clearCoverArtSession();
-	displayCoverArt(null);
 	setCoverArtRemovalRequested(markRemoval);
 	setHasCustomCoverArt(false);
 	setCoverArtUrlInputValue('');
 	clearCoverArtMessage();
 	setCoverArtDragOver(false);
 	setCoverArtHovered(false);
+	refreshCoverArtDisplay();
 }

--- a/src/ui/coverArt.ts
+++ b/src/ui/coverArt.ts
@@ -48,14 +48,14 @@ function buildCoverArtIntentPatch(
 	return { cover_art: { op: 'set', value: [...coverArtBytes] } };
 }
 
-function commitCoverArtToOwners(coverArtBytes: number[] | null, markRemoval: boolean): void {
+function commitCoverArtToOwners(coverArtBytes: number[] | null, markRemoval: boolean): boolean {
 	const ownerPaths = resolveCoverOwnerPaths(
 		readJobType(),
 		getCurrentFileList(),
 		getSelectedFiles(),
 	);
 	if (ownerPaths.length === 0) {
-		return;
+		return false;
 	}
 
 	const intentPatch = buildCoverArtIntentPatch(coverArtBytes, markRemoval);
@@ -67,6 +67,7 @@ function commitCoverArtToOwners(coverArtBytes: number[] | null, markRemoval: boo
 			intentPatch,
 		});
 	}
+	return true;
 }
 
 export function refreshCoverArtDisplay(): void {
@@ -316,7 +317,14 @@ export function setCustomCoverArt(coverArtBytes: number[] | null): void {
 		return;
 	}
 
-	commitCoverArtToOwners(coverArtBytes, false);
+	const committed = commitCoverArtToOwners(coverArtBytes, false);
+	if (!committed) {
+		clearCoverArtSession();
+		setHasCustomCoverArt(false);
+		setCoverArtRemovalRequested(false);
+		refreshCoverArtDisplay();
+		return;
+	}
 	setCoverArtSession(coverArtBytes);
 	setHasCustomCoverArt(true);
 	setCoverArtRemovalRequested(false);
@@ -326,7 +334,7 @@ export function setCustomCoverArt(coverArtBytes: number[] | null): void {
 export function clearCoverArt(options?: { markRemoval?: boolean }): void {
 	const markRemoval = options?.markRemoval ?? false;
 
-	if (markRemoval || coverArtSessionState.hasCustomCoverArt) {
+	if (markRemoval) {
 		commitCoverArtToOwners(null, markRemoval);
 	}
 

--- a/src/ui/coverArt/coverOwner.test.ts
+++ b/src/ui/coverArt/coverOwner.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../types/audio';
+import {
+	effectiveCoverForFile,
+	firstValidFilePath,
+	resolveCoverDisplayPath,
+	resolveCoverOwnerPaths,
+} from './coverOwner';
+
+const metadataStateMocks = vi.hoisted(() => ({
+	getMetadataForFile: vi.fn(),
+	getMetadataIntentPatchForFile: vi.fn(),
+}));
+
+vi.mock('../metadataState', () => ({
+	getMetadataForFile: metadataStateMocks.getMetadataForFile,
+	getMetadataIntentPatchForFile: metadataStateMocks.getMetadataIntentPatchForFile,
+}));
+
+function makeFile(path: string, isValid = true): AudioFile {
+	return {
+		path,
+		isValid,
+		inputId: path,
+	} as AudioFile;
+}
+
+function makeFileList(files: AudioFile[]): FileListInfo {
+	return {
+		files,
+		validCount: files.filter((file) => file.isValid).length,
+		invalidCount: files.filter((file) => !file.isValid).length,
+		totalDuration: 0,
+		totalSize: 0,
+	} as FileListInfo;
+}
+
+describe('coverOwner', () => {
+	beforeEach(() => {
+		metadataStateMocks.getMetadataForFile.mockReset();
+		metadataStateMocks.getMetadataIntentPatchForFile.mockReset();
+	});
+
+	it('resolves merge owner to the first valid input file', () => {
+		const fileList = makeFileList([
+			makeFile('/books/a.m4b'),
+			makeFile('/books/b.m4b'),
+		]);
+
+		expect(resolveCoverOwnerPaths('merge', fileList, [makeFile('/books/b.m4b')])).toEqual([
+			'/books/a.m4b',
+		]);
+	});
+
+	it('resolves batch owner to selected valid files only', () => {
+		const fileList = makeFileList([
+			makeFile('/books/a.m4b'),
+			makeFile('/books/b.m4b'),
+			makeFile('/books/c.m4b', false),
+		]);
+
+		expect(
+			resolveCoverOwnerPaths('batch', fileList, [
+				makeFile('/books/b.m4b'),
+				makeFile('/books/c.m4b', false),
+			]),
+		).toEqual(['/books/b.m4b']);
+	});
+
+	it('prefers intent patch cover art over stored metadata', () => {
+		metadataStateMocks.getMetadataIntentPatchForFile.mockReturnValue({
+			cover_art: { op: 'set', value: [9, 9, 9] },
+		});
+		metadataStateMocks.getMetadataForFile.mockReturnValue({ cover_art: [1, 2, 3] });
+
+		expect(effectiveCoverForFile('/books/a.m4b')).toEqual([9, 9, 9]);
+	});
+
+	it('treats intent clear as no cover art', () => {
+		metadataStateMocks.getMetadataIntentPatchForFile.mockReturnValue({
+			cover_art: { op: 'clear' },
+		});
+		metadataStateMocks.getMetadataForFile.mockReturnValue({ cover_art: [1, 2, 3] });
+
+		expect(effectiveCoverForFile('/books/a.m4b')).toBeNull();
+	});
+
+	it('returns null display path when batch multi-select covers differ', () => {
+		const fileList = makeFileList([makeFile('/books/a.m4b'), makeFile('/books/b.m4b')]);
+		metadataStateMocks.getMetadataIntentPatchForFile.mockImplementation((path: string) => {
+			if (path === '/books/a.m4b') {
+				return { cover_art: { op: 'set', value: [1] } };
+			}
+			return { cover_art: { op: 'set', value: [2] } };
+		});
+		metadataStateMocks.getMetadataForFile.mockReturnValue({});
+
+		expect(
+			resolveCoverDisplayPath('batch', fileList, [
+				makeFile('/books/a.m4b'),
+				makeFile('/books/b.m4b'),
+			]),
+		).toBeNull();
+	});
+
+	it('returns first selected path when batch multi-select covers match', () => {
+		const fileList = makeFileList([makeFile('/books/a.m4b'), makeFile('/books/b.m4b')]);
+		metadataStateMocks.getMetadataIntentPatchForFile.mockReturnValue({
+			cover_art: { op: 'set', value: [1, 2, 3] },
+		});
+		metadataStateMocks.getMetadataForFile.mockReturnValue({});
+
+		expect(
+			resolveCoverDisplayPath('batch', fileList, [
+				makeFile('/books/a.m4b'),
+				makeFile('/books/b.m4b'),
+			]),
+		).toBe('/books/a.m4b');
+	});
+
+	it('finds first valid file path in list order', () => {
+		const fileList = makeFileList([
+			makeFile('/books/invalid.m4b', false),
+			makeFile('/books/first-valid.m4b'),
+		]);
+
+		expect(firstValidFilePath(fileList)).toBe('/books/first-valid.m4b');
+	});
+});

--- a/src/ui/coverArt/coverOwner.test.ts
+++ b/src/ui/coverArt/coverOwner.test.ts
@@ -42,17 +42,14 @@ describe('coverOwner', () => {
 	});
 
 	it('resolves merge owner to the first valid input file', () => {
-		const fileList = makeFileList([
-			makeFile('/books/a.m4b'),
-			makeFile('/books/b.m4b'),
-		]);
+		const fileList = makeFileList([makeFile('/books/a.m4b'), makeFile('/books/b.m4b')]);
 
 		expect(resolveCoverOwnerPaths('merge', fileList, [makeFile('/books/b.m4b')])).toEqual([
 			'/books/a.m4b',
 		]);
 	});
 
-	it('resolves batch owner to selected valid files only', () => {
+	it('resolves batch owner to a single selected valid file only', () => {
 		const fileList = makeFileList([
 			makeFile('/books/a.m4b'),
 			makeFile('/books/b.m4b'),
@@ -65,6 +62,17 @@ describe('coverOwner', () => {
 				makeFile('/books/c.m4b', false),
 			]),
 		).toEqual(['/books/b.m4b']);
+	});
+
+	it('ignores batch multi-select cover ownership', () => {
+		const fileList = makeFileList([makeFile('/books/a.m4b'), makeFile('/books/b.m4b')]);
+
+		expect(
+			resolveCoverOwnerPaths('batch', fileList, [
+				makeFile('/books/a.m4b'),
+				makeFile('/books/b.m4b'),
+			]),
+		).toEqual([]);
 	});
 
 	it('prefers intent patch cover art over stored metadata', () => {

--- a/src/ui/coverArt/coverOwner.ts
+++ b/src/ui/coverArt/coverOwner.ts
@@ -1,0 +1,92 @@
+import type { AudioFile, FileListInfo, JobType } from '../../types/audio';
+import type { MetadataIntentPatch } from '../../types/metadataIntent';
+import { getMetadataForFile, getMetadataIntentPatchForFile } from '../metadataState';
+
+export function firstValidFilePath(fileList: FileListInfo | null): string | null {
+	if (!fileList?.files.length) {
+		return null;
+	}
+	const firstValid = fileList.files.find((file) => file.isValid);
+	return firstValid?.path ?? null;
+}
+
+export function resolveCoverOwnerPaths(
+	jobType: JobType,
+	fileList: FileListInfo | null,
+	selectedFiles: AudioFile[],
+): string[] {
+	if (jobType === 'merge') {
+		const mergeKey = firstValidFilePath(fileList);
+		return mergeKey ? [mergeKey] : [];
+	}
+
+	return selectedFiles.filter((file) => file.isValid).map((file) => file.path);
+}
+
+function coverBytesEqual(left: number[] | null, right: number[] | null): boolean {
+	if (left === right) {
+		return true;
+	}
+	if (!left || !right || left.length !== right.length) {
+		return false;
+	}
+	for (let index = 0; index < left.length; index += 1) {
+		if (left[index] !== right[index]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+export function effectiveCoverForFile(filePath: string): number[] | null {
+	const intentPatch = getMetadataIntentPatchForFile(filePath);
+	const intentCover = readCoverArtFromIntentPatch(intentPatch);
+	if (intentCover !== undefined) {
+		return intentCover;
+	}
+
+	const stored = getMetadataForFile(filePath)?.cover_art;
+	if (stored && stored.length > 0) {
+		return stored;
+	}
+
+	return null;
+}
+
+function readCoverArtFromIntentPatch(
+	intentPatch: MetadataIntentPatch | undefined,
+): number[] | null | undefined {
+	if (!intentPatch?.cover_art) {
+		return undefined;
+	}
+	if (intentPatch.cover_art.op === 'clear') {
+		return null;
+	}
+	if (intentPatch.cover_art.op === 'set') {
+		return intentPatch.cover_art.value.length > 0 ? intentPatch.cover_art.value : null;
+	}
+	return undefined;
+}
+
+export function resolveCoverDisplayPath(
+	jobType: JobType,
+	fileList: FileListInfo | null,
+	selectedFiles: AudioFile[],
+): string | null {
+	if (jobType === 'merge') {
+		return firstValidFilePath(fileList);
+	}
+
+	const validSelected = selectedFiles.filter((file) => file.isValid);
+	if (validSelected.length === 1) {
+		return validSelected[0]?.path ?? null;
+	}
+	if (validSelected.length > 1) {
+		const covers = validSelected.map((file) => effectiveCoverForFile(file.path));
+		const firstCover = covers[0] ?? null;
+		const allSame = covers.every((cover) => coverBytesEqual(cover, firstCover));
+		return allSame ? (validSelected[0]?.path ?? null) : null;
+	}
+
+	return firstValidFilePath(fileList);
+}

--- a/src/ui/coverArt/coverOwner.ts
+++ b/src/ui/coverArt/coverOwner.ts
@@ -20,7 +20,11 @@ export function resolveCoverOwnerPaths(
 		return mergeKey ? [mergeKey] : [];
 	}
 
-	return selectedFiles.filter((file) => file.isValid).map((file) => file.path);
+	const validSelected = selectedFiles.filter((file) => file.isValid);
+	if (validSelected.length !== 1) {
+		return [];
+	}
+	return [validSelected[0].path];
 }
 
 function coverBytesEqual(left: number[] | null, right: number[] | null): boolean {

--- a/src/ui/fileList/AGENTS.md
+++ b/src/ui/fileList/AGENTS.md
@@ -29,7 +29,8 @@
 - Selection/order changes must preserve the selected file identity when moving
   or appending files.
 - Cover-art preview/commit ownership is mode-keyed through `coverArt/coverOwner.ts`
-  (merge → first valid input; batch → selected file[s]); selection flows call
+  (merge → first valid input; batch → exactly one selected valid file; batch
+  multi-select ignores cover-art commits); selection flows call
   `refreshCoverArtDisplay()` rather than gating on a global custom-cover flag.
 - FileList mutations that can affect processing requests must refresh output
   estimates or previews through the output panel public surface.

--- a/src/ui/fileList/AGENTS.md
+++ b/src/ui/fileList/AGENTS.md
@@ -28,6 +28,9 @@
   status path.
 - Selection/order changes must preserve the selected file identity when moving
   or appending files.
+- Cover-art preview/commit ownership is mode-keyed through `coverArt/coverOwner.ts`
+  (merge → first valid input; batch → selected file[s]); selection flows call
+  `refreshCoverArtDisplay()` rather than gating on a global custom-cover flag.
 - FileList mutations that can affect processing requests must refresh output
   estimates or previews through the output panel public surface.
 

--- a/src/ui/fileList/metadataPanel.ts
+++ b/src/ui/fileList/metadataPanel.ts
@@ -3,8 +3,10 @@ import { tauriClient } from '../../lib/tauri/client';
 import type { AudiobookMetadata } from '../../types/metadata';
 import { updateEstimatedSize, updateOutputPath } from '../outputPanel';
 import { updateTagPreview } from '../tagPreview';
-import { clearCoverArt, getHasCustomCoverArt, setCoverArt } from '../coverArt';
-import { getMetadataForFile, setMetadataForFile } from '../metadataState';
+import { clearCoverArt, getHasCustomCoverArt, refreshCoverArtDisplay } from '../coverArt';
+import { effectiveCoverForFile } from '../coverArt/coverOwner';
+import { jobControlsState } from '../jobControls/state.svelte';
+import { getMetadataForFile, getMetadataIntentPatchForFile, setMetadataForFile } from '../metadataState';
 import {
 	populateMetadataFormMulti,
 	populateMetadataFormSingle,
@@ -21,7 +23,7 @@ import {
 	setInspectorValues,
 } from './inspectorState.svelte';
 import { companionSummaryForInputIds } from '../remoteSource/sessionAssets.svelte';
-import { getCurrentFileList, getSelectedFileIndices, getSelectedFileIndex } from './state.svelte';
+import { getCurrentFileList, getSelectedFileIndices, getSelectedFileIndex, getSelectedFiles } from './state.svelte';
 
 let latestSingleSelectionRequestId = 0;
 let latestAutoCoverRequestId = 0;
@@ -253,6 +255,7 @@ export async function showMultiSelection(selectedFiles: AudioFile[]): Promise<vo
 	populateMetadataFormMulti(metadataList, selectedFiles.length);
 	refreshOutputForMetadataChange();
 	updateTagPreview();
+	refreshCoverArtDisplay();
 }
 
 export function refreshSelectionPresentation(selectedFiles: AudioFile[]): void {
@@ -282,40 +285,58 @@ export function clearSelectionPanels(): void {
 export async function autoUpdateCoverArtFromFirstValidFile(): Promise<void> {
 	const requestId = ++latestAutoCoverRequestId;
 	try {
-		if (getHasCustomCoverArt()) return;
 		const fileList = getCurrentFileList();
 		if (!fileList?.files.length) {
-			setCoverArt(null);
+			refreshCoverArtDisplay();
 			return;
 		}
-		const firstValid = fileList.files.find((f) => f.isValid);
-		if (!firstValid) {
-			setCoverArt(null);
+
+		const jobType = jobControlsState.jobType;
+		const selectedValid = getSelectedFiles().find((file) => file.isValid);
+		const firstValid = fileList.files.find((file) => file.isValid);
+		const targetPath =
+			jobType === 'merge'
+				? firstValid?.path
+				: (selectedValid?.path ?? firstValid?.path);
+		if (!targetPath) {
+			refreshCoverArtDisplay();
 			return;
 		}
-		const metadata = await tauriClient.readAudioMetadata(firstValid.path);
+
+		if (
+			effectiveCoverForFile(targetPath) !== null ||
+			getMetadataIntentPatchForFile(targetPath)?.cover_art
+		) {
+			if (requestId === latestAutoCoverRequestId) {
+				refreshCoverArtDisplay();
+			}
+			return;
+		}
+
+		const metadata = await tauriClient.readAudioMetadata(targetPath);
 		if (
 			requestId !== latestAutoCoverRequestId ||
 			getHasCustomCoverArt() ||
-			getCurrentFileList()?.files.find((file) => file.isValid)?.path !== firstValid.path
+			getMetadataIntentPatchForFile(targetPath)?.cover_art ||
+			getCurrentFileList()?.files.find((file) => file.isValid)?.path !==
+				(jobType === 'merge' ? firstValid?.path : targetPath)
 		) {
 			return;
 		}
-		setCoverArt(metadata.cover_art || null);
+
+		const existing = getMetadataForFile(targetPath) ?? {};
+		setMetadataForFile(targetPath, {
+			...existing,
+			cover_art: metadata.cover_art || undefined,
+		});
+		refreshCoverArtDisplay();
 	} catch (error) {
-		if (requestId !== latestAutoCoverRequestId || getHasCustomCoverArt()) {
+		if (requestId !== latestAutoCoverRequestId) {
 			return;
 		}
-		setCoverArt(null);
+		refreshCoverArtDisplay();
 		console.warn('Failed to auto-load cover art:', error);
 	}
 }
 
-export function getSelectedFiles(): AudioFile[] {
-	const fileList = getCurrentFileList();
-	if (!fileList) return [];
-	const selectedIndices = getSelectedFileIndices();
-	return Array.from(selectedIndices)
-		.map((index) => fileList.files[index])
-		.filter((file): file is AudioFile => Boolean(file));
-}
+export { getSelectedFiles } from './state.svelte';

--- a/src/ui/fileList/metadataPanel.ts
+++ b/src/ui/fileList/metadataPanel.ts
@@ -6,7 +6,11 @@ import { updateTagPreview } from '../tagPreview';
 import { clearCoverArt, getHasCustomCoverArt, refreshCoverArtDisplay } from '../coverArt';
 import { effectiveCoverForFile } from '../coverArt/coverOwner';
 import { jobControlsState } from '../jobControls/state.svelte';
-import { getMetadataForFile, getMetadataIntentPatchForFile, setMetadataForFile } from '../metadataState';
+import {
+	getMetadataForFile,
+	getMetadataIntentPatchForFile,
+	setMetadataForFile,
+} from '../metadataState';
 import {
 	populateMetadataFormMulti,
 	populateMetadataFormSingle,
@@ -23,7 +27,12 @@ import {
 	setInspectorValues,
 } from './inspectorState.svelte';
 import { companionSummaryForInputIds } from '../remoteSource/sessionAssets.svelte';
-import { getCurrentFileList, getSelectedFileIndices, getSelectedFileIndex, getSelectedFiles } from './state.svelte';
+import {
+	getCurrentFileList,
+	getSelectedFileIndices,
+	getSelectedFileIndex,
+	getSelectedFiles,
+} from './state.svelte';
 
 let latestSingleSelectionRequestId = 0;
 let latestAutoCoverRequestId = 0;
@@ -295,9 +304,7 @@ export async function autoUpdateCoverArtFromFirstValidFile(): Promise<void> {
 		const selectedValid = getSelectedFiles().find((file) => file.isValid);
 		const firstValid = fileList.files.find((file) => file.isValid);
 		const targetPath =
-			jobType === 'merge'
-				? firstValid?.path
-				: (selectedValid?.path ?? firstValid?.path);
+			jobType === 'merge' ? firstValid?.path : (selectedValid?.path ?? firstValid?.path);
 		if (!targetPath) {
 			refreshCoverArtDisplay();
 			return;
@@ -314,12 +321,20 @@ export async function autoUpdateCoverArtFromFirstValidFile(): Promise<void> {
 		}
 
 		const metadata = await tauriClient.readAudioMetadata(targetPath);
+		const currentJobType = jobControlsState.jobType;
+		const currentFileList = getCurrentFileList();
+		const currentFirstValid = currentFileList?.files.find((file) => file.isValid);
+		const currentSelectedValid = getSelectedFiles().find((file) => file.isValid);
+		const currentTargetPath =
+			currentJobType === 'merge'
+				? currentFirstValid?.path
+				: (currentSelectedValid?.path ?? currentFirstValid?.path);
 		if (
 			requestId !== latestAutoCoverRequestId ||
 			getHasCustomCoverArt() ||
 			getMetadataIntentPatchForFile(targetPath)?.cover_art ||
-			getCurrentFileList()?.files.find((file) => file.isValid)?.path !==
-				(jobType === 'merge' ? firstValid?.path : targetPath)
+			currentJobType !== jobType ||
+			currentTargetPath !== targetPath
 		) {
 			return;
 		}

--- a/src/ui/fileList/state.svelte.ts
+++ b/src/ui/fileList/state.svelte.ts
@@ -1,4 +1,4 @@
-import type { FileListInfo } from '../../types/audio';
+import type { AudioFile, FileListInfo } from '../../types/audio';
 
 type FileListSessionState = {
 	currentFileList: FileListInfo | null;
@@ -53,6 +53,16 @@ export function getSelectedFileIndex(): number {
 
 export function getSelectedFileIndices(): Set<number> {
 	return new Set(fileListSessionState.selectedFileIndices);
+}
+
+export function getSelectedFiles(): AudioFile[] {
+	const fileList = getCurrentFileList();
+	if (!fileList) {
+		return [];
+	}
+	return Array.from(getSelectedFileIndices())
+		.map((index) => fileList.files[index])
+		.filter((file): file is AudioFile => Boolean(file));
 }
 
 export function setSelectedFileIndices(indices: Set<number> | number[]): void {

--- a/src/ui/jobControls/index.ts
+++ b/src/ui/jobControls/index.ts
@@ -5,6 +5,7 @@ import { flushSync } from 'svelte';
 import { jobControlsState } from './state.svelte';
 import { updateOutputPath } from '../outputPanel';
 import { updateStatusPanelConcurrencyStatus } from '../statusPanel';
+import { refreshCoverArtDisplay } from '../coverArt';
 import { loadRuntimeSettingsCapabilities } from '../runtimeSettingsCapabilities.svelte';
 
 export function initJobControls(): void {
@@ -33,6 +34,7 @@ export function handleMaxConcurrentSelectionChange(value: string): void {
 
 function setJobType(jobType: JobType, emitChangeEvent: boolean): void {
 	jobControlsState.jobType = jobType;
+	refreshCoverArtDisplay();
 	if (emitChangeEvent) {
 		updateOutputPath('final');
 	}

--- a/src/ui/metadataForm.ts
+++ b/src/ui/metadataForm.ts
@@ -3,7 +3,7 @@ import {
 	getCurrentCoverArt,
 	getHasCustomCoverArt,
 	isCoverArtRemovalRequested,
-	setCoverArt,
+	refreshCoverArtDisplay,
 } from './coverArt';
 import {
 	resetMetadataFormPreviewState,
@@ -128,10 +128,7 @@ export function populateMetadataFormSingle(metadata: Partial<AudiobookMetadata>)
 		setMetadataFormPreviewValueByInputId(field.inputId, value);
 	}
 
-	if (!getHasCustomCoverArt()) {
-		setCoverArt(metadata.cover_art || null);
-	}
-
+	refreshCoverArtDisplay();
 	resetDirtyState();
 	updateTagPreview();
 }
@@ -176,10 +173,7 @@ export function populateMetadataFormMulti(
 		setMetadataFormPreviewValueByInputId(field.inputId, '');
 	}
 
-	if (!getHasCustomCoverArt()) {
-		setCoverArt(null);
-	}
-
+	refreshCoverArtDisplay();
 	resetDirtyState();
 	updateTagPreview();
 }

--- a/src/ui/metadataLookup/MetadataLookupIsland.svelte
+++ b/src/ui/metadataLookup/MetadataLookupIsland.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { tauriClient } from '../../lib/tauri/client';
 	import {
 		applyMetadataLookupResult,
 		closeMetadataLookup,
@@ -8,6 +9,10 @@
 		skipMetadataLookupQueueItem,
 		useManualMetadataEntryFromLookup,
 	} from '../metadataLookup';
+	import {
+		fetchMetadataLookupCoverPreview,
+		getMetadataLookupCoverPreviewState,
+	} from './metadataLookupCoverPreview.svelte';
 	import { metadataLookupState } from './state.svelte';
 
 	function handleBackdropClick(event: MouseEvent): void {
@@ -48,6 +53,11 @@
 			);
 		}
 		return parts.length ? parts.join(' • ') : 'Series: —';
+	}
+
+	function requestCoverPreview(index: number, coverUrl: string | null | undefined): void {
+		if (!coverUrl) return;
+		void fetchMetadataLookupCoverPreview(index, coverUrl, tauriClient.loadCoverArtFromUrl);
 	}
 
 	onMount(() => {
@@ -193,9 +203,27 @@
 					{/if}
 				{#each metadataLookupState.results as result, index}
 					<div class="app-modal-result">
-						<div class="metadata-lookup-cover">
+						<div
+							class="metadata-lookup-cover"
+							role="presentation"
+							onmouseenter={() => requestCoverPreview(index, result.coverUrl)}
+							onfocusin={() => requestCoverPreview(index, result.coverUrl)}
+						>
 							{#if result.coverUrl}
-								<span data-testid="metadata-lookup-cover-available">Art Available</span>
+								{@const preview = getMetadataLookupCoverPreviewState(index)}
+								{#if preview.status === 'ready'}
+									<img
+										src={preview.dataUrl}
+										alt={`${result.title} cover art`}
+										data-testid="metadata-lookup-cover-image"
+									/>
+								{:else if preview.status === 'loading'}
+									<span data-testid="metadata-lookup-cover-loading">Loading…</span>
+								{:else if preview.status === 'error'}
+									<span data-testid="metadata-lookup-cover-error">Preview failed</span>
+								{:else}
+									<span data-testid="metadata-lookup-cover-available">Art Available</span>
+								{/if}
 							{:else}
 								<span>No Art</span>
 							{/if}
@@ -260,6 +288,12 @@
 		color: var(--text-muted);
 		font-size: 0.7rem;
 		text-align: center;
+	}
+
+	.metadata-lookup-cover img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
 	}
 
 	.metadata-lookup-details {

--- a/src/ui/metadataLookup/MetadataLookupIsland.svelte
+++ b/src/ui/metadataLookup/MetadataLookupIsland.svelte
@@ -11,9 +11,17 @@
 	} from '../metadataLookup';
 	import {
 		fetchMetadataLookupCoverPreview,
-		getMetadataLookupCoverPreviewState,
+		metadataLookupCoverPreviewByIndex,
+		prefetchMetadataLookupCoverPreviews,
 	} from './metadataLookupCoverPreview.svelte';
 	import { metadataLookupState } from './state.svelte';
+
+	$effect(() => {
+		prefetchMetadataLookupCoverPreviews(
+			metadataLookupState.results,
+			tauriClient.loadCoverArtFromUrl,
+		);
+	});
 
 	function handleBackdropClick(event: MouseEvent): void {
 		if (event.target === event.currentTarget) {
@@ -210,7 +218,7 @@
 							onfocusin={() => requestCoverPreview(index, result.coverUrl)}
 						>
 							{#if result.coverUrl}
-								{@const preview = getMetadataLookupCoverPreviewState(index)}
+								{@const preview = metadataLookupCoverPreviewByIndex[index] ?? { status: 'idle' }}
 								{#if preview.status === 'ready'}
 									<img
 										src={preview.dataUrl}

--- a/src/ui/metadataLookup/MetadataLookupIsland.svelte
+++ b/src/ui/metadataLookup/MetadataLookupIsland.svelte
@@ -11,17 +11,9 @@
 	} from '../metadataLookup';
 	import {
 		fetchMetadataLookupCoverPreview,
-		metadataLookupCoverPreviewByIndex,
-		prefetchMetadataLookupCoverPreviews,
+		getMetadataLookupCoverPreviewState,
 	} from './metadataLookupCoverPreview.svelte';
 	import { metadataLookupState } from './state.svelte';
-
-	$effect(() => {
-		prefetchMetadataLookupCoverPreviews(
-			metadataLookupState.results,
-			tauriClient.loadCoverArtFromUrl,
-		);
-	});
 
 	function handleBackdropClick(event: MouseEvent): void {
 		if (event.target === event.currentTarget) {
@@ -63,9 +55,9 @@
 		return parts.length ? parts.join(' • ') : 'Series: —';
 	}
 
-	function requestCoverPreview(index: number, coverUrl: string | null | undefined): void {
+	function requestCoverPreview(coverUrl: string | null | undefined): void {
 		if (!coverUrl) return;
-		void fetchMetadataLookupCoverPreview(index, coverUrl, tauriClient.loadCoverArtFromUrl);
+		void fetchMetadataLookupCoverPreview(coverUrl, tauriClient.loadCoverArtFromUrl);
 	}
 
 	onMount(() => {
@@ -214,11 +206,11 @@
 						<div
 							class="metadata-lookup-cover"
 							role="presentation"
-							onmouseenter={() => requestCoverPreview(index, result.coverUrl)}
-							onfocusin={() => requestCoverPreview(index, result.coverUrl)}
+							onmouseenter={() => requestCoverPreview(result.coverUrl)}
+							onfocusin={() => requestCoverPreview(result.coverUrl)}
 						>
 							{#if result.coverUrl}
-								{@const preview = metadataLookupCoverPreviewByIndex[index] ?? { status: 'idle' }}
+								{@const preview = getMetadataLookupCoverPreviewState(result.coverUrl)}
 								{#if preview.status === 'ready'}
 									<img
 										src={preview.dataUrl}

--- a/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
+++ b/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
@@ -8,6 +8,10 @@ import type {
 	OnlineMetadataResult,
 } from '../../../types/metadata';
 import {
+	fetchMetadataLookupCoverPreview,
+	clearMetadataLookupCoverPreviewCache,
+} from '../metadataLookupCoverPreview.svelte';
+import {
 	makeMetadataLookupWorkflowServicesLayer,
 	MetadataLookupWorkflowFailed,
 	metadataLookupWorkflowExecution,
@@ -143,6 +147,7 @@ function makeHarness(options?: {
 	const clearCoverArt = vi.fn();
 	const setCoverArt = vi.fn();
 	const setCustomCoverArt = vi.fn();
+	const refreshCoverArtDisplay = vi.fn();
 	const searchOnlineMetadata = vi.fn(
 		options?.searchOnlineMetadata ?? (async () => lookupResponse()),
 	);
@@ -171,6 +176,7 @@ function makeHarness(options?: {
 		clearCoverArt,
 		setCoverArt,
 		setCustomCoverArt,
+		refreshCoverArtDisplay,
 		searchOnlineMetadata,
 		loadCoverArtFromUrl,
 		focusElementById,
@@ -200,6 +206,7 @@ function makeHarness(options?: {
 			clearCoverArt,
 			setCoverArt,
 			setCustomCoverArt,
+			refreshCoverArtDisplay,
 			searchOnlineMetadata,
 			loadCoverArtFromUrl,
 			focusElementById,
@@ -211,6 +218,25 @@ function makeHarness(options?: {
 }
 
 describe('MetadataLookupWorkflow', () => {
+	it('reuses cached lookup cover bytes when applying metadata', async () => {
+		clearMetadataLookupCoverPreviewCache();
+		const result = lookupResult({ coverUrl: 'https://example.com/cover.jpg' });
+		const harness = makeHarness({
+			lookupState: { results: [result], replaceCoverArt: true, isOpen: true },
+			queueState: {
+				queue: [{ file: audioFile('/books/alpha.m4b'), index: 0 }],
+				index: 0,
+			},
+			loadCoverArtFromUrl: async () => [9, 9, 9],
+		});
+
+		await fetchMetadataLookupCoverPreview(0, result.coverUrl!, harness.mocks.loadCoverArtFromUrl);
+		await runMetadataLookupWorkflow(harness.layer, { type: 'applyResult', index: 0 });
+
+		expect(harness.mocks.loadCoverArtFromUrl).toHaveBeenCalledTimes(1);
+		expect(harness.mocks.setCustomCoverArt).toHaveBeenCalledWith([9, 9, 9]);
+	});
+
 	it('opens with an error when no selected files are valid', async () => {
 		const harness = makeHarness({
 			selectedIndices: new Set<number>([0]),
@@ -510,8 +536,8 @@ describe('MetadataLookupWorkflow', () => {
 
 		await runMetadataLookupWorkflow(harness.layer, { type: 'skipQueueItem' });
 
-		expect(harness.mocks.clearCoverArt).toHaveBeenCalledTimes(1);
-		expect(harness.mocks.setCoverArt).toHaveBeenCalledWith([2]);
+		expect(harness.mocks.refreshCoverArtDisplay).toHaveBeenCalledTimes(1);
+		expect(harness.mocks.setCoverArt).not.toHaveBeenCalled();
 		expect(harness.lookupState.statusMessage).toBe('Queue complete.');
 	});
 

--- a/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
+++ b/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
@@ -230,11 +230,35 @@ describe('MetadataLookupWorkflow', () => {
 			loadCoverArtFromUrl: async () => [9, 9, 9],
 		});
 
-		await fetchMetadataLookupCoverPreview(0, result.coverUrl!, harness.mocks.loadCoverArtFromUrl);
+		await fetchMetadataLookupCoverPreview(result.coverUrl!, harness.mocks.loadCoverArtFromUrl);
 		await runMetadataLookupWorkflow(harness.layer, { type: 'applyResult', index: 0 });
 
 		expect(harness.mocks.loadCoverArtFromUrl).toHaveBeenCalledTimes(1);
 		expect(harness.mocks.setCustomCoverArt).toHaveBeenCalledWith([9, 9, 9]);
+	});
+
+	it('does not reuse cached lookup cover bytes for a different URL at the same result index', async () => {
+		clearMetadataLookupCoverPreviewCache();
+		const firstCoverUrl = 'https://example.com/first.jpg';
+		const secondCoverUrl = 'https://example.com/second.jpg';
+		const result = lookupResult({ coverUrl: secondCoverUrl });
+		const loadCoverArtFromUrl = vi.fn(async (url: string) =>
+			url === firstCoverUrl ? [1, 1, 1] : [2, 2, 2],
+		);
+		const harness = makeHarness({
+			lookupState: { results: [result], replaceCoverArt: true, isOpen: true },
+			queueState: {
+				queue: [{ file: audioFile('/books/alpha.m4b'), index: 0 }],
+				index: 0,
+			},
+			loadCoverArtFromUrl,
+		});
+
+		await fetchMetadataLookupCoverPreview(firstCoverUrl, harness.mocks.loadCoverArtFromUrl);
+		await runMetadataLookupWorkflow(harness.layer, { type: 'applyResult', index: 0 });
+
+		expect(harness.mocks.loadCoverArtFromUrl).toHaveBeenCalledWith(secondCoverUrl);
+		expect(harness.mocks.setCustomCoverArt).toHaveBeenCalledWith([2, 2, 2]);
 	});
 
 	it('opens with an error when no selected files are valid', async () => {

--- a/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
+++ b/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
@@ -1,0 +1,65 @@
+import { coverArtBytesToDataUrl } from '../coverArt';
+
+export type MetadataLookupCoverPreviewState =
+	| { status: 'idle' }
+	| { status: 'loading' }
+	| { status: 'ready'; bytes: number[]; dataUrl: string }
+	| { status: 'error' };
+
+export const metadataLookupCoverPreviewByIndex = $state<Record<number, MetadataLookupCoverPreviewState>>(
+	{},
+);
+
+const inflightByIndex = new Map<number, Promise<void>>();
+
+export function clearMetadataLookupCoverPreviewCache(): void {
+	for (const key of Object.keys(metadataLookupCoverPreviewByIndex)) {
+		delete metadataLookupCoverPreviewByIndex[Number(key)];
+	}
+	inflightByIndex.clear();
+}
+
+export function getMetadataLookupCoverPreviewState(
+	index: number,
+): MetadataLookupCoverPreviewState {
+	return metadataLookupCoverPreviewByIndex[index] ?? { status: 'idle' };
+}
+
+export function getCachedMetadataLookupCoverBytes(index: number): number[] | null {
+	const state = metadataLookupCoverPreviewByIndex[index];
+	return state?.status === 'ready' ? state.bytes : null;
+}
+
+export async function fetchMetadataLookupCoverPreview(
+	index: number,
+	coverUrl: string,
+	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
+): Promise<void> {
+	const existing = metadataLookupCoverPreviewByIndex[index];
+	if (existing?.status === 'ready') {
+		return;
+	}
+	const inflight = inflightByIndex.get(index);
+	if (inflight) {
+		return inflight;
+	}
+
+	metadataLookupCoverPreviewByIndex[index] = { status: 'loading' };
+	const promise = loadCoverArtFromUrl(coverUrl)
+		.then((bytes) => {
+			metadataLookupCoverPreviewByIndex[index] = {
+				status: 'ready',
+				bytes,
+				dataUrl: coverArtBytesToDataUrl(bytes),
+			};
+		})
+		.catch(() => {
+			metadataLookupCoverPreviewByIndex[index] = { status: 'error' };
+		})
+		.finally(() => {
+			inflightByIndex.delete(index);
+		});
+
+	inflightByIndex.set(index, promise);
+	return promise;
+}

--- a/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
+++ b/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
@@ -6,72 +6,61 @@ export type MetadataLookupCoverPreviewState =
 	| { status: 'ready'; bytes: number[]; dataUrl: string }
 	| { status: 'error' };
 
-export const metadataLookupCoverPreviewByIndex = $state<Record<number, MetadataLookupCoverPreviewState>>(
-	{},
-);
+const metadataLookupCoverPreviewByUrl = $state<Record<string, MetadataLookupCoverPreviewState>>({});
 
-const inflightByIndex = new Map<number, Promise<void>>();
+const inflightByUrl = new Map<string, Promise<void>>();
 
 export function clearMetadataLookupCoverPreviewCache(): void {
-	for (const key of Object.keys(metadataLookupCoverPreviewByIndex)) {
-		delete metadataLookupCoverPreviewByIndex[Number(key)];
+	for (const key of Object.keys(metadataLookupCoverPreviewByUrl)) {
+		delete metadataLookupCoverPreviewByUrl[key];
 	}
-	inflightByIndex.clear();
+	inflightByUrl.clear();
 }
 
 export function getMetadataLookupCoverPreviewState(
-	index: number,
+	coverUrl: string | null | undefined,
 ): MetadataLookupCoverPreviewState {
-	return metadataLookupCoverPreviewByIndex[index] ?? { status: 'idle' };
+	if (!coverUrl) {
+		return { status: 'idle' };
+	}
+	return metadataLookupCoverPreviewByUrl[coverUrl] ?? { status: 'idle' };
 }
 
-export function getCachedMetadataLookupCoverBytes(index: number): number[] | null {
-	const state = metadataLookupCoverPreviewByIndex[index];
+export function getCachedMetadataLookupCoverBytes(coverUrl: string): number[] | null {
+	const state = metadataLookupCoverPreviewByUrl[coverUrl];
 	return state?.status === 'ready' ? state.bytes : null;
 }
 
 export async function fetchMetadataLookupCoverPreview(
-	index: number,
 	coverUrl: string,
 	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
 ): Promise<void> {
-	const existing = metadataLookupCoverPreviewByIndex[index];
+	const existing = metadataLookupCoverPreviewByUrl[coverUrl];
 	if (existing?.status === 'ready') {
 		return;
 	}
-	const inflight = inflightByIndex.get(index);
+	const inflight = inflightByUrl.get(coverUrl);
 	if (inflight) {
 		return inflight;
 	}
 
-	metadataLookupCoverPreviewByIndex[index] = { status: 'loading' };
+	metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'loading' };
 	const promise = loadCoverArtFromUrl(coverUrl)
 		.then((bytes) => {
-			metadataLookupCoverPreviewByIndex[index] = {
+			metadataLookupCoverPreviewByUrl[coverUrl] = {
 				status: 'ready',
 				bytes,
 				dataUrl: coverArtBytesToDataUrl(bytes),
 			};
 		})
-		.catch(() => {
-			metadataLookupCoverPreviewByIndex[index] = { status: 'error' };
+		.catch((error) => {
+			console.warn('Failed to load metadata lookup cover preview:', error);
+			metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'error' };
 		})
 		.finally(() => {
-			inflightByIndex.delete(index);
+			inflightByUrl.delete(coverUrl);
 		});
 
-	inflightByIndex.set(index, promise);
+	inflightByUrl.set(coverUrl, promise);
 	return promise;
-}
-
-export function prefetchMetadataLookupCoverPreviews(
-	results: ReadonlyArray<{ coverUrl: string | null | undefined }>,
-	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
-): void {
-	for (const [index, result] of results.entries()) {
-		if (!result.coverUrl) {
-			continue;
-		}
-		void fetchMetadataLookupCoverPreview(index, result.coverUrl, loadCoverArtFromUrl);
-	}
 }

--- a/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
+++ b/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
@@ -63,3 +63,15 @@ export async function fetchMetadataLookupCoverPreview(
 	inflightByIndex.set(index, promise);
 	return promise;
 }
+
+export function prefetchMetadataLookupCoverPreviews(
+	results: ReadonlyArray<{ coverUrl: string | null | undefined }>,
+	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
+): void {
+	for (const [index, result] of results.entries()) {
+		if (!result.coverUrl) {
+			continue;
+		}
+		void fetchMetadataLookupCoverPreview(index, result.coverUrl, loadCoverArtFromUrl);
+	}
+}

--- a/src/ui/metadataLookup/metadataLookupWorkflow.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflow.ts
@@ -28,6 +28,9 @@ import {
 	type MetadataLookupWorkflowServices,
 	type MetadataLookupWorkflowServicesId,
 } from './metadataLookupWorkflowServices';
+import {
+	getCachedMetadataLookupCoverBytes,
+} from './metadataLookupCoverPreview.svelte';
 
 export {
 	MetadataLookupWorkflowServicesTag,
@@ -132,7 +135,7 @@ async function advanceQueue(
 	const nextIndex = index + 1;
 	const nextItem = queue[nextIndex];
 
-	services.clearCoverArt();
+	services.refreshCoverArtDisplay();
 
 	if (nextItem) {
 		await services.selectFile(
@@ -162,10 +165,13 @@ async function advanceQueue(
 async function applyCoverArt(
 	services: MetadataLookupWorkflowServices,
 	result: OnlineMetadataResult,
+	resultIndex: number,
 ): Promise<CoverArtApplyResult> {
 	if (!result.coverUrl) return { status: 'notRequested' };
 	try {
-		const coverBytes = await services.loadCoverArtFromUrl(result.coverUrl);
+		const cachedBytes = getCachedMetadataLookupCoverBytes(resultIndex);
+		const coverBytes =
+			cachedBytes ?? (await services.loadCoverArtFromUrl(result.coverUrl));
 		services.setCustomCoverArt(coverBytes);
 		return { status: 'applied', bytes: coverBytes };
 	} catch (error) {
@@ -177,6 +183,7 @@ async function applyCoverArt(
 async function applyResult(
 	services: MetadataLookupWorkflowServices,
 	result: OnlineMetadataResult,
+	resultIndex: number,
 ): Promise<void> {
 	const queue = services.getQueueState().queue;
 	if (queue.length === 0) {
@@ -200,7 +207,7 @@ async function applyResult(
 	let queueCoverState: QueueCoverState = { intent: 'keep' };
 	let coverArtFailed = false;
 	if (services.getLookupState().replaceCoverArt) {
-		const coverArtResult = await applyCoverArt(services, result);
+		const coverArtResult = await applyCoverArt(services, result, resultIndex);
 		if (coverArtResult.status === 'applied' && coverArtResult.bytes.length > 0) {
 			queueCoverState = { intent: 'replace', bytes: coverArtResult.bytes };
 		} else if (coverArtResult.status === 'failed') {
@@ -342,7 +349,7 @@ function metadataLookupWorkflowBody(
 				yield* workflowPromise(async () => {
 					const result = services.getLookupState().results[action.index];
 					if (!result) return;
-					await applyResult(services, result);
+					await applyResult(services, result, action.index);
 				}, 'Failed to apply metadata lookup result.');
 				return;
 			}

--- a/src/ui/metadataLookup/metadataLookupWorkflow.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflow.ts
@@ -28,9 +28,7 @@ import {
 	type MetadataLookupWorkflowServices,
 	type MetadataLookupWorkflowServicesId,
 } from './metadataLookupWorkflowServices';
-import {
-	getCachedMetadataLookupCoverBytes,
-} from './metadataLookupCoverPreview.svelte';
+import { getCachedMetadataLookupCoverBytes } from './metadataLookupCoverPreview.svelte';
 
 export {
 	MetadataLookupWorkflowServicesTag,
@@ -165,13 +163,11 @@ async function advanceQueue(
 async function applyCoverArt(
 	services: MetadataLookupWorkflowServices,
 	result: OnlineMetadataResult,
-	resultIndex: number,
 ): Promise<CoverArtApplyResult> {
 	if (!result.coverUrl) return { status: 'notRequested' };
 	try {
-		const cachedBytes = getCachedMetadataLookupCoverBytes(resultIndex);
-		const coverBytes =
-			cachedBytes ?? (await services.loadCoverArtFromUrl(result.coverUrl));
+		const cachedBytes = getCachedMetadataLookupCoverBytes(result.coverUrl);
+		const coverBytes = cachedBytes ?? (await services.loadCoverArtFromUrl(result.coverUrl));
 		services.setCustomCoverArt(coverBytes);
 		return { status: 'applied', bytes: coverBytes };
 	} catch (error) {
@@ -183,7 +179,6 @@ async function applyCoverArt(
 async function applyResult(
 	services: MetadataLookupWorkflowServices,
 	result: OnlineMetadataResult,
-	resultIndex: number,
 ): Promise<void> {
 	const queue = services.getQueueState().queue;
 	if (queue.length === 0) {
@@ -207,7 +202,7 @@ async function applyResult(
 	let queueCoverState: QueueCoverState = { intent: 'keep' };
 	let coverArtFailed = false;
 	if (services.getLookupState().replaceCoverArt) {
-		const coverArtResult = await applyCoverArt(services, result, resultIndex);
+		const coverArtResult = await applyCoverArt(services, result);
 		if (coverArtResult.status === 'applied' && coverArtResult.bytes.length > 0) {
 			queueCoverState = { intent: 'replace', bytes: coverArtResult.bytes };
 		} else if (coverArtResult.status === 'failed') {
@@ -349,7 +344,7 @@ function metadataLookupWorkflowBody(
 				yield* workflowPromise(async () => {
 					const result = services.getLookupState().results[action.index];
 					if (!result) return;
-					await applyResult(services, result, action.index);
+					await applyResult(services, result);
 				}, 'Failed to apply metadata lookup result.');
 				return;
 			}

--- a/src/ui/metadataLookup/metadataLookupWorkflowDomain.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflowDomain.ts
@@ -2,6 +2,7 @@ import type { AudioFile } from '../../types/audio';
 import type { AudiobookMetadata, MetadataSource, OnlineMetadataResult } from '../../types/metadata';
 import type { MetadataIntentPatch } from '../../types/metadataIntent';
 import { applyMetadataDraftIntent, buildMetadataDraftIntent } from '../metadataDraft';
+import { clearMetadataLookupCoverPreviewCache } from './metadataLookupCoverPreview.svelte';
 import type { MetadataLookupWorkflowServices } from './metadataLookupWorkflowServices';
 
 export type ApplyMode = 'current' | 'queue';
@@ -75,6 +76,7 @@ export function resetResults(services: MetadataLookupWorkflowServices): void {
 	const state = services.getLookupState();
 	state.results = [];
 	state.hasSearched = false;
+	clearMetadataLookupCoverPreviewCache();
 }
 
 export function buildQueueMetadataPatch(
@@ -110,12 +112,9 @@ export function persistQueueMetadata(
 
 export function restoreCoverArtForFile(
 	services: MetadataLookupWorkflowServices,
-	file: AudioFile | null,
+	_file: AudioFile | null,
 ): void {
-	services.clearCoverArt();
-	if (!file?.isValid) return;
-	const stored = services.getMetadataForFile(file.path);
-	services.setCoverArt(stored?.cover_art ?? null);
+	services.refreshCoverArtDisplay();
 }
 
 export function mapResultToMetadata(result: OnlineMetadataResult): Partial<AudiobookMetadata> {

--- a/src/ui/metadataLookup/metadataLookupWorkflowLive.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflowLive.ts
@@ -1,5 +1,5 @@
 import { tauriClient } from '../../lib/tauri/client';
-import { clearCoverArt, setCoverArt, setCustomCoverArt } from '../coverArt';
+import { clearCoverArt, refreshCoverArtDisplay, setCoverArt, setCustomCoverArt } from '../coverArt';
 import { selectFile } from '../fileList/actions';
 import { getCurrentFileList, getSelectedFileIndices } from '../fileList/state.svelte';
 import { applyMetadataToForm, readMetadataForm } from '../metadataForm';
@@ -37,6 +37,7 @@ const liveMetadataLookupWorkflowServices: MetadataLookupWorkflowServices = {
 	clearCoverArt,
 	setCoverArt,
 	setCustomCoverArt,
+	refreshCoverArtDisplay,
 	searchOnlineMetadata: tauriClient.searchOnlineMetadata,
 	loadCoverArtFromUrl: tauriClient.loadCoverArtFromUrl,
 	focusElementById: (id) => {

--- a/src/ui/metadataLookup/metadataLookupWorkflowServices.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflowServices.ts
@@ -36,6 +36,7 @@ export interface MetadataLookupWorkflowServices {
 	clearCoverArt: () => void;
 	setCoverArt: (coverArtBytes: number[] | null) => void;
 	setCustomCoverArt: (coverArtBytes: number[] | null) => void;
+	refreshCoverArtDisplay: () => void;
 	searchOnlineMetadata: typeof tauriClient.searchOnlineMetadata;
 	loadCoverArtFromUrl: typeof tauriClient.loadCoverArtFromUrl;
 	focusElementById: (id: string) => void;

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -344,6 +344,46 @@ describe('startProcessing metadata staging', () => {
 		);
 	});
 
+	it('mirrors merge cover intent onto the merge key when a non-first file is selected', async () => {
+		context.getSelectedFileIndexMock.mockReturnValue(1);
+		context.getSelectedFileIndicesMock.mockReturnValue(new Set([1]));
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
+		context.readMetadataFormMock.mockReturnValue({ cover_art: [7, 7, 7] });
+		context.getMetadataForFileMock.mockReturnValue({});
+		context.getMetadataIntentPatchForFileMock.mockImplementation((filePath: string) => {
+			if (filePath === '/books/a.m4b') {
+				return { cover_art: { op: 'set', value: [7, 7, 7] } };
+			}
+			return undefined;
+		});
+
+		await startProcessing(processingContext());
+
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
+			'/books/b.m4b',
+			expect.any(Object),
+			expect.objectContaining({
+				intentPatch: { cover_art: { op: 'set', value: [7, 7, 7] } },
+				markPending: true,
+			}),
+		);
+		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
+			'/books/a.m4b',
+			expect.any(Object),
+			expect.objectContaining({
+				intentPatch: { cover_art: { op: 'set', value: [7, 7, 7] } },
+				markPending: true,
+			}),
+		);
+		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadataIntent: {
+					'/books/a.m4b': { cover_art: { op: 'set', value: [7, 7, 7] } },
+				},
+			}),
+		);
+	});
+
 	it('keeps batch metadata intent entries, including clear-intent values', async () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);

--- a/src/ui/statusPanel/processingWorkflowPreparation.ts
+++ b/src/ui/statusPanel/processingWorkflowPreparation.ts
@@ -77,6 +77,41 @@ function stageMultiSelectionMetadata(
 	});
 }
 
+function stageMetadataIntentForFile(
+	services: ProcessingWorkflowServices,
+	filePath: string,
+	intentPatch: MetadataIntentPatch,
+): void {
+	const existing = services.getMetadataForFile(filePath) ?? {};
+	const currentMetadata = applyMetadataDraftIntent(existing, intentPatch);
+	services.setMetadataForFile(filePath, currentMetadata, {
+		markPending: true,
+		intentPatch,
+	});
+}
+
+function ensureMergeCoverIntentOnMergeKey(
+	services: ProcessingWorkflowServices,
+	fileList: FileListInfo,
+	intentPatch: MetadataIntentPatch,
+	activeFilePath: string | undefined,
+): void {
+	if (services.getJobType() !== 'merge') {
+		return;
+	}
+	const coverIntent = intentPatch.cover_art;
+	if (!coverIntent || coverIntent.op === 'noop') {
+		return;
+	}
+
+	const mergeKey = validInputFilePaths(fileList)[0];
+	if (!mergeKey || activeFilePath === mergeKey) {
+		return;
+	}
+
+	stageMetadataIntentForFile(services, mergeKey, { cover_art: coverIntent });
+}
+
 function stageSingleSelectionMetadata(
 	services: ProcessingWorkflowServices,
 	fileList: FileListInfo,
@@ -106,14 +141,8 @@ function stageSingleSelectionMetadata(
 				? fileList.files[selectedFileIndex]
 				: fileList.files.find((file) => file.isValid);
 		if (activeFile?.isValid && hasActionableMetadataDraftIntent(intentPatch)) {
-			const existing = services.getMetadataForFile(activeFile.path) ?? {};
-			const currentMetadata = applyMetadataDraftIntent(existing, intentPatch);
-			yield* Effect.sync(() =>
-				services.setMetadataForFile(activeFile.path, currentMetadata, {
-					markPending: true,
-					intentPatch,
-				}),
-			);
+			stageMetadataIntentForFile(services, activeFile.path, intentPatch);
+			ensureMergeCoverIntentOnMergeKey(services, fileList, intentPatch, activeFile.path);
 		}
 
 		return true;


### PR DESCRIPTION
## Summary

- Introduces mode-keyed cover ownership (`coverOwner.ts`): merge commits to the first valid input file; batch commits to selected file(s) only.
- Reworks cover session APIs so preview and output read the same effective cover via intent patches + `refreshCoverArtDisplay()`.
- Restores metadata lookup cover thumbnails through backend-validated `loadCoverArtFromUrl` (lazy fetch + cache reuse on apply) without placing provider URLs in the DOM.
- Adds merge processing safety net to mirror cover intent onto the merge key when a non-first file is selected at process time.

Fixes post-v1.1.0 cover art regressions:
- **#3 (v1.1.0 regression):** lookup modal showed "Art Available" after `606e0c80` security hardening.
- **#1/#2 (architectural):** global cover session vs per-file/merge-key intent drift caused preview bleed and output mismatch.

No IPC or generated binding changes.

## Test plan

- [x] `bun run test --` cover owner, cover island, owner integration, metadata panel, metadata save, file list select, lookup island/queue/workflow, processing staging/workflow (91 tests)
- [x] `bun run typecheck`
- [x] `git diff --check`

Manual checks recommended:
- [ ] Merge: load custom cover while a non-first file is selected → output embeds custom cover
- [ ] Batch: cycle files → distinct cover previews; custom cover applies to selected file only
- [ ] Find Metadata Online: hover result → thumbnail before apply; no raw provider URL in DOM


Made with [Cursor](https://cursor.com)