### PR TITLE
fix: eager secure metadata cover previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to AudioBook Boss™ will be documented in this file.
 - Cover art ownership now follows output mode consistently: merge cover updates
   commit to the merge key, batch updates apply only to one selected file, and
   batch multi-select ignores cover-art commits.
-- Metadata lookup cover previews stay backend-proxied and URL-keyed while
-  loading lazily on preview hover/focus to avoid stale thumbnails and eager
-  result-list fetches.
+- Metadata lookup cover previews now load automatically through a bounded,
+  backend-proxied scheduler while preserving URL-keyed cache and stale-result
+  guards.
+- Audible acquisition validation now moves materialized audio probing and hash
+  work off the async executor.
 
 ## [1.1.0] - 2026-06-09
 

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -10,7 +10,7 @@ use reqwest::header::CONTENT_TYPE;
 use std::io;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 pub(crate) mod save_batch;
@@ -118,47 +118,7 @@ pub async fn load_cover_art_file(file_path: String) -> CommandResult<Vec<u8>> {
 pub async fn load_cover_art_from_url(url: String) -> CommandResult<Vec<u8>> {
     let validated_url = validate_cover_art_url(&url)?;
     let url_for_log = validated_url.as_str().to_string();
-    let resolver = Arc::new(BogonFilteringResolver::new());
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(COVER_ART_FETCH_TIMEOUT_SECS))
-        .dns_resolver(resolver)
-        .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            let redirect_count = attempt.previous().len();
-            if redirect_count >= COVER_ART_MAX_REDIRECTS {
-                log::warn!(
-                    "Blocked redirect due to limit (count={}): {}",
-                    redirect_count,
-                    attempt.url()
-                );
-                return attempt.error("too many redirects");
-            }
-
-            let url = attempt.url();
-            if url.scheme() != "https" {
-                log::warn!("Blocked redirect to non-HTTPS URL: {}", url);
-                return attempt.error("Only HTTPS URLs are supported");
-            }
-
-            let Some(host) = url.host_str() else {
-                log::warn!("Blocked redirect without host: {}", url);
-                return attempt.error("Redirect URL has no host");
-            };
-
-            if let Ok(ip) = host.parse::<IpAddr>() {
-                if bogon::is_bogon(ip) {
-                    log::warn!("Blocked redirect to bogon IP {} for host {}", ip, host);
-                    return attempt.error("Redirect to private IP blocked");
-                }
-            }
-
-            attempt.follow()
-        }))
-        .user_agent("audiobook-boss/cover-art")
-        .build()
-        .map_err(|e| {
-            log::error!("Failed to configure HTTP client: {}", e);
-            AppError::General("Failed to configure HTTP client".to_string())
-        })?;
+    let client = cover_art_http_client()?;
 
     let mut response = client.get(validated_url).send().await.map_err(|e| {
         log::error!("Failed to fetch image URL {}: {}", url_for_log, e);
@@ -213,6 +173,60 @@ pub async fn load_cover_art_from_url(url: String) -> CommandResult<Vec<u8>> {
 
     let optimized = optimize_cover_art(&downloaded)?;
     Ok(optimized)
+}
+
+static COVER_ART_HTTP_CLIENT: OnceLock<std::result::Result<reqwest::Client, String>> =
+    OnceLock::new();
+
+fn cover_art_http_client() -> Result<&'static reqwest::Client> {
+    COVER_ART_HTTP_CLIENT
+        .get_or_init(build_cover_art_http_client)
+        .as_ref()
+        .map_err(|message| {
+            log::error!("Failed to configure HTTP client: {}", message);
+            AppError::General("Failed to configure HTTP client".to_string())
+        })
+}
+
+fn build_cover_art_http_client() -> std::result::Result<reqwest::Client, String> {
+    let resolver = Arc::new(BogonFilteringResolver::new());
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(COVER_ART_FETCH_TIMEOUT_SECS))
+        .dns_resolver(resolver)
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            let redirect_count = attempt.previous().len();
+            if redirect_count >= COVER_ART_MAX_REDIRECTS {
+                log::warn!(
+                    "Blocked redirect due to limit (count={}): {}",
+                    redirect_count,
+                    attempt.url()
+                );
+                return attempt.error("too many redirects");
+            }
+
+            let url = attempt.url();
+            if url.scheme() != "https" {
+                log::warn!("Blocked redirect to non-HTTPS URL: {}", url);
+                return attempt.error("Only HTTPS URLs are supported");
+            }
+
+            let Some(host) = url.host_str() else {
+                log::warn!("Blocked redirect without host: {}", url);
+                return attempt.error("Redirect URL has no host");
+            };
+
+            if let Ok(ip) = host.parse::<IpAddr>() {
+                if bogon::is_bogon(ip) {
+                    log::warn!("Blocked redirect to bogon IP {} for host {}", ip, host);
+                    return attempt.error("Redirect to private IP blocked");
+                }
+            }
+
+            attempt.follow()
+        }))
+        .user_agent("audiobook-boss/cover-art")
+        .build()
+        .map_err(|error| error.to_string())
 }
 
 /// Maximum dimension for cover art (width or height)

--- a/src-tauri/src/remote_source/providers/audible/acquisition.rs
+++ b/src-tauri/src/remote_source/providers/audible/acquisition.rs
@@ -289,6 +289,7 @@ async fn acquire_one(
         .map_err(AudibleAcquisitionError::materialization)?
     };
     let file = validate_materialized_audio(&materialized_path, ctx, progress)
+        .await
         .map_err(AudibleAcquisitionError::validation)?;
     let supplemental_pdf_hint_present =
         supplemental_pdf_hint_present_for_acquisition(include_pdf, &title_details, &lane);
@@ -379,7 +380,7 @@ pub(super) fn requested_supplemental_pdf_is_required(
     include_pdf && api_pdf_hint_present
 }
 
-fn validate_materialized_audio(
+async fn validate_materialized_audio(
     materialized_path: &Path,
     ctx: TitleAcquisitionCtx<'_>,
     progress: &mut impl FnMut(AcquisitionProgress),
@@ -389,10 +390,28 @@ fn validate_materialized_audio(
         progress_context,
         ..
     } = ctx;
-    let file = match materialized_file_from_path(title_id, materialized_path) {
+    let title_id = title_id.to_string();
+    let materialized_path = materialized_path.to_path_buf();
+    let validation_result =
+        tokio::task::spawn_blocking(move || {
+            match materialized_file_from_path(&title_id, &materialized_path) {
+                Ok(file) => Ok(file),
+                Err(error) => {
+                    cleanup_download_artifacts(&materialized_path)?;
+                    Err(error)
+                }
+            }
+        })
+        .await
+        .map_err(|error| {
+            AppError::General(format!(
+                "Materialized audio validation task failed: {error}"
+            ))
+        })?;
+
+    let file = match validation_result {
         Ok(file) => file,
         Err(error) => {
-            cleanup_download_artifacts(materialized_path)?;
             progress(title_progress(
                 progress_context,
                 AcquisitionStage::Failed,

--- a/src-tauri/src/remote_source/providers/audible/acquisition.rs
+++ b/src-tauri/src/remote_source/providers/audible/acquisition.rs
@@ -397,7 +397,14 @@ async fn validate_materialized_audio(
             match materialized_file_from_path(&title_id, &materialized_path) {
                 Ok(file) => Ok(file),
                 Err(error) => {
-                    cleanup_download_artifacts(&materialized_path)?;
+                    if let Err(cleanup_error) = cleanup_download_artifacts(&materialized_path) {
+                        log::warn!(
+                            "remote_source audible stage=validation_cleanup_failed title_ref={} path={} error={}",
+                            title_ref(&title_id),
+                            sanitize_path_for_display(&materialized_path),
+                            cleanup_error
+                        );
+                    }
                     Err(error)
                 }
             }

--- a/src/ui/__tests__/metadataLookup-island.test.ts
+++ b/src/ui/__tests__/metadataLookup-island.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import MetadataLookupIsland from '../metadataLookup/MetadataLookupIsland.svelte';
 
 const { loadCoverArtFromUrlMock } = vi.hoisted(() => ({
@@ -76,7 +76,7 @@ describe('MetadataLookup island mount', () => {
 		expect(document.getElementById('metadata-lookup-skip-btn')).toBeTruthy();
 	});
 
-	it('loads cover previews through the backend without exposing provider URLs', async () => {
+	it('eagerly loads cover previews through the backend without exposing provider URLs', async () => {
 		initMetadataLookup();
 		metadataLookupState.isOpen = true;
 		metadataLookupState.hasSearched = true;
@@ -119,13 +119,13 @@ describe('MetadataLookup island mount', () => {
 
 		const coverAreas = document.querySelectorAll('.metadata-lookup-cover');
 		expect(coverAreas.length).toBe(2);
-		expect(loadCoverArtFromUrlMock).not.toHaveBeenCalled();
-
-		await fireEvent.mouseEnter(coverAreas[0]);
 
 		await waitFor(() => {
 			expect(loadCoverArtFromUrlMock).toHaveBeenCalledWith(
 				'https://covers.example.com/private-cover.jpg',
+			);
+			expect(loadCoverArtFromUrlMock).toHaveBeenCalledWith(
+				'https://covers.example.com/loopback-cover.jpg',
 			);
 		});
 

--- a/src/ui/__tests__/metadataLookup-queue-cover-art.test.ts
+++ b/src/ui/__tests__/metadataLookup-queue-cover-art.test.ts
@@ -246,7 +246,8 @@ describe('metadata lookup queue cover art isolation', () => {
 		await runSearchAndApply();
 
 		await waitForStatus('Metadata applied. Found 1 results.');
-		expect(context.loadCoverArtFromUrlMock).not.toHaveBeenCalled();
+		expect(context.loadCoverArtFromUrlMock).toHaveBeenCalledWith('https://example.com/cover.jpg');
+		expect(context.setCustomCoverArtMock).not.toHaveBeenCalled();
 		expect(context.setMetadataForFileMock).toHaveBeenCalledWith(
 			'/books/alpha.m4b',
 			expect.objectContaining({ cover_art: [1, 1, 1] }),
@@ -279,7 +280,7 @@ describe('metadata lookup queue cover art isolation', () => {
 		expect(writesByPath.get('/books/beta.m4b')).toEqual(
 			expect.objectContaining({ cover_art: [2, 2, 2] }),
 		);
-		expect(context.loadCoverArtFromUrlMock).toHaveBeenCalledTimes(1);
+		expect(context.loadCoverArtFromUrlMock).toHaveBeenCalledTimes(2);
 		expect(context.refreshCoverArtDisplayMock).toHaveBeenCalled();
 	});
 

--- a/src/ui/metadataLookup/AGENTS.md
+++ b/src/ui/metadataLookup/AGENTS.md
@@ -1,0 +1,20 @@
+# Metadata Lookup Directives
+
+## Scope
+
+- Applies to metadata lookup modal search, result comparison, safe cover preview
+  loading, result application, and queue advancement under `src/ui/metadataLookup/`.
+
+## Hard Invariants
+
+- Metadata lookup is a decision surface: visible result data needed to choose an
+  action must load from app-owned state scheduling, not hover, focus, or scroll
+  triggers.
+- Provider-controlled remote media URLs must not be rendered directly into DOM
+  attributes. Cover previews route through the Tauri cover-art loader and render
+  only app-owned data URLs from backend-validated bytes.
+
+## Done Criteria
+
+- Preview scheduler, island rendering, and apply workflow behavior stay covered
+  by focused Vitest tests.

--- a/src/ui/metadataLookup/MetadataLookupIsland.svelte
+++ b/src/ui/metadataLookup/MetadataLookupIsland.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { tauriClient } from '../../lib/tauri/client';
 	import {
 		applyMetadataLookupResult,
@@ -10,8 +10,9 @@
 		useManualMetadataEntryFromLookup,
 	} from '../metadataLookup';
 	import {
-		fetchMetadataLookupCoverPreview,
+		cancelMetadataLookupCoverPreviewSchedule,
 		getMetadataLookupCoverPreviewState,
+		scheduleMetadataLookupCoverPreviews,
 	} from './metadataLookupCoverPreview.svelte';
 	import { metadataLookupState } from './state.svelte';
 
@@ -55,13 +56,24 @@
 		return parts.length ? parts.join(' • ') : 'Series: —';
 	}
 
-	function requestCoverPreview(coverUrl: string | null | undefined): void {
-		if (!coverUrl) return;
-		void fetchMetadataLookupCoverPreview(coverUrl, tauriClient.loadCoverArtFromUrl);
-	}
-
 	onMount(() => {
 		initMetadataLookup();
+	});
+
+	$effect(() => {
+		if (!metadataLookupState.isOpen || !metadataLookupState.hasSearched) {
+			untrack(cancelMetadataLookupCoverPreviewSchedule);
+			return;
+		}
+
+		const coverUrls = metadataLookupState.results.map((result) => result.coverUrl);
+		untrack(() => {
+			scheduleMetadataLookupCoverPreviews(coverUrls, tauriClient.loadCoverArtFromUrl);
+		});
+
+		return () => {
+			untrack(cancelMetadataLookupCoverPreviewSchedule);
+		};
 	});
 </script>
 
@@ -206,8 +218,6 @@
 						<div
 							class="metadata-lookup-cover"
 							role="presentation"
-							onmouseenter={() => requestCoverPreview(result.coverUrl)}
-							onfocusin={() => requestCoverPreview(result.coverUrl)}
 						>
 							{#if result.coverUrl}
 								{@const preview = getMetadataLookupCoverPreviewState(result.coverUrl)}
@@ -217,7 +227,7 @@
 										alt={`${result.title} cover art`}
 										data-testid="metadata-lookup-cover-image"
 									/>
-								{:else if preview.status === 'loading'}
+								{:else if preview.status === 'loading' || preview.status === 'queued'}
 									<span data-testid="metadata-lookup-cover-loading">Loading…</span>
 								{:else if preview.status === 'error'}
 									<span data-testid="metadata-lookup-cover-error">Preview failed</span>

--- a/src/ui/metadataLookup/__tests__/metadataLookupCoverPreview.test.ts
+++ b/src/ui/metadataLookup/__tests__/metadataLookupCoverPreview.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	cancelMetadataLookupCoverPreviewSchedule,
+	clearMetadataLookupCoverPreviewCache,
+	getMetadataLookupCoverPreviewState,
+	loadMetadataLookupCoverBytes,
+	scheduleMetadataLookupCoverPreviews,
+} from '../metadataLookupCoverPreview.svelte';
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+async function flushAsync(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe('metadata lookup cover preview scheduler', () => {
+	beforeEach(() => {
+		clearMetadataLookupCoverPreviewCache();
+	});
+
+	it('bounds eager preview concurrency', async () => {
+		const requests: Array<Deferred<number[]>> = [];
+		const loadCoverArtFromUrl = vi.fn((url: string) => {
+			const request = createDeferred<number[]>();
+			requests.push(request);
+			return request.promise.then(() => [url.length]);
+		});
+
+		scheduleMetadataLookupCoverPreviews(
+			['https://example.com/1.jpg', 'https://example.com/2.jpg', 'https://example.com/3.jpg'],
+			loadCoverArtFromUrl,
+		);
+		await flushAsync();
+
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(2);
+		expect(getMetadataLookupCoverPreviewState('https://example.com/3.jpg').status).toBe(
+			'queued',
+		);
+
+		requests[0].resolve([1]);
+		await flushAsync();
+
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(3);
+		expect(loadCoverArtFromUrl).toHaveBeenLastCalledWith('https://example.com/3.jpg');
+
+		requests[1].resolve([2]);
+		requests[2].resolve([3]);
+		await flushAsync();
+	});
+
+	it('dedupes duplicate cover URLs', async () => {
+		const loadCoverArtFromUrl = vi.fn(async () => [1, 2, 3]);
+
+		scheduleMetadataLookupCoverPreviews(
+			['https://example.com/shared.jpg', 'https://example.com/shared.jpg'],
+			loadCoverArtFromUrl,
+		);
+		await flushAsync();
+
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores stale completions after a new schedule excludes the old URL', async () => {
+		const first = createDeferred<number[]>();
+		const second = createDeferred<number[]>();
+		const loadCoverArtFromUrl = vi.fn((url: string) =>
+			url.includes('first') ? first.promise : second.promise,
+		);
+
+		scheduleMetadataLookupCoverPreviews(['https://example.com/first.jpg'], loadCoverArtFromUrl);
+		await flushAsync();
+		cancelMetadataLookupCoverPreviewSchedule();
+		scheduleMetadataLookupCoverPreviews(['https://example.com/second.jpg'], loadCoverArtFromUrl);
+		await flushAsync();
+
+		first.resolve([1]);
+		await flushAsync();
+
+		expect(getMetadataLookupCoverPreviewState('https://example.com/first.jpg').status).toBe(
+			'idle',
+		);
+
+		second.resolve([2]);
+		await flushAsync();
+
+		expect(getMetadataLookupCoverPreviewState('https://example.com/second.jpg').status).toBe(
+			'ready',
+		);
+	});
+
+	it('keeps stale in-flight requests counted against the concurrency limit', async () => {
+		const requests: Array<Deferred<number[]>> = [];
+		const loadCoverArtFromUrl = vi.fn((url: string) => {
+			const request = createDeferred<number[]>();
+			requests.push(request);
+			return request.promise.then(() => [url.length]);
+		});
+
+		scheduleMetadataLookupCoverPreviews(
+			['https://example.com/stale-1.jpg', 'https://example.com/stale-2.jpg'],
+			loadCoverArtFromUrl,
+		);
+		await flushAsync();
+		cancelMetadataLookupCoverPreviewSchedule();
+		scheduleMetadataLookupCoverPreviews(['https://example.com/fresh.jpg'], loadCoverArtFromUrl);
+		await flushAsync();
+
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(2);
+		expect(getMetadataLookupCoverPreviewState('https://example.com/fresh.jpg').status).toBe(
+			'queued',
+		);
+
+		requests[0].resolve([1]);
+		await flushAsync();
+
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(3);
+		expect(loadCoverArtFromUrl).toHaveBeenLastCalledWith('https://example.com/fresh.jpg');
+
+		requests[1].resolve([2]);
+		requests[2].resolve([3]);
+		await flushAsync();
+	});
+
+	it('commits an in-flight preview when the same URL remains visible after reschedule', async () => {
+		const request = createDeferred<number[]>();
+		const loadCoverArtFromUrl = vi.fn(() => request.promise);
+		const coverUrl = 'https://example.com/same-visible.jpg';
+
+		scheduleMetadataLookupCoverPreviews([coverUrl], loadCoverArtFromUrl);
+		await flushAsync();
+		cancelMetadataLookupCoverPreviewSchedule();
+		scheduleMetadataLookupCoverPreviews([coverUrl], loadCoverArtFromUrl);
+		await flushAsync();
+
+		request.resolve([7, 7, 7]);
+		await flushAsync();
+
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(1);
+		expect(getMetadataLookupCoverPreviewState(coverUrl).status).toBe('ready');
+	});
+
+	it('does not repopulate cache after clear while request is in flight', async () => {
+		const request = createDeferred<number[]>();
+		const loadCoverArtFromUrl = vi.fn(() => request.promise);
+
+		scheduleMetadataLookupCoverPreviews(['https://example.com/clear.jpg'], loadCoverArtFromUrl);
+		await flushAsync();
+		clearMetadataLookupCoverPreviewCache();
+
+		request.resolve([9]);
+		await flushAsync();
+
+		expect(getMetadataLookupCoverPreviewState('https://example.com/clear.jpg').status).toBe(
+			'idle',
+		);
+	});
+
+	it('lets apply join an in-flight preview request', async () => {
+		const request = createDeferred<number[]>();
+		const loadCoverArtFromUrl = vi.fn(() => request.promise);
+
+		scheduleMetadataLookupCoverPreviews(['https://example.com/apply.jpg'], loadCoverArtFromUrl);
+		await flushAsync();
+		const bytesPromise = loadMetadataLookupCoverBytes(
+			'https://example.com/apply.jpg',
+			loadCoverArtFromUrl,
+		);
+
+		request.resolve([4, 5, 6]);
+		await expect(bytesPromise).resolves.toEqual([4, 5, 6]);
+		expect(loadCoverArtFromUrl).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/ui/metadataLookup/__tests__/metadataLookupCoverPreview.test.ts
+++ b/src/ui/metadataLookup/__tests__/metadataLookupCoverPreview.test.ts
@@ -4,6 +4,7 @@ import {
 	clearMetadataLookupCoverPreviewCache,
 	getMetadataLookupCoverPreviewState,
 	loadMetadataLookupCoverBytes,
+	MAX_METADATA_LOOKUP_PREVIEW_CACHE_ENTRIES,
 	scheduleMetadataLookupCoverPreviews,
 } from '../metadataLookupCoverPreview.svelte';
 
@@ -171,6 +172,22 @@ describe('metadata lookup cover preview scheduler', () => {
 		expect(getMetadataLookupCoverPreviewState('https://example.com/clear.jpg').status).toBe(
 			'idle',
 		);
+	});
+
+	it('caps cached previews by pruning the oldest ready entries', async () => {
+		const loadCoverArtFromUrl = vi.fn(async (url: string) => [url.length]);
+		const urls = Array.from(
+			{ length: MAX_METADATA_LOOKUP_PREVIEW_CACHE_ENTRIES + 1 },
+			(_, index) => `https://example.com/cache-${index}.jpg`,
+		);
+
+		for (const url of urls) {
+			await loadMetadataLookupCoverBytes(url, loadCoverArtFromUrl);
+		}
+		await flushAsync();
+
+		expect(getMetadataLookupCoverPreviewState(urls[0]).status).toBe('idle');
+		expect(getMetadataLookupCoverPreviewState(urls[urls.length - 1]).status).toBe('ready');
 	});
 
 	it('lets apply join an in-flight preview request', async () => {

--- a/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
+++ b/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
@@ -10,6 +10,7 @@ import type {
 import {
 	fetchMetadataLookupCoverPreview,
 	clearMetadataLookupCoverPreviewCache,
+	scheduleMetadataLookupCoverPreviews,
 } from '../metadataLookupCoverPreview.svelte';
 import {
 	makeMetadataLookupWorkflowServicesLayer,
@@ -69,6 +70,27 @@ function lookupResponse(
 		diagnostics: [],
 		...overrides,
 	};
+}
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+async function flushAsync(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
 }
 
 function defaultLookupState(overrides: Partial<MetadataLookupState> = {}): MetadataLookupState {
@@ -259,6 +281,34 @@ describe('MetadataLookupWorkflow', () => {
 
 		expect(harness.mocks.loadCoverArtFromUrl).toHaveBeenCalledWith(secondCoverUrl);
 		expect(harness.mocks.setCustomCoverArt).toHaveBeenCalledWith([2, 2, 2]);
+	});
+
+	it('joins an in-flight eager lookup cover preview when applying metadata', async () => {
+		clearMetadataLookupCoverPreviewCache();
+		const result = lookupResult({ coverUrl: 'https://example.com/in-flight.jpg' });
+		const request = createDeferred<number[]>();
+		const loadCoverArtFromUrl = vi.fn(() => request.promise);
+		const harness = makeHarness({
+			lookupState: { results: [result], replaceCoverArt: true, isOpen: true },
+			queueState: {
+				queue: [{ file: audioFile('/books/alpha.m4b'), index: 0 }],
+				index: 0,
+			},
+			loadCoverArtFromUrl,
+		});
+
+		scheduleMetadataLookupCoverPreviews([result.coverUrl!], harness.mocks.loadCoverArtFromUrl);
+		await flushAsync();
+		const pendingApply = runMetadataLookupWorkflow(harness.layer, {
+			type: 'applyResult',
+			index: 0,
+		});
+		await flushAsync();
+		request.resolve([8, 8, 8]);
+		await pendingApply;
+
+		expect(harness.mocks.loadCoverArtFromUrl).toHaveBeenCalledTimes(1);
+		expect(harness.mocks.setCustomCoverArt).toHaveBeenCalledWith([8, 8, 8]);
 	});
 
 	it('opens with an error when no selected files are valid', async () => {

--- a/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
+++ b/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
@@ -242,9 +242,18 @@ function touchCacheEntry(coverUrl: string): void {
 }
 
 function prunePreviewCache(): void {
-	while (cacheOrder.length > MAX_METADATA_LOOKUP_PREVIEW_CACHE_ENTRIES) {
+	let remainingCandidates = cacheOrder.length;
+	while (
+		cacheOrder.length > MAX_METADATA_LOOKUP_PREVIEW_CACHE_ENTRIES &&
+		remainingCandidates > 0
+	) {
 		const coverUrl = cacheOrder.shift();
-		if (!coverUrl || inflightByUrl.has(coverUrl)) {
+		remainingCandidates -= 1;
+		if (!coverUrl) {
+			continue;
+		}
+		if (inflightByUrl.has(coverUrl)) {
+			cacheOrder.push(coverUrl);
 			continue;
 		}
 		delete metadataLookupCoverPreviewByUrl[coverUrl];

--- a/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
+++ b/src/ui/metadataLookup/metadataLookupCoverPreview.svelte.ts
@@ -1,20 +1,44 @@
-import { coverArtBytesToDataUrl } from '../coverArt';
+export const MAX_METADATA_LOOKUP_PREVIEW_CONCURRENCY = 2;
+export const MAX_METADATA_LOOKUP_PREVIEW_CACHE_ENTRIES = 64;
 
 export type MetadataLookupCoverPreviewState =
 	| { status: 'idle' }
+	| { status: 'queued' }
 	| { status: 'loading' }
 	| { status: 'ready'; bytes: number[]; dataUrl: string }
 	| { status: 'error' };
 
 const metadataLookupCoverPreviewByUrl = $state<Record<string, MetadataLookupCoverPreviewState>>({});
 
-const inflightByUrl = new Map<string, Promise<void>>();
+const inflightByUrl = new Map<string, Promise<number[]>>();
+const activePreviewTasks = new Set<number>();
+const cacheOrder: string[] = [];
+
+let nextPreviewTaskId = 0;
+let previewScheduleGeneration = 0;
+let queuedCoverUrls: string[] = [];
+let visibleCoverUrls = new Set<string>();
+let activeLoader: ((url: string) => Promise<number[]>) | null = null;
 
 export function clearMetadataLookupCoverPreviewCache(): void {
+	cancelMetadataLookupCoverPreviewSchedule();
 	for (const key of Object.keys(metadataLookupCoverPreviewByUrl)) {
 		delete metadataLookupCoverPreviewByUrl[key];
 	}
+	cacheOrder.length = 0;
 	inflightByUrl.clear();
+}
+
+export function cancelMetadataLookupCoverPreviewSchedule(): void {
+	previewScheduleGeneration += 1;
+	queuedCoverUrls = [];
+	visibleCoverUrls = new Set();
+	activeLoader = null;
+	for (const [coverUrl, state] of Object.entries(metadataLookupCoverPreviewByUrl)) {
+		if (state.status === 'queued' || state.status === 'loading') {
+			delete metadataLookupCoverPreviewByUrl[coverUrl];
+		}
+	}
 }
 
 export function getMetadataLookupCoverPreviewState(
@@ -31,36 +55,230 @@ export function getCachedMetadataLookupCoverBytes(coverUrl: string): number[] | 
 	return state?.status === 'ready' ? state.bytes : null;
 }
 
+export function scheduleMetadataLookupCoverPreviews(
+	coverUrls: ReadonlyArray<string | null | undefined>,
+	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
+): void {
+	previewScheduleGeneration += 1;
+	activeLoader = loadCoverArtFromUrl;
+	const generation = previewScheduleGeneration;
+	const uniqueUrls = uniqueCoverUrls(coverUrls);
+	visibleCoverUrls = new Set(uniqueUrls);
+	queuedCoverUrls = [];
+
+	for (const coverUrl of Object.keys(metadataLookupCoverPreviewByUrl)) {
+		if (!visibleCoverUrls.has(coverUrl)) {
+			const state = metadataLookupCoverPreviewByUrl[coverUrl];
+			if (state.status === 'queued' || state.status === 'loading') {
+				delete metadataLookupCoverPreviewByUrl[coverUrl];
+			}
+		}
+	}
+
+	for (const coverUrl of uniqueUrls) {
+		const state = metadataLookupCoverPreviewByUrl[coverUrl];
+		if (state?.status === 'ready') {
+			touchCacheEntry(coverUrl);
+			continue;
+		}
+		const inflight = inflightByUrl.get(coverUrl);
+		if (inflight) {
+			metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'loading' };
+			attachScheduledInflightCompletion(coverUrl, inflight, generation);
+			continue;
+		}
+		metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'queued' };
+		queuedCoverUrls.push(coverUrl);
+	}
+
+	pumpPreviewQueue(generation);
+}
+
+export async function loadMetadataLookupCoverBytes(
+	coverUrl: string,
+	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
+): Promise<number[]> {
+	const existing = metadataLookupCoverPreviewByUrl[coverUrl];
+	if (existing?.status === 'ready') {
+		touchCacheEntry(coverUrl);
+		return existing.bytes;
+	}
+	const inflight = inflightByUrl.get(coverUrl);
+	if (inflight) {
+		const generation = previewScheduleGeneration;
+		return inflight.then((bytes) => {
+			if (shouldCommitPreviewCompletion(coverUrl, generation, true)) {
+				commitReadyPreview(coverUrl, bytes);
+			}
+			return bytes;
+		});
+	}
+	return startPreviewFetch(coverUrl, loadCoverArtFromUrl, previewScheduleGeneration, true);
+}
+
 export async function fetchMetadataLookupCoverPreview(
 	coverUrl: string,
 	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
 ): Promise<void> {
-	const existing = metadataLookupCoverPreviewByUrl[coverUrl];
-	if (existing?.status === 'ready') {
-		return;
-	}
-	const inflight = inflightByUrl.get(coverUrl);
-	if (inflight) {
-		return inflight;
-	}
+	await loadMetadataLookupCoverBytes(coverUrl, loadCoverArtFromUrl);
+}
 
-	metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'loading' };
-	const promise = loadCoverArtFromUrl(coverUrl)
+function uniqueCoverUrls(coverUrls: ReadonlyArray<string | null | undefined>): string[] {
+	const unique = new Set<string>();
+	for (const coverUrl of coverUrls) {
+		if (coverUrl) {
+			unique.add(coverUrl);
+		}
+	}
+	return [...unique];
+}
+
+function attachScheduledInflightCompletion(
+	coverUrl: string,
+	inflight: Promise<number[]>,
+	generation: number,
+): void {
+	void inflight
 		.then((bytes) => {
-			metadataLookupCoverPreviewByUrl[coverUrl] = {
-				status: 'ready',
-				bytes,
-				dataUrl: coverArtBytesToDataUrl(bytes),
-			};
+			if (shouldCommitPreviewCompletion(coverUrl, generation, false)) {
+				commitReadyPreview(coverUrl, bytes);
+			}
 		})
 		.catch((error) => {
-			console.warn('Failed to load metadata lookup cover preview:', error);
-			metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'error' };
+			if (shouldCommitPreviewCompletion(coverUrl, generation, false)) {
+				console.warn('Failed to load metadata lookup cover preview:', error);
+				metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'error' };
+				touchCacheEntry(coverUrl);
+				prunePreviewCache();
+			}
+		});
+}
+
+function pumpPreviewQueue(generation: number): void {
+	if (!activeLoader || generation !== previewScheduleGeneration) {
+		return;
+	}
+	while (
+		activePreviewTasks.size < MAX_METADATA_LOOKUP_PREVIEW_CONCURRENCY &&
+		queuedCoverUrls.length > 0
+	) {
+		const coverUrl = queuedCoverUrls.shift();
+		if (!coverUrl || !visibleCoverUrls.has(coverUrl)) {
+			continue;
+		}
+		const state = metadataLookupCoverPreviewByUrl[coverUrl];
+		if (state?.status === 'ready' || inflightByUrl.has(coverUrl)) {
+			continue;
+		}
+		void startPreviewFetch(coverUrl, activeLoader, generation, false).catch(() => undefined);
+	}
+}
+
+function startPreviewFetch(
+	coverUrl: string,
+	loadCoverArtFromUrl: (url: string) => Promise<number[]>,
+	generation: number,
+	allowOffscreenCompletion: boolean,
+): Promise<number[]> {
+	metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'loading' };
+	const taskId = ++nextPreviewTaskId;
+	activePreviewTasks.add(taskId);
+	let promise!: Promise<number[]>;
+	promise = loadCoverArtFromUrl(coverUrl)
+		.then((bytes): number[] => {
+			if (shouldCommitPreviewCompletion(coverUrl, generation, allowOffscreenCompletion)) {
+				commitReadyPreview(coverUrl, bytes);
+			}
+			return bytes;
+		})
+		.catch((error): never => {
+			if (shouldCommitPreviewCompletion(coverUrl, generation, allowOffscreenCompletion)) {
+				console.warn('Failed to load metadata lookup cover preview:', error);
+				metadataLookupCoverPreviewByUrl[coverUrl] = { status: 'error' };
+				touchCacheEntry(coverUrl);
+				prunePreviewCache();
+			}
+			throw error;
 		})
 		.finally(() => {
-			inflightByUrl.delete(coverUrl);
+			activePreviewTasks.delete(taskId);
+			if (inflightByUrl.get(coverUrl) === promise) {
+				inflightByUrl.delete(coverUrl);
+			}
+			pumpPreviewQueue(previewScheduleGeneration);
 		});
 
 	inflightByUrl.set(coverUrl, promise);
 	return promise;
+}
+
+function commitReadyPreview(coverUrl: string, bytes: number[]): void {
+	metadataLookupCoverPreviewByUrl[coverUrl] = {
+		status: 'ready',
+		bytes,
+		dataUrl: coverArtBytesToDataUrl(bytes),
+	};
+	touchCacheEntry(coverUrl);
+	prunePreviewCache();
+}
+
+function shouldCommitPreviewCompletion(
+	coverUrl: string,
+	generation: number,
+	allowOffscreenCompletion: boolean,
+): boolean {
+	return (
+		generation === previewScheduleGeneration &&
+		(allowOffscreenCompletion || visibleCoverUrls.has(coverUrl))
+	);
+}
+
+function touchCacheEntry(coverUrl: string): void {
+	const existingIndex = cacheOrder.indexOf(coverUrl);
+	if (existingIndex >= 0) {
+		cacheOrder.splice(existingIndex, 1);
+	}
+	cacheOrder.push(coverUrl);
+}
+
+function prunePreviewCache(): void {
+	while (cacheOrder.length > MAX_METADATA_LOOKUP_PREVIEW_CACHE_ENTRIES) {
+		const coverUrl = cacheOrder.shift();
+		if (!coverUrl || inflightByUrl.has(coverUrl)) {
+			continue;
+		}
+		delete metadataLookupCoverPreviewByUrl[coverUrl];
+	}
+}
+
+function coverArtBytesToDataUrl(coverArtBytes: number[]): string {
+	const uint8Array = new Uint8Array(coverArtBytes);
+	const chunkSize = 0x8000;
+	let binary = '';
+	for (let offset = 0; offset < uint8Array.length; offset += chunkSize) {
+		binary += String.fromCharCode(...uint8Array.subarray(offset, offset + chunkSize));
+	}
+	const base64String = btoa(binary);
+
+	let mimeType = 'image/jpeg';
+	if (coverArtBytes.length >= 12) {
+		if (coverArtBytes[0] === 0x89 && coverArtBytes[1] === 0x50) {
+			mimeType = 'image/png';
+		} else if (
+			coverArtBytes[0] === 0x52 &&
+			coverArtBytes[1] === 0x49 &&
+			coverArtBytes[2] === 0x46 &&
+			coverArtBytes[3] === 0x46 &&
+			coverArtBytes[8] === 0x57 &&
+			coverArtBytes[9] === 0x45 &&
+			coverArtBytes[10] === 0x42 &&
+			coverArtBytes[11] === 0x50
+		) {
+			mimeType = 'image/webp';
+		}
+	} else if (coverArtBytes.length >= 2 && coverArtBytes[0] === 0x89 && coverArtBytes[1] === 0x50) {
+		mimeType = 'image/png';
+	}
+
+	return `data:${mimeType};base64,${base64String}`;
 }

--- a/src/ui/metadataLookup/metadataLookupWorkflow.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflow.ts
@@ -28,7 +28,7 @@ import {
 	type MetadataLookupWorkflowServices,
 	type MetadataLookupWorkflowServicesId,
 } from './metadataLookupWorkflowServices';
-import { getCachedMetadataLookupCoverBytes } from './metadataLookupCoverPreview.svelte';
+import { loadMetadataLookupCoverBytes } from './metadataLookupCoverPreview.svelte';
 
 export {
 	MetadataLookupWorkflowServicesTag,
@@ -166,8 +166,10 @@ async function applyCoverArt(
 ): Promise<CoverArtApplyResult> {
 	if (!result.coverUrl) return { status: 'notRequested' };
 	try {
-		const cachedBytes = getCachedMetadataLookupCoverBytes(result.coverUrl);
-		const coverBytes = cachedBytes ?? (await services.loadCoverArtFromUrl(result.coverUrl));
+		const coverBytes = await loadMetadataLookupCoverBytes(
+			result.coverUrl,
+			services.loadCoverArtFromUrl,
+		);
 		services.setCustomCoverArt(coverBytes);
 		return { status: 'applied', bytes: coverBytes };
 	} catch (error) {


### PR DESCRIPTION
## Summary
- replace hover/focus metadata lookup cover previews with automatic app-owned scheduling for visible results
- keep previews backend-proxied and DOM-safe while adding URL-keyed in-flight joining, stale-generation guards, bounded concurrency, and cache limits
- reuse a module-private shared cover-art HTTP client without changing the Tauri command shape
- move Audible materialized audio validation/probing/hash work onto `spawn_blocking`

## Notes
- No temporary `docs/specs/*` file was created for this workblock.
- Added `src/ui/metadataLookup/AGENTS.md` with the durable UI/security invariants for metadata lookup previews.
- Review Auditor found one scheduler bug around stale in-flight requests and same-URL reschedules; this PR includes the fix and regression tests.

## Validation
- `bun run test -- src/ui/__tests__/metadataLookup-island.test.ts src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts src/ui/metadataLookup/__tests__/metadataLookupCoverPreview.test.ts`
- `bun run test -- src/ui`
- `bun run typecheck`
- `cargo nextest run -p audiobook-boss --lib remote_source`
- `cargo nextest run -p audiobook-boss --lib metadata`
- `git diff --check`
- `bash scripts/check-generated-bindings.sh --mode local`
