### PR TITLE
Grey-box boundary hardening (#304)

### DIFF
--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -116,6 +116,19 @@ nested ownership rules, narrow boundary checks, and contract tests.
 
 Each Public API has a nearest nested `AGENTS.md` that lists the allowed import/export surface, private cluster, edit rules, and breaking-change triggers.
 
+### Frontend Owner Strips
+
+| Strip | Entry | Owns |
+| --- | --- | --- |
+| Output Panel | `src/ui/outputPanel` | Output directory, naming presets, path preview, estimated-size display reads, and `OutputPanelIsland`. |
+| File List | `src/ui/fileList` | Pre-processing file list session, mutations, metadata staging hooks, `readCombinedSizeText()`, and `FileListIsland` rendering. |
+| File Import | `src/ui/fileImport` | Drag/drop, picker, and import-analysis workflow; composes `FileListIsland`. |
+| Status Panel | `src/ui/statusPanel` | Processing controls, concurrency display, and backend progress rendering. |
+| Encoder Panel | `src/ui/encoderPanel` | Encoder settings UI and encoding request config reads. |
+| App Settings | `src/ui/appSettings` | Settings hydration and durable preference coordination. |
+
+Exact export lists live in each strip's nearest `AGENTS.md`.
+
 Boundary-aligned Rust core crates under `crates/abb-*-core` are testing and
 packaging surfaces for pure domain logic inside these owners. They are not new
 Grey-Box Public APIs. `abb-media-core` is the first backend-neutral media

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"bindings:generate": "cargo run --manifest-path src-tauri/Cargo.toml --bin export_bindings",
 		"bindings:check": "scripts/check-generated-bindings.sh --mode verify",
 		"bindings:check:local": "scripts/check-generated-bindings.sh --mode local",
+		"bindings:check:runtime-boundary": "bun scripts/check-tauri-runtime-boundary.ts",
 		"bindings:sync": "scripts/check-generated-bindings.sh --mode sync",
 		"test": "vitest run",
 		"test:watch": "vitest"

--- a/src-tauri/src/audio/contract_tests.rs
+++ b/src-tauri/src/audio/contract_tests.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+
+use crate::audio::{
+    supported_audio_import_metadata, validate_encoder_settings, validate_input_audio_path,
+    BitrateMode, ChannelConfig, EncoderSettings, EncoderType, ThreadSetting,
+};
+
+#[test]
+fn audio_contract_supported_import_metadata_exposes_m4b_family() {
+    let metadata = supported_audio_import_metadata();
+    assert!(
+        metadata
+            .formats
+            .iter()
+            .any(|format| format.extension == "m4b"),
+        "supported import metadata should include m4b"
+    );
+}
+
+#[test]
+fn audio_contract_rejects_missing_input_path() {
+    let err = validate_input_audio_path(Path::new(
+        "/definitely/not/a/real/audiobook-boss-input.m4b",
+    ))
+        .expect_err("missing path should fail validation");
+    let message = err.to_string().to_lowercase();
+    assert!(
+        message.contains("not found")
+            || message.contains("no such file")
+            || message.contains("exist")
+            || message.contains("cannot read"),
+        "expected filesystem validation failure, got: {err}"
+    );
+}
+
+#[test]
+fn audio_contract_rejects_invalid_encoder_bitrate() {
+    let settings = EncoderSettings {
+        encoder_type: EncoderType::NativeAac,
+        bitrate_kbps: 1,
+        bitrate_mode: BitrateMode::Cbr,
+        channels: ChannelConfig::Mono,
+        afterburner: true,
+        threads: ThreadSetting::Auto,
+        twoloop: true,
+    };
+
+    let err = validate_encoder_settings(&settings).expect_err("invalid bitrate should fail");
+    assert!(
+        !err.to_string().is_empty(),
+        "encoder validation should return a concrete error"
+    );
+}

--- a/src-tauri/src/audio/contract_tests.rs
+++ b/src-tauri/src/audio/contract_tests.rs
@@ -19,10 +19,9 @@ fn audio_contract_supported_import_metadata_exposes_m4b_family() {
 
 #[test]
 fn audio_contract_rejects_missing_input_path() {
-    let err = validate_input_audio_path(Path::new(
-        "/definitely/not/a/real/audiobook-boss-input.m4b",
-    ))
-        .expect_err("missing path should fail validation");
+    let err =
+        validate_input_audio_path(Path::new("definitely-not-a-real-audiobook-boss-input.m4b"))
+            .expect_err("missing path should fail validation");
     let message = err.to_string().to_lowercase();
     assert!(
         message.contains("not found")

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -132,3 +132,6 @@ pub(crate) fn cleanup_abandoned_processing_workspaces(
 ) -> crate::errors::Result<()> {
     processor::cleanup_abandoned_processing_workspaces(cache_dir)
 }
+
+#[cfg(test)]
+mod contract_tests;

--- a/src-tauri/src/audio/processor/encoder/context.rs
+++ b/src-tauri/src/audio/processor/encoder/context.rs
@@ -109,7 +109,7 @@ pub(crate) fn setup_encoder(
     plan: &crate::audio::processor::plan::MediaProcessingPlan,
     metadata: Option<&crate::metadata::AudiobookMetadata>,
     skip_chapter_passthrough: bool,
-    passthrough: Option<&crate::metadata::passthrough::PassthroughMetadata>,
+    passthrough: Option<&crate::metadata::PassthroughMetadata>,
 ) -> Result<(
     ff::format::context::Output,
     ff::codec::encoder::audio::Encoder,
@@ -209,7 +209,7 @@ pub(crate) fn setup_encoder(
     // Skip in preview mode since chapters won't align with shortened output
     if !skip_chapter_passthrough {
         if let Some(p) = passthrough {
-            match crate::metadata::passthrough::add_chapters_to_output(&mut octx, &p.chapters) {
+            match crate::metadata::add_chapters_to_output(&mut octx, &p.chapters) {
                 Ok(count) if count > 0 => {
                     log::info!("✓ Copied {} chapters from source files", count);
                 }

--- a/src-tauri/src/audio/processor/encoder/mod.rs
+++ b/src-tauri/src/audio/processor/encoder/mod.rs
@@ -14,7 +14,7 @@ mod context;
 pub mod options;
 mod write;
 
-// Tests moved to src-tauri/tests/contract/encoder.rs
+// Encoder boundary behavior pinned in src-tauri/src/audio/contract_tests.rs
 
 // Re-export public API (crate-internal)
 // Note: create_audio_encoder and finalize_encoding are internal to this module

--- a/src-tauri/src/audio/processor/engine.rs
+++ b/src-tauri/src/audio/processor/engine.rs
@@ -110,7 +110,7 @@ impl MediaProcessor for FfmpegNextProcessor {
         plan: &'a MediaProcessingPlan,
         context: &'a ProcessingContext,
         metadata: Option<&'a crate::metadata::AudiobookMetadata>,
-        passthrough: Option<&'a crate::metadata::passthrough::PassthroughMetadata>,
+        passthrough: Option<&'a crate::metadata::PassthroughMetadata>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
         // Initialize FFmpeg (idempotent)
         static INIT: Once = Once::new();

--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -24,7 +24,7 @@ pub(crate) async fn execute_processing(
     workflow: &ProcessingWorkflow,
     files: &[AudioFile],
     metadata: Option<&crate::metadata::AudiobookMetadata>,
-    passthrough: Option<&crate::metadata::passthrough::PassthroughMetadata>,
+    passthrough: Option<&crate::metadata::PassthroughMetadata>,
     reporter: &mut ProgressReporter,
 ) -> Result<PathBuf> {
     let mut emitter = ProgressReporter::new(1); // Single logical processing unit
@@ -63,7 +63,7 @@ pub(crate) async fn merge_audio_files_with_context(
     total_duration: f64,
     files: &[AudioFile],
     metadata: Option<&crate::metadata::AudiobookMetadata>,
-    passthrough: Option<&crate::metadata::passthrough::PassthroughMetadata>,
+    passthrough: Option<&crate::metadata::PassthroughMetadata>,
 ) -> Result<PathBuf> {
     let temp_output = temp_dir.join(TEMP_MERGED_FILENAME);
 

--- a/src-tauri/src/audio/processor/external_fdk/mod.rs
+++ b/src-tauri/src/audio/processor/external_fdk/mod.rs
@@ -9,7 +9,7 @@ use crate::audio::toolchain::ValidatedExternalToolchain;
 use crate::audio::CleanupGuard;
 use crate::audio::{AudioFile, DecoderSelection};
 use crate::errors::{sanitize_path_for_display, AppError, Result};
-use crate::metadata::passthrough::merge_passthrough_cover_art;
+use crate::metadata::merge_passthrough_cover_art;
 use crate::metadata::{rewrite_metadata_with_ffmpeg, AudiobookMetadata, CoverArtPassthroughPolicy};
 use crate::processing::ProcessingContext;
 use std::path::PathBuf;

--- a/src-tauri/src/audio/processor/external_fdk/passthrough.rs
+++ b/src-tauri/src/audio/processor/external_fdk/passthrough.rs
@@ -1,11 +1,13 @@
+use crate::audio::processor::passthrough_sources_from_audio_files;
 use crate::audio::AudioFile;
-use crate::metadata::passthrough::{extract_passthrough_metadata, PassthroughMetadata};
+use crate::metadata::{extract_passthrough_metadata, PassthroughMetadata};
 
 pub(super) fn collect_passthrough_metadata(
     valid_files: &[AudioFile],
     preview: bool,
 ) -> Option<PassthroughMetadata> {
-    let passthrough = extract_passthrough_metadata(valid_files);
+    let sources = passthrough_sources_from_audio_files(valid_files);
+    let passthrough = extract_passthrough_metadata(&sources);
     if preview {
         passthrough.cover_art_only()
     } else {

--- a/src-tauri/src/audio/processor/external_fdk/passthrough.rs
+++ b/src-tauri/src/audio/processor/external_fdk/passthrough.rs
@@ -6,6 +6,10 @@ pub(super) fn collect_passthrough_metadata(
     valid_files: &[AudioFile],
     preview: bool,
 ) -> Option<PassthroughMetadata> {
+    if valid_files.is_empty() {
+        return None;
+    }
+
     let sources = passthrough_sources_from_audio_files(valid_files);
     let passthrough = extract_passthrough_metadata(&sources);
     if preview {

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -26,7 +26,7 @@ pub(crate) fn write_metadata_stage(
     _context: &ProcessingContext,
     merged_output: &Path,
     metadata: Option<AudiobookMetadata>,
-    _passthrough: Option<&crate::metadata::passthrough::PassthroughMetadata>,
+    _passthrough: Option<&crate::metadata::PassthroughMetadata>,
     reporter: &mut ProgressReporter,
 ) -> Result<()> {
     let Some(metadata) = metadata else {
@@ -126,7 +126,7 @@ pub(crate) async fn finalize_processing(
     workflow: ProcessingWorkflow,
     merged_output: PathBuf,
     metadata: Option<AudiobookMetadata>,
-    passthrough: Option<crate::metadata::passthrough::PassthroughMetadata>,
+    passthrough: Option<crate::metadata::PassthroughMetadata>,
     reporter: &mut ProgressReporter,
 ) -> Result<String> {
     let passthrough_ref = passthrough.as_ref();

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -17,8 +17,10 @@ use crate::audio::metrics::ProcessingMetrics;
 use crate::audio::settings_encoder::EncoderSettings;
 use crate::audio::AudioFile;
 use crate::errors::Result;
-use crate::metadata::passthrough::merge_passthrough_cover_art;
-use crate::metadata::{AudiobookMetadata, CoverArtPassthroughPolicy};
+use crate::metadata::{
+    extract_passthrough_metadata, merge_passthrough_cover_art, AudiobookMetadata,
+    CoverArtPassthroughPolicy, PassthroughSource,
+};
 use crate::processing::{ProcessingContext, ProcessingStage, ProgressReporter};
 use std::time::Duration;
 
@@ -83,6 +85,17 @@ pub(crate) fn processing_workspace_root(cache_dir: &std::path::Path) -> std::pat
 pub(crate) fn cleanup_abandoned_processing_workspaces(cache_dir: &std::path::Path) -> Result<()> {
     let root = processing_workspace_root(cache_dir);
     staging::cleanup_abandoned_processing_sessions(&root)
+}
+
+pub(crate) fn passthrough_sources_from_audio_files(files: &[AudioFile]) -> Vec<PassthroughSource> {
+    files
+        .iter()
+        .map(|file| PassthroughSource {
+            path: file.path.clone(),
+            duration: file.duration,
+            is_valid: file.is_valid,
+        })
+        .collect()
 }
 
 pub async fn execute_audio_engine(request: AudioExecutionRequest) -> Result<String> {
@@ -158,9 +171,9 @@ async fn process_audiobook_with_context(
     workflow_cleanup.add_path(&workflow_temp_dir);
 
     // Extract passthrough metadata (chapters, original cover art) from all valid files.
-    let passthrough_metadata = cover_art_passthrough.apply_to_passthrough(
-        crate::metadata::passthrough::extract_passthrough_metadata(&files).into_option(),
-    );
+    let passthrough_sources = passthrough_sources_from_audio_files(&files);
+    let passthrough_metadata = cover_art_passthrough
+        .apply_to_passthrough(extract_passthrough_metadata(&passthrough_sources).into_option());
 
     let effective_metadata = merge_passthrough_cover_art(metadata, passthrough_metadata.as_ref());
 

--- a/src-tauri/src/audio/processor/plan.rs
+++ b/src-tauri/src/audio/processor/plan.rs
@@ -53,6 +53,6 @@ pub trait MediaProcessor {
         plan: &'a MediaProcessingPlan,
         context: &'a ProcessingContext,
         metadata: Option<&'a crate::metadata::AudiobookMetadata>,
-        passthrough: Option<&'a crate::metadata::passthrough::PassthroughMetadata>,
+        passthrough: Option<&'a crate::metadata::PassthroughMetadata>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -9,13 +9,15 @@ use crate::commands::CommandResult;
 use crate::errors::AppError;
 use crate::metadata::{MetadataIntentPatch, NamingMetadata};
 use crate::opened_audio::OpenedAudioFileQueue;
-use crate::output_artifact::{build_output_path_preview, derive_output_artifact_path, OutputKind};
+use crate::output_artifact::{
+    build_output_path_preview, derive_output_artifact_path, OutputKind, OutputNamingConfig,
+};
 use crate::processing::job_registry::JobId;
 use crate::processing::run;
 use crate::processing::{JobRegistry, MaxConcurrentJobsCapabilities};
 pub use crate::processing::{
-    JobType, OutputNamingConfig, ProcessCommandResult, ProcessPayload, ProcessResultEntry,
-    ProcessResultStatus, ProcessResultSummary, ProcessingPreflightPlan,
+    JobType, ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
+    ProcessResultSummary, ProcessingPreflightPlan,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,11 +28,6 @@ pub use metadata::{
     NamingMetadata, PatchOp,
 };
 
-// Test-facing passthrough helpers used by integration tests.
-pub use metadata::passthrough::{
-    add_chapters_to_output, extract_passthrough_metadata, ChapterSpec,
-};
-
 pub mod audio;
 pub use errors::{
     sanitize_path_for_display, sanitize_path_str_for_display, AppError, AppErrorCategory,

--- a/src-tauri/src/metadata/AGENTS.md
+++ b/src-tauri/src/metadata/AGENTS.md
@@ -7,6 +7,10 @@
 - Outcome symbols: `MetadataOutcomeRequest`, `MetadataOutcomePlan`,
   `NamingMetadata`, `CoverArtPassthroughPolicy`, `plan_metadata_outcome`,
   `plan_metadata_write`.
+- Passthrough symbols: `PassthroughSource`, `PassthroughMetadata`, `ChapterSpec`,
+  `extract_passthrough_metadata`, `add_chapters_to_output`. Private modules:
+  `passthrough`, `mp4ameta_bridge`. Audio maps `AudioFile` → `PassthroughSource`
+  at call sites; metadata must not import `crate::audio::AudioFile`.
 - Crate-local write-plan support: `MetadataWritePlan`, `AlbumSortWriteAction`.
 - Pure intent, validation, naming, and write-plan facts are packaged in
   `abb-metadata-core`; `src-tauri/src/metadata` owns container adapters and

--- a/src-tauri/src/metadata/contract_tests.rs
+++ b/src-tauri/src/metadata/contract_tests.rs
@@ -1,7 +1,7 @@
 use crate::metadata::{
-    plan_metadata_outcome, plan_metadata_write, validate_metadata_intent_patch, AlbumSortPatchOp,
-    AudiobookMetadata, CoverArtPassthroughPolicy, MetadataIntentPatch, MetadataOutcomeRequest,
-    PatchOp,
+    extract_passthrough_metadata, plan_metadata_outcome, plan_metadata_write,
+    validate_metadata_intent_patch, AlbumSortPatchOp, AudiobookMetadata, CoverArtPassthroughPolicy,
+    MetadataIntentPatch, MetadataOutcomeRequest, PassthroughSource, PatchOp,
 };
 use abb_metadata_core::{MetadataIntentValidationCode, MetadataIntentValidationField};
 
@@ -147,6 +147,27 @@ fn metadata_intent_validation_contract_preserves_invalid_date_for_validation() {
         result.field_errors.first().map(|error| error.field),
         Some(MetadataIntentValidationField::Date)
     );
+}
+
+#[test]
+fn metadata_passthrough_contract_synthesizes_chapters_from_source_facts() {
+    let sources = vec![
+        PassthroughSource {
+            path: std::path::PathBuf::from("/tmp/chapter-one.m4b"),
+            duration: Some(60.0),
+            is_valid: true,
+        },
+        PassthroughSource {
+            path: std::path::PathBuf::from("/tmp/chapter-two.m4b"),
+            duration: Some(90.0),
+            is_valid: true,
+        },
+    ];
+
+    let passthrough = extract_passthrough_metadata(&sources);
+    assert_eq!(passthrough.chapters.len(), 2);
+    assert_eq!(passthrough.chapters[0].start_ms, 0);
+    assert_eq!(passthrough.chapters[1].start_ms, 60_000);
 }
 
 #[test]

--- a/src-tauri/src/metadata/contract_tests.rs
+++ b/src-tauri/src/metadata/contract_tests.rs
@@ -153,12 +153,12 @@ fn metadata_intent_validation_contract_preserves_invalid_date_for_validation() {
 fn metadata_passthrough_contract_synthesizes_chapters_from_source_facts() {
     let sources = vec![
         PassthroughSource {
-            path: std::path::PathBuf::from("/tmp/chapter-one.m4b"),
+            path: std::path::PathBuf::from("chapter-one.m4b"),
             duration: Some(60.0),
             is_valid: true,
         },
         PassthroughSource {
-            path: std::path::PathBuf::from("/tmp/chapter-two.m4b"),
+            path: std::path::PathBuf::from("chapter-two.m4b"),
             duration: Some(90.0),
             is_valid: true,
         },

--- a/src-tauri/src/metadata/intent_plan.rs
+++ b/src-tauri/src/metadata/intent_plan.rs
@@ -1,6 +1,6 @@
 use super::{AudiobookMetadata, MetadataIntentPatch, MetadataWritePlan, NamingMetadata};
 use crate::errors::Result;
-use crate::metadata::passthrough::PassthroughMetadata;
+use crate::metadata::PassthroughMetadata;
 use std::path::Path;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -17,8 +17,8 @@ mod cover_art;
 mod ffi;
 mod ffmpeg_dict;
 mod intent_plan;
-pub mod mp4ameta_bridge;
-pub mod passthrough;
+mod mp4ameta_bridge;
+mod passthrough;
 mod remux;
 
 pub use abb_metadata_core::{
@@ -48,6 +48,12 @@ pub use cover_art::{
     CoverFormat,
 };
 pub use ffmpeg_dict::{set_container_metadata, validate_metadata_compatibility};
+pub use passthrough::{
+    add_chapters_to_output, extract_passthrough_metadata, PassthroughMetadata, PassthroughSource,
+};
+#[allow(unused_imports)]
+pub use passthrough::ChapterSpec;
+pub(crate) use passthrough::merge_passthrough_cover_art;
 pub use remux::rewrite_metadata_with_ffmpeg;
 
 pub(crate) fn save_metadata_with_plan(

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -48,12 +48,12 @@ pub use cover_art::{
     CoverFormat,
 };
 pub use ffmpeg_dict::{set_container_metadata, validate_metadata_compatibility};
+pub(crate) use passthrough::merge_passthrough_cover_art;
+#[allow(unused_imports)]
+pub use passthrough::ChapterSpec;
 pub use passthrough::{
     add_chapters_to_output, extract_passthrough_metadata, PassthroughMetadata, PassthroughSource,
 };
-#[allow(unused_imports)]
-pub use passthrough::ChapterSpec;
-pub(crate) use passthrough::merge_passthrough_cover_art;
 pub use remux::rewrite_metadata_with_ffmpeg;
 
 pub(crate) fn save_metadata_with_plan(

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -3,11 +3,20 @@
 //! This module extracts metadata that should be copied from source files
 //! without re-encoding or rewriting (chapters and original cover art).
 
+use std::path::PathBuf;
+
 use ffmpeg_next as ff;
 
-use crate::audio::AudioFile as PipelineAudioFile;
 use crate::errors::Result;
 use crate::metadata::AudiobookMetadata;
+
+/// Metadata-owned facts needed to extract chapters and cover art from source files.
+#[derive(Debug, Clone)]
+pub struct PassthroughSource {
+    pub path: PathBuf,
+    pub duration: Option<f64>,
+    pub is_valid: bool,
+}
 
 /// Minimal chapter representation for passthrough (milliseconds time base).
 #[derive(Debug, Clone)]
@@ -66,7 +75,7 @@ pub(crate) fn merge_passthrough_cover_art(
     }
 }
 
-fn synthesize_chapters_from_files(files: &[PipelineAudioFile]) -> Vec<ChapterSpec> {
+fn synthesize_chapters_from_files(files: &[PassthroughSource]) -> Vec<ChapterSpec> {
     let mut chapters = Vec::new();
     let mut offset_ms: i64 = 0;
 
@@ -99,7 +108,7 @@ fn synthesize_chapters_from_files(files: &[PipelineAudioFile]) -> Vec<ChapterSpe
 /// Extract chapters and original cover art from all valid input files.
 /// Chapters are normalized to milliseconds and offset by cumulative durations
 /// to preserve ordering for multi-file merges.
-pub fn extract_passthrough_metadata(files: &[PipelineAudioFile]) -> PassthroughMetadata {
+pub fn extract_passthrough_metadata(files: &[PassthroughSource]) -> PassthroughMetadata {
     // Ensure FFmpeg is initialized before probing chapters.
     let _ = ff::init();
 

--- a/src-tauri/src/metadata/remux.rs
+++ b/src-tauri/src/metadata/remux.rs
@@ -180,9 +180,7 @@ fn copy_chapters(
     passthrough: Option<&PassthroughMetadata>,
 ) -> Result<()> {
     if let Some(passthrough) = passthrough {
-        if let Err(error) =
-            crate::metadata::passthrough::add_chapters_to_output(octx, &passthrough.chapters)
-        {
+        if let Err(error) = crate::metadata::add_chapters_to_output(octx, &passthrough.chapters) {
             log::warn!(
                 "Could not preserve passthrough chapters during metadata remux: {}",
                 error

--- a/src-tauri/src/processing.rs
+++ b/src-tauri/src/processing.rs
@@ -58,8 +58,9 @@ pub use progress::{
 };
 pub use session::ProcessingSession;
 pub use types::{
-    CollisionPolicy, JobType, NamingPreset, OutputCollisionInfo, OutputCollisionKind, OutputKind,
-    OutputNamingConfig, OutputReviewRequirement, PlannedOutput, PlannedOutputAction,
-    ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
+    JobType, ProcessCommandResult, ProcessPayload, ProcessResultEntry, ProcessResultStatus,
     ProcessResultSummary, ProcessingPreflightPlan, SupplementalProcessingAsset,
 };
+
+#[cfg(test)]
+mod contract_tests;

--- a/src-tauri/src/processing/AGENTS.md
+++ b/src-tauri/src/processing/AGENTS.md
@@ -12,6 +12,9 @@
   `ProgressEmitter`.
 - Pure lifecycle/terminal summary classification that has no runtime/media
   dependency is packaged in `abb-processing-core`.
+- Processing may consume `crate::output_artifact` types in payloads and plans;
+  it does not re-export output-artifact ownership. Command layers import
+  output-owned types from `crate::output_artifact` directly.
 
 ## Private Cluster
 - Files: `../processing.rs`, `plan.rs`, `run.rs`, `terminal_outcomes/`,

--- a/src-tauri/src/processing/contract_tests.rs
+++ b/src-tauri/src/processing/contract_tests.rs
@@ -1,0 +1,38 @@
+use crate::processing::{EventStage, OperationKind, ProcessResultStatus, ProgressEvent};
+
+#[test]
+fn processing_contract_lifecycle_kinds_are_distinct() {
+    assert_ne!(
+        OperationKind::ProcessingMerge,
+        OperationKind::ProcessingBatch
+    );
+    assert_ne!(
+        OperationKind::MetadataSave,
+        OperationKind::RemoteAcquisition
+    );
+}
+
+#[test]
+fn processing_contract_progress_event_shape_matches_frontend_contract() {
+    let event = ProgressEvent {
+        operation_id: None,
+        operation_kind: OperationKind::ProcessingBatch,
+        stage: EventStage::Converting,
+        percentage: 42.5,
+        message: "Converting".to_string(),
+        current_file: Some("book.m4b".to_string()),
+        eta_seconds: Some(12.0),
+        job_id: None,
+        input_index: Some(0),
+    };
+
+    assert_eq!(event.stage, EventStage::Converting);
+    assert!((event.percentage - 42.5).abs() < f32::EPSILON);
+    assert_eq!(event.operation_kind, OperationKind::ProcessingBatch);
+}
+
+#[test]
+fn processing_contract_terminal_status_values_remain_stable() {
+    assert_ne!(ProcessResultStatus::Success, ProcessResultStatus::Failed);
+    assert_ne!(ProcessResultStatus::Cancelled, ProcessResultStatus::Skipped);
+}

--- a/src-tauri/src/processing/plan.rs
+++ b/src-tauri/src/processing/plan.rs
@@ -4,12 +4,13 @@ use crate::metadata::{
     plan_metadata_outcome, CoverArtPassthroughPolicy, MetadataOutcomePlan, MetadataOutcomeRequest,
     NamingMetadata,
 };
+use crate::output_artifact::OutputNamingConfig;
 use crate::output_artifact::{
     build_output_path_preview, enforce_output_plan_review, ensure_output_parent_dirs,
     CollisionPolicy, OutputKind, OutputParentDirCleanup, OutputPlanLedger, OutputPlanReview,
     PlannedOutputAction, ResolvedOutputPlan,
 };
-use crate::processing::{JobType, OutputNamingConfig, ProcessPayload, ProcessingPreflightPlan};
+use crate::processing::{JobType, ProcessPayload, ProcessingPreflightPlan};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/src-tauri/src/processing/types.rs
+++ b/src-tauri/src/processing/types.rs
@@ -2,10 +2,7 @@ use super::lifecycle::{OperationKind, OperationResultSummary};
 use crate::audio;
 use crate::audio::EncoderSettings;
 use crate::errors::AppErrorEnvelope;
-pub use crate::output_artifact::{
-    CollisionPolicy, NamingPreset, OutputCollisionInfo, OutputCollisionKind, OutputKind,
-    OutputNamingConfig, OutputReviewRequirement, PlannedOutput, PlannedOutputAction,
-};
+use crate::output_artifact::{CollisionPolicy, OutputNamingConfig, PlannedOutput};
 pub use abb_processing_core::ProcessResultStatus;
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/ui/__tests__/coverArt-island.test.ts
+++ b/src/ui/__tests__/coverArt-island.test.ts
@@ -11,7 +11,7 @@ import {
 	getCurrentCoverArt,
 	isCoverArtRemovalRequested,
 } from '../coverArt';
-import { setCurrentFileList, setSelectedFileIndices, setSelectedIndex } from '../fileList/state.svelte';
+import { setCurrentFileList, setSelectedFileIndices, setSelectedIndex } from '../fileList';
 import type { AudioFile, FileListInfo } from '../../types/audio';
 
 const { openFileMock, loadCoverArtFileMock, loadCoverArtFromUrlMock } = vi.hoisted(() => ({

--- a/src/ui/__tests__/coverArt-owner-integration.test.ts
+++ b/src/ui/__tests__/coverArt-owner-integration.test.ts
@@ -12,7 +12,7 @@ import {
 	setCurrentFileList,
 	setSelectedFileIndices,
 	setSelectedIndex,
-} from '../fileList/state.svelte';
+} from '../fileList';
 import {
 	clearMetadataState,
 	getMetadataIntentPatchForFile,

--- a/src/ui/__tests__/coverArt-owner-integration.test.ts
+++ b/src/ui/__tests__/coverArt-owner-integration.test.ts
@@ -8,11 +8,7 @@ import {
 	setCustomCoverArt,
 } from '../coverArt';
 import { jobControlsState } from '../jobControls/state.svelte';
-import {
-	setCurrentFileList,
-	setSelectedFileIndices,
-	setSelectedIndex,
-} from '../fileList';
+import { setCurrentFileList, setSelectedFileIndices, setSelectedIndex } from '../fileList';
 import {
 	clearMetadataState,
 	getMetadataIntentPatchForFile,

--- a/src/ui/__tests__/encoderPanel-behavior.test.ts
+++ b/src/ui/__tests__/encoderPanel-behavior.test.ts
@@ -5,7 +5,7 @@ import { defaultEncoderSettings } from '../../types/audio';
 import { encoderPanelState, resetEncoderPanelState } from '../encoderPanel/state.svelte';
 import { readEncodingRequestConfig } from '../encoderPanel';
 import { renderAutoResolutionHints } from '../encoderPanel/autoResolutionHints';
-import { outputPanelState } from '../outputPanel';
+import { readEstimatedSizeText } from '../outputPanel';
 import {
 	encoderAvailabilityFixture,
 	runtimeSettingsCapabilitiesFixture,
@@ -28,7 +28,7 @@ vi.mock('../../lib/tauri/client', () => ({
 	},
 }));
 
-vi.mock('../fileList/state.svelte', () => ({
+vi.mock('../fileList', () => ({
 	getCurrentFileList: context.getCurrentFileListMock,
 	isOrderLocked: vi.fn(() => false),
 	onOrderLockChange: vi.fn(() => () => undefined),
@@ -62,7 +62,6 @@ describe('encoder panel behavior controls', () => {
 		resetEncoderPanelState();
 		setRuntimeSettingsCapabilities(null);
 		runtimeSettingsCapabilitiesState.loading = false;
-		outputPanelState.estimatedSizeText = '~ --- MB';
 	});
 
 	it('defaults to truthful default-on encoder behavior settings', () => {
@@ -346,17 +345,15 @@ describe('encoder panel behavior controls', () => {
 		changeSelectValue(bitrateSelect, '48');
 
 		await vi.waitFor(() => {
-			expect(outputPanelState.estimatedSizeText).not.toBe('~ --- MB');
+			expect(readEstimatedSizeText()).not.toBe('~ --- MB');
 		});
-		const lowValue = Number.parseFloat(outputPanelState.estimatedSizeText.replace(/[^\d.]+/g, ''));
+		const lowValue = Number.parseFloat(readEstimatedSizeText().replace(/[^\d.]+/g, ''));
 
 		const channelsSelect = document.getElementById('output-channels') as HTMLSelectElement;
 		changeSelectValue(channelsSelect, 'stereo');
 
 		await vi.waitFor(() => {
-			const highValue = Number.parseFloat(
-				outputPanelState.estimatedSizeText.replace(/[^\d.]+/g, ''),
-			);
+			const highValue = Number.parseFloat(readEstimatedSizeText().replace(/[^\d.]+/g, ''));
 			expect(highValue).toBeGreaterThan(lowValue);
 		});
 	});

--- a/src/ui/__tests__/encodingWorkbench-island.test.ts
+++ b/src/ui/__tests__/encodingWorkbench-island.test.ts
@@ -24,9 +24,11 @@ vi.mock('../core/actions', () => ({
 }));
 vi.mock('../../lib/tauri/client', () => ({
 	tauriClient: {
-		previewOutputPath: vi.fn().mockResolvedValue(
-			'/Users/jstar/Projects/ABB Tests/output/Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings.m4b',
-		),
+		previewOutputPath: vi
+			.fn()
+			.mockResolvedValue(
+				'/Users/jstar/Projects/ABB Tests/output/Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings.m4b',
+			),
 		validateMetadataIntentPatch: vi.fn(async (metadataPatch: unknown) => ({
 			isValid: true,
 			metadataPatch,
@@ -74,7 +76,9 @@ describe('EncodingWorkbenchIsland', () => {
 		expect(outputBlock.querySelector('h3')?.textContent).toBe('Output');
 		expect(tagsBlock.querySelector('h3')?.textContent).toBe('Tags Preview');
 		await vi.waitFor(() => {
-			expect(screen.getByTestId('output-directory-value').textContent).toContain('ABB Tests/output');
+			expect(screen.getByTestId('output-directory-value').textContent).toContain(
+				'ABB Tests/output',
+			);
 			expect(screen.getByTestId('output-example').textContent).toContain('The Way of Kings.m4b');
 		});
 		expect(encoderLogicMocks.initializeEncoderPanelLogic).toHaveBeenCalledTimes(1);

--- a/src/ui/__tests__/encodingWorkbench-island.test.ts
+++ b/src/ui/__tests__/encodingWorkbench-island.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import EncodingWorkbenchIsland from '../encodingWorkbench/EncodingWorkbenchIsland.svelte';
-import { outputPanelState } from '../outputPanel';
+import { applyOutputDefaultsFromSettings, updateOutputPath } from '../outputPanel';
 
 const { encoderLogicMocks, startPreviewAudioMock } = vi.hoisted(() => ({
 	encoderLogicMocks: {
@@ -21,6 +21,18 @@ const { encoderLogicMocks, startPreviewAudioMock } = vi.hoisted(() => ({
 vi.mock('../encoderPanel/logic', () => encoderLogicMocks);
 vi.mock('../core/actions', () => ({
 	startPreviewAudio: startPreviewAudioMock,
+}));
+vi.mock('../../lib/tauri/client', () => ({
+	tauriClient: {
+		previewOutputPath: vi.fn().mockResolvedValue(
+			'/Users/jstar/Projects/ABB Tests/output/Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings.m4b',
+		),
+		validateMetadataIntentPatch: vi.fn(async (metadataPatch: unknown) => ({
+			isValid: true,
+			metadataPatch,
+			fieldErrors: [],
+		})),
+	},
 }));
 
 function setupMetadataInputs(): void {
@@ -44,14 +56,15 @@ describe('EncodingWorkbenchIsland', () => {
 			mock.mockReset();
 		}
 		startPreviewAudioMock.mockReset();
-		outputPanelState.outputDirectory = '/Users/jstar/Projects/ABB Tests/output';
-		outputPanelState.previewText =
-			'/Users/jstar/Projects/ABB Tests/output/Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings.m4b';
-		outputPanelState.previewTitle = outputPanelState.previewText;
 	});
 
-	it('renders encoder, output, and tags as one scoped workbench row', () => {
+	it('renders encoder, output, and tags as one scoped workbench row', async () => {
 		render(EncodingWorkbenchIsland);
+		applyOutputDefaultsFromSettings({
+			outputDirectory: '/Users/jstar/Projects/ABB Tests/output',
+			outputNaming: { preset: 'absDefault', includeYear: true, customTemplate: '' },
+		});
+		updateOutputPath('final');
 
 		expect(screen.getByTestId('encoding-workbench')).toBeTruthy();
 		const encoderBlock = screen.getByTestId('encoding-workbench-encoder');
@@ -60,8 +73,10 @@ describe('EncodingWorkbenchIsland', () => {
 		expect(encoderBlock.querySelector('h3')?.textContent).toBe('Encoder');
 		expect(outputBlock.querySelector('h3')?.textContent).toBe('Output');
 		expect(tagsBlock.querySelector('h3')?.textContent).toBe('Tags Preview');
-		expect(screen.getByTestId('output-directory-value').textContent).toContain('ABB Tests/output');
-		expect(screen.getByTestId('output-example').textContent).toContain('The Way of Kings.m4b');
+		await vi.waitFor(() => {
+			expect(screen.getByTestId('output-directory-value').textContent).toContain('ABB Tests/output');
+			expect(screen.getByTestId('output-example').textContent).toContain('The Way of Kings.m4b');
+		});
 		expect(encoderLogicMocks.initializeEncoderPanelLogic).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/ui/__tests__/fileList-appendResult.test.ts
+++ b/src/ui/__tests__/fileList-appendResult.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AudioFile, FileListInfo } from '../../types/audio';
-import {
-	buildFileListAppendResult,
-	collectUniqueFiles,
-	normalizeFileListInfo,
-} from '../fileList';
+import { buildFileListAppendResult, collectUniqueFiles, normalizeFileListInfo } from '../fileList';
 
 function file(path: string, options: Partial<AudioFile> = {}): AudioFile {
 	return {

--- a/src/ui/__tests__/fileList-appendResult.test.ts
+++ b/src/ui/__tests__/fileList-appendResult.test.ts
@@ -4,7 +4,7 @@ import {
 	buildFileListAppendResult,
 	collectUniqueFiles,
 	normalizeFileListInfo,
-} from '../fileList/appendResult';
+} from '../fileList';
 
 function file(path: string, options: Partial<AudioFile> = {}): AudioFile {
 	return {

--- a/src/ui/__tests__/fileList-reorder-mirror.test.ts
+++ b/src/ui/__tests__/fileList-reorder-mirror.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AudioFile, FileListInfo } from '../../types/audio';
-import { moveFileDown, moveFileUp, reorderFiles } from '../fileList/actions';
 import {
 	getSelectedFileIndices,
+	moveFileDown,
+	moveFileUp,
+	reorderFiles,
 	setCurrentFileList,
 	setSelectedFileIndices,
 	setSelectedIndex,
-} from '../fileList/state.svelte';
+} from '../fileList';
 
 vi.mock('../metadataForm', () => ({
 	hasDirtyMetadataFields: vi.fn(() => false),

--- a/src/ui/__tests__/leftColumn-layout.test.ts
+++ b/src/ui/__tests__/leftColumn-layout.test.ts
@@ -45,7 +45,7 @@ describe('left column sibling layout', () => {
 		}
 
 		expect(fileInspectorSource).toContain('inspectorState');
-		expect(fileInspectorSource).toContain('fileListViewState.combinedSizeText');
+		expect(fileInspectorSource).toContain('readCombinedSizeText');
 		expect(fileInspectorSource).toContain('data-testid="file-inspector-panel"');
 	});
 });

--- a/src/ui/__tests__/metadata-stage.test.ts
+++ b/src/ui/__tests__/metadata-stage.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	persistPendingMetadataDraftsForCurrentSelection,
+	setCurrentFileList,
+	setSelectedFileIndices,
 	stageMetadataToSelection,
-} from '../fileList/metadataStaging';
-import { setCurrentFileList, setSelectedFileIndices } from '../fileList/state.svelte';
+} from '../fileList';
 import {
 	clearMetadataState,
 	getMetadataForFile,

--- a/src/ui/__tests__/metadataPanel-inspector.test.ts
+++ b/src/ui/__tests__/metadataPanel-inspector.test.ts
@@ -2,11 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AudioFile, FileListInfo } from '../../types/audio';
 import {
 	clearSelectionPanels,
+	setCurrentFileList,
+	setSelectedIndex,
 	showMultiSelection,
 	showSingleSelection,
-} from '../fileList/metadataPanel';
+} from '../fileList';
 import { inspectorState } from '../fileList/inspectorState.svelte';
-import { setCurrentFileList, setSelectedIndex } from '../fileList/state.svelte';
 
 const context = vi.hoisted(() => ({
 	readAudioMetadataMock: vi.fn(),

--- a/src/ui/__tests__/metadataPanel-race.test.ts
+++ b/src/ui/__tests__/metadataPanel-race.test.ts
@@ -3,14 +3,12 @@ import type { AudioFile, FileListInfo } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
 import {
 	autoUpdateCoverArtFromFirstValidFile,
-	showMultiSelection,
-	showSingleSelection,
-} from '../fileList/metadataPanel';
-import {
 	setCurrentFileList,
 	setSelectedFileIndices,
 	setSelectedIndex,
-} from '../fileList/state.svelte';
+	showMultiSelection,
+	showSingleSelection,
+} from '../fileList';
 import { jobControlsState } from '../jobControls/state.svelte';
 
 type Deferred<T> = {

--- a/src/ui/core/metadataSaveWorkflowEntryLive.ts
+++ b/src/ui/core/metadataSaveWorkflowEntryLive.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 
-import { getCurrentFileList } from '../fileList/state.svelte';
+import { getCurrentFileList } from '../fileList';
 import { metadataSaveInProgressStore } from '../metadataSaveState';
 import {
 	initStatusPanel,

--- a/src/ui/core/metadataSaveWorkflowLive.ts
+++ b/src/ui/core/metadataSaveWorkflowLive.ts
@@ -1,8 +1,7 @@
 import { get } from 'svelte/store';
 
 import { tauriClient } from '../../lib/tauri/client';
-import { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/metadataStaging';
-import { getCurrentFileList } from '../fileList/state.svelte';
+import { getCurrentFileList, persistPendingMetadataDraftsForCurrentSelection } from '../fileList';
 import { resetDirtyState } from '../metadataForm';
 import { clearPendingMetadataForFile, getPendingMetadataIntentEntries } from '../metadataState';
 import { metadataSaveInProgressStore } from '../metadataSaveState';

--- a/src/ui/core/metadataSaveWorkflowServices.ts
+++ b/src/ui/core/metadataSaveWorkflowServices.ts
@@ -4,8 +4,7 @@ import {
 	makeWorkflowLayer,
 	makeWorkflowServiceTag,
 } from '../../lib/effect/appEffect';
-import type { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/metadataStaging';
-import type { getCurrentFileList } from '../fileList/state.svelte';
+import type { getCurrentFileList, persistPendingMetadataDraftsForCurrentSelection } from '../fileList';
 import type { resetDirtyState } from '../metadataForm';
 import type {
 	clearPendingMetadataForFile,

--- a/src/ui/core/metadataSaveWorkflowServices.ts
+++ b/src/ui/core/metadataSaveWorkflowServices.ts
@@ -4,7 +4,10 @@ import {
 	makeWorkflowLayer,
 	makeWorkflowServiceTag,
 } from '../../lib/effect/appEffect';
-import type { getCurrentFileList, persistPendingMetadataDraftsForCurrentSelection } from '../fileList';
+import type {
+	getCurrentFileList,
+	persistPendingMetadataDraftsForCurrentSelection,
+} from '../fileList';
 import type { resetDirtyState } from '../metadataForm';
 import type {
 	clearPendingMetadataForFile,

--- a/src/ui/coverArt.ts
+++ b/src/ui/coverArt.ts
@@ -2,8 +2,7 @@ import { tauriClient } from '../lib/tauri/client';
 import { normalizeAppError } from '../lib/tauri/appError';
 import type { MetadataIntentPatch } from '../types/metadataIntent';
 import { jobControlsState } from './jobControls/state.svelte';
-import { getSelectedFiles } from './fileList/state.svelte';
-import { getCurrentFileList } from './fileList/state.svelte';
+import { getCurrentFileList, getSelectedFiles } from './fileList';
 import { applyMetadataDraftIntent } from './metadataDraft';
 import { getMetadataForFile, setMetadataForFile } from './metadataState';
 import {

--- a/src/ui/encoderPanel/EncoderWorkbenchIsland.svelte
+++ b/src/ui/encoderPanel/EncoderWorkbenchIsland.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { outputPanelState } from '../outputPanel';
+	import { readEstimatedSizeText } from '../outputPanel';
 	import {
 		handleBitrateModeChange,
 		handleBitrateValueChange,
@@ -24,6 +24,8 @@
 		sampleRateLabel,
 	} from './view';
 
+	const estimatedSizeText = $derived(readEstimatedSizeText());
+
 	onMount(() => {
 		initializeEncoderPanelLogic();
 	});
@@ -33,7 +35,7 @@
 	<div class="encoder-workbench-header">
 		<h3>Encoder</h3>
 		<span class="inline-info">
-			(<span id="estimated-size" data-testid="estimated-size">{outputPanelState.estimatedSizeText}</span>)
+			(<span id="estimated-size" data-testid="estimated-size">{estimatedSizeText}</span>)
 		</span>
 	</div>
 

--- a/src/ui/fileImport/FileImportIsland.svelte
+++ b/src/ui/fileImport/FileImportIsland.svelte
@@ -1,19 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { formatDuration, formatFileSize } from '../../types/audio';
-	import { clearAllFiles, toggleFileSort } from '../fileList/actions';
-	import {
-		onFileListClick,
-		onFileListDragEnd,
-		onFileListDragOver,
-		onFileListDragStart,
-		onFileListDrop,
-		onFileListKeyDown,
-		onFileListMoveDown,
-		onFileListMoveUp,
-		onFileListRemove,
-	} from '../fileList/events';
-	import { fileListViewState } from '../fileList/viewState.svelte';
+	import { FileListIsland, getCurrentFileList } from '../fileList';
 	import type { DragDropContext } from './handlers';
 	import {
 		attachTauriDragHandlers,
@@ -22,16 +9,15 @@
 	} from './handlers';
 	import { fileImportUiState } from './state.svelte';
 	import RemoteSourceAcquireIsland from '../remoteSource/RemoteSourceAcquireIsland.svelte';
-	import { hasSupplementalAssetsForInputId } from '../remoteSource/sessionAssets.svelte';
 
-	let dropZoneHeader: HTMLDivElement | null = null;
-	let fileManagementContainer: HTMLDivElement | null = null;
-	let fileListContent: HTMLDivElement | null = null;
+	let fileManagementContainer = $state<HTMLDivElement | null>(null);
 
 	const context: DragDropContext = {
 		getCoverArtArea: () => document.getElementById('cover-art-area'),
-		getFileManagementContainer: () => fileManagementContainer,
-		getVisibleFiles: () => [...fileListViewState.files],
+		getFileManagementContainer: () =>
+			fileManagementContainer ??
+			document.querySelector<HTMLDivElement>('.file-management-container'),
+		getVisibleFiles: () => getCurrentFileList()?.files ?? [],
 	};
 
 	onMount(() => {
@@ -39,438 +25,45 @@
 	});
 
 	function handleHeaderClick(): void {
-		void handleClickToSelect([...fileListViewState.files]);
+		void handleClickToSelect(getCurrentFileList()?.files ?? []);
 	}
 
 	function handleFolderClick(): void {
-		void handleClickToSelectFolder([...fileListViewState.files]);
+		void handleClickToSelectFolder(getCurrentFileList()?.files ?? []);
 	}
 
 	function handleHeaderKeydown(event: KeyboardEvent): void {
 		if (event.key === 'Enter' || event.key === ' ') {
 			event.preventDefault();
-			void handleClickToSelect([...fileListViewState.files]);
+			void handleClickToSelect(getCurrentFileList()?.files ?? []);
 		}
 	}
-
-	function focusFileListContent(): void {
-		fileListContent?.focus({ preventScroll: true });
-	}
-
-	function handleFileListClick(index: number, event: MouseEvent): void {
-		focusFileListContent();
-		onFileListClick(index, event);
-	}
-
-	function handleSortClick(): void {
-		void toggleFileSort();
-	}
-
-	function handleClearClick(): void {
-		clearAllFiles();
-	}
-
-	function getFileName(path: string): string {
-		return path.split(/[\\/]/).pop() || path;
-	}
-
-	function formatFileDetails(file: (typeof fileListViewState.files)[number]): string {
-		if (file.isValid && file.duration && file.size) {
-			return `${formatDuration(file.duration)} • ${formatFileSize(file.size)} • ${file.format}`;
-		}
-		return `Error: ${file.error || 'Invalid file'}`;
-	}
-
-	function scrollSelectedFileIntoView(index: number): void {
-		requestAnimationFrame(() => {
-			const selectedItem = fileListContent?.querySelector<HTMLElement>(
-				`[data-file-index="${index}"]`,
-			);
-			selectedItem?.scrollIntoView({ block: 'nearest' });
-		});
-	}
-
-	$effect(() => {
-		const selectedIndices = fileListViewState.selectedIndices;
-		const selectedIndex = selectedIndices[selectedIndices.length - 1];
-		if (typeof selectedIndex !== 'number') return;
-
-		scrollSelectedFileIntoView(selectedIndex);
-	});
 </script>
 
-<div class="flex flex-col gap-2 mb-2">
-  <div class="flex items-center justify-end gap-2">
-    <div class="flex items-center gap-2 mr-auto self-center pl-1">
-      <span class="text-xs muted-text italic" id="file-count-display">
-        {fileListViewState.files.length} {fileListViewState.files.length === 1 ? 'file' : 'files'}
-      </span>
-      <span
-        class="text-xs muted-text italic"
-        id="file-order-lock"
-        style:display={fileListViewState.orderLockVisible ? 'inline' : 'none'}
-        data-testid="file-order-lock"
-      >
-        Order locked while processing
-      </span>
-    </div>
-    <button
-      id="add-folder-btn"
-      class="btn-pill btn-pill-secondary"
-      onclick={handleFolderClick}
-    >
-      Add Folder
-    </button>
-    <RemoteSourceAcquireIsland />
-    <button
-      id="sort-toggle-btn"
-      class="btn-pill btn-pill-secondary"
-      style:display={fileListViewState.showSortButton ? 'block' : 'none'}
-      disabled={fileListViewState.sortDisabled}
-      onclick={handleSortClick}
-    >
-      {fileListViewState.sortLabel}
-    </button>
-    <button
-      id="clear-files-btn"
-      class="btn-pill btn-pill-secondary"
-      style:display={fileListViewState.showClearButton ? 'block' : 'none'}
-      disabled={fileListViewState.clearDisabled}
-      onclick={handleClearClick}
-    >
-      Clear
-    </button>
-  </div>
-</div>
-
-<style>
-	.file-management-container {
-		display: flex;
-		flex: 1 1 auto;
-		flex-direction: column;
-		min-height: 8rem;
-		overflow: hidden;
-		border: 1px solid var(--border-primary);
-		border-radius: 0.375rem;
-		background-color: var(--bg-input);
-	}
-
-	.file-list-content:focus-visible {
-		outline: 2px solid var(--border-focus);
-		outline-offset: -2px;
-	}
-
-	.drop-zone-header[data-has-files='false'] {
-		display: flex;
-		flex: 1 1 auto;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		padding: 2rem 1rem;
-		border: 2px dashed var(--border-secondary);
-		background-color: var(--bg-drag-area);
-		cursor: pointer;
-		transition: all 0.2s ease;
-	}
-
-	.drop-zone-header[data-has-files='false']:hover,
-	.drop-zone-header[data-has-files='false'].drag-over {
-		border-color: var(--accent-primary);
-		background-color: var(--bg-hover);
-	}
-
-	.drop-zone-header[data-has-files='false'].drag-over {
-		transform: scale(1.02);
-	}
-
-	.drop-zone-header[data-has-files='false']:focus {
-		outline: 2px solid var(--border-focus);
-		outline-offset: 2px;
-	}
-
-	.drop-zone-header[data-has-files='true'] {
-		flex-shrink: 0;
-		min-height: 2.5rem;
-		padding: 0.5rem 1rem;
-		border-bottom: 1px solid var(--border-primary);
-		background-color: var(--bg-input);
-		cursor: pointer;
-		transition: all 0.2s ease;
-	}
-
-	.drop-zone-header[data-has-files='true']:hover {
-		background-color: var(--bg-hover);
-	}
-
-	.drop-zone-header[data-has-files='true']:focus {
-		outline: 2px solid var(--border-focus);
-		outline-offset: -2px;
-	}
-
-	.file-list-content {
-		flex: 1 1 auto;
-		min-height: 0;
-		overflow-y: auto;
-	}
-
-	.file-list-item {
-		padding: 0.75rem;
-		border-bottom: 1px solid var(--border-primary);
-		cursor: pointer;
-		transition: background-color 0.2s ease;
-		user-select: none;
-	}
-
-	.file-list-item:last-child {
-		border-bottom: none;
-	}
-
-	.file-list-item:hover {
-		background-color: var(--bg-hover);
-	}
-
-	.file-list-item.selected {
-		background-color: var(--accent-primary);
-		color: var(--text-inverse);
-	}
-
-	.file-list-item.dragging {
-		opacity: 0.5;
-	}
-
-	.file-list-item.drag-over {
-		border-top: 2px solid var(--accent-primary);
-	}
-
-	.file-item-content {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		min-width: 0;
-	}
-
-	.file-status {
-		min-width: 1rem;
-		font-size: 1rem;
-		font-weight: bold;
-	}
-
-	.file-info {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.file-name-row {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-		margin-bottom: 0.25rem;
-		min-width: 0;
-	}
-
-	.file-name {
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		font-size: 0.875rem;
-		font-weight: 500;
-	}
-
-	.companion-chip {
-		flex: 0 0 auto;
-		padding: 0.0625rem 0.25rem;
-		border: 1px solid var(--accent-primary);
-		border-radius: 0.25rem;
-		background-color: rgb(59 130 246 / 0.12);
-		color: var(--accent-primary);
-		font-size: 0.625rem;
-		font-weight: 600;
-		line-height: 1;
-	}
-
-	.file-list-item.selected .companion-chip {
-		border-color: rgb(255 255 255 / 0.7);
-		background-color: rgb(255 255 255 / 0.18);
-		color: var(--text-inverse);
-	}
-
-	.file-details {
-		overflow: hidden;
-		color: var(--text-muted);
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		font-size: 0.75rem;
-	}
-
-	.file-list-item.selected .file-details {
-		color: var(--text-inverse);
-		opacity: 0.9;
-	}
-
-	.remove-file-btn,
-	.move-up-btn,
-	.move-down-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 1.5rem;
-		height: 1.5rem;
-		padding: 0.25rem;
-		border: none;
-		border-radius: 0.25rem;
-		background: none;
-		color: var(--text-muted);
-		font-size: 1.25rem;
-		font-weight: bold;
-		cursor: pointer;
-	}
-
-	.remove-file-btn:hover {
-		background-color: rgb(239 68 68 / 0.1);
-		color: #ef4444;
-	}
-
-	.move-up-btn:hover,
-	.move-down-btn:hover {
-		background-color: var(--bg-hover);
-		color: var(--accent-primary);
-		transform: translateY(-1px);
-	}
-
-	.move-up-btn:focus-visible,
-	.move-down-btn:focus-visible {
-		outline: 2px solid var(--border-focus);
-		outline-offset: 2px;
-	}
-
-	.move-up-btn:disabled,
-	.move-down-btn:disabled {
-		opacity: 0.3;
-		cursor: not-allowed;
-	}
-
-	.move-up-btn:disabled:hover,
-	.move-down-btn:disabled:hover {
-		background-color: transparent;
-		color: var(--text-muted);
-		transform: none;
-	}
-
-	.file-list-item.selected .remove-file-btn,
-	.file-list-item.selected .move-up-btn,
-	.file-list-item.selected .move-down-btn {
-		color: var(--text-inverse);
-		opacity: 0.8;
-	}
-
-	.file-list-item.selected .remove-file-btn:hover,
-	.file-list-item.selected .move-up-btn:hover,
-	.file-list-item.selected .move-down-btn:hover {
-		background-color: rgb(255 255 255 / 0.2);
-		color: var(--text-inverse);
-		opacity: 1;
-	}
-
-	.file-list-item.selected .move-up-btn:disabled,
-	.file-list-item.selected .move-down-btn:disabled {
-		color: var(--text-inverse);
-	}
-</style>
-
-<div
-  id="file-import-error"
-  class="error-message mb-3"
-  style:display={fileImportUiState.errorMessage ? 'block' : 'none'}
->
-  {fileImportUiState.errorMessage}
+<div class="flex items-center justify-end gap-2 mb-2">
+	<button
+		id="add-folder-btn"
+		class="btn-pill btn-pill-secondary"
+		onclick={handleFolderClick}
+	>
+		Add Folder
+	</button>
+	<RemoteSourceAcquireIsland />
 </div>
 
 <div
-  class="file-management-container mb-3"
-  role="region"
-  aria-label="File list"
-  bind:this={fileManagementContainer}
+	id="file-import-error"
+	class="error-message mb-3"
+	style:display={fileImportUiState.errorMessage ? 'block' : 'none'}
 >
-  <div
-    bind:this={dropZoneHeader}
-    class="drop-zone-header"
-    class:drag-over={fileImportUiState.isDragOver}
-    data-has-files={fileImportUiState.hasFiles.toString()}
-    role="button"
-    aria-label="Add audio files"
-    tabindex="0"
-    onclick={handleHeaderClick}
-    onkeydown={handleHeaderKeydown}
-  >
-    <p class="text-sm muted-text">Drop files or folders here, click to choose files, or use Add Folder</p>
-    <p class="text-xs muted-text mt-1">{fileImportUiState.supportText}</p>
-  </div>
-
-  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions -->
-  <div
-    bind:this={fileListContent}
-    class="file-list-content"
-    role="listbox"
-    aria-label="Audio files"
-    aria-multiselectable="true"
-    tabindex="0"
-    onkeydown={onFileListKeyDown}
-  >
-    {#each fileListViewState.files as file, index (file.inputId ?? file.path)}
-      <div
-        data-file-index={index}
-        class="file-list-item {file.isValid ? 'valid' : 'invalid'}"
-        class:selected={fileListViewState.selectedIndices.includes(index)}
-        class:dragging={fileListViewState.draggedIndex === index}
-        class:drag-over={fileListViewState.hoveredIndex === index}
-        draggable={fileListViewState.orderLockVisible ? 'false' : 'true'}
-        role="option"
-        aria-selected={fileListViewState.selectedIndices.includes(index)}
-        aria-label={getFileName(file.path)}
-        tabindex="-1"
-        onclick={(event) => handleFileListClick(index, event)}
-        ondragstart={(event) => onFileListDragStart(index, event)}
-        ondragover={(event) => onFileListDragOver(index, event)}
-        ondrop={(event) => onFileListDrop(index, event)}
-        ondragend={onFileListDragEnd}
-      >
-        <div class="file-item-content">
-          <div class="file-status {file.isValid ? 'text-green-500' : 'text-red-500'}">
-            {file.isValid ? '✓' : '✗'}
-          </div>
-          <div class="file-info">
-            <div class="file-name-row">
-              <div class="file-name">{getFileName(file.path)}</div>
-              {#if hasSupplementalAssetsForInputId(file.inputId)}
-                <span class="companion-chip" title="Supplemental PDF attached">PDF</span>
-              {/if}
-            </div>
-            <div class="file-details">{formatFileDetails(file)}</div>
-          </div>
-          <button
-            class="move-up-btn"
-            onclick={(event) => onFileListMoveUp(index, event)}
-            disabled={index === 0 || fileListViewState.orderLockVisible}
-          >
-            ▲
-          </button>
-          <button
-            class="move-down-btn"
-            onclick={(event) => onFileListMoveDown(index, event)}
-            disabled={index === fileListViewState.files.length - 1 || fileListViewState.orderLockVisible}
-          >
-            ▼
-          </button>
-          <button
-            class="remove-file-btn"
-            disabled={fileListViewState.orderLockVisible}
-            onclick={(event) => onFileListRemove(index, event)}
-          >
-            ×
-          </button>
-        </div>
-      </div>
-    {/each}
-  </div>
+	{fileImportUiState.errorMessage}
 </div>
+
+<FileListIsland
+	bind:fileManagementContainer
+	isDragOver={fileImportUiState.isDragOver}
+	hasFiles={fileImportUiState.hasFiles}
+	supportText={fileImportUiState.supportText}
+	onHeaderClick={handleHeaderClick}
+	onHeaderKeydown={handleHeaderKeydown}
+/>

--- a/src/ui/fileImport/__tests__/coverArtDrop.test.ts
+++ b/src/ui/fileImport/__tests__/coverArtDrop.test.ts
@@ -4,14 +4,7 @@ import type { TauriFileDropEvents } from '../../../types/events';
 import type { AcquisitionJob } from '../../../types/remoteSource';
 import FileImportIsland from '../FileImportIsland.svelte';
 import { clearFileImportError } from '../state.svelte';
-import { clearSelectionPanels } from '../../fileList/metadataPanel';
-import {
-	getCurrentFileList,
-	setCurrentFileList,
-	setSelectedFileIndices,
-	setSelectedIndex,
-} from '../../fileList/state.svelte';
-import { fileListViewState, resetFileListViewState } from '../../fileList/viewState.svelte';
+import { displayFileList, getCurrentFileList } from '../../fileList';
 import { clearMetadataState } from '../../metadataState';
 import {
 	registerRemoteSourceSupplementalAssets,
@@ -175,15 +168,11 @@ describe('File import drop vs cover art drop isolation', () => {
 		clearMetadataState();
 		clearFileImportError();
 		removeRemoteSourceSupplementalAssets(['current-input-1']);
-		setCurrentFileList(null);
-		setSelectedFileIndices([]);
-		setSelectedIndex(-1);
-		clearSelectionPanels();
-		resetFileListViewState();
 		document.body.innerHTML = `
       <div id="cover-art-area"></div>
 		`;
 		render(FileImportIsland);
+		displayFileList(makeAnalyzedFileList([]));
 
 		const dropZone = document.querySelector('.drop-zone-header') as HTMLElement | null;
 		if (!dropZone) {
@@ -370,7 +359,7 @@ describe('File import drop vs cover art drop isolation', () => {
 
 		await waitFor(() => {
 			expect(document.querySelectorAll('.file-list-item')).toHaveLength(2);
-			expect(fileListViewState.files.map((file) => file.path)).toEqual([
+			expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual([
 				'/tmp/book-a.mp3',
 				'/tmp/book-b.mp3',
 			]);
@@ -403,7 +392,7 @@ describe('File import drop vs cover art drop isolation', () => {
 
 		await waitFor(() => {
 			expect(document.querySelectorAll('.file-list-item')).toHaveLength(2);
-			expect(fileListViewState.files.map((file) => file.path)).toEqual([
+			expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual([
 				'/tmp/book-a.mp3',
 				'/tmp/book-b.mp3',
 			]);
@@ -416,7 +405,7 @@ describe('File import drop vs cover art drop isolation', () => {
 		);
 		fireDragDrop({ x: 200, y: 200 }, ['/tmp/book-a.mp3']);
 		await waitFor(() => {
-			expect(fileListViewState.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
+			expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
 		});
 
 		analyzeAudioFilesMock.mockResolvedValueOnce(
@@ -431,9 +420,9 @@ describe('File import drop vs cover art drop isolation', () => {
 
 		await waitFor(() => {
 			expect(document.querySelectorAll('.file-list-item')).toHaveLength(1);
-			expect(fileListViewState.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
+			expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
 		});
-		expect(fileListViewState.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
+		expect(getCurrentFileList()?.files.map((file) => file.path)).toEqual(['/tmp/book-a.mp3']);
 		await waitFor(() => {
 			expect(document.querySelector('#file-import-error')?.textContent).toContain(
 				'No new files added. All analyzed files were already in the list.',

--- a/src/ui/fileImport/__tests__/coverArtDrop.test.ts
+++ b/src/ui/fileImport/__tests__/coverArtDrop.test.ts
@@ -1,23 +1,22 @@
 import { render, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { TauriFileDropEvents } from '../../types/events';
-import type { AcquisitionJob } from '../../types/remoteSource';
-import FileImportIsland from '../fileImport/FileImportIsland.svelte';
-import { clearFileImportError } from '../fileImport/state.svelte';
-import { clearSelectionPanels } from '../fileList/metadataPanel';
+import type { TauriFileDropEvents } from '../../../types/events';
+import type { AcquisitionJob } from '../../../types/remoteSource';
+import FileImportIsland from '../FileImportIsland.svelte';
+import { clearFileImportError } from '../state.svelte';
+import { clearSelectionPanels } from '../../fileList/metadataPanel';
 import {
 	getCurrentFileList,
 	setCurrentFileList,
 	setSelectedFileIndices,
 	setSelectedIndex,
-} from '../fileList/state.svelte';
-import { fileListViewState } from '../fileList/viewState.svelte';
-import { resetFileListViewState } from '../fileList/viewState.svelte';
-import { clearMetadataState } from '../metadataState';
+} from '../../fileList/state.svelte';
+import { fileListViewState, resetFileListViewState } from '../../fileList/viewState.svelte';
+import { clearMetadataState } from '../../metadataState';
 import {
 	registerRemoteSourceSupplementalAssets,
 	removeRemoteSourceSupplementalAssets,
-} from '../remoteSource/sessionAssets.svelte';
+} from '../../remoteSource/sessionAssets.svelte';
 
 type DragDropPayload = TauriFileDropEvents['tauri://drag-drop'];
 type DragDropListener = (event: { payload: DragDropPayload }) => void;
@@ -47,7 +46,7 @@ const {
 	listeners: {} as Record<string, TauriListener>,
 }));
 
-vi.mock('../../lib/tauri/client', () => ({
+vi.mock('../../../lib/tauri/client', () => ({
 	tauriClient: {
 		listen: vi.fn((event: string, cb: TauriListener) => {
 			listeners[event] = cb;
@@ -63,7 +62,7 @@ vi.mock('../../lib/tauri/client', () => ({
 	},
 }));
 
-vi.mock('../statusPanel', () => ({
+vi.mock('../../statusPanel', () => ({
 	pushStatusPanelTransientStatus: pushStatusPanelTransientStatusMock,
 }));
 

--- a/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
+++ b/src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Effect, runAppEffect } from '../../../lib/effect/appEffect';
 import type { AudioFile, FileListInfo, SupportedAudioImportMetadata } from '../../../types/audio';
-import type { FileListAppendResult } from '../../fileList/appendResult';
+import type { FileListAppendResult } from '../../fileList';
 import {
 	importAnalysisWorkflowExecution,
 	makeImportAnalysisWorkflowServicesLayer,

--- a/src/ui/fileImport/handlers.ts
+++ b/src/ui/fileImport/handlers.ts
@@ -2,7 +2,7 @@ import { tauriClient } from '../../lib/tauri/client';
 import type { AudioFile } from '../../types/audio';
 import { EVENTS, isFileDropEvent } from '../../types/events';
 import { applyCoverArtDrop } from '../coverArt';
-import { getCurrentFileList, onOrderLockChange } from '../fileList/state.svelte';
+import { getCurrentFileList, onOrderLockChange } from '../fileList';
 import {
 	setFileImportDragOver,
 	setFileImportError,

--- a/src/ui/fileImport/importAnalysisWorkflowLive.ts
+++ b/src/ui/fileImport/importAnalysisWorkflowLive.ts
@@ -1,7 +1,9 @@
 import { tauriClient } from '../../lib/tauri/client';
-import { appendFileList } from '../fileList/actions';
-import { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/metadataStaging';
-import { isOrderLocked } from '../fileList/state.svelte';
+import {
+	appendFileList,
+	isOrderLocked,
+	persistPendingMetadataDraftsForCurrentSelection,
+} from '../fileList';
 import { pushStatusPanelTransientStatus } from '../statusPanel';
 import { clearFileImportError, setFileImportError } from './state.svelte';
 import {

--- a/src/ui/fileImport/importAnalysisWorkflowServices.ts
+++ b/src/ui/fileImport/importAnalysisWorkflowServices.ts
@@ -5,9 +5,11 @@ import {
 	makeWorkflowLayer,
 	makeWorkflowServiceTag,
 } from '../../lib/effect/appEffect';
-import type { appendFileList } from '../fileList/actions';
-import type { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/metadataStaging';
-import type { isOrderLocked } from '../fileList/state.svelte';
+import type {
+	appendFileList,
+	isOrderLocked,
+	persistPendingMetadataDraftsForCurrentSelection,
+} from '../fileList';
 import type { pushStatusPanelTransientStatus } from '../statusPanel';
 import type { clearFileImportError, setFileImportError } from './state.svelte';
 

--- a/src/ui/fileList/AGENTS.md
+++ b/src/ui/fileList/AGENTS.md
@@ -8,6 +8,28 @@
 - FileList owns pre-processing workbench state after backend import analysis has
   returned `FileListInfo`.
 
+## Public API Strip
+
+- Import file list runtime symbols from `src/ui/fileList`.
+- Exports: `FileListIsland`, list mutation actions (`displayFileList`,
+  `appendFileList`, `selectFile`, `clearAllFiles`, `toggleFileSort`,
+  `setFileOrderLocked`, reorder/remove helpers), session accessors
+  (`getCurrentFileList`, `getSelectedFiles`, `getSelectedFileIndices`,
+  `isOrderLocked`, `onOrderLockChange`, setters used by workflows), metadata
+  staging/presentation entrypoints (`stageMetadataToSelection`,
+  `persistPendingMetadataDraftsForCurrentSelection`, `showSingleSelection`,
+  `clearSelectionPanels`), append helpers/types for import workflows, and
+  `readCombinedSizeText()`.
+- Do **not** export `fileListViewState`, `fileListSessionState`, DOM helpers,
+  selection internals, or event handlers from the index.
+
+## Private Cluster
+
+- Files: `FileListIsland.svelte`, `actions.ts`, `state.svelte.ts`,
+  `viewState.svelte.ts`, `events.ts`, `dom.ts`, `selection.ts`,
+  `metadataStaging.ts`, `metadataPanel.ts`, `appendResult.ts`,
+  `inspectorState.svelte.ts`, `keyboardNavigation.ts`, `__tests__/`.
+
 ## Preferred Path
 
 - Keep append/dedupe calculation in `appendResult.ts`. Import workflows may
@@ -17,6 +39,8 @@
   call it before changing selection when dirty drafts must be preserved.
 - Keep `actions.ts` focused on visible FileList mutations: display, append,
   select, reorder, remove, clear, lock, totals, and output refresh.
+- `FileListIsland.svelte` owns list rendering; `FileImportIsland` composes it
+  and owns import/drop/picker workflow.
 - Preserve `FileListInfo` truth from the backend. Do not add frontend-owned
   audio importability or supported-extension allowlists.
 

--- a/src/ui/fileList/FileListIsland.svelte
+++ b/src/ui/fileList/FileListIsland.svelte
@@ -418,14 +418,20 @@
 					</div>
 					<button
 						class="move-up-btn"
-						onclick={(event) => onFileListMoveUp(index, event)}
+						onclick={(event) => {
+							event.stopPropagation();
+							onFileListMoveUp(index, event);
+						}}
 						disabled={index === 0 || fileListViewState.orderLockVisible}
 					>
 						▲
 					</button>
 					<button
 						class="move-down-btn"
-						onclick={(event) => onFileListMoveDown(index, event)}
+						onclick={(event) => {
+							event.stopPropagation();
+							onFileListMoveDown(index, event);
+						}}
 						disabled={index === fileListViewState.files.length - 1 || fileListViewState.orderLockVisible}
 					>
 						▼
@@ -433,7 +439,10 @@
 					<button
 						class="remove-file-btn"
 						disabled={fileListViewState.orderLockVisible}
-						onclick={(event) => onFileListRemove(index, event)}
+						onclick={(event) => {
+							event.stopPropagation();
+							onFileListRemove(index, event);
+						}}
 					>
 						×
 					</button>

--- a/src/ui/fileList/FileListIsland.svelte
+++ b/src/ui/fileList/FileListIsland.svelte
@@ -1,0 +1,444 @@
+<script lang="ts">
+	import { formatDuration, formatFileSize } from '../../types/audio';
+	import { clearAllFiles, toggleFileSort } from './actions';
+	import {
+		onFileListClick,
+		onFileListDragEnd,
+		onFileListDragOver,
+		onFileListDragStart,
+		onFileListDrop,
+		onFileListKeyDown,
+		onFileListMoveDown,
+		onFileListMoveUp,
+		onFileListRemove,
+	} from './events';
+	import { fileListViewState } from './viewState.svelte';
+	import { hasSupplementalAssetsForInputId } from '../remoteSource/sessionAssets.svelte';
+
+	interface Props {
+		isDragOver?: boolean;
+		hasFiles?: boolean;
+		supportText?: string;
+		onHeaderClick?: () => void;
+		onHeaderKeydown?: (event: KeyboardEvent) => void;
+		fileManagementContainer?: HTMLDivElement | null;
+	}
+
+	let {
+		isDragOver = false,
+		hasFiles = false,
+		supportText = '',
+		onHeaderClick,
+		onHeaderKeydown,
+		fileManagementContainer = $bindable(null),
+	}: Props = $props();
+
+	let fileListContent: HTMLDivElement | null = null;
+
+	function focusFileListContent(): void {
+		fileListContent?.focus({ preventScroll: true });
+	}
+
+	function handleFileListClick(index: number, event: MouseEvent): void {
+		focusFileListContent();
+		onFileListClick(index, event);
+	}
+
+	function handleSortClick(): void {
+		void toggleFileSort();
+	}
+
+	function handleClearClick(): void {
+		clearAllFiles();
+	}
+
+	function getFileName(path: string): string {
+		return path.split(/[\\/]/).pop() || path;
+	}
+
+	function formatFileDetails(file: (typeof fileListViewState.files)[number]): string {
+		if (file.isValid && file.duration && file.size) {
+			return `${formatDuration(file.duration)} • ${formatFileSize(file.size)} • ${file.format}`;
+		}
+		return `Error: ${file.error || 'Invalid file'}`;
+	}
+
+	function scrollSelectedFileIntoView(index: number): void {
+		requestAnimationFrame(() => {
+			const selectedItem = fileListContent?.querySelector<HTMLElement>(
+				`[data-file-index="${index}"]`,
+			);
+			selectedItem?.scrollIntoView({ block: 'nearest' });
+		});
+	}
+
+	$effect(() => {
+		const selectedIndices = fileListViewState.selectedIndices;
+		const selectedIndex = selectedIndices[selectedIndices.length - 1];
+		if (typeof selectedIndex !== 'number') return;
+
+		scrollSelectedFileIntoView(selectedIndex);
+	});
+</script>
+
+<div class="flex flex-col gap-2 mb-2">
+	<div class="flex items-center justify-end gap-2">
+		<div class="flex items-center gap-2 mr-auto self-center pl-1">
+			<span class="text-xs muted-text italic" id="file-count-display">
+				{fileListViewState.files.length}
+				{fileListViewState.files.length === 1 ? 'file' : 'files'}
+			</span>
+			<span
+				class="text-xs muted-text italic"
+				id="file-order-lock"
+				style:display={fileListViewState.orderLockVisible ? 'inline' : 'none'}
+				data-testid="file-order-lock"
+			>
+				Order locked while processing
+			</span>
+		</div>
+		<button
+			id="sort-toggle-btn"
+			class="btn-pill btn-pill-secondary"
+			style:display={fileListViewState.showSortButton ? 'block' : 'none'}
+			disabled={fileListViewState.sortDisabled}
+			onclick={handleSortClick}
+		>
+			{fileListViewState.sortLabel}
+		</button>
+		<button
+			id="clear-files-btn"
+			class="btn-pill btn-pill-secondary"
+			style:display={fileListViewState.showClearButton ? 'block' : 'none'}
+			disabled={fileListViewState.clearDisabled}
+			onclick={handleClearClick}
+		>
+			Clear
+		</button>
+	</div>
+</div>
+
+<style>
+	.file-management-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 8rem;
+		overflow: hidden;
+		border: 1px solid var(--border-primary);
+		border-radius: 0.375rem;
+		background-color: var(--bg-input);
+	}
+
+	.file-list-content:focus-visible {
+		outline: 2px solid var(--border-focus);
+		outline-offset: -2px;
+	}
+
+	.drop-zone-header[data-has-files='false'] {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem 1rem;
+		border: 2px dashed var(--border-secondary);
+		background-color: var(--bg-drag-area);
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.drop-zone-header[data-has-files='false']:hover,
+	.drop-zone-header[data-has-files='false'].drag-over {
+		border-color: var(--accent-primary);
+		background-color: var(--bg-hover);
+	}
+
+	.drop-zone-header[data-has-files='false'].drag-over {
+		transform: scale(1.02);
+	}
+
+	.drop-zone-header[data-has-files='false']:focus {
+		outline: 2px solid var(--border-focus);
+		outline-offset: 2px;
+	}
+
+	.drop-zone-header[data-has-files='true'] {
+		flex-shrink: 0;
+		min-height: 2.5rem;
+		padding: 0.5rem 1rem;
+		border-bottom: 1px solid var(--border-primary);
+		background-color: var(--bg-input);
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.drop-zone-header[data-has-files='true']:hover {
+		background-color: var(--bg-hover);
+	}
+
+	.drop-zone-header[data-has-files='true']:focus {
+		outline: 2px solid var(--border-focus);
+		outline-offset: -2px;
+	}
+
+	.file-list-content {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.file-list-item {
+		padding: 0.75rem;
+		border-bottom: 1px solid var(--border-primary);
+		cursor: pointer;
+		transition: background-color 0.2s ease;
+		user-select: none;
+	}
+
+	.file-list-item:last-child {
+		border-bottom: none;
+	}
+
+	.file-list-item:hover {
+		background-color: var(--bg-hover);
+	}
+
+	.file-list-item.selected {
+		background-color: var(--accent-primary);
+		color: var(--text-inverse);
+	}
+
+	.file-list-item.dragging {
+		opacity: 0.5;
+	}
+
+	.file-list-item.drag-over {
+		border-top: 2px solid var(--accent-primary);
+	}
+
+	.file-item-content {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		min-width: 0;
+	}
+
+	.file-status {
+		min-width: 1rem;
+		font-size: 1rem;
+		font-weight: bold;
+	}
+
+	.file-info {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.file-name-row {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		margin-bottom: 0.25rem;
+		min-width: 0;
+	}
+
+	.file-name {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+
+	.companion-chip {
+		flex: 0 0 auto;
+		padding: 0.0625rem 0.25rem;
+		border: 1px solid var(--accent-primary);
+		border-radius: 0.25rem;
+		background-color: rgb(59 130 246 / 0.12);
+		color: var(--accent-primary);
+		font-size: 0.625rem;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	.file-list-item.selected .companion-chip {
+		border-color: rgb(255 255 255 / 0.7);
+		background-color: rgb(255 255 255 / 0.18);
+		color: var(--text-inverse);
+	}
+
+	.file-details {
+		overflow: hidden;
+		color: var(--text-muted);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 0.75rem;
+	}
+
+	.file-list-item.selected .file-details {
+		color: var(--text-inverse);
+		opacity: 0.9;
+	}
+
+	.remove-file-btn,
+	.move-up-btn,
+	.move-down-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.5rem;
+		height: 1.5rem;
+		padding: 0.25rem;
+		border: none;
+		border-radius: 0.25rem;
+		background: none;
+		color: var(--text-muted);
+		font-size: 1.25rem;
+		font-weight: bold;
+		cursor: pointer;
+	}
+
+	.remove-file-btn:hover {
+		background-color: rgb(239 68 68 / 0.1);
+		color: #ef4444;
+	}
+
+	.move-up-btn:hover,
+	.move-down-btn:hover {
+		background-color: var(--bg-hover);
+		color: var(--accent-primary);
+		transform: translateY(-1px);
+	}
+
+	.move-up-btn:focus-visible,
+	.move-down-btn:focus-visible {
+		outline: 2px solid var(--border-focus);
+		outline-offset: 2px;
+	}
+
+	.move-up-btn:disabled,
+	.move-down-btn:disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
+	}
+
+	.move-up-btn:disabled:hover,
+	.move-down-btn:disabled:hover {
+		background-color: transparent;
+		color: var(--text-muted);
+		transform: none;
+	}
+
+	.file-list-item.selected .remove-file-btn,
+	.file-list-item.selected .move-up-btn,
+	.file-list-item.selected .move-down-btn {
+		color: var(--text-inverse);
+		opacity: 0.8;
+	}
+
+	.file-list-item.selected .remove-file-btn:hover,
+	.file-list-item.selected .move-up-btn:hover,
+	.file-list-item.selected .move-down-btn:hover {
+		background-color: rgb(255 255 255 / 0.2);
+		color: var(--text-inverse);
+		opacity: 1;
+	}
+
+	.file-list-item.selected .move-up-btn:disabled,
+	.file-list-item.selected .move-down-btn:disabled {
+		color: var(--text-inverse);
+	}
+</style>
+
+<div
+	class="file-management-container mb-3"
+	role="region"
+	aria-label="File list"
+	bind:this={fileManagementContainer}
+>
+	<div
+		class="drop-zone-header"
+		class:drag-over={isDragOver}
+		data-has-files={hasFiles.toString()}
+		role="button"
+		aria-label="Add audio files"
+		tabindex="0"
+		onclick={() => onHeaderClick?.()}
+		onkeydown={(event) => onHeaderKeydown?.(event)}
+	>
+		<p class="text-sm muted-text">
+			Drop files or folders here, click to choose files, or use Add Folder
+		</p>
+		<p class="text-xs muted-text mt-1">{supportText}</p>
+	</div>
+
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions -->
+	<div
+		bind:this={fileListContent}
+		class="file-list-content"
+		role="listbox"
+		aria-label="Audio files"
+		aria-multiselectable="true"
+		tabindex="0"
+		onkeydown={onFileListKeyDown}
+	>
+		{#each fileListViewState.files as file, index (file.inputId ?? file.path)}
+			<div
+				data-file-index={index}
+				class="file-list-item {file.isValid ? 'valid' : 'invalid'}"
+				class:selected={fileListViewState.selectedIndices.includes(index)}
+				class:dragging={fileListViewState.draggedIndex === index}
+				class:drag-over={fileListViewState.hoveredIndex === index}
+				draggable={fileListViewState.orderLockVisible ? 'false' : 'true'}
+				role="option"
+				aria-selected={fileListViewState.selectedIndices.includes(index)}
+				aria-label={getFileName(file.path)}
+				tabindex="-1"
+				onclick={(event) => handleFileListClick(index, event)}
+				ondragstart={(event) => onFileListDragStart(index, event)}
+				ondragover={(event) => onFileListDragOver(index, event)}
+				ondrop={(event) => onFileListDrop(index, event)}
+				ondragend={onFileListDragEnd}
+			>
+				<div class="file-item-content">
+					<div class="file-status {file.isValid ? 'text-green-500' : 'text-red-500'}">
+						{file.isValid ? '✓' : '✗'}
+					</div>
+					<div class="file-info">
+						<div class="file-name-row">
+							<div class="file-name">{getFileName(file.path)}</div>
+							{#if hasSupplementalAssetsForInputId(file.inputId)}
+								<span class="companion-chip" title="Supplemental PDF attached">PDF</span>
+							{/if}
+						</div>
+						<div class="file-details">{formatFileDetails(file)}</div>
+					</div>
+					<button
+						class="move-up-btn"
+						onclick={(event) => onFileListMoveUp(index, event)}
+						disabled={index === 0 || fileListViewState.orderLockVisible}
+					>
+						▲
+					</button>
+					<button
+						class="move-down-btn"
+						onclick={(event) => onFileListMoveDown(index, event)}
+						disabled={index === fileListViewState.files.length - 1 || fileListViewState.orderLockVisible}
+					>
+						▼
+					</button>
+					<button
+						class="remove-file-btn"
+						disabled={fileListViewState.orderLockVisible}
+						onclick={(event) => onFileListRemove(index, event)}
+					>
+						×
+					</button>
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>

--- a/src/ui/fileList/__tests__/keyboardEvents.test.ts
+++ b/src/ui/fileList/__tests__/keyboardEvents.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AudioFile, FileListInfo } from '../../types/audio';
-import {
-	setCurrentFileList,
-	setSelectedFileIndices,
-	setSelectedIndex,
-} from '../fileList/state.svelte';
+import type { AudioFile, FileListInfo } from '../../../types/audio';
+import { setCurrentFileList, setSelectedFileIndices, setSelectedIndex } from '../index';
 
 const context = vi.hoisted(() => ({
 	clearSelectionActionMock: vi.fn(),
@@ -16,7 +12,7 @@ const context = vi.hoisted(() => ({
 	selectFileMock: vi.fn(async () => undefined),
 }));
 
-vi.mock('../fileList/actions', () => ({
+vi.mock('../actions', () => ({
 	clearSelectionAction: context.clearSelectionActionMock,
 	moveFileDown: context.moveFileDownMock,
 	moveFileUp: context.moveFileUpMock,
@@ -80,7 +76,7 @@ describe('file list keyboard events', () => {
 	});
 
 	it('selects the first file from an empty selection on ArrowDown', async () => {
-		const { onFileListKeyDown } = await import('../fileList/events');
+		const { onFileListKeyDown } = await import('../events');
 		const event = keyboardEvent('ArrowDown');
 
 		onFileListKeyDown(event);
@@ -90,7 +86,7 @@ describe('file list keyboard events', () => {
 	});
 
 	it('jumps to the bottom of the file list on End', async () => {
-		const { onFileListKeyDown } = await import('../fileList/events');
+		const { onFileListKeyDown } = await import('../events');
 		setSelectedIndex(1);
 		setSelectedFileIndices([1]);
 		const event = keyboardEvent('End');
@@ -102,7 +98,7 @@ describe('file list keyboard events', () => {
 	});
 
 	it('does not reselect while already colliding with a list edge', async () => {
-		const { onFileListKeyDown } = await import('../fileList/events');
+		const { onFileListKeyDown } = await import('../events');
 		setSelectedIndex(4);
 		setSelectedFileIndices([4]);
 		const event = keyboardEvent('ArrowDown');
@@ -114,7 +110,7 @@ describe('file list keyboard events', () => {
 	});
 
 	it('leaves text input arrow handling alone', async () => {
-		const { onFileListKeyDown } = await import('../fileList/events');
+		const { onFileListKeyDown } = await import('../events');
 		const input = document.createElement('input');
 		const event = keyboardEvent('ArrowDown', { target: input });
 
@@ -125,7 +121,7 @@ describe('file list keyboard events', () => {
 	});
 
 	it('keeps existing file-list select all behavior inside the focused region', async () => {
-		const { onFileListKeyDown } = await import('../fileList/events');
+		const { onFileListKeyDown } = await import('../events');
 		const event = keyboardEvent('a', { metaKey: true });
 
 		onFileListKeyDown(event);

--- a/src/ui/fileList/__tests__/order-lock-lifecycle.test.ts
+++ b/src/ui/fileList/__tests__/order-lock-lifecycle.test.ts
@@ -1,22 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { FileListInfo } from '../../types/audio';
+import type { FileListInfo } from '../../../types/audio';
 import {
+	getCurrentFileList,
 	isOrderLocked,
 	onOrderLockChange,
-	setOrderLocked,
 	setCurrentFileList,
-	getCurrentFileList,
-} from '../fileList/state.svelte';
-import { fileListViewState } from '../fileList/viewState.svelte';
+	setOrderLocked,
+} from '../state.svelte';
+import { fileListViewState } from '../viewState.svelte';
 
 // Mock modules that actions.ts imports but aren't relevant to lock behavior
-vi.mock('../metadataForm', () => ({
+vi.mock('../../metadataForm', () => ({
 	hasDirtyMetadataFields: vi.fn(() => false),
 	readMetadataForm: vi.fn(() => ({})),
 	resetDirtyState: vi.fn(),
 }));
 
-vi.mock('../metadataState', () => ({
+vi.mock('../../metadataState', () => ({
 	clearMetadataState: vi.fn(),
 	getMetadataForFile: vi.fn(() => ({})),
 	metadataEqualsNullish: vi.fn(() => false),
@@ -24,12 +24,12 @@ vi.mock('../metadataState', () => ({
 	setMetadataForFile: vi.fn(),
 }));
 
-vi.mock('../outputPanel', () => ({
+vi.mock('../../outputPanel', () => ({
 	updateEstimatedSize: vi.fn(),
 	updateOutputPath: vi.fn(),
 }));
 
-vi.mock('../metadataValidation', () => ({
+vi.mock('../../metadataValidation', () => ({
 	firstMetadataIntentValidationError: vi.fn(() => null),
 	validateMetadataDraftIntent: vi.fn(async () => ({
 		intentPatch: {},
@@ -37,12 +37,12 @@ vi.mock('../metadataValidation', () => ({
 	})),
 }));
 
-vi.mock('../fileList/events', () => ({
+vi.mock('../events', () => ({
 	initFileListEvents: vi.fn(),
 	setupDragStartHandlers: vi.fn(),
 }));
 
-vi.mock('../fileList/selection', () => ({
+vi.mock('../selection', () => ({
 	clearSelection: vi.fn(() => true),
 	handleSelection: vi.fn(() => ({ changed: true })),
 	reindexSelectionAfterMove: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('../fileList/selection', () => ({
 	swapSelectionIndices: vi.fn(),
 }));
 
-vi.mock('../fileList/metadataPanel', () => ({
+vi.mock('../metadataPanel', () => ({
 	autoUpdateCoverArtFromFirstValidFile: vi.fn(async () => undefined),
 	clearSelectionPanels: vi.fn(),
 	ensureMetadataForFiles: vi.fn(async () => undefined),
@@ -61,7 +61,7 @@ vi.mock('../fileList/metadataPanel', () => ({
 	showSingleSelection: vi.fn(async () => undefined),
 }));
 
-vi.mock('../fileImport', () => ({
+vi.mock('../../fileImport', () => ({
 	updateDropZoneState: vi.fn(),
 }));
 
@@ -98,14 +98,14 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('locks when setFileOrderLocked(true) is called', async () => {
-			const { setFileOrderLocked } = await import('../fileList/actions');
+			const { setFileOrderLocked } = await import('../index');
 			setCurrentFileList(makeFileList(2));
 			setFileOrderLocked(true);
 			expect(isOrderLocked()).toBe(true);
 		});
 
 		it('unlocks when setFileOrderLocked(false) is called', async () => {
-			const { setFileOrderLocked } = await import('../fileList/actions');
+			const { setFileOrderLocked } = await import('../index');
 			setCurrentFileList(makeFileList(2));
 			setFileOrderLocked(true);
 			expect(isOrderLocked()).toBe(true);
@@ -114,7 +114,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('is idempotent — double lock/unlock does not break state', async () => {
-			const { setFileOrderLocked } = await import('../fileList/actions');
+			const { setFileOrderLocked } = await import('../index');
 			setCurrentFileList(makeFileList(2));
 			setFileOrderLocked(true);
 			setFileOrderLocked(true);
@@ -142,7 +142,7 @@ describe('order lock lifecycle', () => {
 
 	describe('guard behavior — locked prevents mutations', () => {
 		it('clearAllFiles() no-ops when locked', async () => {
-			const { clearAllFiles, setFileOrderLocked } = await import('../fileList/actions');
+			const { clearAllFiles, setFileOrderLocked } = await import('../index');
 			const fileList = makeFileList(3);
 			setCurrentFileList(fileList);
 			setFileOrderLocked(true);
@@ -154,7 +154,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('removeFile() no-ops when locked', async () => {
-			const { removeFile, setFileOrderLocked } = await import('../fileList/actions');
+			const { removeFile, setFileOrderLocked } = await import('../index');
 			const fileList = makeFileList(3);
 			setCurrentFileList(fileList);
 			setFileOrderLocked(true);
@@ -166,7 +166,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('moveFileUp() no-ops when locked', async () => {
-			const { moveFileUp, setFileOrderLocked } = await import('../fileList/actions');
+			const { moveFileUp, setFileOrderLocked } = await import('../index');
 			const fileList = makeFileList(3);
 			setCurrentFileList(fileList);
 			const originalOrder = fileList.files.map((f) => f.path);
@@ -179,7 +179,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('moveFileDown() no-ops when locked', async () => {
-			const { moveFileDown, setFileOrderLocked } = await import('../fileList/actions');
+			const { moveFileDown, setFileOrderLocked } = await import('../index');
 			const fileList = makeFileList(3);
 			setCurrentFileList(fileList);
 			const originalOrder = fileList.files.map((f) => f.path);
@@ -192,7 +192,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('toggleFileSort() no-ops when locked', async () => {
-			const { toggleFileSort, setFileOrderLocked } = await import('../fileList/actions');
+			const { toggleFileSort, setFileOrderLocked } = await import('../index');
 			const fileList = makeFileList(3);
 			setCurrentFileList(fileList);
 			const originalOrder = fileList.files.map((f) => f.path);
@@ -205,7 +205,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('reorderFiles() no-ops when locked', async () => {
-			const { reorderFiles, setFileOrderLocked } = await import('../fileList/actions');
+			const { reorderFiles, setFileOrderLocked } = await import('../index');
 			const fileList = makeFileList(3);
 			setCurrentFileList(fileList);
 			const originalOrder = fileList.files.map((f) => f.path);
@@ -220,7 +220,7 @@ describe('order lock lifecycle', () => {
 
 	describe('view state reflects lock', () => {
 		it('disables sort and clear controls when locked', async () => {
-			const { updateButtonVisibility } = await import('../fileList/dom');
+			const { updateButtonVisibility } = await import('../dom');
 			setCurrentFileList(makeFileList(3));
 			setOrderLocked(true);
 
@@ -231,7 +231,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('enables sort and clear controls when unlocked', async () => {
-			const { updateButtonVisibility } = await import('../fileList/dom');
+			const { updateButtonVisibility } = await import('../dom');
 			setCurrentFileList(makeFileList(3));
 			setOrderLocked(false);
 
@@ -242,7 +242,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('shows lock notice when locked', async () => {
-			const { setOrderLockNotice } = await import('../fileList/dom');
+			const { setOrderLockNotice } = await import('../dom');
 
 			setOrderLockNotice(true);
 
@@ -250,7 +250,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('hides lock notice when unlocked', async () => {
-			const { setOrderLockNotice } = await import('../fileList/dom');
+			const { setOrderLockNotice } = await import('../dom');
 			setOrderLockNotice(true);
 
 			setOrderLockNotice(false);
@@ -261,7 +261,7 @@ describe('order lock lifecycle', () => {
 
 	describe('round-trip: lock → unlock restores full interactivity', () => {
 		it('mutations work after lock/unlock cycle', async () => {
-			const { setFileOrderLocked, clearAllFiles } = await import('../fileList/actions');
+			const { setFileOrderLocked, clearAllFiles } = await import('../index');
 			setCurrentFileList(makeFileList(3));
 
 			// Lock then unlock
@@ -276,7 +276,7 @@ describe('order lock lifecycle', () => {
 		});
 
 		it('view controls re-enabled after lock/unlock cycle', async () => {
-			const { updateButtonVisibility } = await import('../fileList/dom');
+			const { updateButtonVisibility } = await import('../dom');
 			setCurrentFileList(makeFileList(3));
 
 			// Lock

--- a/src/ui/fileList/__tests__/reorder-behavior.test.ts
+++ b/src/ui/fileList/__tests__/reorder-behavior.test.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AudioFile, FileListInfo } from '../../types/audio';
+import type { AudioFile, FileListInfo } from '../../../types/audio';
 import {
 	appendFileList,
 	displayFileList,
 	moveFileDown,
 	moveFileUp,
+	persistPendingMetadataDraftsForCurrentSelection,
 	reorderFiles,
 	toggleFileSort,
-} from '../fileList/actions';
-import { persistPendingMetadataDraftsForCurrentSelection } from '../fileList/metadataStaging';
-import { inspectorState } from '../fileList/inspectorState.svelte';
-import { showSingleSelection } from '../fileList/metadataPanel';
+} from '../index';
+import { inspectorState } from '../inspectorState.svelte';
+import { showSingleSelection } from '../metadataPanel';
 import {
 	getCurrentFileList,
 	getSelectedFileIndex,
@@ -18,8 +18,8 @@ import {
 	setSelectedFileIndices,
 	setSelectedIndex,
 	setSortAscending,
-} from '../fileList/state.svelte';
-import { resetFileListViewState } from '../fileList/viewState.svelte';
+} from '../state.svelte';
+import { resetFileListViewState } from '../viewState.svelte';
 
 const context = vi.hoisted(() => ({
 	readAudioMetadataMock: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock('../../lib/tauri/client', () => ({
 	},
 }));
 
-vi.mock('../metadataState', () => ({
+vi.mock('../../metadataState', () => ({
 	clearMetadataState: context.clearMetadataStateMock,
 	getMetadataForFile: context.getMetadataForFileMock,
 	metadataEqualsNullish: context.metadataEqualsNullishMock,
@@ -66,7 +66,7 @@ vi.mock('../metadataState', () => ({
 	setMetadataForFile: context.setMetadataForFileMock,
 }));
 
-vi.mock('../metadataForm', () => ({
+vi.mock('../../metadataForm', () => ({
 	hasDirtyMetadataFields: context.hasDirtyMetadataFieldsMock,
 	populateMetadataFormSingle: context.populateMetadataFormSingleMock,
 	populateMetadataFormMulti: context.populateMetadataFormMultiMock,
@@ -74,32 +74,32 @@ vi.mock('../metadataForm', () => ({
 	resetDirtyState: context.resetDirtyStateMock,
 }));
 
-vi.mock('../outputPanel', () => ({
+vi.mock('../../outputPanel', () => ({
 	updateEstimatedSize: context.updateEstimatedSizeMock,
 	updateOutputPath: context.updateOutputPathMock,
 }));
 
-vi.mock('../tagPreview', () => ({
+vi.mock('../../tagPreview', () => ({
 	updateTagPreview: context.updateTagPreviewMock,
 }));
 
-vi.mock('../coverArt', () => ({
+vi.mock('../../coverArt', () => ({
 	clearCoverArt: context.clearCoverArtMock,
 	getHasCustomCoverArt: context.getHasCustomCoverArtMock,
 	refreshCoverArtDisplay: context.refreshCoverArtDisplayMock,
 	setCoverArt: context.setCoverArtMock,
 }));
 
-vi.mock('../statusPanel', () => ({
+vi.mock('../../statusPanel', () => ({
 	pushStatusPanelTransientStatus: context.pushStatusPanelTransientStatusMock,
 }));
 
-vi.mock('../metadataValidation', () => ({
+vi.mock('../../metadataValidation', () => ({
 	firstMetadataIntentValidationError: context.validationErrorMock,
 	validateMetadataDraftIntent: context.validateMetadataDraftIntentMock,
 }));
 
-vi.mock('../fileList/dom', () => ({
+vi.mock('../dom', () => ({
 	updateFileListDOM: vi.fn(),
 	updateTotalStats: vi.fn(),
 	updateSelection: vi.fn(),
@@ -109,7 +109,7 @@ vi.mock('../fileList/dom', () => ({
 	setOrderLockNotice: vi.fn(),
 }));
 
-vi.mock('../encoderPanel/autoResolutionHints', () => ({
+vi.mock('../../encoderPanel/autoResolutionHints', () => ({
 	renderAutoResolutionHints: context.renderAutoResolutionHintsMock,
 	resetAutoResolutionHints: context.resetAutoResolutionHintsMock,
 }));

--- a/src/ui/fileList/__tests__/runtime-api-contract.test.ts
+++ b/src/ui/fileList/__tests__/runtime-api-contract.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import * as fileList from '..';
+
+const EXPECTED_FILE_LIST_EXPORTS = [
+	'FileListIsland',
+	'appendFileList',
+	'autoUpdateCoverArtFromFirstValidFile',
+	'buildFileListAppendResult',
+	'buildFileListInfoFromFiles',
+	'buildSelectedDecoderByPath',
+	'clearAllFiles',
+	'clearSelectionAction',
+	'clearSelectionPanels',
+	'collectUniqueFiles',
+	'displayFileList',
+	'ensureMetadataForFiles',
+	'getCurrentFileList',
+	'getSelectedFileIndex',
+	'getSelectedFileIndices',
+	'getSelectedFiles',
+	'getSortAscending',
+	'isOrderLocked',
+	'moveFileDown',
+	'moveFileUp',
+	'normalizeFileListInfo',
+	'onOrderLockChange',
+	'persistPendingMetadataDraftsForCurrentSelection',
+	'persistSingleSelectionMetadata',
+	'preserveMetadataDraftsBeforeSelectionChange',
+	'readCombinedSizeText',
+	'recalculateTotals',
+	'refreshSelectionPresentation',
+	'removeFile',
+	'reorderFiles',
+	'selectAll',
+	'selectFile',
+	'setCurrentFileList',
+	'setFileOrderLocked',
+	'setOrderLocked',
+	'setSelectedFileIndices',
+	'setSelectedIndex',
+	'setSortAscending',
+	'showMultiSelection',
+	'showSingleSelection',
+	'stageMetadataToSelection',
+	'toggleFileSort',
+	'updateFileProperties',
+] as const;
+
+describe('File List Runtime public API contract', () => {
+	beforeEach(() => {
+		fileList.setCurrentFileList(null);
+	});
+
+	it('pins the file list public export strip', () => {
+		expect(Object.keys(fileList).sort()).toEqual([...EXPECTED_FILE_LIST_EXPORTS].sort());
+	});
+
+	it('reads combined size through the public accessor', () => {
+		expect(fileList.readCombinedSizeText()).toBe('--- MB');
+	});
+});

--- a/src/ui/fileList/__tests__/selectFile-transition.test.ts
+++ b/src/ui/fileList/__tests__/selectFile-transition.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { FileListInfo } from '../../types/audio';
-import { setCurrentFileList, setSelectedIndex } from '../fileList/state.svelte';
+import type { FileListInfo } from '../../../types/audio';
+import { setCurrentFileList, setSelectedIndex } from '../index';
 
 const context = vi.hoisted(() => ({
 	readMetadataFormMock: vi.fn<() => Record<string, unknown>>(() => ({ title: 'Persisted Title' })),
@@ -21,13 +21,13 @@ const context = vi.hoisted(() => ({
 	clearSelectionMock: vi.fn(() => true),
 }));
 
-vi.mock('../metadataForm', () => ({
+vi.mock('../../metadataForm', () => ({
 	hasDirtyMetadataFields: vi.fn(() => true),
 	readMetadataForm: context.readMetadataFormMock,
 	resetDirtyState: vi.fn(),
 }));
 
-vi.mock('../metadataState', () => ({
+vi.mock('../../metadataState', () => ({
 	clearMetadataState: vi.fn(),
 	getMetadataForFile: vi.fn(() => ({})),
 	metadataEqualsNullish: vi.fn(() => false),
@@ -35,17 +35,17 @@ vi.mock('../metadataState', () => ({
 	setMetadataForFile: context.setMetadataForFileMock,
 }));
 
-vi.mock('../outputPanel', () => ({
+vi.mock('../../outputPanel', () => ({
 	updateEstimatedSize: vi.fn(),
 	updateOutputPath: vi.fn(),
 }));
 
-vi.mock('../metadataValidation', () => ({
+vi.mock('../../metadataValidation', () => ({
 	firstMetadataIntentValidationError: context.validationErrorMock,
 	validateMetadataDraftIntent: context.validateMetadataDraftIntentMock,
 }));
 
-vi.mock('../fileList/dom', () => ({
+vi.mock('../dom', () => ({
 	updateFileListDOM: vi.fn(),
 	updateTotalStats: vi.fn(),
 	updateSelection: vi.fn(),
@@ -55,12 +55,12 @@ vi.mock('../fileList/dom', () => ({
 	setOrderLockNotice: vi.fn(),
 }));
 
-vi.mock('../fileList/events', () => ({
+vi.mock('../events', () => ({
 	initFileListEvents: vi.fn(),
 	setupDragStartHandlers: vi.fn(),
 }));
 
-vi.mock('../fileList/selection', () => ({
+vi.mock('../selection', () => ({
 	clearSelection: context.clearSelectionMock,
 	handleSelection: context.handleSelectionMock,
 	reindexSelectionAfterMove: vi.fn(),
@@ -69,7 +69,7 @@ vi.mock('../fileList/selection', () => ({
 	swapSelectionIndices: vi.fn(),
 }));
 
-vi.mock('../fileList/metadataPanel', () => ({
+vi.mock('../metadataPanel', () => ({
 	autoUpdateCoverArtFromFirstValidFile: vi.fn(async () => undefined),
 	clearSelectionPanels: vi.fn(),
 	ensureMetadataForFiles: vi.fn(async () => undefined),
@@ -79,7 +79,7 @@ vi.mock('../fileList/metadataPanel', () => ({
 	showSingleSelection: context.showSingleSelectionMock,
 }));
 
-vi.mock('../statusPanel', () => ({
+vi.mock('../../statusPanel', () => ({
 	pushStatusPanelTransientStatus: context.pushStatusPanelTransientStatusMock,
 }));
 
@@ -144,7 +144,7 @@ describe('selectFile transition options', () => {
 	});
 
 	it('skips previous-file autosave for queue-managed transitions', async () => {
-		const { selectFile } = await import('../fileList/actions');
+		const { selectFile } = await import('../index');
 		await selectFile(1, { multi: false, range: false }, { skipPersistPrevious: true });
 
 		expect(context.readMetadataFormMock).not.toHaveBeenCalled();
@@ -152,7 +152,7 @@ describe('selectFile transition options', () => {
 	});
 
 	it('preserves default autosave behavior when transition option is omitted', async () => {
-		const { selectFile } = await import('../fileList/actions');
+		const { selectFile } = await import('../index');
 		await selectFile(1, { multi: false, range: false });
 
 		expect(context.readMetadataFormMock).toHaveBeenCalledWith({ mode: 'single' });
@@ -165,7 +165,7 @@ describe('selectFile transition options', () => {
 
 	it('keeps the current selection when staging validation fails', async () => {
 		context.validationErrorMock.mockReturnValue('Series part must be a number');
-		const { selectFile } = await import('../fileList/actions');
+		const { selectFile } = await import('../index');
 
 		await selectFile(1, { multi: false, range: false });
 
@@ -183,7 +183,7 @@ describe('selectFile transition options', () => {
 			{ path: '/books/alpha.m4b', isValid: true },
 			{ path: '/books/beta.m4b', isValid: true },
 		]);
-		const { clearSelectionAction } = await import('../fileList/actions');
+		const { clearSelectionAction } = await import('../index');
 
 		await clearSelectionAction();
 
@@ -200,7 +200,7 @@ describe('selectFile transition options', () => {
 			{ path: '/books/alpha.m4b', isValid: true },
 			{ path: '/books/beta.m4b', isValid: true },
 		]);
-		const { selectAll } = await import('../fileList/actions');
+		const { selectAll } = await import('../index');
 
 		await selectAll();
 

--- a/src/ui/fileList/__tests__/selection.test.ts
+++ b/src/ui/fileList/__tests__/selection.test.ts
@@ -6,17 +6,17 @@ import {
 	reindexSelectionAfterRemoval,
 	reindexSelectionAfterMove,
 	swapSelectionIndices,
-} from '../fileList/selection';
+} from '../selection';
 import {
+	clearSelectedIndices,
 	getCurrentFileList,
 	getSelectedFileIndex,
-	setCurrentFileList,
-	setSelectedIndex,
-	setSelectedFileIndices,
-	clearSelectedIndices,
 	getSelectedFileIndices,
-} from '../fileList/state.svelte';
-import type { AudioFile, FileListInfo } from '../../types/audio';
+	setCurrentFileList,
+	setSelectedFileIndices,
+	setSelectedIndex,
+} from '../state.svelte';
+import type { AudioFile, FileListInfo } from '../../../types/audio';
 
 const makeFileList = (count: number): FileListInfo => {
 	const files: AudioFile[] = Array.from({ length: count }, (_, index) => ({

--- a/src/ui/fileList/index.ts
+++ b/src/ui/fileList/index.ts
@@ -1,0 +1,67 @@
+/**
+ * File list module — pre-processing workbench file list state, actions, and rendering.
+ */
+import { fileListViewState } from './viewState.svelte';
+
+export {
+	appendFileList,
+	clearAllFiles,
+	clearSelectionAction,
+	displayFileList,
+	moveFileDown,
+	moveFileUp,
+	recalculateTotals,
+	removeFile,
+	reorderFiles,
+	selectAll,
+	selectFile,
+	setFileOrderLocked,
+	toggleFileSort,
+} from './actions';
+
+export {
+	getCurrentFileList,
+	getSelectedFileIndex,
+	getSelectedFileIndices,
+	getSelectedFiles,
+	getSortAscending,
+	isOrderLocked,
+	onOrderLockChange,
+	setCurrentFileList,
+	setOrderLocked,
+	setSelectedFileIndices,
+	setSelectedIndex,
+	setSortAscending,
+} from './state.svelte';
+
+export {
+	persistPendingMetadataDraftsForCurrentSelection,
+	persistSingleSelectionMetadata,
+	preserveMetadataDraftsBeforeSelectionChange,
+	stageMetadataToSelection,
+} from './metadataStaging';
+
+export {
+	autoUpdateCoverArtFromFirstValidFile,
+	clearSelectionPanels,
+	ensureMetadataForFiles,
+	refreshSelectionPresentation,
+	showMultiSelection,
+	showSingleSelection,
+	updateFileProperties,
+} from './metadataPanel';
+
+export type { FileListAppendOutcome, FileListAppendResult } from './appendResult';
+export {
+	buildFileListAppendResult,
+	buildFileListInfoFromFiles,
+	buildSelectedDecoderByPath,
+	collectUniqueFiles,
+	normalizeFileListInfo,
+} from './appendResult';
+
+export function readCombinedSizeText(): string {
+	return fileListViewState.combinedSizeText;
+}
+
+export { default as FileListIsland } from './FileListIsland.svelte';

--- a/src/ui/leftColumn/FileInspectorPanel.svelte
+++ b/src/ui/leftColumn/FileInspectorPanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { readCombinedSizeText } from '../fileList';
 	import { inspectorState } from '../fileList/inspectorState.svelte';
-	import { fileListViewState } from '../fileList/viewState.svelte';
+
+	const combinedSizeText = $derived(readCombinedSizeText());
 </script>
 
 <section
@@ -35,7 +37,7 @@
 			title={inspectorState.companionsTitle}>{inspectorState.companionsText}</span
 		>
 		<span class="property-label">Combined Size:</span><span class="property-value"
-			>{fileListViewState.combinedSizeText}</span
+			>{combinedSizeText}</span
 		>
 	</div>
 </section>

--- a/src/ui/metadataLookup/metadataLookupWorkflowLive.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflowLive.ts
@@ -1,7 +1,6 @@
 import { tauriClient } from '../../lib/tauri/client';
 import { clearCoverArt, refreshCoverArtDisplay, setCoverArt, setCustomCoverArt } from '../coverArt';
-import { selectFile } from '../fileList/actions';
-import { getCurrentFileList, getSelectedFileIndices } from '../fileList/state.svelte';
+import { getCurrentFileList, getSelectedFileIndices, selectFile } from '../fileList';
 import { applyMetadataToForm, readMetadataForm } from '../metadataForm';
 import { getMetadataForFile, setMetadataForFile } from '../metadataState';
 import { updateEstimatedSize, updateOutputPath } from '../outputPanel';

--- a/src/ui/metadataLookup/metadataLookupWorkflowServices.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflowServices.ts
@@ -6,7 +6,7 @@ import {
 } from '../../lib/effect/appEffect';
 import type { FileListInfo } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
-import type { selectFile } from '../fileList/actions';
+import type { selectFile } from '../fileList';
 import type { applyMetadataToForm, readMetadataForm } from '../metadataForm';
 import type { setMetadataForFile } from '../metadataState';
 import type { updateEstimatedSize, updateOutputPath } from '../outputPanel';

--- a/src/ui/outputPanel/AGENTS.md
+++ b/src/ui/outputPanel/AGENTS.md
@@ -2,10 +2,13 @@
 
 ## Public API Strip
 - Import output panel runtime symbols from `src/ui/outputPanel`.
-- Exports: `initOutputPanel`, `applyOutputDefaultsFromSettings`, `getState`,
-  `outputPanelState`, `readOutputDefaultsFromState`, `readOutputRequestConfig`,
-  `updateOutputPath`, `updateEstimatedSize`, `getCurrentMetadata`,
-  `OutputPanelIsland`.
+- Exports: `initOutputPanel`, `applyOutputDefaultsFromSettings`,
+  `readEstimatedSizeText`, `readOutputDisplaySnapshot`,
+  `readOutputDefaultsFromState`, `readOutputRequestConfig`, `updateOutputPath`,
+  `updateEstimatedSize`, `getCurrentMetadata`, `OutputPanelIsland`,
+  `OutputDisplaySnapshot` (type).
+- External Svelte consumers read display fields through `readEstimatedSizeText()`
+  or `readOutputDisplaySnapshot()` inside reactive markup (`$derived(...)`).
 
 ## Private Cluster
 - Files: `OutputPanelIsland.svelte`, `actions.ts`, `preview.ts`, `state.svelte.ts`, `outputPlanWorkflow.ts`, `outputPlanWorkflowLive.ts`, `outputPlanWorkflowServices.ts`, `__tests__/`.

--- a/src/ui/outputPanel/AGENTS.md
+++ b/src/ui/outputPanel/AGENTS.md
@@ -5,8 +5,9 @@
 - Exports: `initOutputPanel`, `applyOutputDefaultsFromSettings`,
   `readEstimatedSizeText`, `readOutputDisplaySnapshot`,
   `readOutputDefaultsFromState`, `readOutputRequestConfig`, `updateOutputPath`,
-  `updateEstimatedSize`, `getCurrentMetadata`, `OutputPanelIsland`,
-  `OutputDisplaySnapshot` (type).
+  `updateEstimatedSize`, `getCurrentMetadata`, `runOutputPlanReviewWorkflow`,
+  `OutputPanelIsland`, `OutputDisplaySnapshot` (type),
+  `OutputPlanReviewResult` (type).
 - External Svelte consumers read display fields through `readEstimatedSizeText()`
   or `readOutputDisplaySnapshot()` inside reactive markup (`$derived(...)`).
 

--- a/src/ui/outputPanel/__tests__/actions.test.ts
+++ b/src/ui/outputPanel/__tests__/actions.test.ts
@@ -5,30 +5,30 @@ import {
 	resetOutputPanelActions,
 	selectNamingPreset,
 	setAbsIncludeYear,
-} from '../outputPanel/actions';
-import { updateNamingOptionState, updateOutputPath } from '../outputPanel/preview';
+} from '../actions';
+import { updateNamingOptionState, updateOutputPath } from '../preview';
 import {
 	updateAbsIncludeYear,
 	updateNamingPreset,
 	updateNamingTemplate,
 	updateOutputDirectory,
-} from '../outputPanel/state.svelte';
-import { tauriClient } from '../../lib/tauri/client';
+} from '../state.svelte';
+import { tauriClient } from '../../../lib/tauri/client';
 
-vi.mock('../../lib/tauri/client', () => ({
+vi.mock('../../../lib/tauri/client', () => ({
 	tauriClient: {
 		openDirectory: vi.fn(),
 		updateAppSettings: vi.fn().mockResolvedValue(undefined),
 	},
 }));
 
-vi.mock('../outputPanel/preview', () => ({
+vi.mock('../preview', () => ({
 	updateOutputPath: vi.fn(),
 	updateNamingOptionState: vi.fn(),
 	showOutputError: vi.fn(),
 }));
 
-vi.mock('../outputPanel/state.svelte', () => ({
+vi.mock('../state.svelte', () => ({
 	readOutputDefaultsFromState: vi.fn(() => ({
 		outputDirectory: '/books/out',
 		outputNaming: { preset: 'absDefault', includeYear: false },

--- a/src/ui/outputPanel/__tests__/preview-resilience.test.ts
+++ b/src/ui/outputPanel/__tests__/preview-resilience.test.ts
@@ -1,20 +1,20 @@
 import { render, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { tauriClient } from '../../lib/tauri/client';
-import OutputPanelIsland from '../outputPanel/OutputPanelIsland.svelte';
-import { setJobTypeSelection } from '../jobControls';
-import { populateMetadataFormMulti, populateMetadataFormSingle } from '../metadataForm';
-import { metadataFormState } from '../metadataForm/state.svelte';
-import { updateOutputPath } from '../outputPanel/preview';
+import { tauriClient } from '../../../lib/tauri/client';
+import OutputPanelIsland from '../OutputPanelIsland.svelte';
+import { setJobTypeSelection } from '../../jobControls';
+import { populateMetadataFormMulti, populateMetadataFormSingle } from '../../metadataForm';
+import { metadataFormState } from '../../metadataForm/state.svelte';
+import { updateOutputPath } from '../preview';
 import {
 	outputPanelState,
 	setOutputPreview,
 	updateOutputDirectory,
 	updateNamingPreset,
 	updateAbsIncludeYear,
-} from '../outputPanel/state.svelte';
+} from '../state.svelte';
 
-vi.mock('../../lib/tauri/client', () => ({
+vi.mock('../../../lib/tauri/client', () => ({
 	tauriClient: {
 		previewOutputPath: vi.fn(),
 		validateMetadataIntentPatch: vi.fn(async (metadataPatch) => ({

--- a/src/ui/outputPanel/__tests__/runtime-api-contract.test.ts
+++ b/src/ui/outputPanel/__tests__/runtime-api-contract.test.ts
@@ -10,6 +10,7 @@ const EXPECTED_OUTPUT_PANEL_EXPORTS = [
 	'readOutputDefaultsFromState',
 	'readOutputDisplaySnapshot',
 	'readOutputRequestConfig',
+	'runOutputPlanReviewWorkflow',
 	'updateEstimatedSize',
 	'updateOutputPath',
 	'getCurrentMetadata',

--- a/src/ui/outputPanel/__tests__/runtime-api-contract.test.ts
+++ b/src/ui/outputPanel/__tests__/runtime-api-contract.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import * as outputPanel from '..';
+
+const EXPECTED_OUTPUT_PANEL_EXPORTS = [
+	'OutputPanelIsland',
+	'applyOutputDefaultsFromSettings',
+	'initOutputPanel',
+	'readEstimatedSizeText',
+	'readOutputDefaultsFromState',
+	'readOutputDisplaySnapshot',
+	'readOutputRequestConfig',
+	'updateEstimatedSize',
+	'updateOutputPath',
+	'getCurrentMetadata',
+] as const;
+
+describe('Output Panel Runtime public API contract', () => {
+	beforeEach(() => {
+		outputPanel.initOutputPanel();
+	});
+
+	it('pins the output panel public export strip', () => {
+		expect(Object.keys(outputPanel).sort()).toEqual([...EXPECTED_OUTPUT_PANEL_EXPORTS].sort());
+	});
+
+	it('reads estimated size through the public accessor after refresh', () => {
+		outputPanel.updateEstimatedSize();
+		expect(outputPanel.readEstimatedSizeText()).toMatch(/^~/);
+		expect(outputPanel.readOutputDisplaySnapshot().estimatedSizeText).toBe(
+			outputPanel.readEstimatedSizeText(),
+		);
+	});
+});

--- a/src/ui/outputPanel/__tests__/store-driven.test.ts
+++ b/src/ui/outputPanel/__tests__/store-driven.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { updateEstimatedSize } from '../outputPanel/preview';
+import { updateEstimatedSize } from '../preview';
 import {
 	outputPanelState,
 	readOutputRequestConfig,
@@ -7,14 +7,14 @@ import {
 	updateNamingPreset,
 	updateNamingTemplate,
 	updateOutputDirectory,
-} from '../outputPanel/state.svelte';
-import { encoderPanelState, resetEncoderPanelState } from '../encoderPanel/state.svelte';
+} from '../state.svelte';
+import { encoderPanelState, resetEncoderPanelState } from '../../encoderPanel/state.svelte';
 
 const context = vi.hoisted(() => ({
 	getCurrentFileListMock: vi.fn(),
 }));
 
-vi.mock('../fileList/state.svelte', () => ({
+vi.mock('../../fileList/state.svelte', () => ({
 	getCurrentFileList: context.getCurrentFileListMock,
 	isOrderLocked: vi.fn(() => false),
 	onOrderLockChange: vi.fn(() => () => undefined),

--- a/src/ui/outputPanel/index.ts
+++ b/src/ui/outputPanel/index.ts
@@ -28,5 +28,6 @@ export {
 	readOutputDisplaySnapshot,
 	readOutputRequestConfig,
 } from './state.svelte';
+export { runOutputPlanReviewWorkflow, type OutputPlanReviewResult } from './outputPlanWorkflow';
 export { updateOutputPath, updateEstimatedSize, getCurrentMetadata } from './preview';
 export { default as OutputPanelIsland } from './OutputPanelIsland.svelte';

--- a/src/ui/outputPanel/index.ts
+++ b/src/ui/outputPanel/index.ts
@@ -21,10 +21,11 @@ export function applyOutputDefaultsFromSettings(defaults: OutputDefaults): void 
 	updateEstimatedSize();
 }
 
+export type { OutputDisplaySnapshot } from './state.svelte';
 export {
-	getState,
-	outputPanelState,
+	readEstimatedSizeText,
 	readOutputDefaultsFromState,
+	readOutputDisplaySnapshot,
 	readOutputRequestConfig,
 } from './state.svelte';
 export { updateOutputPath, updateEstimatedSize, getCurrentMetadata } from './preview';

--- a/src/ui/outputPanel/preview.ts
+++ b/src/ui/outputPanel/preview.ts
@@ -1,8 +1,7 @@
 import { formatFileSize } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
 import { tauriClient } from '../../lib/tauri/client';
-import { getCurrentFileList } from '../fileList/state.svelte';
-import { getSelectedFileIndices } from '../fileList/state.svelte';
+import { getCurrentFileList, getSelectedFileIndices } from '../fileList';
 import { getCurrentCoverArt } from '../coverArt';
 import { readMetadataForm } from '../metadataForm';
 import {

--- a/src/ui/outputPanel/state.svelte.ts
+++ b/src/ui/outputPanel/state.svelte.ts
@@ -4,6 +4,19 @@ import type { OutputDefaults } from '../../types/appSettings';
 export type OutputNamingPreset = OutputNamingConfig['preset'];
 const DEFAULT_CUSTOM_TEMPLATE = '{author}/{title}';
 
+export type OutputDisplaySnapshot = {
+	outputDirectory: string;
+	previewText: string;
+	previewTitle: string;
+	namingPreset: OutputNamingPreset;
+	namingTemplate: string;
+	absIncludeYear: boolean;
+	absHintText: string;
+	absHintHidden: boolean;
+	templateRowHidden: boolean;
+	estimatedSizeText: string;
+};
+
 export interface OutputPanelState {
 	outputDirectory: string;
 	namingPreset: OutputNamingPreset;
@@ -49,6 +62,25 @@ export function isLatestOutputPreviewRequest(requestId: number): boolean {
 
 export function getState(): OutputPanelState {
 	return outputPanelState;
+}
+
+export function readEstimatedSizeText(): string {
+	return outputPanelState.estimatedSizeText;
+}
+
+export function readOutputDisplaySnapshot(): OutputDisplaySnapshot {
+	return {
+		outputDirectory: outputPanelState.outputDirectory,
+		previewText: outputPanelState.previewText,
+		previewTitle: outputPanelState.previewTitle,
+		namingPreset: outputPanelState.namingPreset,
+		namingTemplate: outputPanelState.namingTemplate,
+		absIncludeYear: outputPanelState.absIncludeYear,
+		absHintText: outputPanelState.absHintText,
+		absHintHidden: outputPanelState.absHintHidden,
+		templateRowHidden: outputPanelState.templateRowHidden,
+		estimatedSizeText: outputPanelState.estimatedSizeText,
+	};
 }
 
 export function getOutputNamingConfig(): OutputNamingConfig {

--- a/src/ui/remoteSource/acquisitionWorkflow.ts
+++ b/src/ui/remoteSource/acquisitionWorkflow.ts
@@ -1,5 +1,5 @@
 import { tick } from 'svelte';
-import { getCurrentFileList } from '../fileList/state.svelte';
+import { getCurrentFileList } from '../fileList';
 import {
 	getImportedAudioPathsBlockedMessage,
 	handleImportedAudioPaths,

--- a/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../types/audio';
 import type { AcquisitionJob } from '../../../types/remoteSource';
 import type { WorkSubmissionAccepted } from '../../../types/workRuntime';
-import type { OutputPlanReviewResult } from '../../outputPanel/outputPlanWorkflow';
+import type { OutputPlanReviewResult } from '../../outputPanel';
 import {
 	purgeRemoteSourceSessionsForInputIds,
 	registerRemoteSourceSupplementalAssets,

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -1,7 +1,6 @@
 import type { MetadataSaveBatchResult } from '../../types/metadata';
 import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../types/events';
-import { setFileOrderLocked } from '../fileList/actions';
-import { getCurrentFileList } from '../fileList/state.svelte';
+import { getCurrentFileList, setFileOrderLocked } from '../fileList';
 import { setJobControlsEnabled } from '../jobControls';
 import * as feedback from './feedback';
 import { buildQueueLabels, extractFilenameFromProgress } from './formatting';

--- a/src/ui/statusPanel/processingWorkflowLive.ts
+++ b/src/ui/statusPanel/processingWorkflowLive.ts
@@ -1,11 +1,11 @@
 import { tauriClient } from '../../lib/tauri/client';
-import { setFileOrderLocked } from '../fileList/actions';
-import { stageMetadataToSelection } from '../fileList/metadataStaging';
 import {
 	getCurrentFileList,
 	getSelectedFileIndex,
 	getSelectedFileIndices,
-} from '../fileList/state.svelte';
+	setFileOrderLocked,
+	stageMetadataToSelection,
+} from '../fileList';
 import { getJobType, setJobControlsEnabled } from '../jobControls';
 import { hasDirtyMetadataFields, readMetadataForm } from '../metadataForm';
 import {

--- a/src/ui/statusPanel/processingWorkflowLive.ts
+++ b/src/ui/statusPanel/processingWorkflowLive.ts
@@ -14,8 +14,7 @@ import {
 	getMetadataIntentPatchForFile,
 	setMetadataForFile,
 } from '../metadataState';
-import { updateOutputPath } from '../outputPanel';
-import { runOutputPlanReviewWorkflow } from '../outputPanel/outputPlanWorkflow';
+import { runOutputPlanReviewWorkflow, updateOutputPath } from '../outputPanel';
 import * as feedback from './feedback';
 import { openGeneratedPreviewIfSingle } from './preview';
 import { readProcessingRequestConfig } from './processingConfig';

--- a/src/ui/statusPanel/processingWorkflowPreparation.ts
+++ b/src/ui/statusPanel/processingWorkflowPreparation.ts
@@ -11,7 +11,7 @@ import {
 	firstMetadataIntentValidationError,
 	validateMetadataDraftIntent,
 } from '../metadataValidation';
-import type { OutputPlanReviewResult } from '../outputPanel/outputPlanWorkflow';
+import type { OutputPlanReviewResult } from '../outputPanel';
 import type { ProcessingWorkflowFailed } from './processingWorkflow';
 import type { ProcessingWorkflowServices } from './processingWorkflowServices';
 import { supplementalAssetsForInputIds } from '../remoteSource/sessionAssets.svelte';

--- a/src/ui/statusPanel/processingWorkflowServices.ts
+++ b/src/ui/statusPanel/processingWorkflowServices.ts
@@ -19,8 +19,7 @@ import type {
 	getMetadataIntentPatchForFile,
 	setMetadataForFile,
 } from '../metadataState';
-import type { runOutputPlanReviewWorkflow } from '../outputPanel/outputPlanWorkflow';
-import type { updateOutputPath } from '../outputPanel';
+import type { runOutputPlanReviewWorkflow, updateOutputPath } from '../outputPanel';
 import type * as feedback from './feedback';
 import type { openGeneratedPreviewIfSingle } from './preview';
 import type { readProcessingRequestConfig } from './processingConfig';

--- a/src/ui/statusPanel/processingWorkflowServices.ts
+++ b/src/ui/statusPanel/processingWorkflowServices.ts
@@ -4,13 +4,13 @@ import {
 	makeWorkflowLayer,
 	makeWorkflowServiceTag,
 } from '../../lib/effect/appEffect';
-import type { setFileOrderLocked } from '../fileList/actions';
-import type { stageMetadataToSelection } from '../fileList/metadataStaging';
 import type {
 	getCurrentFileList,
 	getSelectedFileIndex,
 	getSelectedFileIndices,
-} from '../fileList/state.svelte';
+	setFileOrderLocked,
+	stageMetadataToSelection,
+} from '../fileList';
 import type { getJobType, setJobControlsEnabled } from '../jobControls';
 import type { hasDirtyMetadataFields, readMetadataForm } from '../metadataForm';
 import type {

--- a/src/ui/statusPanel/services/coverArtTracker.ts
+++ b/src/ui/statusPanel/services/coverArtTracker.ts
@@ -1,6 +1,6 @@
 import { tauriClient } from '../../../lib/tauri/client';
 import type { FileListInfo } from '../../../types/audio';
-import { getCurrentFileList } from '../../fileList/state.svelte';
+import { getCurrentFileList } from '../../fileList';
 import * as feedback from '../feedback';
 import { convertBytesToDataUrl } from '../formatting';
 


### PR DESCRIPTION
## Summary

- **Metadata:** Private `passthrough`/`mp4ameta_bridge` modules; `PassthroughSource` boundary; audio maps `AudioFile` at call sites; crate-root passthrough re-exports removed after `all_tests` pass.
- **Processing:** Stops re-exporting output-artifact types; `commands/audio.rs` imports `OutputNamingConfig` from `output_artifact`; adds `audio/` and `processing/` contract tests.
- **Frontend strips:** `fileList/index.ts` + `FileListIsland.svelte`; `readCombinedSizeText()` / `readEstimatedSizeText()` accessors; output panel index no longer exports mutable state; runtime API contract tests for changed strips.
- **Tooling/docs:** `bindings:check:runtime-boundary` script; owner AGENTS + `docs/system-map.md` frontend strips table.

Closes #304

## Deferrals

- `lib.rs` ffmpeg re-exports
- `job_registry` integration reach-through
- WorkRuntime / RemoteSource contract redesign
- God-file splits
- Audible false-green cleanup
- `reqwest` dedup
- Fallback-policy automation
- `nextest.toml`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run -p abb-metadata-core -p abb-output-artifact-core -p abb-processing-core`
- [x] `cargo nextest run -p audiobook-boss --lib`
- [x] `cargo nextest run -p audiobook-boss --test all_tests`
- [x] Targeted Vitest (outputPanel, fileList, fileImport, encoder workbench)
- [x] `bun run typecheck`
- [x] `bash scripts/check-generated-bindings.sh --mode local`
- [x] `bun run bindings:check:runtime-boundary`
- [x] Guardrail tripwire `rg` searches (no unintended private-import leaks)


Made with [Cursor](https://cursor.com)