### PR TITLE
[codex] Tighten issue 371 contract hygiene

### DIFF
--- a/crates/abb-remote-source-core/src/lib.rs
+++ b/crates/abb-remote-source-core/src/lib.rs
@@ -183,19 +183,6 @@ pub fn choose_acquisition_strategy(facts: &LicenseFacts) -> AcquisitionStrategy 
     }
 }
 
-pub fn strategy_allows_import_handoff(
-    strategy: AcquisitionStrategy,
-    source_kind: MaterializedSourceKind,
-) -> bool {
-    matches!(
-        (strategy, source_kind),
-        (
-            AcquisitionStrategy::DownloadImportReady,
-            MaterializedSourceKind::ImportReadyM4b
-        )
-    )
-}
-
 pub fn acquisition_progress(
     stage: AcquisitionStage,
     fraction: Option<f32>,
@@ -382,16 +369,22 @@ mod tests {
     }
 
     #[test]
-    fn only_m4b_family_is_import_ready() {
-        assert!(materialized_source_is_import_ready(
-            MaterializedSourceKind::ImportReadyM4b
-        ));
-        assert!(!materialized_source_is_import_ready(
-            MaterializedSourceKind::EncryptedAax
-        ));
-        assert!(!materialized_source_is_import_ready(
-            MaterializedSourceKind::EncryptedAaxc
-        ));
+    fn only_m4b_family_is_import_ready_for_materialized_handoff() {
+        let cases = [
+            (MaterializedSourceKind::ImportReadyM4b, true),
+            (MaterializedSourceKind::EncryptedAax, false),
+            (MaterializedSourceKind::EncryptedAaxc, false),
+            (MaterializedSourceKind::SupplementalPdf, false),
+            (MaterializedSourceKind::Unsupported, false),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(
+                materialized_source_is_import_ready(kind),
+                expected,
+                "{kind:?}"
+            );
+        }
     }
 
     #[cfg(unix)]
@@ -511,22 +504,6 @@ mod tests {
             choose_acquisition_strategy(&facts),
             AcquisitionStrategy::DownloadThenDecryptDash
         );
-    }
-
-    #[test]
-    fn encrypted_sources_are_not_import_ready_before_decryption() {
-        assert!(!strategy_allows_import_handoff(
-            AcquisitionStrategy::DownloadThenDecryptAax,
-            MaterializedSourceKind::EncryptedAax
-        ));
-        assert!(!strategy_allows_import_handoff(
-            AcquisitionStrategy::DownloadThenDecryptAaxc,
-            MaterializedSourceKind::EncryptedAaxc
-        ));
-        assert!(strategy_allows_import_handoff(
-            AcquisitionStrategy::DownloadImportReady,
-            MaterializedSourceKind::ImportReadyM4b
-        ));
     }
 
     #[test]

--- a/src-tauri/src/audio/AGENTS.md
+++ b/src-tauri/src/audio/AGENTS.md
@@ -65,6 +65,12 @@
 - Keep small tests inline when they clarify the nearby code; move bulky private
   test blocks to sibling test files when readability is the real issue.
 
+## Path Display Policy
+
+- Filesystem and process identity uses `Path`, `OsStr`, or `OsString`.
+- Diagnostics and logs use sanitized display strings.
+- Lossy strings are allowed only for display ordering, never identity or command argv.
+
 ## Allowed Agent Edits Without Escalation
 
 - Change private implementation files when focused audio/processing tests stay

--- a/src-tauri/src/audio/processor/engine.rs
+++ b/src-tauri/src/audio/processor/engine.rs
@@ -28,22 +28,19 @@ impl FfmpegNextProcessor {
     ) -> Result<PreviewAction> {
         use crate::errors::AppError;
 
-        log::info!(
-            "🎵 Starting to process input file: {}",
-            sanitize_path_for_display(input_path)
-        );
+        let input_label = sanitize_path_for_display(input_path);
+        log::info!("🎵 Starting to process input file: {}", input_label);
 
         if ctx.context.is_cancelled() {
             log::warn!(
                 "Processing was cancelled before processing file: {}",
-                sanitize_path_for_display(input_path)
+                input_label
             );
             ctx.emitter.emit_cancelled("Processing was cancelled");
             return Err(AppError::cancelled());
         }
 
         // Initialize per-file preview state if adaptive preview is active
-        let input_label = sanitize_path_for_display(input_path);
         if let Some(ref mut ps) = ctx.preview_state {
             ps.start_new_file(file_index);
             log::info!(
@@ -54,10 +51,7 @@ impl FfmpegNextProcessor {
             );
         }
 
-        log::info!(
-            "Setting up decoder and resampler for: {}",
-            sanitize_path_for_display(input_path)
-        );
+        log::info!("Setting up decoder and resampler for: {}", input_label);
         let (mut ictx, mut decoder, mut resampler, stream_index) =
             crate::audio::processor::streams::setup_decoder_and_resampler(input_path, encoder)?;
         log::info!(
@@ -74,10 +68,7 @@ impl FfmpegNextProcessor {
             stream_index
         );
 
-        log::info!(
-            "Processing input packets from: {}",
-            sanitize_path_for_display(input_path)
-        );
+        log::info!("Processing input packets from: {}", input_label);
         let action = crate::audio::processor::frame_pipeline::process_input_packets(
             &mut ictx,
             &mut decoder,
@@ -92,10 +83,7 @@ impl FfmpegNextProcessor {
             action
         );
 
-        log::info!(
-            "✅ Completed processing file: {}",
-            sanitize_path_for_display(input_path)
-        );
+        log::info!("✅ Completed processing file: {}", input_label);
         Ok(action)
     }
 }

--- a/src-tauri/src/audio/processor/engine.rs
+++ b/src-tauri/src/audio/processor/engine.rs
@@ -9,7 +9,7 @@ use crate::audio::cleanup::CleanupGuard;
 use crate::audio::processor::frame_pipeline::PreviewAction;
 use crate::audio::processor::plan::{MediaProcessingPlan, MediaProcessor};
 use crate::audio::SampleRateConfig;
-use crate::errors::Result;
+use crate::errors::{sanitize_path_for_display, Result};
 use crate::processing::ProcessingContext;
 
 /// ffmpeg-next based processor
@@ -30,36 +30,33 @@ impl FfmpegNextProcessor {
 
         log::info!(
             "🎵 Starting to process input file: {}",
-            input_path.display()
+            sanitize_path_for_display(input_path)
         );
 
         if ctx.context.is_cancelled() {
             log::warn!(
                 "Processing was cancelled before processing file: {}",
-                input_path.display()
+                sanitize_path_for_display(input_path)
             );
             ctx.emitter.emit_cancelled("Processing was cancelled");
             return Err(AppError::cancelled());
         }
 
         // Initialize per-file preview state if adaptive preview is active
-        let file_name = input_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown");
+        let input_label = sanitize_path_for_display(input_path);
         if let Some(ref mut ps) = ctx.preview_state {
             ps.start_new_file(file_index);
             log::info!(
                 "Adaptive preview: starting file {} '{}' at pts={}",
                 file_index + 1,
-                file_name,
+                input_label,
                 *ctx.running_pts
             );
         }
 
         log::info!(
             "Setting up decoder and resampler for: {}",
-            input_path.display()
+            sanitize_path_for_display(input_path)
         );
         let (mut ictx, mut decoder, mut resampler, stream_index) =
             crate::audio::processor::streams::setup_decoder_and_resampler(input_path, encoder)?;
@@ -77,7 +74,10 @@ impl FfmpegNextProcessor {
             stream_index
         );
 
-        log::info!("Processing input packets from: {}", input_path.display());
+        log::info!(
+            "Processing input packets from: {}",
+            sanitize_path_for_display(input_path)
+        );
         let action = crate::audio::processor::frame_pipeline::process_input_packets(
             &mut ictx,
             &mut decoder,
@@ -92,7 +92,10 @@ impl FfmpegNextProcessor {
             action
         );
 
-        log::info!("✅ Completed processing file: {}", input_path.display());
+        log::info!(
+            "✅ Completed processing file: {}",
+            sanitize_path_for_display(input_path)
+        );
         Ok(action)
     }
 }
@@ -229,7 +232,7 @@ pub(crate) fn probe_first_input(plan: &MediaProcessingPlan) -> Result<(u32, i32)
     let inspection = crate::audio::processor::streams::inspect_audio_decoder(first)?;
     log::info!(
         "probe_first_input path={} selected_decoder={} rate={} channels={}",
-        first.display(),
+        sanitize_path_for_display(first),
         inspection.selected_decoder,
         inspection.sample_rate,
         inspection.channels

--- a/src-tauri/src/audio/processor/engine_orchestrator.rs
+++ b/src-tauri/src/audio/processor/engine_orchestrator.rs
@@ -8,7 +8,7 @@ use crate::audio::processor::frame_pipeline::{
 };
 use crate::audio::processor::plan::MediaProcessingPlan;
 use crate::audio::processor::preview_state::PreviewState;
-use crate::errors::Result;
+use crate::errors::{sanitize_path_for_display, Result};
 use crate::processing::{ProcessingContext, ProgressEmitter};
 
 use super::engine::FfmpegNextProcessor;
@@ -30,20 +30,21 @@ pub(crate) fn process_input_files(
     let mut encoded_samples_total: u64 = 0;
     let mut preview_early_stop = false;
     let file_count = plan.input_file_paths.len();
-    let mut preview_state_storage = context
-        .preview
-        .as_ref()
-        .filter(|_| file_count > 1)
-        .map(|cfg| {
-            let per_file_sec = cfg.per_file_seconds(file_count);
-            log::info!(
-                "Adaptive preview: {} files × {:.3}s/file = {:.3}s total",
-                file_count,
-                per_file_sec,
-                per_file_sec * file_count as f64
-            );
-            PreviewState::new(file_count, per_file_sec)
-        });
+    let mut preview_state_storage =
+        context
+            .preview
+            .as_ref()
+            .filter(|_| file_count > 1)
+            .map(|cfg| {
+                let per_file_sec = cfg.per_file_seconds(file_count);
+                log::info!(
+                    "Adaptive preview: {} files × {:.3}s/file = {:.3}s total",
+                    file_count,
+                    per_file_sec,
+                    per_file_sec * file_count as f64
+                );
+                PreviewState::new(file_count, per_file_sec)
+            });
 
     let mut ctx = FramePipelineCtx {
         context,
@@ -84,12 +85,8 @@ pub(crate) fn process_input_files(
                 .and_then(|n| n.to_str())
                 .unwrap_or("unknown");
             ctx.current_file_name = file_label.to_string();
-            log::info!(
-                "Processing input file {}/{}: {}",
-                idx + 1,
-                plan.input_file_paths.len(),
-                in_path.display()
-            );
+            let path = sanitize_path_for_display(in_path);
+            log::info!("Processing input file {}/{}: {}", idx + 1, file_count, path);
             let action = FfmpegNextProcessor::process_input_file(
                 in_path,
                 enc_ctx,
@@ -101,7 +98,7 @@ pub(crate) fn process_input_files(
             log::info!(
                 "✓ Completed processing input file {}/{}",
                 idx + 1,
-                plan.input_file_paths.len()
+                file_count
             );
 
             if *ctx.early_stop {

--- a/src-tauri/src/audio/processor/external_fdk/args.rs
+++ b/src-tauri/src/audio/processor/external_fdk/args.rs
@@ -1,5 +1,6 @@
 use crate::audio::settings_encoder::{BitrateMode, EncoderSettings, ThreadSetting};
 use crate::audio::{AudioFile, DecoderSelection};
+use std::ffi::OsString;
 use std::path::Path;
 
 pub(super) fn build_ffmpeg_args(
@@ -9,93 +10,93 @@ pub(super) fn build_ffmpeg_args(
     files: &[AudioFile],
     selected_decoders: &[Option<DecoderSelection>],
     temp_output: &Path,
-) -> Vec<String> {
+) -> Vec<OsString> {
     let mut args = vec![
-        "-y".to_string(),
-        "-hide_banner".to_string(),
-        "-loglevel".to_string(),
-        "error".to_string(),
-        "-nostats".to_string(),
-        "-progress".to_string(),
-        "pipe:1".to_string(),
+        OsString::from("-y"),
+        OsString::from("-hide_banner"),
+        OsString::from("-loglevel"),
+        OsString::from("error"),
+        OsString::from("-nostats"),
+        OsString::from("-progress"),
+        OsString::from("pipe:1"),
     ];
 
     let preview_per_file = preview.map(|value| value.per_file_seconds(files.len()).to_string());
     for (file, selection) in files.iter().zip(selected_decoders.iter()) {
         if let Some(seconds) = preview_per_file.as_ref() {
-            args.push("-t".to_string());
-            args.push(seconds.clone());
+            args.push(OsString::from("-t"));
+            args.push(OsString::from(seconds));
         }
         args.extend(build_input_decoder_args(selection.as_ref()));
-        args.push("-i".to_string());
-        args.push(file.path.to_string_lossy().to_string());
+        args.push(OsString::from("-i"));
+        args.push(file.path.as_os_str().to_owned());
     }
 
     args.extend([
-        "-map_metadata".to_string(),
-        "-1".to_string(),
-        "-map_chapters".to_string(),
-        "-1".to_string(),
-        "-vn".to_string(),
+        OsString::from("-map_metadata"),
+        OsString::from("-1"),
+        OsString::from("-map_chapters"),
+        OsString::from("-1"),
+        OsString::from("-vn"),
     ]);
 
     if files.len() > 1 {
-        args.push("-filter_complex".to_string());
-        args.push(build_concat_filter(files.len()));
-        args.push("-map".to_string());
-        args.push("[outa]".to_string());
+        args.push(OsString::from("-filter_complex"));
+        args.push(OsString::from(build_concat_filter(files.len())));
+        args.push(OsString::from("-map"));
+        args.push(OsString::from("[outa]"));
     } else {
-        args.push("-map".to_string());
-        args.push("0:a:0".to_string());
+        args.push(OsString::from("-map"));
+        args.push(OsString::from("0:a:0"));
     }
 
     args.extend([
-        "-c:a".to_string(),
-        "libfdk_aac".to_string(),
-        "-profile:a".to_string(),
-        "aac_he".to_string(),
+        OsString::from("-c:a"),
+        OsString::from("libfdk_aac"),
+        OsString::from("-profile:a"),
+        OsString::from("aac_he"),
     ]);
 
     if let BitrateMode::Vbr(level) = settings.bitrate_mode {
-        args.push("-vbr".to_string());
-        args.push(level.to_string());
+        args.push(OsString::from("-vbr"));
+        args.push(OsString::from(level.to_string()));
     }
 
-    args.push("-afterburner".to_string());
-    args.push(if settings.afterburner { "1" } else { "0" }.to_string());
+    args.push(OsString::from("-afterburner"));
+    args.push(OsString::from(if settings.afterburner { "1" } else { "0" }));
 
     if let Some(channels) = settings.channels.forced_channels() {
-        args.push("-ac".to_string());
-        args.push(channels.to_string());
+        args.push(OsString::from("-ac"));
+        args.push(OsString::from(channels.to_string()));
     }
 
     if let crate::audio::SampleRateConfig::Explicit(rate) = sample_rate {
-        args.push("-ar".to_string());
-        args.push(rate.to_string());
+        args.push(OsString::from("-ar"));
+        args.push(OsString::from(rate.to_string()));
     }
 
     match settings.threads {
         ThreadSetting::Auto => {}
         ThreadSetting::Off => {
-            args.push("-threads".to_string());
-            args.push("1".to_string());
+            args.push(OsString::from("-threads"));
+            args.push(OsString::from("1"));
         }
         ThreadSetting::Fixed(value) => {
-            args.push("-threads".to_string());
-            args.push(value.to_string());
+            args.push(OsString::from("-threads"));
+            args.push(OsString::from(value.to_string()));
         }
     }
 
-    args.push(temp_output.to_string_lossy().to_string());
+    args.push(temp_output.as_os_str().to_owned());
     args
 }
 
-fn build_input_decoder_args(selection: Option<&DecoderSelection>) -> Vec<String> {
+fn build_input_decoder_args(selection: Option<&DecoderSelection>) -> Vec<OsString> {
     let Some(decoder_name) = external_input_decoder_name(selection) else {
         return Vec::new();
     };
 
-    vec!["-c:a".to_string(), decoder_name.to_string()]
+    vec![OsString::from("-c:a"), OsString::from(decoder_name)]
 }
 
 pub(super) fn external_input_decoder_name(selection: Option<&DecoderSelection>) -> Option<&str> {
@@ -113,4 +114,51 @@ fn build_concat_filter(input_count: usize) -> String {
     }
     filter.push_str(&format!("concat=n={}:v=0:a=1[outa]", input_count));
     filter
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::{AudioFile, ChannelConfig, EncoderType, SampleRateConfig};
+
+    fn encoder_settings() -> EncoderSettings {
+        EncoderSettings {
+            encoder_type: EncoderType::FdkHeAac,
+            bitrate_kbps: 64,
+            bitrate_mode: BitrateMode::Vbr(3),
+            channels: ChannelConfig::Auto,
+            afterburner: true,
+            threads: ThreadSetting::Auto,
+            twoloop: true,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ffmpeg_args_preserve_non_utf8_paths_as_os_strings() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = tempfile::TempDir::new().expect("temp root");
+        let input_name = OsString::from_vec(b"book-\xFF.m4b".to_vec());
+        let output_name = OsString::from_vec(b"worker-\xFE.m4b".to_vec());
+        let input_path = root.path().join(input_name);
+        let output_path = root.path().join(output_name);
+        let file = AudioFile::new(input_path.clone());
+
+        let args = build_ffmpeg_args(
+            &encoder_settings(),
+            &SampleRateConfig::Auto,
+            None,
+            &[file],
+            &[None],
+            &output_path,
+        );
+
+        assert!(args
+            .iter()
+            .any(|arg| arg.as_os_str() == input_path.as_os_str()));
+        assert!(args
+            .iter()
+            .any(|arg| arg.as_os_str() == output_path.as_os_str()));
+    }
 }

--- a/src-tauri/src/audio/processor/staging.rs
+++ b/src-tauri/src/audio/processor/staging.rs
@@ -42,8 +42,8 @@ pub(crate) fn create_processing_workspace_dir(
 
     log::info!(
         "processing_workspace kind=app-cache status=created root={} session_dir={}",
-        workspace_root.display(),
-        staging_dir.display()
+        sanitize_path_for_display(workspace_root),
+        sanitize_path_for_display(&staging_dir)
     );
 
     Ok(staging_dir)

--- a/src-tauri/src/audio/toolchain.rs
+++ b/src-tauri/src/audio/toolchain.rs
@@ -155,7 +155,7 @@ fn validate_candidates(
 }
 
 fn path_to_string(path: &Path) -> Option<String> {
-    Some(path.to_string_lossy().to_string())
+    path.to_str().map(str::to_owned)
 }
 
 fn auto_candidates() -> Vec<PathBuf> {
@@ -488,6 +488,17 @@ mod tests {
             resolution.detected_toolchain_path.as_deref(),
             Some(validated.ffmpeg_path.to_string_lossy().as_ref())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detected_toolchain_path_omits_non_utf8_display_value() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from("/tmp").join(OsString::from_vec(b"ffmpeg-\xFF".to_vec()));
+
+        assert_eq!(path_to_string(&path), None);
     }
 
     #[test]

--- a/src-tauri/src/audio/toolchain.rs
+++ b/src-tauri/src/audio/toolchain.rs
@@ -137,7 +137,7 @@ fn validate_candidates(
             Err(error) => {
                 log::info!(
                     "external ffmpeg candidate failed: path={} reason={}",
-                    candidate.display(),
+                    sanitize_path_for_display(candidate),
                     error
                 );
                 if preferred_error.is_none() && !error.starts_with("FFmpeg executable not found at")
@@ -376,9 +376,7 @@ pub fn validate_external_input_decoders(
 }
 
 fn is_supported_apple_silicon_ffmpeg(candidate: &Path) -> bool {
-    let lipo = Command::new("lipo")
-        .args(["-archs", &candidate.to_string_lossy()])
-        .output();
+    let lipo = Command::new("lipo").arg("-archs").arg(candidate).output();
     if let Ok(output) = lipo {
         if output.status.success() {
             let arches = String::from_utf8_lossy(&output.stdout);
@@ -388,9 +386,7 @@ fn is_supported_apple_silicon_ffmpeg(candidate: &Path) -> bool {
         }
     }
 
-    let file = Command::new("file")
-        .args(["-b", &candidate.to_string_lossy()])
-        .output();
+    let file = Command::new("file").arg("-b").arg(candidate).output();
     if let Ok(output) = file {
         if output.status.success() {
             let description = String::from_utf8_lossy(&output.stdout);

--- a/src-tauri/src/remote_source/cancellation.rs
+++ b/src-tauri/src/remote_source/cancellation.rs
@@ -4,7 +4,9 @@ pub(in crate::remote_source) fn remote_acquisition_cancelled() -> AppError {
     AppError::Cancellation("Remote source acquisition was cancelled.".to_string())
 }
 
-pub(in crate::remote_source) fn ensure_not_cancelled(is_cancelled: &impl Fn() -> bool) -> Result<()> {
+pub(in crate::remote_source) fn ensure_not_cancelled(
+    is_cancelled: &impl Fn() -> bool,
+) -> Result<()> {
     if is_cancelled() {
         return Err(remote_acquisition_cancelled());
     }

--- a/src-tauri/src/remote_source/providers/audible/acquisition/mod.rs
+++ b/src-tauri/src/remote_source/providers/audible/acquisition/mod.rs
@@ -4,14 +4,6 @@ mod paths;
 mod progress;
 mod validation;
 
-use abb_audible_core::{
-    supplemental_pdf_display_file_name, title_ref, AudibleLicenseDecryptContext,
-};
-use abb_remote_source_core::{
-    acquisition_progress, AcquisitionProgress, AcquisitionStage, AcquisitionStrategy,
-};
-use audible_api::api::Client as AudibleClient;
-use audible_api::auth::Auth;
 use super::audio_download::{cleanup_download_artifacts, download_audio};
 use super::diagnostics::AudibleAcquisitionError;
 use super::license::{
@@ -33,6 +25,14 @@ use crate::remote_source::{
     RemoteAcquisitionFailureKind, RemoteAcquisitionStatus, RemoteSourceDiagnostic,
     SupplementalAsset,
 };
+use abb_audible_core::{
+    supplemental_pdf_display_file_name, title_ref, AudibleLicenseDecryptContext,
+};
+use abb_remote_source_core::{
+    acquisition_progress, AcquisitionProgress, AcquisitionStage, AcquisitionStrategy,
+};
+use audible_api::api::Client as AudibleClient;
+use audible_api::auth::Auth;
 
 pub(super) struct AcquiredTitle {
     pub(super) file: Option<MaterializedSourceFile>,
@@ -391,7 +391,7 @@ pub(super) async fn download_supplemental_pdf_if_requested(
         Err(failure) if failure.category == "cancelled" => {
             return Err(AudibleAcquisitionError::cancellation(
                 remote_acquisition_cancelled(),
-            ))
+            ));
         }
         Err(failure) => {
             log_supplemental_pdf_failed(job_id, title_id, failure);
@@ -417,8 +417,6 @@ pub(super) fn required_supplemental_pdf_failure_message(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use abb_remote_source_core::MaterializedSourceKind;
-    use std::path::Path;
     use crate::remote_source::providers::audible::audio_download::{
         cleanup_download_artifacts, download_status_failure, partial_download_path,
     };
@@ -428,6 +426,7 @@ mod tests {
     use secrecy::ExposeSecret;
     use serde_json::json;
     use std::collections::HashMap;
+    use std::path::Path;
 
     fn fixture_auth_without_pdf_cookies() -> Auth {
         Auth {
@@ -562,32 +561,6 @@ mod tests {
             Some(expected.as_str())
         );
         assert!(!materialized_path.to_string_lossy().contains(title_id));
-    }
-
-    fn materialized_source_kind_label(kind: MaterializedSourceKind) -> &'static str {
-        match kind {
-            MaterializedSourceKind::ImportReadyM4b => "M4B",
-            MaterializedSourceKind::EncryptedAax => "AAX",
-            MaterializedSourceKind::EncryptedAaxc => "AAXC",
-            MaterializedSourceKind::SupplementalPdf => "PDF",
-            MaterializedSourceKind::Unsupported => "file",
-        }
-    }
-
-    fn materialized_file_from_downloaded_path(
-        title_id: &str,
-        path: &Path,
-        strategy: AcquisitionStrategy,
-    ) -> Result<MaterializedSourceFile> {
-        let source_kind = abb_remote_source_core::classify_materialized_source_path(path);
-        if !abb_remote_source_core::strategy_allows_import_handoff(strategy, source_kind) {
-            return Err(AppError::FileValidation(format!(
-                "Downloaded Audible {} requires Audible decryption before ABB import handoff.",
-                materialized_source_kind_label(source_kind)
-            )));
-        }
-
-        validation::materialized_file_from_path(title_id, path)
     }
 
     #[test]
@@ -740,11 +713,7 @@ mod tests {
         let encrypted = root.path().join("book.aax");
         std::fs::write(&encrypted, b"encrypted").expect("write encrypted fixture");
 
-        let result = materialized_file_from_downloaded_path(
-            "B000000001",
-            &encrypted,
-            abb_remote_source_core::AcquisitionStrategy::DownloadThenDecryptAax,
-        );
+        let result = validation::materialized_file_from_path("B000000001", &encrypted);
 
         let error = result.expect_err("encrypted download must not be import-ready");
         assert!(error.to_string().contains("requires Audible decryption"));

--- a/src-tauri/src/remote_source/providers/audible/acquisition/validation.rs
+++ b/src-tauri/src/remote_source/providers/audible/acquisition/validation.rs
@@ -73,7 +73,10 @@ pub(super) async fn validate_materialized_audio(
     Ok(file)
 }
 
-pub(super) fn materialized_file_from_path(title_id: &str, path: &Path) -> Result<MaterializedSourceFile> {
+pub(super) fn materialized_file_from_path(
+    title_id: &str,
+    path: &Path,
+) -> Result<MaterializedSourceFile> {
     let source_kind = abb_remote_source_core::classify_materialized_source_path(path);
     if !abb_remote_source_core::materialized_source_is_import_ready(source_kind) {
         return Err(AppError::FileValidation(format!(

--- a/src-tauri/src/remote_source/providers/audible/audio_download.rs
+++ b/src-tauri/src/remote_source/providers/audible/audio_download.rs
@@ -1,9 +1,6 @@
 use std::fs;
 use std::path::Path;
 
-use abb_audible_core::{classify_download_response_for_mode, title_ref, DownloadResponseError};
-use abb_remote_source_core::{acquisition_progress, AcquisitionProgress, AcquisitionStage};
-use reqwest::header::{CONTENT_RANGE, RANGE, USER_AGENT};
 use super::acquisition::{ensure_not_cancelled, with_title_progress, TitleAcquisitionCtx};
 use super::http::{audio_download_client, stream_response_chunks};
 use super::{
@@ -12,6 +9,9 @@ use super::{
 };
 use crate::errors::{AppError, Result};
 use crate::remote_source::scoped_output::StagedTempFile;
+use abb_audible_core::{classify_download_response_for_mode, title_ref, DownloadResponseError};
+use abb_remote_source_core::{acquisition_progress, AcquisitionProgress, AcquisitionStage};
+use reqwest::header::{CONTENT_RANGE, RANGE, USER_AGENT};
 
 #[derive(Clone, Copy)]
 pub(super) struct DownloadLogContext<'a> {

--- a/src-tauri/src/remote_source/providers/audible/http/client.rs
+++ b/src-tauri/src/remote_source/providers/audible/http/client.rs
@@ -20,7 +20,8 @@ pub(in crate::remote_source::providers::audible) fn audio_download_client(
 }
 
 /// Build a client that does not follow redirects; callers handle redirect loops manually.
-pub(in crate::remote_source::providers::audible) fn no_redirect_client() -> Result<reqwest::Client, ()> {
+pub(in crate::remote_source::providers::audible) fn no_redirect_client(
+) -> Result<reqwest::Client, ()> {
     reqwest::Client::builder()
         .redirect(Policy::none())
         .build()

--- a/src-tauri/src/remote_source/providers/audible/http/mod.rs
+++ b/src-tauri/src/remote_source/providers/audible/http/mod.rs
@@ -1,5 +1,7 @@
 mod client;
 mod stream;
 
-pub(in crate::remote_source::providers::audible) use client::{audio_download_client, no_redirect_client};
+pub(in crate::remote_source::providers::audible) use client::{
+    audio_download_client, no_redirect_client,
+};
 pub(in crate::remote_source::providers::audible) use stream::stream_response_chunks;

--- a/src-tauri/src/remote_source/providers/audible/http/stream.rs
+++ b/src-tauri/src/remote_source/providers/audible/http/stream.rs
@@ -1,7 +1,7 @@
 use tokio::io::AsyncWriteExt;
 
-use crate::remote_source::cancellation::ensure_not_cancelled;
 use crate::errors::Result;
+use crate::remote_source::cancellation::ensure_not_cancelled;
 
 /// Stream one HTTP response body into append-mode `file`, invoking `on_chunk` for each
 /// non-empty chunk after a cancellation check. Returns `true` if the body read failed

--- a/src-tauri/src/remote_source/providers/audible/mod.rs
+++ b/src-tauri/src/remote_source/providers/audible/mod.rs
@@ -9,8 +9,8 @@ use serde_json::{json, Value};
 
 pub(super) mod acquisition;
 mod audio_download;
-mod http;
 mod diagnostics;
+mod http;
 mod library;
 mod license;
 mod materialization;
@@ -304,17 +304,12 @@ fn extract_audible_auth_code(response_url: &str) -> Result<String> {
 mod library_probe;
 
 #[cfg(test)]
-pub(in crate::remote_source::providers::audible) use library_probe::{
-    first_array_len_for_keys, first_string_for_keys, first_u64_for_keys, library_probe_params,
-    library_probe_summary, LibraryProbeSummary,
-};
-
-#[cfg(test)]
 mod probe;
 
 #[cfg(test)]
 mod tests {
     use super::audio_download::{build_download_request, download_to_path, partial_download_path};
+    use super::library_probe::library_probe_summary;
     use super::license::{license_request_payload, license_request_spec};
     use super::*;
     use abb_remote_source_core::AcquisitionProgress;

--- a/src-tauri/src/remote_source/providers/audible/probe.rs
+++ b/src-tauri/src/remote_source/providers/audible/probe.rs
@@ -2,6 +2,7 @@
 // All tests are `#[ignore]` and must never be used as backend proof.
 // Only run manually with explicit environment configuration.
 
+use super::library_probe::{first_array_len_for_keys, library_probe_params, library_probe_summary};
 use super::*;
 use crate::remote_source::vault::KeyringSecretVault;
 use abb_audible_core::supplemental_pdf_display_file_name;

--- a/src-tauri/src/remote_source/providers/audible/supplemental_pdf.rs
+++ b/src-tauri/src/remote_source/providers/audible/supplemental_pdf.rs
@@ -127,8 +127,7 @@ pub(super) async fn download_supplemental_pdf(
     request: SupplementalPdfRequest<'_>,
     is_cancelled: &impl Fn() -> bool,
 ) -> std::result::Result<SupplementalAsset, SupplementalPdfFailure> {
-    let client =
-        no_redirect_client().map_err(|_| SupplementalPdfFailure::new("request", None))?;
+    let client = no_redirect_client().map_err(|_| SupplementalPdfFailure::new("request", None))?;
     let url = companion_file_url(request.title_id)?;
     download_supplemental_pdf_with_client(&client, request, url, false, is_cancelled).await
 }

--- a/src/lib/path/basename.test.ts
+++ b/src/lib/path/basename.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { pathBasename, pathSegments } from './basename';
+
+describe('pathBasename', () => {
+	it('returns the final path segment while ignoring trailing separators', () => {
+		expect(pathBasename('foo/bar/')).toBe('bar');
+		expect(pathBasename('foo\\bar\\')).toBe('bar');
+	});
+
+	it('returns an empty string for empty paths under either fallback', () => {
+		expect(pathBasename('')).toBe('');
+		expect(pathBasename('', { fallback: 'empty' })).toBe('');
+	});
+
+	it('uses the fallback for separator-only paths', () => {
+		expect(pathBasename('/')).toBe('/');
+		expect(pathBasename('/', { fallback: 'empty' })).toBe('');
+	});
+});
+
+describe('pathSegments', () => {
+	it('returns non-empty path segments', () => {
+		expect(pathSegments('/foo//bar/')).toEqual(['foo', 'bar']);
+	});
+});

--- a/src/lib/path/basename.test.ts
+++ b/src/lib/path/basename.test.ts
@@ -4,17 +4,17 @@ import { pathBasename, pathSegments } from './basename';
 
 describe('pathBasename', () => {
 	it('returns the final path segment while ignoring trailing separators', () => {
-		expect(pathBasename('foo/bar/')).toBe('bar');
-		expect(pathBasename('foo\\bar\\')).toBe('bar');
+		expect(pathBasename('foo/bar/', { fallback: 'path' })).toBe('bar');
+		expect(pathBasename('foo\\bar\\', { fallback: 'path' })).toBe('bar');
 	});
 
 	it('returns an empty string for empty paths under either fallback', () => {
-		expect(pathBasename('')).toBe('');
+		expect(pathBasename('', { fallback: 'path' })).toBe('');
 		expect(pathBasename('', { fallback: 'empty' })).toBe('');
 	});
 
 	it('uses the fallback for separator-only paths', () => {
-		expect(pathBasename('/')).toBe('/');
+		expect(pathBasename('/', { fallback: 'path' })).toBe('/');
 		expect(pathBasename('/', { fallback: 'empty' })).toBe('');
 	});
 });

--- a/src/lib/path/basename.ts
+++ b/src/lib/path/basename.ts
@@ -2,14 +2,11 @@ export type PathBasenameFallback = 'path' | 'empty';
 
 type PathBasenameOptions = {
 	fallback?: PathBasenameFallback;
-	trimTrailingSeparators?: boolean;
 };
 
 export function pathBasename(path: string, options: PathBasenameOptions = {}): string {
-	const { fallback = 'path', trimTrailingSeparators = false } = options;
-	const segments = path
-		.split(/[\\/]/)
-		.filter((segment) => (trimTrailingSeparators ? segment.length > 0 : segment !== ''));
+	const { fallback = 'path' } = options;
+	const segments = path.split(/[\\/]/).filter((segment) => segment !== '');
 	const last = segments[segments.length - 1];
 	if (last) {
 		return last;

--- a/src/lib/path/basename.ts
+++ b/src/lib/path/basename.ts
@@ -1,11 +1,11 @@
 export type PathBasenameFallback = 'path' | 'empty';
 
 type PathBasenameOptions = {
-	fallback?: PathBasenameFallback;
+	fallback: PathBasenameFallback;
 };
 
-export function pathBasename(path: string, options: PathBasenameOptions = {}): string {
-	const { fallback = 'path' } = options;
+export function pathBasename(path: string, options: PathBasenameOptions): string {
+	const { fallback } = options;
 	const segments = path.split(/[\\/]/).filter((segment) => segment !== '');
 	const last = segments[segments.length - 1];
 	if (last) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -77,7 +77,7 @@ function mockOperationSnapshot(
 		children: inputFiles.map((path, index) => ({
 			childJobId: `input-${index}`,
 			operationId,
-			label: pathBasename(path),
+			label: pathBasename(path, { fallback: 'path' }),
 			status: 'queued' as const,
 			lane: 'encodeCpu' as const,
 			progress: {

--- a/src/ui/collisionDialog/CollisionDialogIsland.svelte
+++ b/src/ui/collisionDialog/CollisionDialogIsland.svelte
@@ -34,7 +34,7 @@
 	}
 
 	function getBasename(path: string): string {
-		return pathBasename(path);
+		return pathBasename(path, { fallback: 'path' });
 	}
 
 	function getParentPath(path: string): string {

--- a/src/ui/collisionDialog/CollisionDialogIsland.svelte
+++ b/src/ui/collisionDialog/CollisionDialogIsland.svelte
@@ -34,7 +34,7 @@
 	}
 
 	function getBasename(path: string): string {
-		return pathBasename(path, { trimTrailingSeparators: true });
+		return pathBasename(path);
 	}
 
 	function getParentPath(path: string): string {

--- a/src/ui/fileList/FileListIsland.svelte
+++ b/src/ui/fileList/FileListIsland.svelte
@@ -70,7 +70,7 @@
 	}
 
 	function getFileName(path: string): string {
-		return pathBasename(path);
+		return pathBasename(path, { fallback: 'path' });
 	}
 
 	function formatFileDetails(file: (typeof files)[number]): string {

--- a/src/ui/fileList/actions.ts
+++ b/src/ui/fileList/actions.ts
@@ -294,8 +294,8 @@ export async function toggleFileSort(): Promise<void> {
 
 	const nextFiles = [...fileList.files];
 	nextFiles.sort((a, b) => {
-		const nameA = pathBasename(a.path);
-		const nameB = pathBasename(b.path);
+		const nameA = pathBasename(a.path, { fallback: 'path' });
+		const nameB = pathBasename(b.path, { fallback: 'path' });
 
 		if (getSortAscending()) {
 			return nameA.localeCompare(nameB);

--- a/src/ui/fileList/metadataPanel.ts
+++ b/src/ui/fileList/metadataPanel.ts
@@ -53,7 +53,7 @@ function updatePropertiesContextSingle(file: AudioFile, index: number): void {
 		return;
 	}
 
-	const fileName = pathBasename(file.path);
+	const fileName = pathBasename(file.path, { fallback: 'path' });
 	setInspectorContext({
 		text: fileName,
 		variant: 'single',

--- a/src/ui/metadataLookup/metadataLookupWorkflowDomain.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflowDomain.ts
@@ -15,7 +15,7 @@ export type QueueItemState = {
 };
 
 function formatFileName(path: string): string {
-	return pathBasename(path);
+	return pathBasename(path, { fallback: 'path' });
 }
 
 function isTrackLikeTitle(value: string): boolean {

--- a/src/ui/remoteSource/AGENTS.md
+++ b/src/ui/remoteSource/AGENTS.md
@@ -6,7 +6,7 @@
 - Exports: `companionSummaryForInputIds`, `hasSupplementalAssetsForInputId`,
   `purgeRemoteSourceSessionsForInputIds`, `releaseRemoteSourceSessionRetainers`,
   `retainRemoteSourceSessionsForInputIds`, `registerRemoteSourceSupplementalAssets`,
-  `CompanionAssetSummary` (type).
+  `supplementalAssetsByInputIdForProcessing`, `CompanionAssetSummary` (type).
 - Do not re-export acquisition workflow symbols, islands, or private
   `sessionAssets.svelte` helpers such as `supplementalAssetsForInputIds` from
   the index.

--- a/src/ui/remoteSource/index.ts
+++ b/src/ui/remoteSource/index.ts
@@ -6,4 +6,5 @@ export {
 	releaseRemoteSourceSessionRetainers,
 	retainRemoteSourceSessionsForInputIds,
 	registerRemoteSourceSupplementalAssets,
+	supplementalAssetsByInputIdForProcessing,
 } from './sessionAssets.svelte';

--- a/src/ui/remoteSource/sessionAssets.svelte.ts
+++ b/src/ui/remoteSource/sessionAssets.svelte.ts
@@ -1,5 +1,4 @@
 import type { AudioFile, FileListInfo, SupplementalProcessingAsset } from '../../types/audio';
-import type { ProcessCommandResult } from '../../types/audio';
 import { normalizeAppError } from '../../lib/tauri/appError';
 import { tauriClient } from '../../lib/tauri/client';
 import type { AcquisitionJob, SupplementalAsset } from '../../types/remoteSource';
@@ -69,6 +68,12 @@ export function supplementalAssetsForInputIds(
 			}),
 	);
 	return Object.keys(selected).length > 0 ? selected : undefined;
+}
+
+export function supplementalAssetsByInputIdForProcessing(
+	inputIds: readonly (string | undefined)[],
+): Record<string, SupplementalProcessingAsset[]> | undefined {
+	return supplementalAssetsForInputIds(inputIds);
 }
 
 export function supplementalAssetsForInputId(
@@ -222,17 +227,4 @@ export async function purgeRemoteSourceSessionsForInputIds(
 		}
 	}
 	removeRemoteSourceSupplementalAssets(purgeableIds);
-}
-
-export async function purgeSuccessfulRemoteSourceSessions(
-	result: ProcessCommandResult,
-	inputIds: readonly (string | undefined)[],
-): Promise<void> {
-	if (result.jobType !== 'batch') return;
-
-	const successfulInputIds = result.results
-		.filter((entry) => entry.status === 'success' && typeof entry.inputIndex === 'number')
-		.map((entry) => inputIds[entry.inputIndex as number])
-		.filter((inputId): inputId is string => Boolean(inputId));
-	await purgeRemoteSourceSessionsForInputIds(successfulInputIds);
 }

--- a/src/ui/remoteSource/sessionAssets.test.ts
+++ b/src/ui/remoteSource/sessionAssets.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AcquisitionJob } from '../../types/remoteSource';
-import type { FileListInfo, ProcessCommandResult } from '../../types/audio';
+import type { FileListInfo } from '../../types/audio';
 
 const purgeRemoteSourceSessionMock = vi.hoisted(() => vi.fn());
 const primaryPdfFileName = 'Being You - A New Science of Consciousness - Supplemental PDF.pdf';
@@ -191,26 +191,11 @@ describe('remote source session assets', () => {
 		expect(summary.fileCountWithCompanions).toBe(2);
 	});
 
-	it('purges acquired session roots after matching final batch success', async () => {
+	it('purges acquired session roots for explicit input ids', async () => {
 		const module = await import('./sessionAssets.svelte');
 		module.registerRemoteSourceSupplementalAssets(acquisitionJob(), fileList());
-		const result: ProcessCommandResult = {
-			jobType: 'batch',
-			summary: { total: 1, succeeded: 1, skipped: 0, cancelled: 0, failed: 0 },
-			results: [
-				{
-					inputIndex: 0,
-					status: 'success',
-					message: 'ok',
-					error: undefined,
-					previewFilePath: undefined,
-					previewActualSeconds: undefined,
-					jobId: 'processing-job-1',
-				},
-			],
-		};
 
-		await module.purgeSuccessfulRemoteSourceSessions(result, ['current-input-1']);
+		await module.purgeRemoteSourceSessionsForInputIds(['current-input-1']);
 
 		expect(purgeRemoteSourceSessionMock).toHaveBeenCalledWith('remote-job-1');
 		expect(module.supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
@@ -256,39 +241,8 @@ describe('remote source session assets', () => {
 	it('waits to purge shared acquisition sessions until every registered input is removable', async () => {
 		const module = await import('./sessionAssets.svelte');
 		module.registerRemoteSourceSupplementalAssets(multiTitleAcquisitionJob(), multiTitleFileList());
-		const partialResult: ProcessCommandResult = {
-			jobType: 'batch',
-			summary: { total: 2, succeeded: 1, skipped: 0, cancelled: 0, failed: 1 },
-			results: [
-				{
-					inputIndex: 0,
-					status: 'success',
-					message: 'ok',
-					error: undefined,
-					previewFilePath: undefined,
-					previewActualSeconds: undefined,
-					jobId: 'processing-job-1',
-				},
-				{
-					inputIndex: 1,
-					status: 'failed',
-					message: 'failed',
-					error: {
-						code: 'processing_failed',
-						category: 'processing',
-						message: 'failed',
-					},
-					previewFilePath: undefined,
-					previewActualSeconds: undefined,
-					jobId: 'processing-job-2',
-				},
-			],
-		};
 
-		await module.purgeSuccessfulRemoteSourceSessions(partialResult, [
-			'current-input-1',
-			'current-input-2',
-		]);
+		await module.purgeRemoteSourceSessionsForInputIds(['current-input-1']);
 
 		expect(purgeRemoteSourceSessionMock).not.toHaveBeenCalled();
 		expect(module.supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
@@ -306,23 +260,7 @@ describe('remote source session assets', () => {
 			],
 		});
 
-		const retryResult: ProcessCommandResult = {
-			jobType: 'batch',
-			summary: { total: 1, succeeded: 1, skipped: 0, cancelled: 0, failed: 0 },
-			results: [
-				{
-					inputIndex: 0,
-					status: 'success',
-					message: 'ok',
-					error: undefined,
-					previewFilePath: undefined,
-					previewActualSeconds: undefined,
-					jobId: 'processing-job-3',
-				},
-			],
-		};
-
-		await module.purgeSuccessfulRemoteSourceSessions(retryResult, ['current-input-2']);
+		await module.purgeRemoteSourceSessionsForInputIds(['current-input-2']);
 
 		expect(purgeRemoteSourceSessionMock).toHaveBeenCalledTimes(1);
 		expect(purgeRemoteSourceSessionMock).toHaveBeenCalledWith('remote-job-1');

--- a/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
+++ b/src/ui/statusPanel/__tests__/processingWorkflow.test.ts
@@ -22,9 +22,9 @@ import type { OutputPlanReviewResult } from '../../outputPanel';
 import {
 	purgeRemoteSourceSessionsForInputIds,
 	registerRemoteSourceSupplementalAssets,
-	removeRemoteSourceSupplementalAssets,
-	supplementalAssetsForInputIds,
-} from '../../remoteSource/sessionAssets.svelte';
+	supplementalAssetsByInputIdForProcessing,
+} from '../../remoteSource';
+import { removeRemoteSourceSupplementalAssets } from '../../remoteSource/sessionAssets.svelte';
 
 function audioFile(path: string, overrides: Partial<AudioFile> = {}): AudioFile {
 	return {
@@ -390,6 +390,38 @@ describe('ProcessingWorkflow', () => {
 		expect(services.updateOutputPath).toHaveBeenLastCalledWith('final');
 	});
 
+	it('keeps retained remote-source sessions when submission fails without a pending purge', async () => {
+		const currentFileList: FileListInfo = {
+			files: [audioFile('/session/book.m4b', { inputId: 'current-input-1' })],
+			selectedDecoders: [null],
+			totalDuration: 1,
+			totalSize: 1,
+			validCount: 1,
+			invalidCount: 0,
+		};
+		registerRemoteSourceSupplementalAssets(acquisitionJobWithPdf(), currentFileList);
+		const purgeSpy = vi.spyOn(tauriClient, 'purgeRemoteSourceSession').mockResolvedValue(undefined);
+		const ctx = workflowContext();
+		const { services, feedback } = workflowServices({
+			getCurrentFileList: vi.fn(() => currentFileList),
+			getJobType: vi.fn((): JobType => 'batch'),
+			submitProcessingOperation: vi.fn(async () => {
+				throw {
+					code: 'decoder_unavailable',
+					category: 'toolchain',
+					message: 'Decoder unavailable.',
+					detail: null,
+				};
+			}),
+		});
+
+		await runWithServices(ctx, services);
+
+		expect(feedback.showError).toHaveBeenCalledWith('Processing failed: Decoder unavailable.');
+		expect(purgeSpy).not.toHaveBeenCalled();
+		expect(supplementalAssetsByInputIdForProcessing(['current-input-1'])).toBeDefined();
+	});
+
 	it('purges retained remote-source sessions that were pending purge when submission fails', async () => {
 		const currentFileList: FileListInfo = {
 			files: [audioFile('/session/book.m4b', { inputId: 'current-input-1' })],
@@ -420,6 +452,6 @@ describe('ProcessingWorkflow', () => {
 
 		expect(feedback.showError).toHaveBeenCalledWith('Processing failed: Decoder unavailable.');
 		expect(purgeSpy).toHaveBeenCalledWith('remote-job-1');
-		expect(supplementalAssetsForInputIds(['current-input-1'])).toBeUndefined();
+		expect(supplementalAssetsByInputIdForProcessing(['current-input-1'])).toBeUndefined();
 	});
 });

--- a/src/ui/statusPanel/__tests__/remote-source-boundary.test.ts
+++ b/src/ui/statusPanel/__tests__/remote-source-boundary.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import * as remoteSource from '../../remoteSource';
+
+const EXPECTED_REMOTE_SOURCE_EXPORTS = [
+	'companionSummaryForInputIds',
+	'hasSupplementalAssetsForInputId',
+	'purgeRemoteSourceSessionsForInputIds',
+	'registerRemoteSourceSupplementalAssets',
+	'releaseRemoteSourceSessionRetainers',
+	'retainRemoteSourceSessionsForInputIds',
+	'supplementalAssetsByInputIdForProcessing',
+] as const;
+
+const FORBIDDEN_REMOTE_SOURCE_IMPORTS = [
+	'remoteSource/sessionAssets.svelte',
+	'remoteSource/acquisitionWorkflow',
+	'remoteSource/acquisitionState.svelte',
+	'remoteSource/state.svelte',
+	'remoteSource/RemoteSourceAcquireIsland.svelte',
+	'remoteSource/RemoteSourceAcquireDialog.svelte',
+	'remoteSource/acquisitionAccount',
+	'remoteSource/remoteSourceSelection',
+] as const;
+
+const statusPanelSources = import.meta.glob<string>('../**/*.{ts,svelte}', {
+	eager: true,
+	import: 'default',
+	query: '?raw',
+});
+
+function importViolations(source: string): string[] {
+	return FORBIDDEN_REMOTE_SOURCE_IMPORTS.filter((pattern) => source.includes(pattern));
+}
+
+function productionStatusPanelSources(): [string, string][] {
+	return Object.entries(statusPanelSources).filter(
+		([file]) => !file.includes('/__tests__/') && !/\.(test|spec)\.ts$/.test(file),
+	);
+}
+
+describe('Status Panel remoteSource Public API Strip boundary', () => {
+	it('pins the remoteSource public export strip', () => {
+		expect(Object.keys(remoteSource).sort()).toEqual([...EXPECTED_REMOTE_SOURCE_EXPORTS].sort());
+	});
+
+	it('does not export private sessionAssets helpers or acquisition workflow symbols', () => {
+		expect(remoteSource).not.toHaveProperty('supplementalAssetsForInputIds');
+		expect(remoteSource).not.toHaveProperty('removeRemoteSourceSupplementalAssets');
+		expect(remoteSource).not.toHaveProperty('purgeSuccessfulRemoteSourceSessions');
+	});
+
+	it('keeps production statusPanel code on the remoteSource public import surface', () => {
+		const violations = productionStatusPanelSources().flatMap(([file, source]) => {
+			const matched = importViolations(source);
+			return matched.map((pattern) => `${file} imports ${pattern}`);
+		});
+
+		expect(violations).toEqual([]);
+	});
+});

--- a/src/ui/statusPanel/metadataSaveFeedback.ts
+++ b/src/ui/statusPanel/metadataSaveFeedback.ts
@@ -36,5 +36,5 @@ export function buildMetadataSaveCompletionFeedback(
 }
 
 function filenameFromPath(filePath: string): string {
-	return pathBasename(filePath);
+	return pathBasename(filePath, { fallback: 'path' });
 }

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -155,7 +155,7 @@ function summarizeBatchOutcome(result: ProcessCommandResult, filePaths: string[]
 					if (typeof entry.inputIndex === 'number') {
 						const path = filePaths[entry.inputIndex];
 						if (path) {
-							return pathBasename(path);
+								return pathBasename(path, { fallback: 'path' });
 						}
 					}
 					if (entry.error != null) {

--- a/src/ui/statusPanel/processingWorkflowPreparation.ts
+++ b/src/ui/statusPanel/processingWorkflowPreparation.ts
@@ -15,7 +15,7 @@ import { isUsableMetadataCache } from '../metadataState';
 import type { OutputPlanReviewResult } from '../outputPanel';
 import type { ProcessingWorkflowFailed } from './processingWorkflow';
 import type { ProcessingWorkflowServices } from './processingWorkflow';
-import { supplementalAssetsForInputIds } from '../remoteSource/sessionAssets.svelte';
+import { supplementalAssetsByInputIdForProcessing } from '../remoteSource';
 
 type MetadataIntentByPath = Record<string, MetadataIntentPatch>;
 
@@ -50,7 +50,7 @@ export function buildProcessPayload(
 		sampleRate: processingRequestConfig.sampleRate,
 		jobType,
 		outputNaming: processingRequestConfig.outputNaming,
-		supplementalAssetsByInputId: supplementalAssetsForInputIds(inputIds),
+		supplementalAssetsByInputId: supplementalAssetsByInputIdForProcessing(inputIds),
 	};
 }
 


### PR DESCRIPTION
Closes #371.

## Summary
- Removes dead path basename and remote-source handoff strategy gates while keeping canonical production predicates covered by focused tests.
- Routes Status Panel processing prep through the remoteSource public strip and adds a production-import boundary test.
- Tightens audio path handling so process argv uses `OsString`/`Path`, touched diagnostics use sanitized display strings, and non-UTF-8 FDK args have a Unix counterexample.
- Removes the stale Audible `library_probe` test re-export layer and the dead private `purgeSuccessfulRemoteSourceSessions` helper.

## Validation
- `bun run test -- src/lib/path/basename.test.ts`
- `bun run test -- src/ui/statusPanel/__tests__/processingWorkflow.test.ts src/ui/remoteSource/sessionAssets.test.ts src/ui/statusPanel/__tests__/remote-source-boundary.test.ts`
- `bun run typecheck`
- `bun run lint:check`
- `cargo fmt --all -- --check`
- `cargo nextest run -p abb-remote-source-core`
- `cargo nextest run -p audiobook-boss --lib`
- `cargo clippy -p audiobook-boss --lib --tests`
- `cargo clippy -p audiobook-boss -- -W clippy::too_many_lines`
- `bun run bindings:check:runtime-boundary`
- `git diff --check`

## Findings
- `reject`: #371 item 6 remains rejected because `work_runtime too_many_lines` does not reproduce.
- `defer`: pre-existing `work_runtime::state` `let_and_return`, Audible `acquire_one` `too_many_lines`, and audio `process_input_files` `too_many_arguments` Clippy warnings remain. Clippy exits 0; this PR did not fold those owner refactors into scope.
- `defer`: broader audio `.display()` log cleanup remains outside this touched sweep; the new audio policy is enforced for paths changed here.

Cursor was used as a bounded opinion lane and Codex Review Auditor returned no blocking findings.