### PR TITLE
perf(audio): offload native encode pipeline via spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to AudioBook Boss™ will be documented in this file.
 - Tightened metadata cover-art compatibility, Audible Supplemental PDF
   acquisition, and Status Panel ownership so format detection, PDF
   orchestration, and UI state updates live with their owning modules.
+- Moved native audio processing onto a blocking worker so long encodes do not
+  occupy async runtime workers and cancellation stays responsive during
+  concurrent processing.
 
 ### Fixed
 

--- a/src-tauri/src/audio/processor/adapter.rs
+++ b/src-tauri/src/audio/processor/adapter.rs
@@ -54,13 +54,23 @@ impl ResolvedProcessorAdapter {
     ) -> Result<String> {
         match self {
             Self::NativeFfmpegNext => {
-                super::process_audiobook_with_context(
-                    context,
-                    files,
-                    metadata,
-                    cover_art_passthrough,
-                )
+                // The native pipeline (prepare -> encode -> finalize) is fully
+                // synchronous, CPU-bound work. Offload it onto a blocking thread
+                // so it never occupies an async runtime worker. Progress emission
+                // (`window.emit`) and cooperative cancellation (atomic flag) both
+                // operate correctly off the runtime.
+                tokio::task::spawn_blocking(move || {
+                    super::process_audiobook_with_context(
+                        context,
+                        files,
+                        metadata,
+                        cover_art_passthrough,
+                    )
+                })
                 .await
+                .map_err(|join_error| {
+                    AppError::General(format!("audio processing task failed: {join_error}"))
+                })?
             }
             Self::ExternalFdk { toolchain } => {
                 super::external_fdk::process_audiobook_with_external_fdk(

--- a/src-tauri/src/audio/processor/engine.rs
+++ b/src-tauri/src/audio/processor/engine.rs
@@ -90,7 +90,10 @@ impl FfmpegNextProcessor {
 
 impl FfmpegNextProcessor {
     /// Executes a media processing plan through the native ffmpeg-next pipeline.
-    pub(crate) async fn execute(
+    ///
+    /// Synchronous and CPU-bound; the caller offloads this onto a blocking
+    /// thread via `spawn_blocking` so it never occupies an async worker.
+    pub(crate) fn execute(
         plan: &MediaProcessingPlan,
         context: &ProcessingContext,
         metadata: Option<&crate::metadata::AudiobookMetadata>,

--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -19,7 +19,7 @@ use super::plan::MediaProcessingPlan;
 use super::ProcessingWorkflow;
 
 /// Executes core audio processing operations (merge / convert).
-pub(crate) async fn execute_processing(
+pub(crate) fn execute_processing(
     context: &ProcessingContext,
     workflow: &ProcessingWorkflow,
     files: &[AudioFile],
@@ -45,8 +45,7 @@ pub(crate) async fn execute_processing(
         files,
         metadata,
         passthrough,
-    )
-    .await?;
+    )?;
 
     if context.is_cancelled() {
         return Err(AppError::cancelled());
@@ -56,7 +55,7 @@ pub(crate) async fn execute_processing(
 }
 
 /// Merges audio files with context-based progress tracking.
-pub(crate) async fn merge_audio_files_with_context(
+pub(crate) fn merge_audio_files_with_context(
     temp_dir: &Path,
     context: &ProcessingContext,
     _reporter: &mut ProgressReporter,
@@ -76,7 +75,7 @@ pub(crate) async fn merge_audio_files_with_context(
         total_duration,
     );
 
-    FfmpegNextProcessor::execute(&plan, context, metadata, passthrough).await?;
+    FfmpegNextProcessor::execute(&plan, context, metadata, passthrough)?;
 
     Ok(temp_output)
 }

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -124,7 +124,7 @@ pub(crate) fn complete_processing(
 }
 
 /// Finalize pipeline: metadata + completion
-pub(crate) async fn finalize_processing(
+pub(crate) fn finalize_processing(
     context: &ProcessingContext,
     workflow: ProcessingWorkflow,
     merged_output: PathBuf,

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -154,7 +154,7 @@ impl ProcessingWorkflow {
 /// 1. Validate & Prepare
 /// 2. Execute Processing
 /// 3. Finalize Processing
-async fn process_audiobook_with_context(
+fn process_audiobook_with_context(
     context: ProcessingContext,
     files: Vec<AudioFile>,
     metadata: Option<AudiobookMetadata>,
@@ -196,8 +196,7 @@ async fn process_audiobook_with_context(
         effective_metadata.as_ref(),
         passthrough_metadata.as_ref(),
         &mut reporter,
-    )
-    .await?;
+    )?;
 
     // Stage 3: Finalize
     let result = finalize::finalize_processing(
@@ -207,8 +206,7 @@ async fn process_audiobook_with_context(
         effective_metadata,
         passthrough_metadata,
         &mut reporter,
-    )
-    .await?;
+    )?;
     let _ = workflow_cleanup.remove_path(&workflow_temp_dir);
 
     // Suppress full-run metrics summary during preview; log preview-specific stats instead


### PR DESCRIPTION
Stacked on #381 (depends on the sync `FfmpegNextProcessor::execute` that #381 introduces). Base will auto-retarget to `main` once #381 merges.

## Problem

The native processing pipeline (`prepare -> encode -> finalize`) is fully synchronous, CPU-bound work, but ran directly on a tokio async worker thread with **no yield points**. Each running encode pinned a worker for the entire (minutes-long) encode. Jobs run concurrently (`JoinSet::spawn` on the multi-thread runtime, default `max_concurrent = cores/2`), so concurrent encodes blocked up to `cores/2` workers — more if `max_concurrent` is raised toward the worker count — starving other async work, including the `cancel_processing` command. This also contradicted the backend guidance ("Offload CPU-bound encoding and heavy synchronous work via `tokio::task::spawn_blocking`").

## Fix

Offload the whole native pipeline at the adapter's native branch (where inputs are already owned), and flatten the now-honest synchronous chain.

- `adapter.rs` — native branch wrapped in `tokio::task::spawn_blocking`; `JoinError` mapped to `AppError::General`.
- `async fn` → sync `fn`: `process_audiobook_with_context`, `execute_processing`, `merge_audio_files_with_context`, `finalize_processing`, `FfmpegNextProcessor::execute`.
- **FDK branch left untouched** — it's genuinely async (`tokio::process`, `child.wait().await`), so it already yields during the external encode and does not block a worker.
- `CHANGELOG.md` — `[Unreleased]` notes the native encode offload / cancellation responsiveness outcome.

## Why it's safe

- **Progress** is emitted synchronously (`window.emit`) — works off-runtime.
- **Cancellation** is a shared `Arc<AtomicBool>` checked cooperatively in the encode loop — works off-runtime; freeing the async workers makes the cancel command *more* responsive under load.
- The moved data is already `Send + 'static` (the job future is already `JoinSet::spawn`'d, which requires it), so `spawn_blocking` adds no new bound.
- The entire native pipeline had no genuine async I/O (`prepare` was already sync, `finalize` had zero awaits), so the sync conversion is mechanical.

This also supersedes the Gemini suggestion on #381 to make `execute` sync — it's now sync as a consequence of the real offload, not a keyword swap.

## Verification

- `git diff --check` ✓
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p audiobook-boss --all-targets` — no new warnings ✓
- `cargo nextest run -p audiobook-boss --lib` — 308 passed, 4 skipped ✓
- `cargo nextest run -p audiobook-boss --test all_tests` — 88 passed ✓
- `bun run typecheck` ✓
- Targeted encoder-default Vitest set — 54 passed ✓

**Residual risk:** no manual end-to-end app encode was run in this slice. #341 matters only because it records that ABB currently has no maintained media-execution test lane; it is not a technical dependency of this PR. A manual app encode is the extra confidence check if we want runtime proof beyond structural tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
