### PR TITLE
refactor: finish hollow-seam cleanup (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to AudioBook Boss™ will be documented in this file.
 - Moved native audio processing onto a blocking worker so long encodes do not
   occupy async runtime workers and cancellation stays responsive during
   concurrent processing.
+- Removed dead internal seams from the audio processing pipeline — the
+  `ProcessorAdapterKind` mirror enum, unused finalize reporter/passthrough
+  parameters, the `ProcessingRun` namespace struct, and a stray progress
+  reporter — leaving the encode path with less unused indirection. No behavior
+  change.
 
 ### Fixed
 

--- a/src-tauri/src/audio/processor/adapter.rs
+++ b/src-tauri/src/audio/processor/adapter.rs
@@ -11,12 +11,6 @@ use crate::errors::{AppError, Result};
 use crate::metadata::{AudiobookMetadata, CoverArtPassthroughPolicy};
 use crate::processing::ProcessingContext;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProcessorAdapterKind {
-    NativeFfmpegNext,
-    ExternalFdk,
-}
-
 #[derive(Debug, Clone)]
 pub enum ResolvedProcessorAdapter {
     NativeFfmpegNext,
@@ -26,13 +20,6 @@ pub enum ResolvedProcessorAdapter {
 }
 
 impl ResolvedProcessorAdapter {
-    pub fn kind(&self) -> ProcessorAdapterKind {
-        match self {
-            Self::NativeFfmpegNext => ProcessorAdapterKind::NativeFfmpegNext,
-            Self::ExternalFdk { .. } => ProcessorAdapterKind::ExternalFdk,
-        }
-    }
-
     pub fn validate_inputs(&self, file_info: &FileListInfo) -> Result<()> {
         match self {
             Self::NativeFfmpegNext => Ok(()),
@@ -133,7 +120,7 @@ mod tests {
         )
         .expect("native adapter should resolve");
 
-        assert_eq!(adapter.kind(), ProcessorAdapterKind::NativeFfmpegNext);
+        assert!(matches!(adapter, ResolvedProcessorAdapter::NativeFfmpegNext));
     }
 
     #[test]
@@ -148,7 +135,10 @@ mod tests {
         )
         .expect("external adapter should resolve");
 
-        assert_eq!(adapter.kind(), ProcessorAdapterKind::ExternalFdk);
+        assert!(matches!(
+            adapter,
+            ResolvedProcessorAdapter::ExternalFdk { .. }
+        ));
     }
 
     #[test]

--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -27,9 +27,7 @@ pub(crate) fn execute_processing(
     passthrough: Option<&crate::metadata::PassthroughMetadata>,
     reporter: &mut ProgressReporter,
 ) -> Result<PathBuf> {
-    let mut emitter = ProgressReporter::new(1); // Single logical processing unit
     reporter.set_stage(ProcessingStage::Converting);
-    emitter.set_stage(ProcessingStage::Converting);
 
     log::info!(
         "Starting FFmpeg merge - Total duration: {:.2}s, Bitrate: {}k",

--- a/src-tauri/src/audio/processor/execute.rs
+++ b/src-tauri/src/audio/processor/execute.rs
@@ -40,7 +40,6 @@ pub(crate) fn execute_processing(
     let merged_output = merge_audio_files_with_context(
         &workflow.temp_dir,
         context,
-        reporter,
         workflow.total_duration(),
         files,
         metadata,
@@ -58,7 +57,6 @@ pub(crate) fn execute_processing(
 pub(crate) fn merge_audio_files_with_context(
     temp_dir: &Path,
     context: &ProcessingContext,
-    _reporter: &mut ProgressReporter,
     total_duration: f64,
     files: &[AudioFile],
     metadata: Option<&crate::metadata::AudiobookMetadata>,

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -26,7 +26,6 @@ pub(crate) fn write_metadata_stage(
     _context: &ProcessingContext,
     merged_output: &Path,
     metadata: Option<AudiobookMetadata>,
-    _passthrough: Option<&crate::metadata::PassthroughMetadata>,
     reporter: &mut ProgressReporter,
 ) -> Result<()> {
     let Some(metadata) = metadata else {
@@ -129,11 +128,9 @@ pub(crate) fn finalize_processing(
     workflow: ProcessingWorkflow,
     merged_output: PathBuf,
     metadata: Option<AudiobookMetadata>,
-    passthrough: Option<crate::metadata::PassthroughMetadata>,
     reporter: &mut ProgressReporter,
 ) -> Result<String> {
-    let passthrough_ref = passthrough.as_ref();
-    write_metadata_stage(context, &merged_output, metadata, passthrough_ref, reporter)?;
+    write_metadata_stage(context, &merged_output, metadata, reporter)?;
 
     complete_processing(context, workflow, merged_output, reporter)
 }

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -105,9 +105,12 @@ pub async fn execute_audio_engine(request: AudioExecutionRequest) -> Result<Stri
         ..
     } = request.file_info;
     let adapter = adapter::resolve_processor_adapter(&request.encoder_settings)?;
+    let adapter_label = match &adapter {
+        adapter::ResolvedProcessorAdapter::NativeFfmpegNext => "native_ffmpeg_next",
+        adapter::ResolvedProcessorAdapter::ExternalFdk { .. } => "external_fdk",
+    };
     log::info!(
-        "audio engine adapter: kind={:?} requested_encoder={:?}",
-        adapter.kind(),
+        "audio engine adapter: kind={adapter_label} requested_encoder={:?}",
         request.encoder_settings.encoder_type,
     );
     adapter
@@ -204,7 +207,6 @@ fn process_audiobook_with_context(
         workflow,
         merged_output,
         effective_metadata,
-        passthrough_metadata,
         &mut reporter,
     )?;
     let _ = workflow_cleanup.remove_path(&workflow_temp_dir);

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -13,8 +13,6 @@ mod run_validation;
 pub(crate) use run_options::ProcessingRunOptions;
 use run_validation::{log_encoder_summary, validate_external_processing_contract};
 
-pub(crate) struct ProcessingRun;
-
 pub(crate) async fn process_payload(
     window: tauri::Window,
     registry: crate::ManagedJobRegistry,
@@ -44,7 +42,7 @@ pub(crate) async fn process_payload_with_options(
     preview_seconds: Option<f64>,
     options: ProcessingRunOptions,
 ) -> Result<ProcessCommandResult> {
-    ProcessingRun::execute(
+    run_execute(
         window,
         registry,
         workspace_root,
@@ -61,62 +59,60 @@ pub(crate) fn preflight_payload(
     metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
     preview_seconds: Option<f64>,
 ) -> Result<ProcessingPreflightPlan> {
-    ProcessingRun::preflight(payload, metadata, preview_seconds)
+    run_preflight(payload, metadata, preview_seconds)
 }
 
-impl ProcessingRun {
-    pub(crate) async fn execute(
-        window: tauri::Window,
-        registry: crate::ManagedJobRegistry,
-        workspace_root: PathBuf,
-        payload: ProcessPayload,
-        metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
-        preview_seconds: Option<f64>,
-        options: ProcessingRunOptions,
-    ) -> Result<ProcessCommandResult> {
-        validate_encoder_settings(&payload.settings)?;
-        validate_external_processing_contract(&payload)?;
-        log_encoder_summary(&payload);
+async fn run_execute(
+    window: tauri::Window,
+    registry: crate::ManagedJobRegistry,
+    workspace_root: PathBuf,
+    payload: ProcessPayload,
+    metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
+    preview_seconds: Option<f64>,
+    options: ProcessingRunOptions,
+) -> Result<ProcessCommandResult> {
+    validate_encoder_settings(&payload.settings)?;
+    validate_external_processing_contract(&payload)?;
+    log_encoder_summary(&payload);
 
-        let execution_plan = prepare_execution_plan(&payload, metadata.as_ref(), preview_seconds)?;
-        let job_type = execution_plan.plan.job_type;
+    let execution_plan = prepare_execution_plan(&payload, metadata.as_ref(), preview_seconds)?;
+    let job_type = execution_plan.plan.job_type;
 
-        match job_type {
-            JobType::Merge => {
-                run_dispatch::dispatch_merge_job(
-                    window,
-                    registry,
-                    workspace_root,
-                    &payload,
-                    execution_plan,
-                    options,
-                )
-                .await
-            }
-            JobType::Batch => {
-                run_dispatch::dispatch_batch_jobs(
-                    window,
-                    registry,
-                    workspace_root,
-                    &payload,
-                    execution_plan,
-                    options,
-                )
-                .await
-            }
+    match job_type {
+        JobType::Merge => {
+            run_dispatch::dispatch_merge_job(
+                window,
+                registry,
+                workspace_root,
+                &payload,
+                execution_plan,
+                options,
+            )
+            .await
+        }
+        JobType::Batch => {
+            run_dispatch::dispatch_batch_jobs(
+                window,
+                registry,
+                workspace_root,
+                &payload,
+                execution_plan,
+                options,
+            )
+            .await
         }
     }
+}
 
-    pub(crate) fn preflight(
-        payload: ProcessPayload,
-        metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
-        preview_seconds: Option<f64>,
-    ) -> Result<ProcessingPreflightPlan> {
-        validate_encoder_settings(&payload.settings)?;
-        validate_external_processing_contract(&payload)?;
+fn run_preflight(
+    payload: ProcessPayload,
+    metadata: Option<HashMap<String, crate::metadata::MetadataIntentPatch>>,
+    preview_seconds: Option<f64>,
+) -> Result<ProcessingPreflightPlan> {
+    validate_encoder_settings(&payload.settings)?;
+    validate_external_processing_contract(&payload)?;
 
-        resolve_preflight_plan(&payload, metadata.as_ref(), preview_seconds)
-    }
+    resolve_preflight_plan(&payload, metadata.as_ref(), preview_seconds)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #380

Completes the remaining hollow-seam cleanup items from #380 (items 1 and 5 landed in #381/#382):

- **Item 2:** Delete `ProcessorAdapterKind` mirror; log adapter choice via direct `ResolvedProcessorAdapter` match
- **Item 3:** Remove dead `passthrough` from finalize path; drop unused `_reporter` from `merge_audio_files_with_context` (mux-path passthrough unchanged)
- **Item 4:** Collapse `ProcessingRun` namespace struct into private `run_execute` / `run_preflight` free functions

## Verification

```bash
cargo check -p audiobook-boss
cargo nextest run -p audiobook-boss -E 'test(/adapter/)'
cargo nextest run -p audiobook-boss -E 'test(/finalize/)'
cargo nextest run -p audiobook-boss -E 'test(/processing::run/)'
rg 'ProcessorAdapterKind|create_default_processor|get_engine_description|DefaultProcessor|struct ProcessingRun' src-tauri/src  # clean (ProcessingRunOptions retained)
```