### PR TITLE
rel: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to AudioBook Boss™ will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-24
+
+### Added
+
+- Remote acquisition now shows cover thumbnails for matched audiobooks, with
+  Audible product-image covers mapped into the acquire-dialog preview.
+
 ### Changed
 
 - Tightened metadata cover-art compatibility, Audible Supplemental PDF
@@ -23,6 +30,18 @@ All notable changes to AudioBook Boss™ will be documented in this file.
 - Cover-art compatibility warnings now distinguish supported JPEG/PNG, known
   unsupported formats, and unrecognized bytes without warning on arbitrary
   placeholder data.
+
+### Security
+
+- Updated quinn-proto to 0.11.15, fixing RUSTSEC-2026-0185 (memory exhaustion
+  via unbounded out-of-order QUIC stream reassembly) on remote acquisition
+  paths.
+- Dropped the keyring umbrella crate in favor of registering the native OS
+  keychain directly via `keyring-core`, removing the memmap2 advisory
+  (RUSTSEC-2026-0186) and its unused database keystore backends. Keychain
+  behavior is unchanged.
+- Pinned undici to >=7.28.0 to clear transitive jsdom dev-only advisories and
+  updated Vite to 8.0.16 plus other build/test dependencies.
 
 ## [1.1.4] - 2026-06-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "audiobook-boss"
-version = "1.1.4"
+version = "1.2.0"
 dependencies = [
  "abb-audible-core",
  "abb-media-core",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "audiobook-boss",
 	"private": true,
 	"description": "AudioBook Boss™ — Batch audiobook processing and metadata management",
-	"version": "1.1.4",
+	"version": "1.2.0",
 	"type": "module",
 	"packageManager": "bun@1.3.14",
 	"scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audiobook-boss"
-version = "1.1.4"
+version = "1.2.0"
 description = "AudioBook Boss™ — Batch audiobook processing and metadata management"
 authors = ["JStar"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AudioBook Boss",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "identifier": "com.audiobook-boss",
   "build": {
     "beforeDevCommand": "bun run aaxclean-helper:publish && bun run dev",


### PR DESCRIPTION
Release metadata for **v1.2.0**. Version surfaces synced via `bun scripts/bump-version.ts 1.2.0` (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`) and the `CHANGELOG.md` `[1.2.0]` section written.

Rolls up the previously-unreleased metadata/audio/cover-art work already on main plus PR #395:

- **Added** — remote acquisition cover thumbnails (Audible product-image mapping into the acquire-dialog preview).
- **Security** — quinn-proto 0.11.15 (RUSTSEC-2026-0185); native keychain via `keyring-core` removing the memmap2 advisory (RUSTSEC-2026-0186); undici `>=7.28.0`; Vite 8.0.16 + other build/test deps.
- **Changed/Fixed** — the metadata cover-art / blocking-worker / dead-seam cleanup that was staged under `[Unreleased]`.

(PR #397's AGENTS/skills prune is repo guidance — no user-facing changelog line.)

**Build/tag/DMG/publish are intentionally held** — this PR lands version + changelog only; the DMG ship is a separate Public Release pass.

Direct push to `main` is blocked by branch protection, so the release commit rides this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014AgWCGxNdoKS3nUvZk7evG)_