### PR TITLE
refactor: cover-art format facts + selection/severity owner (#387)

### DIFF
--- a/src-tauri/src/metadata/cover_art/embedding.rs
+++ b/src-tauri/src/metadata/cover_art/embedding.rs
@@ -21,10 +21,7 @@ pub fn add_cover_art_stream_pre_header(
         ));
     };
 
-    let codec_id = match format {
-        CoverFormat::Jpeg => ff::codec::Id::MJPEG,
-        CoverFormat::Png => ff::codec::Id::PNG,
-    };
+    let codec_id = format.codec_id();
     let Some(codec) = ff::encoder::find(codec_id) else {
         return Err(AppError::General(format!(
             "Cover art codec {:?} missing in ffmpeg build",
@@ -100,10 +97,7 @@ fn configure_cover_art_stream_parameters(
     use crate::errors::AppError;
 
     // Create a codec context for the cover art
-    let codec_id = match format {
-        CoverFormat::Jpeg => ff::codec::Id::MJPEG,
-        CoverFormat::Png => ff::codec::Id::PNG,
-    };
+    let codec_id = format.codec_id();
 
     let codec = ff::encoder::find(codec_id)
         .ok_or_else(|| AppError::General(format!("Codec {:?} not found", codec_id)))?;
@@ -128,11 +122,7 @@ fn configure_cover_art_stream_parameters(
     ctx.set_height(height as u32);
 
     // Set pixel format for the codec
-    let pixel_format = match format {
-        CoverFormat::Jpeg => ff::format::Pixel::YUVJ420P, // Common JPEG pixel format
-        CoverFormat::Png => ff::format::Pixel::RGBA,      // PNG with alpha
-    };
-    ctx.set_format(pixel_format);
+    ctx.set_format(format.pixel_format());
 
     // Set time base for single frame
     ctx.set_time_base(ff::Rational(1, 1));

--- a/src-tauri/src/metadata/cover_art/format.rs
+++ b/src-tauri/src/metadata/cover_art/format.rs
@@ -1,7 +1,44 @@
+use ffmpeg_next as ff;
+use mp4ameta::ImgFmt;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum CoverFormat {
     Jpeg,
     Png,
+}
+
+impl CoverFormat {
+    /// FFmpeg encoder/codec id used to embed this cover image.
+    pub(crate) fn codec_id(self) -> ff::codec::Id {
+        match self {
+            CoverFormat::Jpeg => ff::codec::Id::MJPEG,
+            CoverFormat::Png => ff::codec::Id::PNG,
+        }
+    }
+
+    /// FFmpeg pixel format for the cover-art encoder context.
+    pub(crate) fn pixel_format(self) -> ff::format::Pixel {
+        match self {
+            CoverFormat::Jpeg => ff::format::Pixel::YUVJ420P, // Common JPEG pixel format
+            CoverFormat::Png => ff::format::Pixel::RGBA,      // PNG with alpha
+        }
+    }
+
+    /// mp4ameta image format variant for MP4 artwork atoms.
+    pub(crate) fn img_fmt(self) -> ImgFmt {
+        match self {
+            CoverFormat::Jpeg => ImgFmt::Jpeg,
+            CoverFormat::Png => ImgFmt::Png,
+        }
+    }
+
+    /// Human-readable format name for diagnostics and warnings.
+    pub(crate) fn display_name(self) -> &'static str {
+        match self {
+            CoverFormat::Jpeg => "JPEG",
+            CoverFormat::Png => "PNG",
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -189,5 +226,30 @@ mod tests {
             classify_cover_art_format(&[0, 1, 2, 3, 4, 5, 6, 7]),
             CoverArtFormatClassification::Unrecognized
         );
+    }
+
+    #[test]
+    fn cover_format_accessors_map_each_downstream_fact() {
+        for (format, codec, pixel, img, name) in [
+            (
+                CoverFormat::Jpeg,
+                ff::codec::Id::MJPEG,
+                ff::format::Pixel::YUVJ420P,
+                ImgFmt::Jpeg,
+                "JPEG",
+            ),
+            (
+                CoverFormat::Png,
+                ff::codec::Id::PNG,
+                ff::format::Pixel::RGBA,
+                ImgFmt::Png,
+                "PNG",
+            ),
+        ] {
+            assert_eq!(format.codec_id(), codec, "codec_id for {format:?}");
+            assert_eq!(format.pixel_format(), pixel, "pixel_format for {format:?}");
+            assert_eq!(format.img_fmt(), img, "img_fmt for {format:?}");
+            assert_eq!(format.display_name(), name, "display_name for {format:?}");
+        }
     }
 }

--- a/src-tauri/src/metadata/cover_art/mod.rs
+++ b/src-tauri/src/metadata/cover_art/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod embedding;
 pub(crate) mod format;
+pub(crate) mod selection;
 
 pub use embedding::{add_cover_art_stream_pre_header, write_cover_art_packet_post_header};
 pub use format::{detect_cover_art_format, CoverFormat};
+pub(crate) use selection::ResolvedCover;

--- a/src-tauri/src/metadata/cover_art/selection.rs
+++ b/src-tauri/src/metadata/cover_art/selection.rs
@@ -1,0 +1,126 @@
+//! Remux-time cover-art selection and embed-failure severity.
+//!
+//! Owns two decisions in one place: which cover wins when both an explicit
+//! (metadata) and a passthrough (source-preserved) cover are available, and how
+//! an embed failure is graded by that source. Explicit covers are mandatory —
+//! a failed embed is fatal; passthrough covers are best-effort — a failed embed
+//! is warned and skipped.
+
+use crate::errors::{AppError, Result};
+
+use super::super::passthrough::PassthroughMetadata;
+use super::super::AudiobookMetadata;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResolvedCover<'a> {
+    Explicit(&'a Vec<u8>),
+    Passthrough(&'a Vec<u8>),
+}
+
+impl<'a> ResolvedCover<'a> {
+    /// Select the cover to write: an explicit metadata cover wins over a
+    /// passthrough cover, and an empty cover is dropped (`set | clear | noop`).
+    pub(crate) fn select(
+        metadata: Option<&'a AudiobookMetadata>,
+        passthrough: Option<&'a PassthroughMetadata>,
+    ) -> Option<Self> {
+        metadata
+            .and_then(|value| value.cover_art.as_ref())
+            .map(ResolvedCover::Explicit)
+            .or_else(|| {
+                passthrough
+                    .and_then(|value| value.cover_art.as_ref())
+                    .map(ResolvedCover::Passthrough)
+            })
+            .filter(|selection| !selection.bytes().is_empty())
+    }
+
+    pub(crate) fn bytes(self) -> &'a Vec<u8> {
+        match self {
+            Self::Explicit(bytes) | Self::Passthrough(bytes) => bytes,
+        }
+    }
+
+    fn is_passthrough(self) -> bool {
+        matches!(self, Self::Passthrough(_))
+    }
+
+    /// Grade an embed-stage failure by cover source: passthrough covers warn and
+    /// continue (`Ok`), explicit covers propagate the error (`Err`). This is the
+    /// single owner of the severity decision shared by the pre-header stream and
+    /// post-header packet remux stages.
+    pub(crate) fn handle_embed_failure(self, error: AppError, stage: &str) -> Result<()> {
+        if self.is_passthrough() {
+            log::warn!("Could not preserve passthrough {stage} during metadata remux: {error}");
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata_with_cover(bytes: Vec<u8>) -> AudiobookMetadata {
+        AudiobookMetadata {
+            cover_art: Some(bytes),
+            ..Default::default()
+        }
+    }
+
+    fn passthrough_with_cover(bytes: Vec<u8>) -> PassthroughMetadata {
+        PassthroughMetadata {
+            cover_art: Some(bytes),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn explicit_cover_wins_over_passthrough() {
+        let explicit = metadata_with_cover(vec![1, 2, 3]);
+        let passthrough = passthrough_with_cover(vec![9, 9, 9]);
+        let selection = ResolvedCover::select(Some(&explicit), Some(&passthrough))
+            .expect("a cover is selected");
+        assert!(matches!(selection, ResolvedCover::Explicit(_)));
+        assert_eq!(selection.bytes(), &vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn passthrough_used_when_no_explicit_cover() {
+        let passthrough = passthrough_with_cover(vec![9, 9, 9]);
+        let selection =
+            ResolvedCover::select(None, Some(&passthrough)).expect("a cover is selected");
+        assert!(matches!(selection, ResolvedCover::Passthrough(_)));
+        assert_eq!(selection.bytes(), &vec![9, 9, 9]);
+    }
+
+    #[test]
+    fn empty_cover_is_dropped() {
+        let empty_explicit = metadata_with_cover(Vec::new());
+        let passthrough = passthrough_with_cover(vec![9, 9, 9]);
+        // An empty explicit cover drops rather than falling back to passthrough:
+        // an explicit empty cover is a clear, not a request for the source art.
+        assert!(ResolvedCover::select(Some(&empty_explicit), Some(&passthrough)).is_none());
+        assert!(ResolvedCover::select(None, None).is_none());
+    }
+
+    #[test]
+    fn passthrough_embed_failure_warns_and_continues() {
+        let passthrough = passthrough_with_cover(vec![9, 9, 9]);
+        let selection = ResolvedCover::select(None, Some(&passthrough)).expect("selected");
+        let result =
+            selection.handle_embed_failure(AppError::General("boom".to_string()), "cover art");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn explicit_embed_failure_propagates() {
+        let explicit = metadata_with_cover(vec![1, 2, 3]);
+        let selection = ResolvedCover::select(Some(&explicit), None).expect("selected");
+        let result =
+            selection.handle_embed_failure(AppError::General("boom".to_string()), "cover art");
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/metadata/ffmpeg_dict.rs
+++ b/src-tauri/src/metadata/ffmpeg_dict.rs
@@ -171,7 +171,7 @@ fn validate_supported_cover_art_format(
 ) {
     log::debug!(
         "Cover art format validation: {} detected and supported",
-        cover_art_format_name(format)
+        format.display_name()
     );
     check_cover_art_dimensions(format, cover_data, warnings);
     check_cover_art_codec(format, warnings);
@@ -194,31 +194,17 @@ fn check_cover_art_dimensions(format: CoverFormat, cover_data: &[u8], warnings: 
         // Suppress dimension warning for tiny (<100B) placeholder images.
         warnings.push(format!(
             "Could not detect {} dimensions - file may be corrupted",
-            cover_art_format_name(format)
+            format.display_name()
         ));
     }
 }
 
 fn check_cover_art_codec(format: CoverFormat, warnings: &mut Vec<String>) {
-    if ff::encoder::find(cover_art_codec_id(format)).is_none() {
+    if ff::encoder::find(format.codec_id()).is_none() {
         warnings.push(format!(
             "FFmpeg codec for {:?} format not available in this build - cover art will be skipped",
             format
         ));
-    }
-}
-
-fn cover_art_codec_id(format: CoverFormat) -> ff::codec::Id {
-    match format {
-        CoverFormat::Jpeg => ff::codec::Id::MJPEG,
-        CoverFormat::Png => ff::codec::Id::PNG,
-    }
-}
-
-fn cover_art_format_name(format: CoverFormat) -> &'static str {
-    match format {
-        CoverFormat::Jpeg => "JPEG",
-        CoverFormat::Png => "PNG",
     }
 }
 

--- a/src-tauri/src/metadata/mp4ameta_bridge.rs
+++ b/src-tauri/src/metadata/mp4ameta_bridge.rs
@@ -7,7 +7,7 @@ use crate::metadata::{
     normalize_publication_date, split_series_list, AlbumSortWriteAction, AudiobookMetadata,
     MetadataWritePlan,
 };
-use mp4ameta::{FreeformIdent, Img, ImgFmt, Tag, WriteConfig};
+use mp4ameta::{FreeformIdent, Img, Tag, WriteConfig};
 use std::path::Path;
 
 pub fn read_metadata(path: &Path) -> Result<AudiobookMetadata> {
@@ -208,9 +208,5 @@ fn cover_art_to_img(bytes: &[u8]) -> Result<Option<Img<Vec<u8>>>> {
         return Ok(None);
     };
 
-    let img = match format {
-        crate::metadata::CoverFormat::Jpeg => Img::new(ImgFmt::Jpeg, bytes.to_vec()),
-        crate::metadata::CoverFormat::Png => Img::new(ImgFmt::Png, bytes.to_vec()),
-    };
-    Ok(Some(img))
+    Ok(Some(Img::new(format.img_fmt(), bytes.to_vec())))
 }

--- a/src-tauri/src/metadata/remux.rs
+++ b/src-tauri/src/metadata/remux.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use super::cover_art::embedding::{
     add_cover_art_stream_pre_header, write_cover_art_packet_post_header,
 };
+use super::cover_art::ResolvedCover;
 use super::ffi::set_stream_disposition_and_clear_codec_tag;
 
 /// Rewrite metadata and optional passthrough state using ffmpeg-next via remux/stream-copy.
@@ -54,18 +55,14 @@ pub(crate) fn rewrite_metadata_with_ffmpeg_plan_as(
     copy_chapters(&ictx, &mut octx, passthrough)?;
     copy_container_metadata(&ictx, &mut octx, metadata)?;
 
-    let cover = select_cover_art(metadata_value, passthrough);
+    let cover = ResolvedCover::select(metadata_value, passthrough);
     let cover_stream_info = if let Some(selection) = cover {
         match add_cover_art_stream_pre_header(&mut octx, selection.bytes()) {
             Ok(stream_info) => stream_info,
-            Err(error) if selection.is_passthrough() => {
-                log::warn!(
-                    "Could not preserve passthrough cover art during metadata remux: {}",
-                    error
-                );
+            Err(error) => {
+                selection.handle_embed_failure(error, "cover art")?;
                 None
             }
-            Err(error) => return Err(error),
         }
     } else {
         None
@@ -76,14 +73,7 @@ pub(crate) fn rewrite_metadata_with_ffmpeg_plan_as(
         if let Err(error) =
             write_cover_art_packet_post_header(&mut octx, stream_index, selection.bytes(), format)
         {
-            if selection.is_passthrough() {
-                log::warn!(
-                    "Could not preserve passthrough cover art packet during metadata remux: {}",
-                    error
-                );
-            } else {
-                return Err(error);
-            }
+            selection.handle_embed_failure(error, "cover art packet")?;
         }
     }
 
@@ -226,39 +216,6 @@ fn copy_container_metadata(
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy)]
-enum CoverArtSelection<'a> {
-    Explicit(&'a Vec<u8>),
-    Passthrough(&'a Vec<u8>),
-}
-
-impl<'a> CoverArtSelection<'a> {
-    fn bytes(self) -> &'a Vec<u8> {
-        match self {
-            Self::Explicit(bytes) | Self::Passthrough(bytes) => bytes,
-        }
-    }
-
-    fn is_passthrough(self) -> bool {
-        matches!(self, Self::Passthrough(_))
-    }
-}
-
-fn select_cover_art<'a>(
-    metadata: Option<&'a AudiobookMetadata>,
-    passthrough: Option<&'a PassthroughMetadata>,
-) -> Option<CoverArtSelection<'a>> {
-    metadata
-        .and_then(|value| value.cover_art.as_ref())
-        .map(CoverArtSelection::Explicit)
-        .or_else(|| {
-            passthrough
-                .and_then(|value| value.cover_art.as_ref())
-                .map(CoverArtSelection::Passthrough)
-        })
-        .filter(|selection| !selection.bytes().is_empty())
 }
 
 fn stream_copy_packets(


### PR DESCRIPTION
## #387 — Cover-art format facts + selection/severity owner

Part of #383 (deepen shallow modules). A backend-private `metadata` refactor: cover-art "facts" and "decisions" were restated across call sites; this gives each a single owner. **Behavior-preserving** (issue marks no known bug; none found). Net **−7 lines**.

### What changed

**1. Format facts → inherent methods on `CoverFormat`** (`metadata/cover_art/format.rs`)
A cover format now owns its four downstream facts via `codec_id()`, `pixel_format()`, `img_fmt()`, `display_name()`. The six former match sites route through them:
- `embedding.rs` — two inline codec-id matches + the pixel-format match (the real remaining duplication);
- `ffmpeg_dict.rs` — the `cover_art_codec_id` / `cover_art_format_name` helpers (deleted, callers inlined);
- `mp4ameta_bridge.rs` — the `ImgFmt` match.

Codec-id alone was restated **3×**; it is now one arm.

**2. Selection + severity → one crate-private owner `ResolvedCover`** (new `metadata/cover_art/selection.rs`)
Owns remux-time **selection precedence** (explicit cover beats passthrough, empty drops — preserves `set | clear | noop`) and the **embed-failure severity** decision (passthrough failure warns and continues; explicit failure propagates). It replaces the local `CoverArtSelection` enum + `select_cover_art` fn in `remux.rs` and collapses the severity branch that `remux.rs` re-implemented **twice** (pre-header stream + post-header packet) into one `handle_embed_failure` call. Warn text and fail semantics are reproduced exactly.

### Deliberately out of scope

- **Hydration is left untouched.** `merge_passthrough_cover_art` (`passthrough.rs`) is a *distinct, sequential* stage: it fills `metadata.cover_art` from passthrough *before* encode, and remux *re-selects* from that result. They compose, they are not two parallel expressions of one rule — so there is no honest "agreement" to assert, and routing its owned/cloned `AudiobookMetadata` through a borrowing `ResolvedCover` would be lifetime contortion for no gain. Its existing fill-missing/keep-explicit tests stay green.
- No #281 metadata-artifact UX, no external-file-hazard redesign, no IPC/bindings/UI/runtime-lifecycle change.

### Why this slice is one PR

Single `metadata` owner, backend-private, Rust-test-proven, no IPC/UI/runtime-flow change → **no manual smoke**. `ResolvedCover` stays `pub(crate)` — **no Public API Strip change**, so no contract-test or `AGENTS.md` edit.

### Proof

- New tests: table-driven `CoverFormat` accessor test over `[Jpeg, Png]`; `ResolvedCover` selection (explicit-wins, passthrough-fallback, empty-drop) + severity (passthrough→`Ok`, explicit→`Err`) tests.
- Existing `merge_passthrough_cover_art`, cover-art clear-policy, and ffmpeg_dict cover-validation tests stay green.
- `cargo nextest run -p audiobook-boss --lib` → **347 passed**; `cargo clippy -p audiobook-boss --all-targets` clean; `cargo fmt --all -- --check` clean.
- #341 media-execution freeze honored (no real ffmpeg/container tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
