### PR TITLE
refactor: frontend IPC lifecycle - subscription group + appError presenter (#388)

### DIFF
--- a/src/lib/tauri/AGENTS.md
+++ b/src/lib/tauri/AGENTS.md
@@ -8,8 +8,23 @@
   bindings.
 - Runtime UI modules call `tauriClient`; generated command/event invokers stay private to `src/lib/tauri`.
 
+## Frontend Utility Surface
+- `appError.ts` and `subscriptionGroup.ts` are deliberate frontend utilities that
+  UI islands may import directly from `src/lib/tauri/*`. They are not IPC
+  command/event adapters and not `tauriClient` methods.
+- `appError.ts` is the single owner of error normalization and presentation:
+  `normalizeAppError`, `toUserMessage`, `isCancellation`, `isAppErrorCategory`,
+  `logAppError`, `unwrapGeneratedResult`. Derive user-facing messages and
+  cancellation here; do not re-derive cancellation by ad-hoc regex in islands.
+- `subscriptionGroup.ts` (`createSubscriptionGroup`) is the single owner of Tauri
+  event-unlisten teardown and the dispose / late-arrival race. Islands collect
+  unlisteners through a group, not bespoke arrays/flags.
+- These utilities are NOT pinned by `src/lib/tauri-public-api.contract.test.ts`
+  (which guards the `tauriClient` IPC strip); each carries its own focused module
+  test (`appError.test.ts`, `subscriptionGroup.test.ts`).
+
 ## Private Cluster
-- Files: `client.ts`, `commands.ts`, `normalizers.ts`, `appError.ts`, `AGENTS.md`.
+- Files: `client.ts`, `commands.ts`, `normalizers.ts`, `AGENTS.md`.
 - Generated bindings live at `src/lib/generated/tauri.ts`; do not hand-edit them.
 
 ## Allowed Agent Edits Without Escalation

--- a/src/lib/tauri/appError.test.ts
+++ b/src/lib/tauri/appError.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type AppErrorEnvelope, isCancellation, logAppError, toUserMessage } from './appError';
+
+function envelope(partial: Partial<AppErrorEnvelope>): AppErrorEnvelope {
+	return {
+		code: 'some_code',
+		category: 'processing',
+		message: 'something failed',
+		...partial,
+	};
+}
+
+describe('toUserMessage', () => {
+	it('returns the normalized message for typed envelopes', () => {
+		expect(toUserMessage(envelope({ message: 'boom' }))).toBe('boom');
+	});
+
+	it('falls back when the message is empty', () => {
+		expect(toUserMessage(envelope({ message: '' }), { fallback: 'fallback' })).toBe('fallback');
+	});
+
+	it('collapses unknown-coded errors to the fallback when suppressUnknown is set', () => {
+		expect(
+			toUserMessage(new Error('internal detail'), {
+				fallback: 'Friendly message',
+				suppressUnknown: true,
+			}),
+		).toBe('Friendly message');
+	});
+
+	it('keeps the message for unknown errors when suppressUnknown is not set', () => {
+		expect(toUserMessage(new Error('raw detail'), { fallback: 'Friendly message' })).toBe(
+			'raw detail',
+		);
+	});
+});
+
+describe('isCancellation', () => {
+	it('detects the typed cancellation category', () => {
+		expect(isCancellation(envelope({ category: 'cancellation', message: 'done' }))).toBe(true);
+	});
+
+	it('detects an un-enveloped cancellation via the message fallback', () => {
+		expect(isCancellation(new Error('Processing was cancelled.'))).toBe(true);
+	});
+
+	it('returns false for unrelated errors', () => {
+		expect(isCancellation(envelope({ category: 'processing', message: 'encode failed' }))).toBe(
+			false,
+		);
+		expect(isCancellation(new Error('disk full'))).toBe(false);
+	});
+});
+
+describe('logAppError', () => {
+	it('logs code and category at error level by default', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		logAppError('Scope', envelope({ code: 'x', category: 'io' }));
+		expect(spy).toHaveBeenCalledWith('Scope code=x category=io');
+		spy.mockRestore();
+	});
+
+	it('logs at warn level when requested', () => {
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		logAppError('Purge', envelope({ code: 'y', category: 'resource' }), 'warn');
+		expect(spy).toHaveBeenCalledWith('Purge code=y category=resource');
+		spy.mockRestore();
+	});
+});

--- a/src/lib/tauri/appError.ts
+++ b/src/lib/tauri/appError.ts
@@ -126,3 +126,53 @@ export function unwrapGeneratedResult<T>(value: unknown): T {
 export function isAppErrorCategory(error: unknown, category: AppErrorCategory): boolean {
 	return normalizeAppError(error).category === category;
 }
+
+/**
+ * Derive a user-facing message from any thrown cause. Centralizes the
+ * `normalizeAppError(...).message` derivation the UI islands re-implement.
+ * With `suppressUnknown`, an unclassified (`unknown_error`) cause collapses to
+ * `fallback` instead of surfacing a raw/internal message.
+ */
+export function toUserMessage(
+	cause: unknown,
+	options: { fallback?: string; suppressUnknown?: boolean } = {},
+): string {
+	const fallback = options.fallback ?? 'Unknown error';
+	const normalized = normalizeAppError(cause, fallback);
+	if (options.suppressUnknown && normalized.code === 'unknown_error') {
+		return fallback;
+	}
+	return normalized.message || fallback;
+}
+
+/**
+ * True when a cause represents a cancellation. Prefers the typed
+ * `category: 'cancellation'`, and keeps a message fallback because cancellations
+ * can still arrive un-enveloped (a raw error normalizes to category `unknown`).
+ * Proving cancellations are always typed is owned by the lifecycle-truth work
+ * (#376); until then this is the single owner of that dual check.
+ */
+export function isCancellation(cause: unknown): boolean {
+	const normalized = normalizeAppError(cause);
+	return (
+		normalized.category === 'cancellation' || normalized.message.toLowerCase().includes('cancelled')
+	);
+}
+
+/**
+ * Log a normalized error with a consistent `code=/category=` shape. Defaults to
+ * `console.error`; pass `level: 'warn'` for non-fatal diagnostics.
+ */
+export function logAppError(
+	scope: string,
+	cause: unknown,
+	level: 'error' | 'warn' = 'error',
+): void {
+	const error = normalizeAppError(cause);
+	const line = `${scope} code=${error.code} category=${error.category}`;
+	if (level === 'warn') {
+		console.warn(line);
+	} else {
+		console.error(line);
+	}
+}

--- a/src/lib/tauri/subscriptionGroup.test.ts
+++ b/src/lib/tauri/subscriptionGroup.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSubscriptionGroup } from './subscriptionGroup';
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe('subscription group', () => {
+	it('invokes every registered unlisten exactly once on dispose', async () => {
+		const group = createSubscriptionGroup();
+		const fromPromise = vi.fn();
+		const fromSync = vi.fn();
+		await group.add(Promise.resolve(fromPromise));
+		await group.add(fromSync);
+		expect(group.disposed).toBe(false);
+
+		group.dispose();
+		group.dispose(); // idempotent
+
+		expect(fromPromise).toHaveBeenCalledTimes(1);
+		expect(fromSync).toHaveBeenCalledTimes(1);
+		expect(group.disposed).toBe(true);
+	});
+
+	it('immediately unlistens a registration that resolves after dispose', async () => {
+		const group = createSubscriptionGroup();
+		const deferred = createDeferred<() => void>();
+		const unlisten = vi.fn();
+
+		const pending = group.add(deferred.promise);
+		group.dispose();
+		deferred.resolve(unlisten);
+		await pending;
+
+		expect(unlisten).toHaveBeenCalledTimes(1);
+	});
+
+	it('immediately unlistens a sync registration added after dispose', async () => {
+		const group = createSubscriptionGroup();
+		const unlisten = vi.fn();
+		group.dispose();
+		await group.add(unlisten);
+		expect(unlisten).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/tauri/subscriptionGroup.ts
+++ b/src/lib/tauri/subscriptionGroup.ts
@@ -1,0 +1,58 @@
+import type { UnlistenFn } from '@tauri-apps/api/event';
+
+/**
+ * A lifecycle-owned collection of Tauri event unlisteners.
+ *
+ * Centralizes the dispose / late-arrival race that UI islands otherwise
+ * re-implement per subscription: if the group is disposed before a pending
+ * `listen` promise resolves, the resolved unlisten is invoked immediately so the
+ * listener cannot leak; otherwise it is collected and invoked once on `dispose()`.
+ *
+ * This is a deliberate frontend utility surface (see `AGENTS.md`); it is not a
+ * `tauriClient` IPC method.
+ */
+export interface SubscriptionGroup {
+	/**
+	 * Register an unlisten — or a pending `listen` promise that resolves to one —
+	 * with the group. If the group is already disposed when the unlisten becomes
+	 * available, it is invoked immediately instead of stored. Resolves once the
+	 * registration settles, so a caller needing subscribe-before-X ordering can await.
+	 */
+	add(registration: Promise<UnlistenFn> | UnlistenFn): Promise<void>;
+	/** Invoke and drop every registered unlisten exactly once; idempotent. */
+	dispose(): void;
+	/** True once `dispose()` has run; further `add()`s unlisten immediately. */
+	readonly disposed: boolean;
+}
+
+export function createSubscriptionGroup(): SubscriptionGroup {
+	let disposed = false;
+	const unlisteners: UnlistenFn[] = [];
+
+	const register = (unlisten: UnlistenFn): void => {
+		if (disposed) {
+			unlisten();
+			return;
+		}
+		unlisteners.push(unlisten);
+	};
+
+	return {
+		get disposed() {
+			return disposed;
+		},
+		async add(registration) {
+			const unlisten = typeof registration === 'function' ? registration : await registration;
+			register(unlisten);
+		},
+		dispose() {
+			if (disposed) {
+				return;
+			}
+			disposed = true;
+			for (const unlisten of unlisteners.splice(0)) {
+				unlisten();
+			}
+		},
+	};
+}

--- a/src/ui/coverArt/index.ts
+++ b/src/ui/coverArt/index.ts
@@ -1,6 +1,6 @@
 import { coverArtBytesToDataUrl } from '../../lib/media/coverArtDataUrl';
 import { tauriClient } from '../../lib/tauri/client';
-import { normalizeAppError } from '../../lib/tauri/appError';
+import { toUserMessage } from '../../lib/tauri/appError';
 import type { MetadataIntentPatch } from '../../types/metadataIntent';
 import { getJobType } from '../jobControls';
 import { getCurrentFileList, getSelectedFiles } from '../fileList';
@@ -229,7 +229,7 @@ export async function applyCoverArtDrop(paths: string[]): Promise<boolean> {
 }
 
 function formatCoverArtError(error: unknown, fallback: string): string {
-	const raw = normalizeAppError(error, fallback).message;
+	const raw = toUserMessage(error, { fallback });
 	if (/status 403/i.test(raw) || /403 Forbidden/i.test(raw)) {
 		return 'That URL blocked the image request (Error 403) - download the image and Load Cover Art from file.';
 	}

--- a/src/ui/fileImport/__tests__/coverArtDrop.test.ts
+++ b/src/ui/fileImport/__tests__/coverArtDrop.test.ts
@@ -44,6 +44,8 @@ vi.mock('../../../lib/tauri/client', () => ({
 	tauriClient: {
 		listen: vi.fn((event: string, cb: TauriListener) => {
 			listeners[event] = cb;
+			// Honor the real `tauriClient.listen` contract: resolve to an UnlistenFn.
+			return Promise.resolve(() => {});
 		}),
 		getSupportedAudioImportMetadata: getSupportedAudioImportMetadataMock,
 		discoverAudioImportPaths: discoverAudioImportPathsMock,

--- a/src/ui/fileImport/handlers.ts
+++ b/src/ui/fileImport/handlers.ts
@@ -1,4 +1,5 @@
 import { tauriClient } from '../../lib/tauri/client';
+import { createSubscriptionGroup } from '../../lib/tauri/subscriptionGroup';
 import type { AudioFile } from '../../types/audio';
 import { EVENTS, isFileDropEvent } from '../../types/events';
 import { applyCoverArtDrop } from '../coverArt';
@@ -38,31 +39,8 @@ export function getImportedAudioPathsBlockedMessage(): string | null {
 
 export function attachTauriDragHandlers(context: DragDropContext): Unlisten {
 	const { getCoverArtArea, getFileManagementContainer, getVisibleFiles } = context;
-	const unlisteners: Unlisten[] = [];
-	let isDisposed = false;
+	const subscriptions = createSubscriptionGroup();
 	let hasDeferredOpenedAudioDrain = false;
-
-	const registerUnlistener = (unlisten: Unlisten): void => {
-		if (isDisposed) {
-			unlisten();
-			return;
-		}
-		unlisteners.push(unlisten);
-	};
-
-	const captureUnlistener = (result: unknown): void => {
-		if (typeof result === 'function') {
-			registerUnlistener(result as Unlisten);
-			return;
-		}
-		if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
-			void (result as Promise<unknown>).then((unlisten) => {
-				if (typeof unlisten === 'function') {
-					registerUnlistener(unlisten as Unlisten);
-				}
-			});
-		}
-	};
 
 	const drainOpenedAudioFiles = async (): Promise<void> => {
 		const drained = await handleOpenedAudioFiles(getVisibleFiles());
@@ -101,19 +79,19 @@ export function attachTauriDragHandlers(context: DragDropContext): Unlisten {
 		}
 	};
 
-	captureUnlistener(tauriClient.listen('tauri://drag-drop', dragDropHandler));
-	captureUnlistener(
+	void subscriptions.add(tauriClient.listen('tauri://drag-drop', dragDropHandler));
+	void subscriptions.add(
 		tauriClient.listen('tauri://drag-enter', () => {
 			setFileImportDragOver(true);
 		}),
 	);
-	captureUnlistener(
+	void subscriptions.add(
 		tauriClient.listen('tauri://drag-leave', () => {
 			setFileImportDragOver(false);
 		}),
 	);
-	captureUnlistener(tauriClient.listen(EVENTS.OPENED_AUDIO_FILES, drainOpenedAudioFiles));
-	registerUnlistener(
+	void subscriptions.add(tauriClient.listen(EVENTS.OPENED_AUDIO_FILES, drainOpenedAudioFiles));
+	void subscriptions.add(
 		onOrderLockChange((locked) => {
 			if (!locked && hasDeferredOpenedAudioDrain) {
 				void drainOpenedAudioFiles();
@@ -125,10 +103,7 @@ export function attachTauriDragHandlers(context: DragDropContext): Unlisten {
 	void drainOpenedAudioFiles();
 
 	return () => {
-		isDisposed = true;
-		for (const unlisten of unlisteners.splice(0, unlisteners.length)) {
-			unlisten();
-		}
+		subscriptions.dispose();
 	};
 }
 

--- a/src/ui/remoteSource/acquisitionState.svelte.ts
+++ b/src/ui/remoteSource/acquisitionState.svelte.ts
@@ -1,5 +1,5 @@
 import type { ProviderId, RemoteSourceAccountState, RemoteTitle } from '../../types/remoteSource';
-import { normalizeAppError } from '../../lib/tauri/appError';
+import { logAppError, toUserMessage } from '../../lib/tauri/appError';
 import type { AcquisitionJobWithProgress } from './remoteSourceAcquireDialogHelpers';
 
 export const remoteSourceProviderId: ProviderId = 'audible';
@@ -44,7 +44,6 @@ export function createInitialAcquisitionState(): AcquisitionState {
 }
 
 export function setAcquisitionError(s: AcquisitionState, cause: unknown, fallback: string): void {
-	const error = normalizeAppError(cause, fallback);
-	console.error(`${fallback} code=${error.code} category=${error.category}`);
-	s.statusMessage = error.code === 'unknown_error' ? fallback : error.message;
+	logAppError(fallback, cause);
+	s.statusMessage = toUserMessage(cause, { fallback, suppressUnknown: true });
 }

--- a/src/ui/remoteSource/sessionAssets.svelte.ts
+++ b/src/ui/remoteSource/sessionAssets.svelte.ts
@@ -1,5 +1,5 @@
 import type { AudioFile, FileListInfo, SupplementalProcessingAsset } from '../../types/audio';
-import { normalizeAppError } from '../../lib/tauri/appError';
+import { logAppError } from '../../lib/tauri/appError';
 import { tauriClient } from '../../lib/tauri/client';
 import type { AcquisitionJob, SupplementalAsset } from '../../types/remoteSource';
 
@@ -220,10 +220,7 @@ export async function purgeRemoteSourceSessionsForInputIds(
 		try {
 			await tauriClient.purgeRemoteSourceSession(jobId);
 		} catch (cause) {
-			const error = normalizeAppError(cause, 'Failed to purge remote source session.');
-			console.warn(
-				`Failed to purge remote source session: ${jobId} code=${error.code} category=${error.category}`,
-			);
+			logAppError(`Failed to purge remote source session: ${jobId}`, cause, 'warn');
 		}
 	}
 	removeRemoteSourceSupplementalAssets(purgeableIds);

--- a/src/ui/statusPanel/__tests__/progressSubscription.test.ts
+++ b/src/ui/statusPanel/__tests__/progressSubscription.test.ts
@@ -115,8 +115,7 @@ describe('progress subscription owner', () => {
 
 		const startPromise = owner.start();
 		progressDeferred.resolve(progressUnlisten);
-		await Promise.resolve();
-		expect(listenForQueueEvents).toHaveBeenCalledTimes(1);
+		await vi.waitFor(() => expect(listenForQueueEvents).toHaveBeenCalledTimes(1));
 
 		owner.stop();
 		queueDeferred.resolve(queueUnlisten);

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../types/audio';
 import type { WorkSubmissionAccepted } from '../../types/workRuntime';
 import type { MetadataIntentPatch } from '../../types/metadataIntent';
-import { isAppErrorCategory, normalizeAppError } from '../../lib/tauri/appError';
+import { isCancellation, toUserMessage } from '../../lib/tauri/appError';
 import {
 	Data,
 	Effect,
@@ -161,7 +161,7 @@ function summarizeBatchOutcome(result: ProcessCommandResult, filePaths: string[]
 						}
 					}
 					if (entry.error != null) {
-						const errorMessage = normalizeAppError(entry.error, '').message;
+						const errorMessage = toUserMessage(entry.error, { fallback: '' });
 						if (errorMessage.length > 0) {
 							return errorMessage;
 						}
@@ -191,9 +191,8 @@ function summarizeBatchOutcome(result: ProcessCommandResult, filePaths: string[]
 }
 
 function workflowFailure(message: string, cause: unknown): ProcessingWorkflowFailed {
-	const normalized = normalizeAppError(cause, message);
 	return new ProcessingWorkflowFailed({
-		message: normalized.message || message,
+		message: toUserMessage(cause, { fallback: message }),
 		cause,
 	});
 }
@@ -206,20 +205,11 @@ function workflowPromise<A>(
 }
 
 function toProcessingWorkflowError(cause: unknown): ProcessingWorkflowError {
-	const normalized = normalizeAppError(cause);
-	const wasCancelled =
-		isAppErrorCategory(cause, 'cancellation') ||
-		normalized.message.toLowerCase().includes('cancelled');
-	if (wasCancelled) {
-		return new ProcessingWorkflowCancelled({
-			message: normalized.message,
-			cause,
-		});
+	const message = toUserMessage(cause);
+	if (isCancellation(cause)) {
+		return new ProcessingWorkflowCancelled({ message, cause });
 	}
-	return new ProcessingWorkflowFailed({
-		message: normalized.message,
-		cause,
-	});
+	return new ProcessingWorkflowFailed({ message, cause });
 }
 
 function processingCommand(

--- a/src/ui/statusPanel/services/progressSubscription.ts
+++ b/src/ui/statusPanel/services/progressSubscription.ts
@@ -1,5 +1,9 @@
 import { listenForProgressEvents, listenForQueueEvents } from '../events';
 import type { ProcessingProgressEvent, ProcessingQueueEvent } from '../../../types/events';
+import {
+	createSubscriptionGroup,
+	type SubscriptionGroup,
+} from '../../../lib/tauri/subscriptionGroup';
 
 type Unlisten = () => void;
 type ProgressListenerRegistration = (
@@ -39,21 +43,14 @@ export function createProgressSubscription({
 	listenForQueueEvents: subscribeToQueue = listenForQueueEvents,
 	eventTarget = getDefaultEventTarget(),
 }: CreateProgressSubscriptionOptions): ProgressSubscriptionOwner {
-	let progressUnlisten: Unlisten | undefined;
-	let queueUnlisten: Unlisten | undefined;
+	// One subscription group per start cycle. Its `disposed` flag is the
+	// stale-start guard (a stop/dispose between a `listen` call and its resolution
+	// unlistens the late arrival), replacing the previous hand-rolled token.
+	let currentGroup: SubscriptionGroup | null = null;
+	let subscribed = false;
 	let beforeUnloadAttached = false;
 	let disposed = false;
-	let subscriptionToken = 0;
 	let startPromise: Promise<void> | null = null;
-
-	const detachActiveListeners = () => {
-		const progressListener = progressUnlisten;
-		const queueListener = queueUnlisten;
-		progressUnlisten = undefined;
-		queueUnlisten = undefined;
-		progressListener?.();
-		queueListener?.();
-	};
 
 	const attachBeforeUnload = () => {
 		if (!eventTarget || beforeUnloadAttached) {
@@ -74,9 +71,10 @@ export function createProgressSubscription({
 	};
 
 	const teardown = () => {
-		subscriptionToken += 1;
+		currentGroup?.dispose();
+		currentGroup = null;
+		subscribed = false;
 		startPromise = null;
-		detachActiveListeners();
 		detachBeforeUnload();
 	};
 
@@ -89,7 +87,7 @@ export function createProgressSubscription({
 			throw new Error('Progress subscription has been disposed.');
 		}
 
-		if (progressUnlisten && queueUnlisten) {
+		if (subscribed) {
 			return;
 		}
 
@@ -97,34 +95,24 @@ export function createProgressSubscription({
 			return startPromise;
 		}
 
-		const token = ++subscriptionToken;
+		const group = createSubscriptionGroup();
+		currentGroup = group;
 		attachBeforeUnload();
 
 		let pendingStart: Promise<void> | null = null;
 		pendingStart = (async () => {
-			let nextProgressUnlisten: Unlisten | undefined;
-			let nextQueueUnlisten: Unlisten | undefined;
-
 			try {
-				nextProgressUnlisten = await subscribeToProgress(onProgress);
-				if (token !== subscriptionToken || disposed) {
-					nextProgressUnlisten();
+				await group.add(subscribeToProgress(onProgress));
+				await group.add(subscribeToQueue(onQueue));
+				// A stop/dispose during startup disposed this group and already
+				// unlistened any late arrivals; do not mark the cycle subscribed.
+				if (group.disposed) {
 					return;
 				}
-
-				nextQueueUnlisten = await subscribeToQueue(onQueue);
-				if (token !== subscriptionToken || disposed) {
-					nextProgressUnlisten();
-					nextQueueUnlisten();
-					return;
-				}
-
-				progressUnlisten = nextProgressUnlisten;
-				queueUnlisten = nextQueueUnlisten;
+				subscribed = true;
 			} catch (error) {
-				nextProgressUnlisten?.();
-				nextQueueUnlisten?.();
-				if (token === subscriptionToken) {
+				group.dispose();
+				if (currentGroup === group) {
 					detachBeforeUnload();
 				}
 				throw error;

--- a/src/ui/workCenter/__tests__/state.test.ts
+++ b/src/ui/workCenter/__tests__/state.test.ts
@@ -13,6 +13,15 @@ vi.mock('../../remoteSource/sessionAssets.svelte', () => ({
 }));
 
 import { applyOperationSnapshot, disposeWorkCenter, initializeWorkCenter } from '../state.svelte';
+import { workCenterState } from '../state.svelte';
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
 
 function completedMergeOperation(operationId: string): OperationSnapshot {
 	return {
@@ -131,5 +140,30 @@ describe('Work Center state', () => {
 		expect(releaseMock).toHaveBeenCalledTimes(1);
 		expect(purgeMock).toHaveBeenCalledTimes(1);
 		resolvePurge();
+	});
+
+	it('does not mark initialized or retain listeners when disposed mid-initialization', async () => {
+		(window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+		const snapshotUnlisten = vi.fn();
+		const listUnlisten = vi.fn();
+		const listDeferred = createDeferred<{ operations: never[] }>();
+		vi.spyOn(tauriClient, 'listen')
+			.mockResolvedValueOnce(snapshotUnlisten)
+			.mockResolvedValueOnce(listUnlisten);
+		vi.spyOn(tauriClient, 'listWorkOperations').mockReturnValueOnce(
+			listDeferred.promise as ReturnType<typeof tauriClient.listWorkOperations>,
+		);
+
+		const initPromise = initializeWorkCenter();
+		// Flush microtasks so both listeners register and init parks on listWorkOperations.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		disposeWorkCenter();
+		listDeferred.resolve({ operations: [] });
+		await initPromise.catch(() => {});
+
+		// Dispose won the race: listeners torn down, state not marked initialized.
+		expect(snapshotUnlisten).toHaveBeenCalledTimes(1);
+		expect(listUnlisten).toHaveBeenCalledTimes(1);
+		expect(workCenterState.initialized).toBe(false);
 	});
 });

--- a/src/ui/workCenter/state.svelte.ts
+++ b/src/ui/workCenter/state.svelte.ts
@@ -11,8 +11,8 @@ import {
 	upsertOperation,
 	type WorkCenterModel,
 } from './model';
-
-type Unlisten = () => void;
+import { toUserMessage } from '../../lib/tauri/appError';
+import { createSubscriptionGroup, type SubscriptionGroup } from '../../lib/tauri/subscriptionGroup';
 
 interface WorkCenterState extends WorkCenterModel {
 	initialized: boolean;
@@ -28,7 +28,7 @@ export const workCenterState = $state<WorkCenterState>({
 });
 
 let initializationPromise: Promise<void> | null = null;
-let unlisteners: Unlisten[] = [];
+let subscriptions: SubscriptionGroup | null = null;
 const purgedOperationIds = new Set<string>();
 
 export function initializeWorkCenter(): Promise<void> {
@@ -39,39 +39,39 @@ export function initializeWorkCenter(): Promise<void> {
 		return Promise.resolve();
 	}
 
+	const group = createSubscriptionGroup();
+	subscriptions = group;
 	initializationPromise = (async () => {
-		const nextUnlisteners: Unlisten[] = [];
-		try {
-			nextUnlisteners.push(
-				await tauriClient.listen(EVENTS.WORK_OPERATION_SNAPSHOT, ({ payload }) => {
-					applyOperationSnapshot(payload.snapshot);
-				}),
-			);
-			nextUnlisteners.push(
-				await tauriClient.listen(EVENTS.WORK_OPERATION_LIST_SNAPSHOT, ({ payload }) => {
-					const model = replaceOperations(workCenterState, { operations: payload.operations });
-					workCenterState.operations = model.operations;
-					for (const operation of workCenterState.operations) {
-						void purgeRemoteSessionsForTerminalOperation(operation);
-					}
-				}),
-			);
-			unlisteners = nextUnlisteners;
+		await group.add(
+			tauriClient.listen(EVENTS.WORK_OPERATION_SNAPSHOT, ({ payload }) => {
+				applyOperationSnapshot(payload.snapshot);
+			}),
+		);
+		await group.add(
+			tauriClient.listen(EVENTS.WORK_OPERATION_LIST_SNAPSHOT, ({ payload }) => {
+				const model = replaceOperations(workCenterState, { operations: payload.operations });
+				workCenterState.operations = model.operations;
+				for (const operation of workCenterState.operations) {
+					void purgeRemoteSessionsForTerminalOperation(operation);
+				}
+			}),
+		);
 
-			const list = await tauriClient.listWorkOperations();
-			const model = replaceOperations(workCenterState, list);
-			workCenterState.operations = model.operations;
-			workCenterState.initialized = true;
-			workCenterState.errorMessage = null;
-		} catch (error) {
-			disposeUnlisteners(nextUnlisteners);
-			if (unlisteners === nextUnlisteners) {
-				unlisteners = [];
-			}
-			throw error;
+		const list = await tauriClient.listWorkOperations();
+		// A dispose during initialization wins: do not mark initialized or apply state.
+		if (group.disposed) {
+			return;
 		}
+		const model = replaceOperations(workCenterState, list);
+		workCenterState.operations = model.operations;
+		workCenterState.initialized = true;
+		workCenterState.errorMessage = null;
 	})().catch((error) => {
-		workCenterState.errorMessage = `Failed to initialize Work Center: ${String(error)}`;
+		group.dispose();
+		if (subscriptions === group) {
+			subscriptions = null;
+		}
+		workCenterState.errorMessage = `Failed to initialize Work Center: ${toUserMessage(error)}`;
 		initializationPromise = null;
 		throw error;
 	});
@@ -88,8 +88,8 @@ function isTauriRuntimeAvailable(): boolean {
 }
 
 export function disposeWorkCenter(): void {
-	disposeUnlisteners(unlisteners);
-	unlisteners = [];
+	subscriptions?.dispose();
+	subscriptions = null;
 	initializationPromise = null;
 	workCenterState.initialized = false;
 }
@@ -109,7 +109,7 @@ export async function cancelWorkOperation(operationId: OperationId): Promise<voi
 		const snapshot = await tauriClient.cancelWorkOperation(operationId);
 		applyOperationSnapshot(snapshot);
 	} catch (error) {
-		workCenterState.errorMessage = `Failed to cancel operation: ${String(error)}`;
+		workCenterState.errorMessage = `Failed to cancel operation: ${toUserMessage(error)}`;
 	} finally {
 		const next = { ...workCenterState.cancelPendingByOperationId };
 		delete next[operationId];
@@ -149,10 +149,4 @@ async function purgeRemoteSessionsForTerminalOperation(
 	}
 
 	await purgeRemoteSourceSessionsForInputIds(purgeInputIds);
-}
-
-function disposeUnlisteners(listeners: Unlisten[]): void {
-	for (const unlisten of listeners.splice(0)) {
-		unlisten();
-	}
 }


### PR DESCRIPTION
## #388 — Frontend IPC lifecycle (subscription group + appError presenter)

Part of #383 (deepen shallow modules). A `src/lib/tauri` + UI-islands slice: two frontend concerns were re-implemented per island; this gives each a single owner. Lands **before #376** so its seams reduce that slice's rework, without touching terminal/progress/cancellation **truth** (that is #376's). No TS↔Rust contract change.

### 1. One subscription-teardown primitive

New `src/lib/tauri/subscriptionGroup.ts` — `createSubscriptionGroup()` with `add(Promise<UnlistenFn> | UnlistenFn)`, `dispose()`, `disposed`. It owns the dispose / late-arrival race once: an unlisten that resolves **after** `dispose()` is invoked immediately instead of leaking.

The three teardown owners migrate onto it — **fileImport**, **workCenter**, **statusPanel/progressSubscription** (the latter keeps its progress token + `beforeunload` + restart semantics on top of a per-cycle group; the group's `disposed` flag replaces the hand-rolled token). `events.ts` stays an event-specific wrapper.

**Fixes a real bug:** Work Center's `initialize`/`dispose` race — `unlisteners = nextUnlisteners` ran unguarded after the awaits, so a concurrent `disposeWorkCenter()` could be overwritten by a late-resolving init, leaving listeners live and `initialized = true`. A **failing-first** test pins it (`workCenter/__tests__/state.test.ts`); the group's `disposed` guard fixes it.

### 2. One error-presenter seam

`src/lib/tauri/appError.ts` gains `toUserMessage`, `isCancellation`, `logAppError`. Five derivation sites repoint onto them (`remoteSource/acquisitionState`, `remoteSource/sessionAssets`, `coverArt`, `statusPanel/processingWorkflow`, and the `workCenter` `String(error)` outliers).

`isCancellation` wraps the existing `isAppErrorCategory(...,'cancellation')` **and keeps the message fallback** — cancellations can arrive un-enveloped (`normalizeAppError` tags a raw error as `unknown`, not `cancellation`), and proving they're always typed is #376's cancellation-contract job. So consolidating the dual check into one owner is **behavior-preserving**, not a tightening.

### Boundary

`appError` + `subscriptionGroup` are documented as a deliberate **frontend-utility surface** in `src/lib/tauri/AGENTS.md` (islands import them directly; they are *not* `tauriClient` IPC methods and are *not* pinned by `tauri-public-api.contract.test.ts`, which is untouched).

### Disciplined deviations from plan

- **Left `isTauriRuntimeAvailable` in Work Center.** Recon found a single runtime consumer, so extracting a shared presence-guard util would be premature.
- **Corrected an incomplete test mock.** `coverArtDrop.test.ts` mocked `tauriClient.listen` to return `undefined`; the old per-island `captureUnlistener` guard silently tolerated that, the group (correctly trusting the `Promise<UnlistenFn>` contract) did not. Fixed the mock to honor the contract rather than adding defensive cruft to the primitive.

### Why this slice is one PR

Single owner pair (`src/lib/tauri` lifecycle/error seams), Vitest + typecheck proof, no IPC/contract change → different modality from PR-2's backend Rust → its own PR. **No manual smoke** (deferred to PR-4 per the roadmap; its smoke scenarios — teardown across navigation, forced-error copy — are carried into PR-4's list).

### Proof

- `bun run typecheck` clean.
- `bun run test` → **580 passed** (was 567 on `main`; +`subscriptionGroup`, +`appError`, +Work Center race regression); **zero unhandled errors**.
- `biome lint` + `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
