### PR TITLE
chore: whittle round 3 — genuine cuts

### DIFF
--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -81,10 +81,8 @@ pub(super) fn complete_staged_output(
     let ui = context.new_emitter();
     ui.emit_cleanup("Cleaning up...");
 
-    let commit_request = OutputCommitRequest::new(
-        context.output.final_path(),
-        context.output.commit_action(),
-    );
+    let commit_request =
+        OutputCommitRequest::new(context.output.final_path(), context.output.commit_action());
     let outcome = commit_output_artifact(commit_request, staged_output, cleanup_guard, || {
         context.is_cancelled()
     })?;

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -73,7 +73,7 @@ pub(super) fn complete_staged_output(
     );
     log::info!(
         "Final output path: {}",
-        sanitize_path_for_display(context.output.artifact_path())
+        sanitize_path_for_display(context.output.final_path())
     );
 
     ensure_not_cancelled_before_commit(context)?;
@@ -82,7 +82,7 @@ pub(super) fn complete_staged_output(
     ui.emit_cleanup("Cleaning up...");
 
     let commit_request = OutputCommitRequest::new(
-        context.output.artifact_path(),
+        context.output.final_path(),
         context.output.commit_action(),
     );
     let outcome = commit_output_artifact(commit_request, staged_output, cleanup_guard, || {

--- a/src-tauri/src/audio/processor/prepare.rs
+++ b/src-tauri/src/audio/processor/prepare.rs
@@ -2,12 +2,9 @@
 //!
 //! Functions are private to the audio processor cluster.
 
-use std::path::{Path, PathBuf};
-
 use crate::audio::AudioFile;
 use crate::errors::{sanitize_path_for_display, AppError, Result};
 use crate::processing::{PreviewConfig, ProcessingContext};
-use uuid::Uuid;
 
 use super::ProcessingWorkflow;
 
@@ -37,33 +34,12 @@ pub(crate) fn validate_processing_inputs(
     Ok(())
 }
 
-/// Creates a session-specific local processing workspace.
-pub(crate) fn create_temp_directory_with_session(
-    session_id: Uuid,
-    workspace_root: &Path,
-) -> Result<PathBuf> {
-    crate::audio::processor::staging::create_processing_workspace_dir(session_id, workspace_root)
-}
-
-/// Validates inputs with cancellation awareness.
-pub(crate) fn validate_inputs_with_progress(
-    context: &ProcessingContext,
-    files: &[AudioFile],
-) -> Result<()> {
-    validate_processing_inputs(context, files)?;
-
-    if context.is_cancelled() {
-        return Err(AppError::cancelled());
-    }
-    Ok(())
-}
-
 /// Prepares workspace (temp dir + concat file + total duration aggregation).
 pub(crate) fn prepare_workspace(
     context: &ProcessingContext,
     files: &[AudioFile],
 ) -> Result<ProcessingWorkflow> {
-    let temp_dir = create_temp_directory_with_session(
+    let temp_dir = crate::audio::processor::staging::create_processing_workspace_dir(
         context.session.uuid(),
         context.processing_workspace_root(),
     )?;
@@ -97,13 +73,17 @@ pub(crate) fn validate_and_prepare(
     context: &ProcessingContext,
     files: &[AudioFile],
 ) -> Result<ProcessingWorkflow> {
-    validate_inputs_with_progress(context, files)?;
+    validate_processing_inputs(context, files)?;
+    if context.is_cancelled() {
+        return Err(AppError::cancelled());
+    }
     prepare_workspace(context, files)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn audio_file(name: &str, duration: Option<f64>, is_valid: bool) -> AudioFile {
         AudioFile {

--- a/src-tauri/src/commands/metadata/save_batch.rs
+++ b/src-tauri/src/commands/metadata/save_batch.rs
@@ -206,7 +206,21 @@ where
 
     for (index, item) in items.into_iter().enumerate() {
         if cancellation.is_cancelled() {
-            push_cancelled_entries(index, item, total, &mut results, &mut emit_progress);
+            let message = METADATA_SAVE_CANCELLED_MESSAGE.to_string();
+            emit_progress(MetadataSaveProgress {
+                input_index: index,
+                file_path: item.file_path.clone(),
+                stage: EventStage::Cancelled,
+                percentage: 0.0,
+                message: format!("{} {}/{}", message, index + 1, total),
+            });
+            results.push(MetadataSaveResultEntry {
+                input_index: index,
+                file_path: item.file_path,
+                status: MetadataSaveResultStatus::Cancelled,
+                message,
+                error: None,
+            });
             continue;
         }
 
@@ -269,32 +283,6 @@ where
     }
 
     Ok(MetadataSaveBatchResult::new(results))
-}
-
-fn push_cancelled_entries<F>(
-    index: usize,
-    item: MetadataSaveRequest,
-    total: usize,
-    results: &mut Vec<MetadataSaveResultEntry>,
-    emit_progress: &mut F,
-) where
-    F: FnMut(MetadataSaveProgress),
-{
-    let message = METADATA_SAVE_CANCELLED_MESSAGE.to_string();
-    emit_progress(MetadataSaveProgress {
-        input_index: index,
-        file_path: item.file_path.clone(),
-        stage: EventStage::Cancelled,
-        percentage: 0.0,
-        message: format!("{} {}/{}", message, index + 1, total),
-    });
-    results.push(MetadataSaveResultEntry {
-        input_index: index,
-        file_path: item.file_path,
-        status: MetadataSaveResultStatus::Cancelled,
-        message,
-        error: None,
-    });
 }
 
 fn save_metadata_item(file_path: &str, metadata_patch: MetadataIntentPatch) -> Result<()> {

--- a/src-tauri/src/processing/context/processing.rs
+++ b/src-tauri/src/processing/context/processing.rs
@@ -1,7 +1,6 @@
 //! Processing context structures and builders.
 
 use crate::audio::{EncoderSettings, SampleRateConfig};
-use crate::errors::sanitize_path_str_for_display;
 use crate::errors::Result;
 use crate::output_artifact::{OutputKind, PlannedOutputAction, ResolvedOutputPlan};
 use crate::processing::lifecycle::OperationKind;
@@ -115,24 +114,6 @@ impl std::fmt::Debug for ProcessingContext {
 }
 
 impl ProcessingContext {
-    /// Creates a new ProcessingContext with the given components
-    pub fn new(
-        window: Window,
-        session: Arc<ProcessingSession>,
-        encoder_settings: EncoderSettings,
-        sample_rate: SampleRateConfig,
-        output: OutputConfig,
-    ) -> Self {
-        Self::new_with_workspace_root(
-            window,
-            session,
-            encoder_settings,
-            sample_rate,
-            output,
-            default_processing_workspace_root(),
-        )
-    }
-
     pub fn new_with_workspace_root(
         window: Window,
         session: Arc<ProcessingSession>,
@@ -217,36 +198,6 @@ impl ProcessingContext {
     /// Checks if the current processing has been cancelled
     pub fn is_cancelled(&self) -> bool {
         self.session.is_cancelled()
-    }
-
-    /// Creates an error with session context
-    pub fn create_error(&self, operation: &str, reason: &str) -> crate::errors::AppError {
-        crate::errors::AppError::General(format!(
-            "Failed to {operation} for session {}: {reason}",
-            self.session.id()
-        ))
-    }
-
-    /// Creates a file validation error with session and file context
-    pub fn create_file_error(
-        &self,
-        operation: &str,
-        file_path: &str,
-        reason: &str,
-    ) -> crate::errors::AppError {
-        crate::errors::AppError::FileValidation(format!(
-            "Failed to {operation} file '{}' in session {}: {reason}",
-            sanitize_path_str_for_display(file_path),
-            self.session.id()
-        ))
-    }
-
-    /// Creates an input validation error with session context
-    pub fn create_input_error(&self, field: &str, reason: &str) -> crate::errors::AppError {
-        crate::errors::AppError::InvalidInput(format!(
-            "Failed to validate {field} for session {}: {reason}",
-            self.session.id()
-        ))
     }
 
     /// Creates a progress emitter scoped to this processing context.

--- a/src-tauri/src/processing/context/processing.rs
+++ b/src-tauri/src/processing/context/processing.rs
@@ -53,10 +53,6 @@ impl OutputConfig {
         &self.final_path
     }
 
-    pub fn artifact_path(&self) -> &Path {
-        &self.final_path
-    }
-
     pub fn output_kind(&self) -> OutputKind {
         self.kind
     }

--- a/src/ui/jobControls/index.ts
+++ b/src/ui/jobControls/index.ts
@@ -70,16 +70,6 @@ export async function applyMaxConcurrentPreference(
 	await pushMaxConcurrentToBackend(selection, false, previousSelection);
 }
 
-export function readMaxConcurrentPreferenceFromState(): ConcurrencyPreference {
-	const effective = jobControlsState.effectiveMaxConcurrent;
-	if (jobControlsState.maxConcurrentSelection === 'auto') {
-		return { mode: 'auto' };
-	}
-
-	const parsed = parseInt(jobControlsState.maxConcurrentSelection, 10);
-	return { mode: 'fixed', value: effective ?? parsed };
-}
-
 export function setJobControlsEnabled(enabled: boolean): void {
 	flushSync(() => {
 		jobControlsState.controlsEnabled = enabled;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,11 +18,7 @@ export default defineConfig({
 		globals: true,
 	},
 
-	// Resolve aliases to match the main vite config if needed
 	resolve: {
 		conditions: ['browser'],
-		alias: {
-			// Add any path aliases here if needed
-		},
 	},
 });


### PR DESCRIPTION
## Whittle round 3 — the genuine cuts

Third over-engineering pass. A multi-agent `/whittle-audit` produced a 38-item
ledger, but on close inspection against the owning `AGENTS.md` boundaries, **most
of it was false positives**: after two prior whittle rounds this codebase is
already near its lean floor, and the LOC-ranked audit surfaced justified,
tested, named factoring rather than over-engineering (it also mis-counted
several call sites). This PR lands only the **genuine** cuts — real dead code and
true single-use pass-throughs — and deliberately keeps the rest.

Net: **+24 / −125 lines, 0 deps**, no contract/IPC/behavior change.

### Applied

**Dead code (0 callers, removed):**
- `jobControls`: `readMaxConcurrentPreferenceFromState` export.
- `ProcessingContext::new()` constructor + `create_error` / `create_file_error` /
  `create_input_error` helpers.
- `OutputConfig::artifact_path()` — byte-identical duplicate of `final_path()`;
  switched its 2 `finalize.rs` callers to `final_path()`.
- `vitest.config.ts`: empty `resolve.alias` block (kept `conditions`).

**True single-use pass-throughs (inlined into their sole caller):**
- `save_batch`: `push_cancelled_entries` → the cancellation branch of the loop.
- `prepare`: `create_temp_directory_with_session` → direct
  `staging::create_processing_workspace_dir` call; `validate_inputs_with_progress`
  → `validate_and_prepare`.

### Deliberately kept (audit false positives — recorded so the next round doesn't re-litigate)

- **Documented invariant:** `metadata_save_progress_event` (its `job_id: None`
  guards WorkRuntime child cross-matching).
- **Cohesive / AGENTS-referenced module:** `terminal_emitter` + `emit_terminal_*`
  (inlining re-duplicates the foreground/background split).
- **Multi-caller helpers:** `plural_suffix` (4×), `normalizeFilePath` (6×),
  `displayPath` (8×), `timestamp_utc` (2×), `readJson` (2×), `formatOptionalText`
  (2×), `blockedResult` (many).
- **Named intent / avoids boolean-blindness:** `sanitize_author`,
  `is_prefixed_subseries`, `getSeries/SubseriesPartValidationError`, `isSemver`,
  `escapeRegExp`, `launchServicesRegisterPath`.
- **Tested seam:** `toMetadataDraft` (directly covered by `metadataDraft.test.ts`).
- **Substantial branching extracted for readability:** `build_abs_title`,
  `output_plan_review_message`, `build_output_path_inner`.
- **Encapsulation:** `new_headless()` (hides `default_processing_workspace_root`).
- **Contradicts guidance:** `encoderPanel/view.ts` inline — `src/AGENTS.md`
  explicitly favors extracting view helpers *out* of components; LOC win was
  illusory (relocation, not deletion).

The Rust core crate (`abb-output-artifact-core`) and the frontend/script tails
yielded **no** genuine cuts — they are exactly the small, individually-testable
named functions `crates/AGENTS.md` and `src/AGENTS.md` prescribe.

### Verification

- `cargo clippy -p audiobook-boss --all-targets -- -D warnings` — clean
- `cargo nextest -p audiobook-boss --lib` (351) + `--test all_tests` (71) — pass
- `cargo fmt --all -- --check` — clean
- `bun run typecheck`, Biome `fmt:check` + `lint:check`, `svelte-check` (0 errors),
  vitest (touched config) — all clean
- No IPC/command/event signature changes → generated-binding & runtime-boundary
  checks not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
