### PR TITLE
[codex] Harden metadata intent artifact proof

### DIFF
--- a/.agents/skills/audiobook-metadata/SKILL.md
+++ b/.agents/skills/audiobook-metadata/SKILL.md
@@ -11,12 +11,15 @@ External compatibility with ABS/Plex/Apple Books is required. Compatibility
 claims must match current code and product decisions.
 
 ABB does not read or write Apple movement tags (`MVNM`/`MVIN`). Series uses
-ffprobe-visible tags plus mirrored freeform atoms.
+ffprobe-visible tags plus mirrored mp4ameta freeform atoms.
 
 ## Series Tag Strategy
 
 For series metadata, write both:
-- ffprobe-visible tags: `series`, `series-part`, plus mirrored freeform atoms `----:com.apple.iTunes:SERIES` and `----:com.apple.iTunes:SERIES-PART`
+- ffprobe-visible tags: `series`, `series-part`
+- mp4ameta freeforms: canonical `----:com.apple.iTunes:series` /
+  `----:com.apple.iTunes:series-part` plus uppercase iTunes mirrors
+  `----:com.apple.iTunes:SERIES` / `----:com.apple.iTunes:SERIES-PART`
 
 Intent semantics (`set | clear | noop`), the Outcome Plan, and naming-to-artifact
 flow are owned by `src-tauri/src/metadata/AGENTS.md` and `src/lib/tauri/AGENTS.md`.

--- a/.agents/skills/audiobook-metadata/references/tag-mapping.md
+++ b/.agents/skills/audiobook-metadata/references/tag-mapping.md
@@ -21,12 +21,22 @@ Current mapping of ABB-written MP4 metadata to Audiobookshelf, Plex, and Apple B
 
 These are the tags that matter most for series detection.
 
-### For ABS and Plex (ffprobe-readable)
+### For ABS and Plex
 
-| Atom | ffmetadata key | Purpose |
-|------|----------------|---------|
-| `----:com.apple.iTunes:SERIES` | `series` | Series name |
-| `----:com.apple.iTunes:SERIES-PART` | `series-part` | Book number |
+| Storage | Key / Atom | Purpose |
+|---------|------------|---------|
+| ffprobe / ffmetadata | `series` | Series name |
+| ffprobe / ffmetadata | `series-part` | Book number |
+| mp4ameta canonical freeform | `----:com.apple.iTunes:series` | Series name |
+| mp4ameta canonical freeform | `----:com.apple.iTunes:series-part` | Book number |
+| iTunes compatibility freeform | `----:com.apple.iTunes:SERIES` | Series name |
+| iTunes compatibility freeform | `----:com.apple.iTunes:SERIES-PART` | Book number |
+
+Read precedence prefers canonical lowercase `series` / `series-part`, then the
+uppercase iTunes mirrors, then legacy `show` / `episode_sort` fallbacks.
+`ffprobe -show_format` collapses freeform names that differ only by case, so
+unit tests around the mp4ameta sink are the proof that both lowercase canonical
+and uppercase mirror atoms exist.
 
 Apple movement tags (`MVNM`/`MVIN`) are not currently written or read as ABB's
 series mechanism. Reintroduce them only with manual player evidence and an
@@ -76,7 +86,8 @@ ffmpeg -i input.m4b \
 ## Writing with ffmpeg-next (Rust)
 
 audiobook-boss writes canonical ffprobe-visible keys plus iTunes freeform mirrors
-for series metadata. These are the series keys ABB currently owns.
+for series metadata. These are the series keys ABB currently owns in the FFmpeg
+dictionary path.
 
 ```rust
 // Primary + mirrored keys written together
@@ -86,6 +97,10 @@ dict.set("----:com.apple.iTunes:SERIES", series_name);
 dict.set("series-part", book_number);
 dict.set("----:com.apple.iTunes:SERIES-PART", book_number);
 ```
+
+The mp4ameta path writes the same logical values to lowercase canonical
+freeforms and uppercase iTunes mirrors. Keep both families unless player
+evidence and an explicit product decision replace this compatibility strategy.
 
 Series-part values should stay scanner-friendly. Slash-form values like `1/5`
 are rejected by validation.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.0.1",
-  "configurations": [
-    {
-      "name": "vite-dev",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "dev"],
-      "port": 1420
-    }
-  ]
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "vite-dev",
+			"runtimeExecutable": "bun",
+			"runtimeArgs": ["run", "dev"],
+			"port": 1420
+		}
+	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,17 @@ All notable changes to AudioBook Boss™ will be documented in this file.
   (#413).
 - Audiobooks encoded with the FDK HE-AAC (external FFmpeg) encoder no longer
   lose series, series number, and album-sort tags on the finished file:
-  artifact metadata finalize now writes MP4 tag truth through the same
-  container-aware writer the other encoder paths use, proven against an
-  external reader (`ffprobe`), with chapters preserved.
+  artifact metadata finalize now rewrites MP4 tag truth through mp4ameta after
+  the remux that carries chapters/cover, proven against an external reader
+  (`ffprobe`), with chapters preserved.
+- Metadata Manager subseries edits no longer disappear unless the full
+  series/subseries quadruple is present: representable partials are written to
+  artifact tags, while touched orphan shapes fail before processing or save
+  instead of silently clearing series tags (#415).
+- Merge processing now stages dirty Metadata Manager edits onto the merge
+  artifact owner instead of dropping edits made while a non-first input is
+  selected; non-merge processing blocks dirty edits on an invalid selection
+  instead of retargeting them to another file (#415).
 
 ## [1.3.0] - 2026-07-02
 

--- a/crates/abb-metadata-core/src/lib.rs
+++ b/crates/abb-metadata-core/src/lib.rs
@@ -7,6 +7,10 @@ const SERIES_PART_INVALID_MESSAGE: &str =
     "Series sequence (#) cannot include '/'. Use a plain number like 24.";
 const SUBSERIES_PART_INVALID_MESSAGE: &str =
     "Sub-series sequence (#) cannot include '/'. Use a plain number like 24.";
+const SERIES_PART_REQUIRES_SERIES_MESSAGE: &str = "Series sequence (#) requires a Series value.";
+const SUBSERIES_REQUIRES_SERIES_MESSAGE: &str = "Sub-series requires a Series value.";
+const SUBSERIES_PART_REQUIRES_COMPLETE_SERIES_MESSAGE: &str =
+    "Sub-series sequence (#) requires Series, Series sequence (#), and Sub-series values.";
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum MetadataCoreError {
@@ -226,6 +230,13 @@ impl MetadataIntentPatch {
         matches!(self.cover_art, PatchOp::Clear)
     }
 
+    pub fn touches_series_family(&self) -> bool {
+        !matches!(self.series, PatchOp::Noop)
+            || !matches!(self.series_part, PatchOp::Noop)
+            || !matches!(self.subseries, PatchOp::Noop)
+            || !matches!(self.subseries_part, PatchOp::Noop)
+    }
+
     pub fn validate_and_normalize(&self) -> MetadataIntentValidationResult {
         validate_metadata_intent_patch(self)
     }
@@ -237,6 +248,7 @@ impl MetadataIntentPatch {
     pub fn apply_to_metadata(&self, mut base: AudiobookMetadata) -> Result<AudiobookMetadata> {
         let patch = self.normalized_or_error()?;
         apply_shared_metadata_patch_fields(&patch, &mut base, PatchFieldSemantics::Processing)?;
+        validate_series_family_if_touched(&base, patch.touches_series_family())?;
         apply_album_sort_patch(&patch.album_sort, &mut base);
         Ok(base)
     }
@@ -246,9 +258,34 @@ impl MetadataIntentPatch {
     }
 
     pub fn to_write_plan(&self) -> Result<MetadataWritePlan> {
+        self.to_write_plan_with_optional_source(None)
+    }
+
+    pub fn to_write_plan_with_source(
+        &self,
+        source_metadata: AudiobookMetadata,
+    ) -> Result<MetadataWritePlan> {
+        self.to_write_plan_with_optional_source(Some(source_metadata))
+    }
+
+    fn to_write_plan_with_optional_source(
+        &self,
+        source_metadata: Option<AudiobookMetadata>,
+    ) -> Result<MetadataWritePlan> {
         let patch = self.normalized_or_error()?;
         let mut metadata = AudiobookMetadata::new();
         apply_shared_metadata_patch_fields(&patch, &mut metadata, PatchFieldSemantics::WritePlan)?;
+
+        if patch.touches_series_family() {
+            let mut effective_metadata = source_metadata.unwrap_or_default();
+            apply_shared_metadata_patch_fields(
+                &patch,
+                &mut effective_metadata,
+                PatchFieldSemantics::Processing,
+            )?;
+            validate_series_family_if_touched(&effective_metadata, true)?;
+            apply_effective_series_family_to_write_plan(&patch, &effective_metadata, &mut metadata);
+        }
 
         let album_sort = match &patch.album_sort {
             AlbumSortPatchOp::Set(value) if value.trim().is_empty() => AlbumSortWriteAction::Clear,
@@ -463,19 +500,83 @@ pub fn build_series_list(
     let secondary_series = normalize(subseries);
     let secondary_part = normalize(subseries_part);
 
-    if let (Some(series), Some(part), Some(subseries), Some(subpart)) = (
-        primary_series.as_deref(),
-        primary_part.as_deref(),
-        secondary_series.as_deref(),
-        secondary_part.as_deref(),
-    ) {
-        return (
-            Some(format!("{}; {}", series, subseries)),
-            Some(format!("{}; {}", part, subpart)),
-        );
+    let series_value = match (primary_series.as_deref(), secondary_series.as_deref()) {
+        (Some(series), Some(subseries)) => Some(format!("{}; {}", series, subseries)),
+        (Some(series), None) => Some(series.to_string()),
+        _ => None,
+    };
+
+    let series_part_value = match (primary_part.as_deref(), secondary_part.as_deref()) {
+        (Some(part), Some(subpart)) => Some(format!("{}; {}", part, subpart)),
+        (Some(part), None) => Some(part.to_string()),
+        _ => None,
+    };
+
+    (series_value, series_part_value)
+}
+
+fn has_metadata_text(value: Option<&str>) -> bool {
+    value.map(str::trim).is_some_and(|text| !text.is_empty())
+}
+
+fn validate_series_family_if_touched(metadata: &AudiobookMetadata, touched: bool) -> Result<()> {
+    if !touched {
+        return Ok(());
     }
 
-    (primary_series, primary_part)
+    let has_series = has_metadata_text(metadata.series.as_deref());
+    let has_series_part = has_metadata_text(metadata.series_part.as_deref());
+    let has_subseries = has_metadata_text(metadata.subseries.as_deref());
+    let has_subseries_part = has_metadata_text(metadata.subseries_part.as_deref());
+
+    if has_series_part && !has_series {
+        return Err(MetadataCoreError::InvalidInput(
+            SERIES_PART_REQUIRES_SERIES_MESSAGE.to_string(),
+        ));
+    }
+    if has_series_part {
+        validate_series_part(metadata.series_part.as_deref().unwrap_or_default())?;
+    }
+
+    if has_subseries && !has_series {
+        return Err(MetadataCoreError::InvalidInput(
+            SUBSERIES_REQUIRES_SERIES_MESSAGE.to_string(),
+        ));
+    }
+
+    if has_subseries_part && !(has_series && has_series_part && has_subseries) {
+        return Err(MetadataCoreError::InvalidInput(
+            SUBSERIES_PART_REQUIRES_COMPLETE_SERIES_MESSAGE.to_string(),
+        ));
+    }
+    if has_subseries_part {
+        validate_series_part(metadata.subseries_part.as_deref().unwrap_or_default())?;
+    }
+
+    Ok(())
+}
+
+fn touched_patch(patch: &PatchOp<String>) -> bool {
+    !matches!(patch, PatchOp::Noop)
+}
+
+fn apply_effective_series_family_to_write_plan(
+    patch: &MetadataIntentPatch,
+    effective: &AudiobookMetadata,
+    metadata: &mut AudiobookMetadata,
+) {
+    let touches_names = touched_patch(&patch.series) || touched_patch(&patch.subseries);
+    let touches_parts = touched_patch(&patch.series_part) || touched_patch(&patch.subseries_part);
+
+    if touches_names {
+        metadata.series = Some(effective.series.clone().unwrap_or_default());
+        metadata.subseries = effective.subseries.clone();
+    }
+
+    if touches_parts {
+        metadata.series_part = Some(effective.series_part.clone().unwrap_or_default());
+        metadata.subseries_part = effective.subseries_part.clone();
+    }
 }
 
 pub fn compute_album_sort(series: &str, series_part: Option<&str>, title: &str) -> Option<String> {
@@ -603,20 +704,6 @@ fn apply_shared_metadata_patch_fields(
             (PatchOp::Clear, PatchFieldSemantics::Processing) => *slot = None,
             (PatchOp::Clear, PatchFieldSemantics::WritePlan) => *slot = Some((0, None)),
             (PatchOp::Noop, _) => {}
-        }
-    }
-
-    if let Some(series_part) = metadata.series_part.as_deref() {
-        let trimmed = series_part.trim();
-        if !trimmed.is_empty() {
-            validate_series_part(trimmed)?;
-        }
-    }
-
-    if let Some(subseries_part) = metadata.subseries_part.as_deref() {
-        let trimmed = subseries_part.trim();
-        if !trimmed.is_empty() {
-            validate_series_part(trimmed)?;
         }
     }
 
@@ -883,6 +970,101 @@ mod tests {
         assert!(compute_album_sort("Series", Some("abc"), "Title").is_none());
         assert!(compute_album_sort("Series", Some("0"), "Title").is_none());
         assert!(compute_album_sort("Series", Some("1/5"), "Title").is_none());
+    }
+
+    #[test]
+    fn build_series_list_folds_representable_partial_subseries() {
+        assert_eq!(
+            build_series_list(Some("Primary"), None, Some("Sub"), None),
+            (Some("Primary; Sub".to_string()), None)
+        );
+        assert_eq!(
+            build_series_list(Some("Primary"), Some("1"), Some("Sub"), None),
+            (Some("Primary; Sub".to_string()), Some("1".to_string()))
+        );
+        assert_eq!(
+            build_series_list(Some("Primary"), Some("1"), Some("Sub"), Some("2")),
+            (Some("Primary; Sub".to_string()), Some("1; 2".to_string()))
+        );
+    }
+
+    #[test]
+    fn series_family_validation_rejects_touched_orphan_shapes() {
+        let subseries_only = MetadataIntentPatch {
+            subseries: PatchOp::Set("Sub".to_string()),
+            ..Default::default()
+        };
+        assert!(subseries_only
+            .to_processing_overlay()
+            .expect_err("orphan subseries should fail")
+            .to_string()
+            .contains("Sub-series requires a Series"));
+
+        let part_only = MetadataIntentPatch {
+            series_part: PatchOp::Set("1".to_string()),
+            ..Default::default()
+        };
+        assert!(part_only
+            .to_processing_overlay()
+            .expect_err("orphan series part should fail")
+            .to_string()
+            .contains("requires a Series"));
+
+        let subseries_part_without_primary_part = MetadataIntentPatch {
+            series: PatchOp::Set("Primary".to_string()),
+            subseries: PatchOp::Set("Sub".to_string()),
+            subseries_part: PatchOp::Set("2".to_string()),
+            ..Default::default()
+        };
+        assert!(subseries_part_without_primary_part
+            .to_processing_overlay()
+            .expect_err("subseries part without primary part should fail")
+            .to_string()
+            .contains("requires Series, Series sequence"));
+    }
+
+    #[test]
+    fn source_aware_write_plan_preserves_valid_partial_subseries() {
+        let source = AudiobookMetadata {
+            series: Some("Primary".to_string()),
+            ..Default::default()
+        };
+        let patch = MetadataIntentPatch {
+            subseries: PatchOp::Set("Sub".to_string()),
+            ..Default::default()
+        };
+
+        let plan = patch
+            .to_write_plan_with_source(source)
+            .expect("primary series allows subseries name");
+
+        assert_eq!(plan.metadata.series.as_deref(), Some("Primary"));
+        assert_eq!(plan.metadata.subseries.as_deref(), Some("Sub"));
+        assert_eq!(plan.metadata.series_part, None);
+        assert_eq!(plan.metadata.subseries_part, None);
+    }
+
+    #[test]
+    fn unrelated_edits_do_not_reject_inherited_orphan_series_tags() {
+        let source = AudiobookMetadata {
+            series_part: Some("7".to_string()),
+            ..Default::default()
+        };
+        let patch = MetadataIntentPatch {
+            title: PatchOp::Set("Retitled".to_string()),
+            ..Default::default()
+        };
+
+        let merged = patch
+            .apply_to_metadata(source.clone())
+            .expect("non-series intent preserves inherited orphan");
+        assert_eq!(merged.series_part.as_deref(), Some("7"));
+
+        let plan = patch
+            .to_write_plan_with_source(source)
+            .expect("non-series write intent should not validate inherited orphan");
+        assert_eq!(plan.metadata.title.as_deref(), Some("Retitled"));
+        assert_eq!(plan.metadata.series_part, None);
     }
 
     #[test]

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -297,3 +297,15 @@
   (ABB readback + external `ffprobe` proof).
 - Guardrail: an encoder path may not write MP4-family artifact tag truth through
   the FFmpeg dictionary alone.
+
+## 2026-07-04 - Series Edits Validate Effective Round-Trip Shape
+
+- Series/subseries writes preserve representable partials (`Series; Subseries`
+  without parts), but reject touched orphan shapes that cannot round-trip
+  (`series-part` without `series`, or `subseries-part` without the complete
+  primary series + primary part + subseries chain).
+- Evidence: `abb-metadata-core` source-aware write-plan tests and
+  `metadata_ops` partial-subseries field-op proof.
+- Guardrail: inherited odd tags from external files do not block unrelated
+  saves or processing; strict shape validation applies when intent touches the
+  series family.

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -2,8 +2,7 @@ use crate::audio::{validate_input_audio_path, validate_input_image_path};
 use crate::commands::CommandResult;
 use crate::errors::{AppError, Result};
 use crate::metadata::{
-    plan_metadata_write, read_metadata, AudiobookMetadata, MetadataIntentPatch,
-    MetadataIntentValidationResult,
+    read_metadata, AudiobookMetadata, MetadataIntentPatch, MetadataIntentValidationResult,
 };
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use reqwest::header::CONTENT_TYPE;
@@ -50,9 +49,8 @@ pub async fn save_metadata_to_file(
     let result: Result<()> = tokio::task::spawn_blocking(move || {
         let path = PathBuf::from(&file_path);
         let validated_path = validate_input_audio_path(&path)?;
-        let write_plan = plan_metadata_write(&metadata_patch)?;
 
-        crate::metadata::save_metadata_with_plan(&validated_path, &write_plan)?;
+        crate::metadata::save_metadata_intent(&validated_path, &metadata_patch)?;
 
         log::info!("Metadata saved to: {}", validated_path.display());
         Ok(())

--- a/src-tauri/src/metadata/AGENTS.md
+++ b/src-tauri/src/metadata/AGENTS.md
@@ -8,7 +8,7 @@ For ABS/Plex/Apple tag-mapping, series-tag strategy, and folder conventions, use
   `MetadataIntentValidationResult`, `validate_metadata_intent_patch`.
 - Outcome symbols: `MetadataOutcomeRequest`, `MetadataOutcomePlan`,
   `NamingMetadata`, `CoverArtPassthroughPolicy`, `plan_metadata_outcome`,
-  `plan_metadata_write`.
+  plus the test-only write-plan contract helper `plan_metadata_write`.
 - Read/write symbols: `read_metadata`, `save_metadata_intent`,
   `finalize_artifact_metadata` (all also re-exported at the crate root for
   external integration tests, e.g. the media-execution lane's tag round-trip
@@ -28,6 +28,11 @@ For ABS/Plex/Apple tag-mapping, series-tag strategy, and folder conventions, use
 - Pure intent, validation, naming, and write-plan facts are packaged in
   `abb-metadata-core`; `src-tauri/src/metadata` owns container adapters and
   runtime file behavior.
+- Series-family validation is effective-metadata aware: inherited odd tags from
+  external files do not block unrelated intent, but touched series/subseries
+  intent must produce a round-trippable shape before save or processing.
+  Real file saves route through `save_metadata_intent`, not raw write-plan
+  construction, so this validation can see source metadata.
 
 ## Private Cluster
 - Files: `intent_plan.rs`, `contract_tests.rs`, `field_schema.rs`, `metadata_ops.rs`,

--- a/src-tauri/src/metadata/intent_plan.rs
+++ b/src-tauri/src/metadata/intent_plan.rs
@@ -61,8 +61,17 @@ pub(crate) fn plan_metadata_outcome(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn plan_metadata_write(patch: &MetadataIntentPatch) -> Result<MetadataWritePlan> {
     Ok(patch.to_write_plan()?)
+}
+
+pub(crate) fn plan_metadata_write_for_path(
+    input_path: &Path,
+    patch: &MetadataIntentPatch,
+) -> Result<MetadataWritePlan> {
+    let source_metadata = crate::metadata::read_metadata(input_path)?;
+    Ok(patch.to_write_plan_with_source(source_metadata)?)
 }
 
 fn resolve_effective_processing_metadata(
@@ -87,7 +96,8 @@ fn resolve_naming_metadata(
 ) -> Option<NamingMetadata> {
     let mut naming_metadata = resolved_metadata.map(NamingMetadata::from_metadata)?;
 
-    if input_path.is_some() && patch.is_none() {
+    let series_family_touched = patch.is_some_and(MetadataIntentPatch::touches_series_family);
+    if input_path.is_some() && !series_family_touched {
         naming_metadata.scrub_legacy_source_series_parts_for_naming();
     }
 
@@ -256,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn naming_metadata_keeps_patch_validation_strict() {
+    fn naming_metadata_scrubs_legacy_series_parts_for_non_series_patch() {
         let metadata = AudiobookMetadata {
             title: Some("Patched Source".to_string()),
             series: Some("Series".to_string()),
@@ -275,13 +285,50 @@ mod tests {
         )
         .expect("naming metadata should exist");
 
+        assert_eq!(naming.title(), Some("Patched Source"));
+        assert_eq!(naming.series_part(), None);
+
+        let output_path = build_output_path_preview(
+            Path::new("/tmp"),
+            Some(&naming),
+            OutputNamingConfig::default(),
+            Some(Path::new("/tmp/source.m4b")),
+        )
+        .expect("non-series patch should not fail on inherited legacy part");
+
+        assert!(
+            output_path.to_string_lossy().contains("Patched Source"),
+            "output naming should still use source metadata"
+        );
+    }
+
+    #[test]
+    fn naming_metadata_keeps_series_patch_validation_strict() {
+        let metadata = AudiobookMetadata {
+            title: Some("Patched Source".to_string()),
+            series: Some("Series".to_string()),
+            series_part: Some("7/8".to_string()),
+            ..Default::default()
+        };
+        let patch = MetadataIntentPatch {
+            series: PatchOp::Set("Renamed Series".to_string()),
+            ..Default::default()
+        };
+
+        let naming = super::resolve_naming_metadata(
+            Some(&metadata),
+            Some(Path::new("/tmp/source.m4b")),
+            Some(&patch),
+        )
+        .expect("naming metadata should exist");
+
         let err = build_output_path_preview(
             Path::new("/tmp"),
             Some(&naming),
             OutputNamingConfig::default(),
             Some(Path::new("/tmp/source.m4b")),
         )
-        .expect_err("patched legacy series part should remain a hard failure");
+        .expect_err("series patch should keep inherited invalid part visible");
 
         assert!(
             err.to_string().contains("Series sequence"),

--- a/src-tauri/src/metadata/metadata_ops.rs
+++ b/src-tauri/src/metadata/metadata_ops.rs
@@ -93,11 +93,11 @@ fn push_series_ops(metadata: &AudiobookMetadata, ops: &mut Vec<MetadataOp>) {
         metadata.subseries_part.as_deref(),
     );
 
-    if metadata.series.is_some() {
+    if metadata.series.is_some() || metadata.subseries.is_some() {
         push_built_series_op(ops, series_value, TagField::Series);
     }
 
-    if metadata.series_part.is_some() {
+    if metadata.series_part.is_some() || metadata.subseries_part.is_some() {
         push_built_series_op(ops, series_part_value, TagField::SeriesPart);
     }
 }
@@ -194,6 +194,28 @@ mod tests {
         assert!(ops
             .iter()
             .any(|op| matches!(op, MetadataOp::SetMediaTypeAudiobook)));
+    }
+
+    #[test]
+    fn subseries_intent_forces_series_write_ops() {
+        let metadata = AudiobookMetadata {
+            series: Some("Primary".to_string()),
+            series_part: Some("1".to_string()),
+            subseries: Some("Sub".to_string()),
+            subseries_part: Some("2".to_string()),
+            ..Default::default()
+        };
+
+        let ops = plan_metadata_field_ops(&metadata);
+
+        assert!(ops.contains(&MetadataOp::SetString {
+            field: TagField::Series,
+            value: "Primary; Sub".to_string(),
+        }));
+        assert!(ops.contains(&MetadataOp::SetString {
+            field: TagField::SeriesPart,
+            value: "1; 2".to_string(),
+        }));
     }
 
     #[test]

--- a/src-tauri/src/metadata/metadata_ops.rs
+++ b/src-tauri/src/metadata/metadata_ops.rs
@@ -219,6 +219,27 @@ mod tests {
     }
 
     #[test]
+    fn partial_subseries_name_writes_combined_series_without_part_clear() {
+        let metadata = AudiobookMetadata {
+            series: Some("Primary".to_string()),
+            subseries: Some("Sub".to_string()),
+            ..Default::default()
+        };
+
+        let ops = plan_metadata_field_ops(&metadata);
+
+        assert!(ops.contains(&MetadataOp::SetString {
+            field: TagField::Series,
+            value: "Primary; Sub".to_string(),
+        }));
+        assert!(
+            !ops.iter()
+                .any(|op| matches!(op, MetadataOp::Clear(TagField::SeriesPart))),
+            "a representable subseries name must not clear series-part"
+        );
+    }
+
+    #[test]
     fn album_sort_is_not_planned() {
         let metadata = AudiobookMetadata {
             album_sort: Some("Custom Sort".to_string()),

--- a/src-tauri/src/metadata/metadata_sinks.rs
+++ b/src-tauri/src/metadata/metadata_sinks.rs
@@ -3,7 +3,9 @@
 use crate::metadata::field_schema::TagField;
 use crate::metadata::metadata_ops::MetadataOp;
 use crate::metadata::publication_year_from_date;
-use crate::metadata::tag_registry::{ITUNES_MEAN, SERIES_FREEFORM_NAME, SERIES_PART_FREEFORM_NAME};
+use crate::metadata::tag_registry::{
+    ITUNES_MEAN, SERIES, SERIES_FREEFORM_NAME, SERIES_PART, SERIES_PART_FREEFORM_NAME,
+};
 use crate::metadata::AudiobookMetadata;
 use ffmpeg_next as ff;
 use mp4ameta::{Data, FreeformIdent, MediaType, Tag};
@@ -33,17 +35,25 @@ impl Mp4ametaSink<'_> {
             TagField::Comment => self.tag.set_comment(value),
             TagField::Description => self.tag.set_description(value),
             TagField::Series => {
+                let canonical_ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES);
                 let ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_FREEFORM_NAME);
+                self.tag.remove_data_of(&canonical_ident);
                 self.tag.remove_data_of(&ident);
                 self.tag.remove_tv_show_name();
                 self.tag.remove_tv_show_name_sort_order();
+                self.tag
+                    .set_data(canonical_ident, Data::Utf8(value.to_string()));
                 self.tag.set_data(ident, Data::Utf8(value.to_string()));
             }
             TagField::SeriesPart => {
+                let canonical_ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_PART);
                 let ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_PART_FREEFORM_NAME);
+                self.tag.remove_data_of(&canonical_ident);
                 self.tag.remove_data_of(&ident);
                 self.tag.remove_tv_episode();
                 self.tag.remove_tv_episode_name();
+                self.tag
+                    .set_data(canonical_ident, Data::Utf8(value.to_string()));
                 self.tag.set_data(ident, Data::Utf8(value.to_string()));
             }
             TagField::Track | TagField::Disk => {}
@@ -64,13 +74,17 @@ impl Mp4ametaSink<'_> {
             TagField::Comment => self.tag.remove_comments(),
             TagField::Description => self.tag.remove_descriptions(),
             TagField::Series => {
+                let canonical_ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES);
                 let ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_FREEFORM_NAME);
+                self.tag.remove_data_of(&canonical_ident);
                 self.tag.remove_data_of(&ident);
                 self.tag.remove_tv_show_name();
                 self.tag.remove_tv_show_name_sort_order();
             }
             TagField::SeriesPart => {
+                let canonical_ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_PART);
                 let ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_PART_FREEFORM_NAME);
+                self.tag.remove_data_of(&canonical_ident);
                 self.tag.remove_data_of(&ident);
                 self.tag.remove_tv_episode();
                 self.tag.remove_tv_episode_name();
@@ -219,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn mp4ameta_sink_writes_series_and_subseries_to_itunes_freeform_atoms() {
+    fn mp4ameta_sink_writes_series_and_subseries_to_canonical_and_itunes_freeform_atoms() {
         let tag = apply_real_sink(&AudiobookMetadata {
             series: Some("Primary".to_string()),
             series_part: Some("1".to_string()),
@@ -228,10 +242,17 @@ mod tests {
             ..Default::default()
         });
 
-        let series = FreeformIdent::new_static("com.apple.iTunes", "SERIES");
-        let series_part = FreeformIdent::new_static("com.apple.iTunes", "SERIES-PART");
-        assert_eq!(tag.strings_of(&series).next(), Some("Primary; Sub"));
-        assert_eq!(tag.strings_of(&series_part).next(), Some("1; 2"));
+        let canonical_series = FreeformIdent::new_static("com.apple.iTunes", "series");
+        let canonical_series_part = FreeformIdent::new_static("com.apple.iTunes", "series-part");
+        let itunes_series = FreeformIdent::new_static("com.apple.iTunes", "SERIES");
+        let itunes_series_part = FreeformIdent::new_static("com.apple.iTunes", "SERIES-PART");
+        assert_eq!(
+            tag.strings_of(&canonical_series).next(),
+            Some("Primary; Sub")
+        );
+        assert_eq!(tag.strings_of(&canonical_series_part).next(), Some("1; 2"));
+        assert_eq!(tag.strings_of(&itunes_series).next(), Some("Primary; Sub"));
+        assert_eq!(tag.strings_of(&itunes_series_part).next(), Some("1; 2"));
 
         // Legacy tv-show/tv-episode compatibility atoms must not be emitted.
         assert_eq!(tag.tv_show_name(), None);
@@ -243,15 +264,30 @@ mod tests {
         let mut tag = apply_real_sink(&AudiobookMetadata {
             title: Some("Temp Title".to_string()),
             artist: Some("Temp Artist".to_string()),
+            series: Some("Temp Series".to_string()),
+            series_part: Some("9".to_string()),
             ..Default::default()
         });
         assert_eq!(tag.title(), Some("Temp Title"));
         assert_eq!(tag.album_artist(), Some("Temp Artist"));
+        let canonical_series = FreeformIdent::new_static("com.apple.iTunes", "series");
+        let canonical_series_part = FreeformIdent::new_static("com.apple.iTunes", "series-part");
+        let itunes_series = FreeformIdent::new_static("com.apple.iTunes", "SERIES");
+        let itunes_series_part = FreeformIdent::new_static("com.apple.iTunes", "SERIES-PART");
+        assert_eq!(
+            tag.strings_of(&canonical_series).next(),
+            Some("Temp Series")
+        );
+        assert_eq!(tag.strings_of(&canonical_series_part).next(), Some("9"));
+        assert_eq!(tag.strings_of(&itunes_series).next(), Some("Temp Series"));
+        assert_eq!(tag.strings_of(&itunes_series_part).next(), Some("9"));
 
         // Empty-string intent flows through the planner as a Clear op.
         let clear_ops = plan_metadata_field_ops(&AudiobookMetadata {
             title: Some("   ".to_string()),
             artist: Some(String::new()),
+            series: Some(String::new()),
+            series_part: Some(String::new()),
             ..Default::default()
         });
         {
@@ -263,6 +299,10 @@ mod tests {
         assert_eq!(tag.title(), None);
         assert_eq!(tag.artist(), None);
         assert_eq!(tag.album_artist(), None);
+        assert_eq!(tag.strings_of(&canonical_series).next(), None);
+        assert_eq!(tag.strings_of(&canonical_series_part).next(), None);
+        assert_eq!(tag.strings_of(&itunes_series).next(), None);
+        assert_eq!(tag.strings_of(&itunes_series_part).next(), None);
     }
 
     #[test]

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -31,9 +31,12 @@ pub use abb_metadata_core::{
     PatchOp,
 };
 pub(crate) use abb_metadata_core::{AlbumSortWriteAction, MetadataWritePlan};
+#[cfg(test)]
+pub(crate) use intent_plan::plan_metadata_write;
 pub use intent_plan::CoverArtPassthroughPolicy;
 pub(crate) use intent_plan::{
-    plan_metadata_outcome, plan_metadata_write, MetadataOutcomePlan, MetadataOutcomeRequest,
+    plan_metadata_outcome, plan_metadata_write_for_path, MetadataOutcomePlan,
+    MetadataOutcomeRequest,
 };
 
 impl From<MetadataCoreError> for AppError {
@@ -59,7 +62,7 @@ pub use passthrough::{
 /// then container-adapted write. The single save entry for command ingress
 /// and integration round-trip proof (media-execution lane).
 pub fn save_metadata_intent(path: &std::path::Path, patch: &MetadataIntentPatch) -> Result<()> {
-    let plan = plan_metadata_write(patch)?;
+    let plan = plan_metadata_write_for_path(path, patch)?;
     save_metadata_with_plan(path, &plan)
 }
 

--- a/src-tauri/src/metadata/mp4ameta_bridge.rs
+++ b/src-tauri/src/metadata/mp4ameta_bridge.rs
@@ -2,7 +2,9 @@ use crate::errors::{AppError, Result};
 use crate::metadata::cover_art::detect_cover_art_format;
 use crate::metadata::metadata_ops::plan_metadata_field_ops;
 use crate::metadata::metadata_sinks::{apply_metadata_ops, Mp4ametaSink};
-use crate::metadata::tag_registry::{ITUNES_MEAN, SERIES_FREEFORM_NAME, SERIES_PART_FREEFORM_NAME};
+use crate::metadata::tag_registry::{
+    ITUNES_MEAN, SERIES, SERIES_FREEFORM_NAME, SERIES_PART, SERIES_PART_FREEFORM_NAME,
+};
 use crate::metadata::{
     normalize_publication_date, split_series_list, AlbumSortWriteAction, AudiobookMetadata,
     MetadataWritePlan,
@@ -185,21 +187,21 @@ fn apply_album_sort(
 }
 
 fn read_series_raw(tag: &Tag) -> Option<String> {
-    let series = {
-        let ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_FREEFORM_NAME);
-        let value = tag.strings_of(&ident).next().map(str::to_string);
-        value
-    };
+    let series = read_freeform_string(tag, SERIES)
+        .or_else(|| read_freeform_string(tag, SERIES_FREEFORM_NAME));
     series.or_else(|| tag.tv_show_name().map(str::to_string))
 }
 
 fn read_series_part_raw(tag: &Tag) -> Option<String> {
-    let series_part = {
-        let ident = FreeformIdent::new_static(ITUNES_MEAN, SERIES_PART_FREEFORM_NAME);
-        let value = tag.strings_of(&ident).next().map(str::to_string);
-        value
-    };
+    let series_part = read_freeform_string(tag, SERIES_PART)
+        .or_else(|| read_freeform_string(tag, SERIES_PART_FREEFORM_NAME));
     series_part.or_else(|| tag.tv_episode().map(|episode| episode.to_string()))
+}
+
+fn read_freeform_string(tag: &Tag, name: &'static str) -> Option<String> {
+    let ident = FreeformIdent::new_static(ITUNES_MEAN, name);
+    let value = tag.strings_of(&ident).next().map(str::to_string);
+    value
 }
 
 fn cover_art_to_img(bytes: &[u8]) -> Result<Option<Img<Vec<u8>>>> {

--- a/src-tauri/tests/cases/integration_media_execution_tests.rs
+++ b/src-tauri/tests/cases/integration_media_execution_tests.rs
@@ -76,6 +76,19 @@ fn ffprobe_tag_ci(tags: &serde_json::Map<String, serde_json::Value>, key: &str) 
         .and_then(|(_, value)| value.as_str().map(str::to_string))
 }
 
+fn assert_ffprobe_tag(
+    tags: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    expected: &str,
+) {
+    let actual = ffprobe_tag_ci(tags, key);
+    assert_eq!(
+        actual.as_deref(),
+        Some(expected),
+        "ffprobe tag `{key}` should be `{expected}`; full tags: {tags:?}"
+    );
+}
+
 const SAMPLE_RATE: u32 = 44_100;
 
 /// Writes a mono 16-bit PCM WAV of `seconds` of sine at `freq_hz`.
@@ -462,6 +475,48 @@ async fn artifact_finalize_preserves_series_tags_and_chapters_on_mp4_route() {
         2,
         "finalized artifact keeps both passthrough chapters"
     );
+}
+
+#[tokio::test]
+async fn metadata_save_writes_external_ffprobe_visible_mp4_tags() {
+    let lane = MediaLane::with_fixtures(&[1.0]);
+    let output = lane.process(None).await;
+
+    let patch = MetadataIntentPatch {
+        title: PatchOp::Set("External Probe Title".to_string()),
+        artist: PatchOp::Set("External Probe Author".to_string()),
+        album: PatchOp::Set("External Probe Album".to_string()),
+        composer: PatchOp::Set("External Probe Composer".to_string()),
+        genre: PatchOp::Set("Audiobook".to_string()),
+        date: PatchOp::Set("2024-05-06".to_string()),
+        description: PatchOp::Set("External reader proof".to_string()),
+        series: PatchOp::Set("Probe Series".to_string()),
+        series_part: PatchOp::Set("2".to_string()),
+        subseries: PatchOp::Set("Probe Subseries".to_string()),
+        subseries_part: PatchOp::Set("7".to_string()),
+        comment: PatchOp::Set("Probe Comment".to_string()),
+        track: PatchOp::Set((3, Some(9))),
+        disk: PatchOp::Set((1, Some(2))),
+        ..Default::default()
+    };
+    save_metadata_intent(&output, &patch).expect("metadata save through mp4ameta path");
+
+    let tags = ffprobe_format_tags(&output);
+    assert_ffprobe_tag(&tags, "title", "External Probe Title");
+    assert_ffprobe_tag(&tags, "artist", "External Probe Author");
+    assert_ffprobe_tag(&tags, "album_artist", "External Probe Author");
+    assert_ffprobe_tag(&tags, "album", "External Probe Album");
+    assert_ffprobe_tag(&tags, "composer", "External Probe Composer");
+    assert_ffprobe_tag(&tags, "genre", "Audiobook");
+    assert_ffprobe_tag(&tags, "date", "2024-05");
+    assert_ffprobe_tag(&tags, "description", "External reader proof");
+    assert_ffprobe_tag(&tags, "comment", "Probe Comment");
+    // mp4ameta writes iTunes freeform series atoms; ffprobe exposes those
+    // atoms by freeform name, not as an exhaustive atom inventory.
+    assert_ffprobe_tag(&tags, "SERIES", "Probe Series; Probe Subseries");
+    assert_ffprobe_tag(&tags, "SERIES-PART", "2; 7");
+    assert_ffprobe_tag(&tags, "track", "3/9");
+    assert_ffprobe_tag(&tags, "disc", "1/2");
 }
 
 fn minimal_jpg_bytes() -> Vec<u8> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,7 +111,7 @@
 	--cover-thumb-size: 4rem;
 }
 
-:root[data-density='compact'] {
+:root[data-density="compact"] {
 	--density-row-h: 1.875rem;
 	--density-pad: var(--space-2);
 	--density-text: var(--text-sm);

--- a/src/ui/__tests__/metadata-session-smoke.test.ts
+++ b/src/ui/__tests__/metadata-session-smoke.test.ts
@@ -8,8 +8,16 @@
  *      pending store that saveMetadataFromUI drains into saveMetadataBatch.
  *   2. lookup-apply→same path: a lookup queue apply stages through the same
  *      seam and drains through the same save.
+ *   3. staged intent→output review→WorkRuntime submission: processing drains
+ *      the same pending store into both the output-plan review and final
+ *      retained processing payload.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultEncoderSettings, type FileListInfo } from '../../types/audio';
+import type { MetadataIntentPatch } from '../../types/metadataIntent';
+import type { WorkSubmissionAccepted } from '../../types/workRuntime';
+import type { ProcessingWorkflowServices } from '../statusPanel/processingWorkflow';
+import type { ProcessingStatus } from '../statusPanel/state';
 
 const context = vi.hoisted(() => ({
 	saveMetadataBatchMock: vi.fn(),
@@ -109,6 +117,79 @@ vi.mock('../fileList', async () => {
 const FILE_A = { path: '/books/edited.m4b', isValid: true };
 const FILE_B = { path: '/books/looked-up.m4b', isValid: true };
 
+function smokeFileList(): FileListInfo {
+	return {
+		files: [
+			{
+				inputId: 'input-smoke',
+				path: FILE_A.path,
+				size: 1024,
+				duration: 60,
+				format: 'm4b',
+				bitrate: 64,
+				sampleRate: 44100,
+				channels: 1,
+				codecLabel: 'AAC',
+				selectedDecoder: undefined,
+				isValid: true,
+				error: undefined,
+			},
+		],
+		selectedDecoders: [null],
+		totalDuration: 60,
+		totalSize: 1024,
+		validCount: 1,
+		invalidCount: 0,
+	};
+}
+
+function processingContext() {
+	return {
+		updateStatus: vi.fn((_status: ProcessingStatus) => undefined),
+		setProcessingState: vi.fn(),
+		updateArtThumbnail: vi.fn(async () => undefined),
+		startProgressListener: vi.fn(async () => undefined),
+		setCurrentWorkKind: vi.fn(),
+		setBatchCompletionMessage: vi.fn(),
+		handleCancellation: vi.fn(),
+		resetToIdle: vi.fn(),
+	};
+}
+
+function acceptedProcessingSubmission(): WorkSubmissionAccepted {
+	return {
+		operationId: 'operation-smoke',
+		snapshot: {
+			operationId: 'operation-smoke',
+			sequence: 1,
+			kind: 'processingMerge',
+			status: 'accepted',
+			title: 'Merge encode (1 file)',
+			createdAtMs: 1,
+			startedAtMs: undefined,
+			finishedAtMs: undefined,
+			cancellable: true,
+			cancelRequested: false,
+			lanes: ['analysis', 'encodeCpu', 'outputCommit'],
+			sourceInputIds: ['input-smoke'],
+			progress: {
+				stage: 'pending',
+				percentage: 0,
+				message: 'Accepted.',
+				currentItemIndex: undefined,
+				totalItems: 1,
+				bytesDownloaded: undefined,
+				bytesTotal: undefined,
+				etaSeconds: undefined,
+			},
+			children: [],
+			terminalSummary: undefined,
+			warnings: [],
+			errors: [],
+		},
+	};
+}
+
 describe('metadata session smoke (edit→save and lookup→save through one seam)', () => {
 	let metadataSession: typeof import('../metadataSession');
 
@@ -140,9 +221,7 @@ describe('metadata session smoke (edit→save and lookup→save through one seam
 		context.readMetadataFormMock.mockReturnValue({ title: 'Edited Title' });
 		context.saveMetadataBatchMock.mockResolvedValue({
 			summary: { total: 1, succeeded: 1, skipped: 0, cancelled: 0, failed: 0 },
-			results: [
-				{ inputIndex: 0, filePath: FILE_A.path, status: 'success', message: 'saved' },
-			],
+			results: [{ inputIndex: 0, filePath: FILE_A.path, status: 'success', message: 'saved' }],
 		});
 		metadataSession.cacheMetadataForFile(FILE_A.path, {
 			title: 'Old Title',
@@ -177,9 +256,7 @@ describe('metadata session smoke (edit→save and lookup→save through one seam
 		context.getSelectedFilesMock.mockReturnValue([]);
 		context.saveMetadataBatchMock.mockResolvedValue({
 			summary: { total: 1, succeeded: 1, skipped: 0, cancelled: 0, failed: 0 },
-			results: [
-				{ inputIndex: 0, filePath: FILE_B.path, status: 'success', message: 'saved' },
-			],
+			results: [{ inputIndex: 0, filePath: FILE_B.path, status: 'success', message: 'saved' }],
 		});
 
 		const { makeMetadataLookupWorkflowServicesLayer, runMetadataLookupWorkflow } = await import(
@@ -251,7 +328,9 @@ describe('metadata session smoke (edit→save and lookup→save through one seam
 		await runMetadataLookupWorkflow(layer, { type: 'applyResult', index: 0 });
 
 		// The lookup apply landed in the SAME pending store the primary path uses.
-		expect(metadataSession.collectActionableMetadataIntent([FILE_B.path])?.[FILE_B.path]).toMatchObject({
+		expect(
+			metadataSession.collectActionableMetadataIntent([FILE_B.path])?.[FILE_B.path],
+		).toMatchObject({
 			title: { op: 'set', value: 'Looked Up Title' },
 			artist: { op: 'set', value: 'Author Person' },
 		});
@@ -268,5 +347,102 @@ describe('metadata session smoke (edit→save and lookup→save through one seam
 			title: { op: 'set', value: 'Looked Up Title' },
 		});
 		expect(metadataSession.collectActionableMetadataIntent([FILE_B.path])).toBeNull();
+	});
+
+	it('drains staged metadata into output review and retained processing submission', async () => {
+		const stagedIntent: MetadataIntentPatch = {
+			title: { op: 'set', value: 'Submitted Title' },
+			series: { op: 'set', value: 'Submitted Series' },
+			series_part: { op: 'set', value: '3' },
+		};
+		expect(metadataSession.stageMetadataIntentPatch(FILE_A.path, stagedIntent)).toBe('staged');
+		const expectedIntent = {
+			[FILE_A.path]: stagedIntent,
+		};
+
+		const { makeProcessingWorkflowServicesLayer, startProcessing } = await import(
+			'../statusPanel/processingWorkflow'
+		);
+		const reviewOutputPlan: ProcessingWorkflowServices['runOutputPlanReviewWorkflow'] = vi.fn(
+			async ({ payload, metadataIntentByPath, previewSeconds }) => ({
+				status: 'approved' as const,
+				payload: { ...payload, preflightSignature: 'smoke-preflight' },
+				plan: {
+					jobType: payload.jobType ?? 'merge',
+					previewSeconds: previewSeconds ?? null,
+					collisionPolicy: payload.collisionPolicy ?? 'fail',
+					planSignature: metadataIntentByPath ? 'smoke-preflight' : 'missing-intent',
+					outputs: [
+						{
+							inputIndex: 0,
+							inputPath: FILE_A.path,
+							kind: 'final' as const,
+							requestedPath: '/tmp/out/Submitted Title.m4b',
+							resolvedPath: '/tmp/out/Submitted Title.m4b',
+							renameCandidate: undefined,
+							collision: undefined,
+							action: 'write' as const,
+						},
+					],
+				},
+			}),
+		);
+		const submitProcessingOperation: ProcessingWorkflowServices['submitProcessingOperation'] =
+			vi.fn(async () => acceptedProcessingSubmission());
+
+		const layer = makeProcessingWorkflowServicesLayer({
+			updateOutputPath: vi.fn(),
+			getCurrentFileList: () => smokeFileList(),
+			getSelectedFileIndex: () => 0,
+			getSelectedFileIndices: () => new Set([0]),
+			readProcessingRequestConfig: () => ({
+				encoderSettings: defaultEncoderSettings(),
+				sampleRate: 'auto',
+				outputDirectory: '/tmp/out',
+				outputNaming: {
+					preset: 'absDefault',
+					includeYear: false,
+					customTemplate: undefined,
+				},
+			}),
+			getJobType: () => 'merge',
+			hasDirtyMetadataFields: () => false,
+			readMetadataForm: vi.fn(() => ({})),
+			collectActionableMetadataIntent: metadataSession.collectActionableMetadataIntent,
+			getMetadataForFile: metadataSession.getMetadataForFile,
+			cacheMetadataForFile: metadataSession.cacheMetadataForFile,
+			stageMetadataIntentPatch: metadataSession.stageMetadataIntentPatch,
+			stageMetadataToSelection: vi.fn(async () => true),
+			setJobControlsEnabled: vi.fn(),
+			setFileOrderLocked: vi.fn(),
+			validateMetadataIntentPatch: vi.fn(async (metadataPatch) => ({
+				isValid: true,
+				metadataPatch,
+				fieldErrors: [],
+			})),
+			readAudioMetadata: vi.fn(async () => ({})),
+			processAudiobookFiles: vi.fn(),
+			submitProcessingOperation,
+			runOutputPlanReviewWorkflow: reviewOutputPlan,
+			openGeneratedPreviewIfSingle: vi.fn(async () => undefined),
+			feedback: { showError: vi.fn() },
+			console: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+		});
+
+		await startProcessing(processingContext(), undefined, layer);
+
+		expect(reviewOutputPlan).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadataIntentByPath: expectedIntent,
+			}),
+		);
+		expect(submitProcessingOperation).toHaveBeenCalledWith(
+			expect.objectContaining({
+				payload: expect.objectContaining({
+					preflightSignature: 'smoke-preflight',
+				}),
+				metadataIntent: expectedIntent,
+			}),
+		);
 	});
 });

--- a/src/ui/fileList/__tests__/reorder-behavior.test.ts
+++ b/src/ui/fileList/__tests__/reorder-behavior.test.ts
@@ -130,7 +130,7 @@ describe('file list reorder behavior', () => {
 		context.stageMetadataIntentPatchMock.mockReturnValue('staged');
 		context.clearMetadataSessionMock.mockReset();
 		context.removeMetadataForFileMock.mockReset();
-						context.populateMetadataFormSingleMock.mockReset();
+		context.populateMetadataFormSingleMock.mockReset();
 		context.populateMetadataFormMultiMock.mockReset();
 		context.hasDirtyMetadataFieldsMock.mockReset();
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
@@ -141,17 +141,19 @@ describe('file list reorder behavior', () => {
 		context.updateOutputPathMock.mockReset();
 		context.updateTagPreviewMock.mockReset();
 		context.validateMetadataDraftMock.mockReset();
-		context.validateMetadataDraftMock.mockImplementation(async (metadata: Record<string, unknown>) => {
-			const first = context.validationErrorMock();
-			return {
-				intentPatch: Object.fromEntries(
-					Object.entries(metadata).map(([key, value]) => [key, { op: 'set', value }]),
-				),
-				ok: first == null,
-				errors: { first, byField: {} },
-				result: { isValid: first == null, metadataPatch: {}, fieldErrors: [] },
-			};
-		});
+		context.validateMetadataDraftMock.mockImplementation(
+			async (metadata: Record<string, unknown>) => {
+				const first = context.validationErrorMock();
+				return {
+					intentPatch: Object.fromEntries(
+						Object.entries(metadata).map(([key, value]) => [key, { op: 'set', value }]),
+					),
+					ok: first == null,
+					errors: { first, byField: {} },
+					result: { isValid: first == null, metadataPatch: {}, fieldErrors: [] },
+				};
+			},
+		);
 		context.clearCoverArtMock.mockReset();
 		context.getHasCustomCoverArtMock.mockReset();
 		context.getHasCustomCoverArtMock.mockReturnValue(false);

--- a/src/ui/fileList/__tests__/selectFile-transition.test.ts
+++ b/src/ui/fileList/__tests__/selectFile-transition.test.ts
@@ -114,17 +114,19 @@ describe('selectFile transition options', () => {
 		context.pushStatusPanelTransientStatusMock.mockClear();
 		context.validationErrorMock.mockReset();
 		context.validateMetadataDraftMock.mockReset();
-		context.validateMetadataDraftMock.mockImplementation(async (metadata: Record<string, unknown>) => {
-			const first = context.validationErrorMock();
-			return {
-				intentPatch: Object.fromEntries(
-					Object.entries(metadata).map(([key, value]) => [key, { op: 'set', value }]),
-				),
-				ok: first == null,
-				errors: { first, byField: {} },
-				result: { isValid: first == null, metadataPatch: {}, fieldErrors: [] },
-			};
-		});
+		context.validateMetadataDraftMock.mockImplementation(
+			async (metadata: Record<string, unknown>) => {
+				const first = context.validationErrorMock();
+				return {
+					intentPatch: Object.fromEntries(
+						Object.entries(metadata).map(([key, value]) => [key, { op: 'set', value }]),
+					),
+					ok: first == null,
+					errors: { first, byField: {} },
+					result: { isValid: first == null, metadataPatch: {}, fieldErrors: [] },
+				};
+			},
+		);
 		context.validationErrorMock.mockReturnValue(null);
 		context.clearSelectionMock.mockClear();
 		context.getSelectedFilesMock.mockReset();

--- a/src/ui/fileList/metadataStaging.ts
+++ b/src/ui/fileList/metadataStaging.ts
@@ -25,10 +25,7 @@ export async function persistSingleSelectionMetadata(file: AudioFile | null): Pr
 	if (!hasDirtyMetadataFields()) return true;
 
 	const metadata = readMetadataForm({ mode: 'single' });
-	const validation = await validateMetadataDraft(
-		metadata,
-		tauriClient.validateMetadataIntentPatch,
-	);
+	const validation = await validateMetadataDraft(metadata, tauriClient.validateMetadataIntentPatch);
 	if (!validation.ok) {
 		setStatusMessage(validation.errors.first ?? 'Metadata validation failed.');
 		return false;

--- a/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
+++ b/src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Effect, runAppEffect } from '../../../lib/effect/appEffect';
 import type { AudioFile, FileListInfo } from '../../../types/audio';
-import {
-	applyMetadataIntentPatch,
-	type MetadataIntentPatch,
-} from '../../../types/metadataIntent';
+import { applyMetadataIntentPatch, type MetadataIntentPatch } from '../../../types/metadataIntent';
 import type {
 	AudiobookMetadata,
 	MetadataLookupResponse,

--- a/src/ui/metadataSession/__tests__/runtime-api-contract.test.ts
+++ b/src/ui/metadataSession/__tests__/runtime-api-contract.test.ts
@@ -79,9 +79,9 @@ describe('Metadata Session runtime public API contract', () => {
 		expect(cached?.disk).toEqual([1, null]);
 
 		// Explicit artifact clears flow through the same staging seam as clear ops.
-		expect(
-			metadataSession.stageMetadataIntentPatch(path, { album_sort: { op: 'clear' } }),
-		).toBe('staged');
+		expect(metadataSession.stageMetadataIntentPatch(path, { album_sort: { op: 'clear' } })).toBe(
+			'staged',
+		);
 		expect(metadataSession.getMetadataForFile(path)?.album_sort).toBeUndefined();
 		expect(metadataSession.collectActionableMetadataIntent([path])?.[path]).toMatchObject({
 			album_sort: { op: 'clear' },

--- a/src/ui/metadataSession/state.ts
+++ b/src/ui/metadataSession/state.ts
@@ -61,10 +61,7 @@ function metadataEqualsNullish(
  * Caches metadata truth from a backend read. Carries no pending-save
  * semantics; staging intent goes through `stageMetadataIntentPatch`.
  */
-export function cacheMetadataForFile(
-	filePath: string,
-	metadata: Partial<AudiobookMetadata>,
-): void {
+export function cacheMetadataForFile(filePath: string, metadata: Partial<AudiobookMetadata>): void {
 	metadataByFile.set(filePath, metadata);
 }
 

--- a/src/ui/outputPanel/preview.ts
+++ b/src/ui/outputPanel/preview.ts
@@ -51,7 +51,10 @@ export function readOutputPathPreviewMetadataDraft(): OutputPathPreviewMetadataD
 	};
 }
 
-function updateSeriesPartWarning(metadata: AudiobookMetadata, seriesPartError: string | null): void {
+function updateSeriesPartWarning(
+	metadata: AudiobookMetadata,
+	seriesPartError: string | null,
+): void {
 	const seriesValue = metadata.series?.trim() ?? '';
 	const seriesPartValue = metadata.series_part?.trim() ?? '';
 	const subseriesValue = metadata.subseries?.trim() ?? '';

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -347,6 +347,30 @@ describe('startProcessing metadata staging', () => {
 		expect(viewState.showError).toHaveBeenCalledWith('Series part must be a number');
 	});
 
+	it('aborts non-merge processing instead of retargeting dirty edits from an invalid row', async () => {
+		context.getJobTypeMock.mockReturnValue('batch');
+		context.getCurrentFileListMock.mockReturnValue({
+			files: [
+				{ path: '/books/invalid.m4b', isValid: false },
+				{ path: '/books/valid.m4b', isValid: true },
+			],
+			validCount: 1,
+		});
+		context.getSelectedFileIndexMock.mockReturnValue(0);
+		context.getSelectedFileIndicesMock.mockReturnValue(new Set([0]));
+		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
+		context.readMetadataFormMock.mockReturnValue({ title: 'Should Not Retarget' });
+		vi.mocked(viewState.showError).mockClear();
+
+		await startProcessing(processingContext());
+
+		expect(context.stageMetadataIntentPatchMock).not.toHaveBeenCalled();
+		expect(context.submitProcessingOperationMock).not.toHaveBeenCalled();
+		expect(viewState.showError).toHaveBeenCalledWith(
+			'Select a valid input file before processing metadata edits.',
+		);
+	});
+
 	it('stages clear intent for dirty-but-empty metadata in merge payload', async () => {
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
 		context.readMetadataFormMock.mockReturnValue({ title: '   ' });

--- a/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
+++ b/src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { defaultEncoderSettings } from '../../../types/audio';
+import { defaultEncoderSettings, type ProcessPayload } from '../../../types/audio';
+import type { MetadataIntentPatch } from '../../../types/metadataIntent';
 import type { ProcessingStatus } from '../state';
 import { startProcessing } from '../processingWorkflow';
 import * as viewState from '../viewState.svelte';
@@ -20,6 +21,7 @@ const context = vi.hoisted(() => ({
 	getSelectedFileIndicesMock: vi.fn(),
 	readProcessingRequestConfigMock: vi.fn(),
 	updateOutputPathMock: vi.fn(),
+	runOutputPlanReviewWorkflowMock: vi.fn(),
 	getJobTypeMock: vi.fn(),
 	readMetadataFormMock: vi.fn(),
 	hasDirtyMetadataFieldsMock: vi.fn(),
@@ -59,7 +61,7 @@ vi.mock('../processingConfig', () => ({
 
 vi.mock('../../outputPanel', () => ({
 	updateOutputPath: context.updateOutputPathMock,
-	runOutputPlanReviewWorkflow: vi.fn(async () => ({ action: 'continue' })),
+	runOutputPlanReviewWorkflow: context.runOutputPlanReviewWorkflowMock,
 }));
 
 vi.mock('../../jobControls', () => ({
@@ -149,6 +151,7 @@ describe('startProcessing metadata staging', () => {
 		context.getSelectedFileIndicesMock.mockReset();
 		context.readProcessingRequestConfigMock.mockReset();
 		context.updateOutputPathMock.mockReset();
+		context.runOutputPlanReviewWorkflowMock.mockReset();
 		context.getJobTypeMock.mockReset();
 		context.readMetadataFormMock.mockReset();
 		context.hasDirtyMetadataFieldsMock.mockReset();
@@ -199,6 +202,25 @@ describe('startProcessing metadata staging', () => {
 			summary: { total: 1, succeeded: 1, skipped: 0, cancelled: 0, failed: 0 },
 			results: [{ inputIndex: 0, status: 'success', message: 'ok', jobId: 'job-1' }],
 		});
+		context.runOutputPlanReviewWorkflowMock.mockImplementation(
+			async ({
+				payload,
+				metadataIntentByPath,
+				previewSeconds,
+			}: {
+				payload: ProcessPayload;
+				metadataIntentByPath: Record<string, MetadataIntentPatch> | null;
+				previewSeconds?: number;
+			}) => ({
+				status: 'approved',
+				payload: { ...payload, preflightSignature: 'preflight-approved' },
+				plan: await context.preflightProcessingPlanMock({
+					payload,
+					metadataIntentByPath,
+					previewSeconds,
+				}),
+			}),
+		);
 		context.submitProcessingOperationMock.mockResolvedValue({
 			operationId: 'operation-1',
 			snapshot: {
@@ -288,6 +310,9 @@ describe('startProcessing metadata staging', () => {
 		});
 		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
+				payload: expect.objectContaining({
+					preflightSignature: 'preflight-approved',
+				}),
 				metadataIntent: {
 					'/books/a.m4b': { title: { op: 'set', value: 'Edited Title' } },
 				},
@@ -364,28 +389,49 @@ describe('startProcessing metadata staging', () => {
 		);
 	});
 
-	it('mirrors merge cover intent onto the merge key when a non-first file is selected', async () => {
+	it('stages merge metadata intent onto the merge key when a non-first file is selected', async () => {
 		context.getSelectedFileIndexMock.mockReturnValue(1);
 		context.getSelectedFileIndicesMock.mockReturnValue(new Set([1]));
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(true);
-		context.readMetadataFormMock.mockReturnValue({ cover_art: [7, 7, 7] });
+		context.readMetadataFormMock.mockReturnValue({
+			title: 'Selected Row Title',
+			cover_art: [7, 7, 7],
+		});
 		context.getMetadataForFileMock.mockReturnValue({});
 		context.storedIntentPatches = {
-			'/books/a.m4b': { cover_art: { op: 'set', value: [7, 7, 7] } },
+			'/books/a.m4b': {
+				title: { op: 'set', value: 'Selected Row Title' },
+				cover_art: { op: 'set', value: [7, 7, 7] },
+			},
 		};
 
 		await startProcessing(processingContext());
 
-		expect(context.stageMetadataIntentPatchMock).toHaveBeenCalledWith('/books/b.m4b', {
-			cover_art: { op: 'set', value: [7, 7, 7] },
-		});
 		expect(context.stageMetadataIntentPatchMock).toHaveBeenCalledWith('/books/a.m4b', {
+			title: { op: 'set', value: 'Selected Row Title' },
 			cover_art: { op: 'set', value: [7, 7, 7] },
 		});
+		expect(context.stageMetadataIntentPatchMock).not.toHaveBeenCalledWith(
+			'/books/b.m4b',
+			expect.anything(),
+		);
+		expect(context.runOutputPlanReviewWorkflowMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadataIntentByPath: {
+					'/books/a.m4b': {
+						title: { op: 'set', value: 'Selected Row Title' },
+						cover_art: { op: 'set', value: [7, 7, 7] },
+					},
+				},
+			}),
+		);
 		expect(context.submitProcessingOperationMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				metadataIntent: {
-					'/books/a.m4b': { cover_art: { op: 'set', value: [7, 7, 7] } },
+					'/books/a.m4b': {
+						title: { op: 'set', value: 'Selected Row Title' },
+						cover_art: { op: 'set', value: [7, 7, 7] },
+					},
 				},
 			}),
 		);
@@ -395,10 +441,10 @@ describe('startProcessing metadata staging', () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
-		context.storedIntentPatches = ({
+		context.storedIntentPatches = {
 			'/books/a.m4b': { title: { op: 'clear' } },
 			'/books/b.m4b': { series: { op: 'set', value: 'Series B' } },
-		});
+		};
 
 		await startProcessing(processingContext());
 
@@ -416,7 +462,7 @@ describe('startProcessing metadata staging', () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
-		context.storedIntentPatches = ({});
+		context.storedIntentPatches = {};
 		context.processAudiobookFilesMock.mockResolvedValue({
 			jobType: 'batch',
 			summary: { total: 2, succeeded: 0, skipped: 0, cancelled: 0, failed: 1 },
@@ -449,7 +495,7 @@ describe('startProcessing metadata staging', () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
-		context.storedIntentPatches = ({});
+		context.storedIntentPatches = {};
 		context.processAudiobookFilesMock.mockResolvedValue({
 			jobType: 'batch',
 			summary: { total: 2, succeeded: 1, skipped: 0, cancelled: 1, failed: 0 },
@@ -491,7 +537,7 @@ describe('startProcessing metadata staging', () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
-		context.storedIntentPatches = ({});
+		context.storedIntentPatches = {};
 		context.submitProcessingOperationMock.mockRejectedValueOnce({
 			code: 'cancelled',
 			category: 'cancellation',
@@ -513,11 +559,11 @@ describe('startProcessing metadata staging', () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
-		context.storedIntentPatches = ({
+		context.storedIntentPatches = {
 			'/books/a.m4b': { title: { op: 'set', value: 'Active A' } },
 			'/books/b.m4b': { series: { op: 'set', value: 'Active B' } },
 			'/books/stale.m4b': { title: { op: 'set', value: 'Stale' } },
-		});
+		};
 
 		await startProcessing(processingContext());
 
@@ -535,10 +581,10 @@ describe('startProcessing metadata staging', () => {
 		context.getJobTypeMock.mockReturnValue('batch');
 		context.hasDirtyMetadataFieldsMock.mockReturnValue(false);
 		context.getMetadataForFileMock.mockReturnValue({ title: 'Already Loaded' });
-		context.storedIntentPatches = ({
+		context.storedIntentPatches = {
 			'/books/a.m4b': {},
 			'/books/b.m4b': {},
-		});
+		};
 
 		await startProcessing(processingContext());
 

--- a/src/ui/statusPanel/processingWorkflowPreparation.ts
+++ b/src/ui/statusPanel/processingWorkflowPreparation.ts
@@ -89,7 +89,7 @@ function metadataIntentTargetPath(
 		}
 	}
 
-	return fileList.files.find((file) => file.isValid)?.path;
+	return undefined;
 }
 
 function stageSingleSelectionMetadata(
@@ -117,9 +117,13 @@ function stageSingleSelectionMetadata(
 
 		const intentPatch = validation.intentPatch;
 		const targetPath = metadataIntentTargetPath(services, fileList, selectedFileIndex);
-		if (targetPath) {
-			services.stageMetadataIntentPatch(targetPath, intentPatch);
+		if (!targetPath) {
+			yield* Effect.sync(() =>
+				services.feedback.showError('Select a valid input file before processing metadata edits.'),
+			);
+			return false;
 		}
+		services.stageMetadataIntentPatch(targetPath, intentPatch);
 
 		return true;
 	});

--- a/src/ui/statusPanel/processingWorkflowPreparation.ts
+++ b/src/ui/statusPanel/processingWorkflowPreparation.ts
@@ -73,26 +73,23 @@ function stageMultiSelectionMetadata(
 	});
 }
 
-function ensureMergeCoverIntentOnMergeKey(
+function metadataIntentTargetPath(
 	services: ProcessingWorkflowServices,
 	fileList: FileListInfo,
-	intentPatch: MetadataIntentPatch,
-	activeFilePath: string | undefined,
-): void {
-	if (services.getJobType() !== 'merge') {
-		return;
-	}
-	const coverIntent = intentPatch.cover_art;
-	if (!coverIntent || coverIntent.op === 'noop') {
-		return;
+	selectedFileIndex: number,
+): string | undefined {
+	if (services.getJobType() === 'merge') {
+		return validInputFilePaths(fileList)[0];
 	}
 
-	const mergeKey = validInputFilePaths(fileList)[0];
-	if (!mergeKey || activeFilePath === mergeKey) {
-		return;
+	if (selectedFileIndex >= 0) {
+		const selectedFile = fileList.files[selectedFileIndex];
+		if (selectedFile?.isValid) {
+			return selectedFile.path;
+		}
 	}
 
-	services.stageMetadataIntentPatch(mergeKey, { cover_art: coverIntent });
+	return fileList.files.find((file) => file.isValid)?.path;
 }
 
 function stageSingleSelectionMetadata(
@@ -119,15 +116,9 @@ function stageSingleSelectionMetadata(
 		}
 
 		const intentPatch = validation.intentPatch;
-		const activeFile =
-			selectedFileIndex >= 0
-				? fileList.files[selectedFileIndex]
-				: fileList.files.find((file) => file.isValid);
-		if (
-			activeFile?.isValid &&
-			services.stageMetadataIntentPatch(activeFile.path, intentPatch) !== 'noop'
-		) {
-			ensureMergeCoverIntentOnMergeKey(services, fileList, intentPatch, activeFile.path);
+		const targetPath = metadataIntentTargetPath(services, fileList, selectedFileIndex);
+		if (targetPath) {
+			services.stageMetadataIntentPatch(targetPath, intentPatch);
 		}
 
 		return true;


### PR DESCRIPTION
## Summary
- Fixes two audit-level intent gaps: subseries/subseries-part edits now force derived series write ops, and merge-mode dirty metadata now stages to the merge artifact key instead of a non-first selected row that final submission ignores.
- Hardens the MP4 adapter contract: the mp4ameta sink now writes/clears both canonical lowercase and iTunes uppercase freeform series atoms, and ABB readback prefers the canonical atom while preserving the existing iTunes fallback.
- Adds proof where the old lane was blind: external `ffprobe` terminal truth for a real M4B save, and a real `MetadataSession` smoke proving staged intent reaches output-plan review and retained WorkRuntime submission.

## Impact vs main
- Metadata manager controls for title/series/series part/subseries/subseries part now have a proved path from staged intent into adapter writes and the final processing payload.
- Merge processing no longer drops non-cover metadata edits made while a non-first row is selected; the metadata form targets the artifact owner, which is the first valid merge input.
- No IPC/generated binding shape changes. This is behavior/proof hardening inside existing owners.

## Audit classification
- Fix: subseries intent was accepted but could produce no container write op unless primary series fields were also present.
- Fix: merge-mode single-selection edits on a non-first file could be staged to a path that `buildMetadataIntentByPath` intentionally excludes; cover art had a special mirror, text fields did not.
- Fix: stale output-plan test mock used an obsolete `{ action: 'continue' }` shape and did not prove the reviewed/preflight payload reached `submitProcessingOperation`.
- Defer: exact MP4 golden atom inventory for canonical lowercase `series`/`series-part` plus iTunes mirror atoms needs an explicit external atom tool decision (`AtomicParsley`/`mp4dump` or an FFmpeg mdta remux strategy). `ffprobe` is useful terminal truth, but with mp4ameta freeforms it presents one freeform key family rather than an exhaustive atom inventory.
- Defer: `write_cover_art` still appears to be a stale public IPC surface; removing or rerouting it should be a separate public-strip cleanup because it changes generated/public API expectations.
- Reject: cover-art clear vs passthrough policy and container routing are coherent in the inspected paths; no hidden fallback found there.

## Validation
- `bash scripts/setup-codex-agent-env.sh`
- `cargo test -p audiobook-boss subseries_intent_forces_series_write_ops -- --nocapture`
- `cargo test -p audiobook-boss mp4ameta_sink -- --nocapture`
- `cargo test -p audiobook-boss --test all_tests metadata_save_writes_external_ffprobe_visible_mp4_tags -- --nocapture`
- `cargo nextest run -p audiobook-boss --test all_tests -E 'test(media_execution)'`
- `bun run typecheck`
- `bun run test -- src/ui/__tests__/metadata-session-smoke.test.ts src/ui/statusPanel/__tests__/processing-metadata-staging.test.ts`
- `bun run lint:check`
- `cargo fmt --all -- --check`
- `git diff --check`

`bun run fmt:check` still fails on pre-existing unrelated formatting drift outside this PR's touched surface (`.claude/launch.json`, `src/styles.css`, file-list tests, metadata/session/output-panel files). The two touched TS files were formatted directly with Biome and verified with a targeted format check.

Cloud note: the repo exposes a setup script for Codex Cloud/Linux agents, not a callable cloud executor in this session. The setup script was pressure-tested locally on macOS; Linux/cloud execution remains through the documented setup command.
