### PR TITLE
docs(canon): route the lab scenario/screenshot layer through its owners

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -70,6 +70,18 @@ commands over invoking internals directly.
   run-scoped artifacts remain under `.logs/runs/<run-id>/`.
 - Frontend owner: `bun run test -- <owner test files>`.
 - Frontend type validation: `bun run typecheck`.
+- Browser-level UI evidence: `bun run lab:shots` — renders the
+  `lab.html?scenario=<id>` fixture stages (chapter queue, locked queue, empty
+  queue, short-window modal) in headless Chromium, saves screenshots to
+  `.artifacts/lab-shots/`, and asserts the short-window modal keeps its footer
+  reachable while the body scrolls. Use it when a UI change needs rendered
+  visual evidence jsdom cannot give (layout, overflow, hit targets); attach
+  the screenshots as review evidence per `src/AGENTS.md`. Manual invocation
+  only — it is not part of `bun run test` or CI. One-time per machine:
+  `bunx playwright install chromium`. Scenario fixtures live in owner-local
+  `labFixtures.ts` adapters and stay fixture-only: adding media synthesis,
+  screenshot-diff baselines, or a default-path/CI hook is an owner decision
+  (same pattern as the media lane), not a default.
 - IPC/generated binding changes:
   `bash scripts/check-generated-bindings.sh --mode local`, then the contract
   Vitest files: `bun run test -- src/lib/tauri-public-api.contract.test.ts
@@ -97,6 +109,8 @@ commands over invoking internals directly.
   plus raw Tauri invoke bypass protection.
 - `build-app.ts`, `install-local-app.ts`, `resolve-release-dmg.ts`,
   `bump-version.ts`: build/release utilities.
+- `lab-shots.ts`: lab scenario screenshots plus the short-window modal layout
+  assertion (command and scope in the Command Menu entry above).
 - `analyze_code_lines.py`: optional human "Commander View" source-size
   diagnostic, not proof.
 - `*.test.ts`: Vitest coverage for script helpers.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -48,6 +48,11 @@
   density switcher. When adding or changing a token or `src/styles.css`
   primitive, add/update its lab rendering in the same change — the lab is the
   visual-review surface for design-system work (screenshot it for evidence).
+- The lab also renders full-component scenario stages
+  (`lab.html?scenario=<id>`), seeded through owner-local `labFixtures.ts`
+  adapters with no Tauri backend; `bun run lab:shots` captures them in a real
+  browser when a UI change needs rendered layout evidence. Command, scenario
+  list, and scope boundary: `scripts/AGENTS.md`.
 - Density is a user preference: read `--density-*` tokens instead of
   hardcoding row heights/padding; `[data-density='compact']` on `<html>`
   flips them.


### PR DESCRIPTION
Follow-up to #423: the lab/Playwright validation layer shipped with only a script usage header and a private-cluster note — the two canon surfaces agents actually consult were silent. This PR routes it properly, per the agents-md-steward discipline (smallest durable home, attractors over prohibitions, no duplication):

- **`scripts/AGENTS.md`** (the owner of proof commands): Command Menu entry for `bun run lab:shots` — what it renders, the one layout assertion it makes, when to reach for it (rendered layout evidence jsdom cannot give), the one-time `bunx playwright install chromium` prerequisite, and the scope boundary: manual invocation only, fixture-only scenarios. Growth (media synthesis, screenshot-diff baselines, default-path/CI hooks) is phrased as *an owner decision, same pattern as the media lane* — a gate with an escalation path, not a "never". Script family line added for `lab-shots.ts`.
- **`src/AGENTS.md`**: the design-lab bullet gains a pointer to the scenario stages and defers all operational detail to the scripts owner — no rule duplicated across surfaces.

19 insertions, docs only. Validation: `git diff --check` clean; stale-language sweep found the layer referenced consistently across the three touched-or-related AGENTS files with each meaning in one home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfMiSrV1PVBd6KoXmjvreT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfMiSrV1PVBd6KoXmjvreT)_