### PR TITLE
PR-1: queue interaction truth — drag drop-position, click suppression, popover dismissal (F1, F18, F3)

### DIFF
--- a/src/ui/__tests__/metadataSurface-lifecycle.test.ts
+++ b/src/ui/__tests__/metadataSurface-lifecycle.test.ts
@@ -128,4 +128,49 @@ describe('MetadataSurfaceIsland lifecycle', () => {
 		await tick();
 		expect(screen.getByRole('tab', { name: 'Metadata' })).toHaveAttribute('aria-selected', 'true');
 	});
+
+	it('dismisses through the draft-preserving path on outside scroll, but ignores scroll inside the popover', async () => {
+		const onDismiss = vi.fn(async () => true);
+		const onPresentationReady = vi.fn();
+		render(MetadataSurfaceIsland, { onDismiss, onPresentationReady });
+		const runtime = onPresentationReady.mock.calls[0]?.[0] as {
+			open(anchor: HTMLElement): void;
+		};
+		const rowControl = document.createElement('button');
+		document.body.append(rowControl);
+		runtime.open(rowControl);
+		await tick();
+
+		const dialog = screen.getByTestId('metadata-surface');
+
+		// Scroll originating inside the popover's own body must not dismiss it.
+		await fireEvent.scroll(dialog);
+		expect(onDismiss).not.toHaveBeenCalled();
+
+		// A nested container scrolling elsewhere in the app (e.g. the file list)
+		// dismisses through the same draft-preserving onDismiss path the
+		// window-click handler uses.
+		const outsideContainer = document.createElement('div');
+		document.body.append(outsideContainer);
+		await fireEvent.scroll(outsideContainer);
+		expect(onDismiss).toHaveBeenCalledTimes(1);
+		expect(onDismiss).toHaveBeenCalledWith({ restoreFocus: false });
+	});
+
+	it('dismisses through the draft-preserving path on window resize', async () => {
+		const onDismiss = vi.fn(async () => true);
+		const onPresentationReady = vi.fn();
+		render(MetadataSurfaceIsland, { onDismiss, onPresentationReady });
+		const runtime = onPresentationReady.mock.calls[0]?.[0] as {
+			open(anchor: HTMLElement): void;
+		};
+		const rowControl = document.createElement('button');
+		document.body.append(rowControl);
+		runtime.open(rowControl);
+		await tick();
+
+		await fireEvent(window, new Event('resize'));
+
+		expect(onDismiss).toHaveBeenCalledWith({ restoreFocus: false });
+	});
 });

--- a/src/ui/fileList/FileListIsland.svelte
+++ b/src/ui/fileList/FileListIsland.svelte
@@ -45,6 +45,7 @@
 	let fileManagementContainer: HTMLDivElement | null = null;
 	let draggedIndex = $state<number | null>(null);
 	let hoveredIndex = $state<number | null>(null);
+	let hoveredEdge = $state<'top' | 'bottom' | null>(null);
 
 	const files = $derived(readFileListViewFiles());
 	const selectedIndices = $derived(readFileListSelectedIndices());
@@ -56,6 +57,7 @@
 	const reorderHandlers = createFileListPointerReorder((state) => {
 		draggedIndex = state.draggedIndex;
 		hoveredIndex = state.hoveredIndex;
+		hoveredEdge = state.hoveredEdge;
 	});
 
 	$effect(() => {
@@ -240,7 +242,8 @@
 						class:selected
 						class:active={active}
 						class:dragging={draggedIndex === index}
-						class:drag-over={hoveredIndex === index}
+						class:drag-over={hoveredIndex === index && hoveredEdge === 'top'}
+						class:drag-over-bottom={hoveredIndex === index && hoveredEdge === 'bottom'}
 						class:order-locked={orderLockVisible}
 						aria-selected={selected}
 						draggable="false"
@@ -333,6 +336,7 @@
 	.file-list-table tbody tr.selected { background: color-mix(in srgb, var(--accent-primary) 12%, transparent); box-shadow: inset 2px 0 0 var(--accent-primary); }
 	.file-list-table tbody tr.dragging { opacity: 0.5; }
 	.file-list-table tbody tr.drag-over { border-top: 2px solid var(--accent-primary); }
+	.file-list-table tbody tr.drag-over-bottom { border-bottom: 2px solid var(--accent-primary); }
 	.file-list-table tbody tr.order-locked { cursor: default; }
 	.file-list-reorder-cell { width: 1.5rem; padding-right: 0 !important; padding-left: var(--space-2) !important; text-align: center !important; }
 	.file-list-reorder-grip { display: inline-flex; align-items: center; justify-content: center; width: 1rem; color: var(--text-muted); cursor: grab; font-size: 0.875rem; line-height: 1; user-select: none; touch-action: none; }

--- a/src/ui/fileList/__tests__/drag-handlers.test.ts
+++ b/src/ui/fileList/__tests__/drag-handlers.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createFileListPointerReorder } from '../events';
+import { createFileListPointerReorder, type FileListRowHit } from '../events';
 import { reorderFiles } from '../actions';
 
 const context = vi.hoisted(() => ({
@@ -38,7 +38,10 @@ function gripPointerDown(clientX = 0, clientY = 0): PointerEvent {
 	} as unknown as PointerEvent;
 }
 
-function firePointer(type: 'pointermove' | 'pointerup' | 'pointercancel', init: PointerEventInit) {
+function firePointer(
+	type: 'pointermove' | 'pointerup' | 'pointercancel',
+	init: PointerEventInit,
+) {
 	window.dispatchEvent(new PointerEvent(type, { pointerId: POINTER_ID, ...init }));
 }
 
@@ -47,15 +50,15 @@ describe('createFileListPointerReorder', () => {
 		vi.mocked(reorderFiles).mockClear();
 		context.isOrderLockedMock.mockReturnValue(false);
 		context.getCurrentFileListMock.mockReturnValue({
-			files: [{ path: '/books/a.m4b' }, { path: '/books/b.m4b' }],
+			files: [{ path: '/a' }, { path: '/b' }, { path: '/c' }, { path: '/d' }, { path: '/e' }],
 		});
 	});
 
-	it('engages only after the movement threshold and reorders onto the hit-tested row', () => {
-		const states: Array<{ draggedIndex: number | null; hoveredIndex: number | null }> = [];
+	it('engages only after the movement threshold', () => {
+		const states: Array<{ draggedIndex: number | null; hoveredIndex: number | null; hoveredEdge: 'top' | 'bottom' | null }> = [];
 		const handlers = createFileListPointerReorder(
 			(state) => states.push(state),
-			() => 1,
+			() => ({ index: 1, edge: 'bottom' }),
 		);
 
 		handlers.onGripPointerDown(0, gripPointerDown());
@@ -63,7 +66,11 @@ describe('createFileListPointerReorder', () => {
 		expect(states).toHaveLength(0);
 
 		firePointer('pointermove', { clientX: 0, clientY: 24 });
-		expect(states[states.length - 1]).toEqual({ draggedIndex: 0, hoveredIndex: 1 });
+		expect(states[states.length - 1]).toEqual({
+			draggedIndex: 0,
+			hoveredIndex: 1,
+			hoveredEdge: 'bottom',
+		});
 
 		firePointer('pointerup', {});
 		expect(reorderFiles).toHaveBeenCalledWith(0, 1);
@@ -74,7 +81,7 @@ describe('createFileListPointerReorder', () => {
 	it('treats a press without threshold movement as a plain click', () => {
 		const handlers = createFileListPointerReorder(
 			() => {},
-			() => 1,
+			() => ({ index: 1, edge: 'top' }),
 		);
 
 		handlers.onGripPointerDown(0, gripPointerDown());
@@ -86,10 +93,10 @@ describe('createFileListPointerReorder', () => {
 	});
 
 	it('abandons the drag without reordering or click suppression on pointercancel', () => {
-		const states: Array<{ draggedIndex: number | null; hoveredIndex: number | null }> = [];
+		const states: Array<{ draggedIndex: number | null; hoveredIndex: number | null; hoveredEdge: 'top' | 'bottom' | null }> = [];
 		const handlers = createFileListPointerReorder(
 			(state) => states.push(state),
-			() => 1,
+			() => ({ index: 1, edge: 'top' }),
 		);
 
 		handlers.onGripPointerDown(0, gripPointerDown());
@@ -97,7 +104,11 @@ describe('createFileListPointerReorder', () => {
 		firePointer('pointercancel', {});
 
 		expect(reorderFiles).not.toHaveBeenCalled();
-		expect(states[states.length - 1]).toEqual({ draggedIndex: null, hoveredIndex: null });
+		expect(states[states.length - 1]).toEqual({
+			draggedIndex: null,
+			hoveredIndex: null,
+			hoveredEdge: null,
+		});
 		// Cancelled pointers emit no click; suppression must not eat the next one.
 		expect(handlers.consumePostDragClick()).toBe(false);
 	});
@@ -105,7 +116,7 @@ describe('createFileListPointerReorder', () => {
 	it('ignores secondary-button presses and locked order', () => {
 		const handlers = createFileListPointerReorder(
 			() => {},
-			() => 1,
+			() => ({ index: 1, edge: 'top' }),
 		);
 
 		handlers.onGripPointerDown(0, {
@@ -124,8 +135,8 @@ describe('createFileListPointerReorder', () => {
 	});
 
 	it('drops the hover target when the hit test misses or points at the dragged row', () => {
-		const states: Array<{ draggedIndex: number | null; hoveredIndex: number | null }> = [];
-		let target: number | null = 0;
+		const states: Array<{ draggedIndex: number | null; hoveredIndex: number | null; hoveredEdge: 'top' | 'bottom' | null }> = [];
+		let target: FileListRowHit | null = { index: 0, edge: 'top' };
 		const handlers = createFileListPointerReorder(
 			(state) => states.push(state),
 			() => target,
@@ -133,13 +144,144 @@ describe('createFileListPointerReorder', () => {
 
 		handlers.onGripPointerDown(0, gripPointerDown());
 		firePointer('pointermove', { clientX: 0, clientY: 24 });
-		expect(states[states.length - 1]).toEqual({ draggedIndex: 0, hoveredIndex: null });
+		expect(states[states.length - 1]).toEqual({
+			draggedIndex: 0,
+			hoveredIndex: null,
+			hoveredEdge: null,
+		});
 
 		target = null;
 		firePointer('pointermove', { clientX: 0, clientY: 30 });
-		expect(states[states.length - 1]).toEqual({ draggedIndex: 0, hoveredIndex: null });
+		expect(states[states.length - 1]).toEqual({
+			draggedIndex: 0,
+			hoveredIndex: null,
+			hoveredEdge: null,
+		});
 
 		firePointer('pointerup', {});
 		expect(reorderFiles).not.toHaveBeenCalled();
+	});
+
+	describe('midpoint hit-testing (F1)', () => {
+		function reorderWithHit(from: number, hit: FileListRowHit): void {
+			const handlers = createFileListPointerReorder(
+				() => {},
+				() => hit,
+			);
+			handlers.onGripPointerDown(from, gripPointerDown());
+			firePointer('pointermove', { clientX: 0, clientY: 24 });
+			firePointer('pointerup', {});
+		}
+
+		it('upper half of a row inserts above it: [A,B,C,D,E] drag A to upper-half D -> (0,2)', () => {
+			reorderWithHit(0, { index: 3, edge: 'top' });
+			expect(reorderFiles).toHaveBeenCalledWith(0, 2);
+		});
+
+		it('lower half of a row inserts below it: [A,B,C,D,E] drag A to lower-half D -> (0,3)', () => {
+			reorderWithHit(0, { index: 3, edge: 'bottom' });
+			expect(reorderFiles).toHaveBeenCalledWith(0, 3);
+		});
+
+		it('lower half of the last row appends at the tail: drag A to lower-half E -> (0,4)', () => {
+			reorderWithHit(0, { index: 4, edge: 'bottom' });
+			expect(reorderFiles).toHaveBeenCalledWith(0, 4);
+		});
+
+		it('dragging downward past a row still compensates correctly: drag E to upper-half B -> (4,1)', () => {
+			reorderWithHit(4, { index: 1, edge: 'top' });
+			expect(reorderFiles).toHaveBeenCalledWith(4, 1);
+		});
+
+		it('no-ops when the compensated destination equals the source', () => {
+			// Dropping on the lower half of the row directly above the dragged one
+			// resolves to the same position it already occupies.
+			reorderWithHit(1, { index: 0, edge: 'bottom' });
+			expect(reorderFiles).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('stuck click-suppression flag (F18a)', () => {
+		it('disarms on the next global pointerdown when no row click ever consumes it', () => {
+			const handlers = createFileListPointerReorder(
+				() => {},
+				() => ({ index: 1, edge: 'top' }),
+			);
+
+			handlers.onGripPointerDown(0, gripPointerDown());
+			firePointer('pointermove', { clientX: 0, clientY: 24 });
+			firePointer('pointerup', {});
+
+			// The click that would normally consume it never reaches a row (e.g.
+			// the pointer released outside any row); a later unrelated pointerdown
+			// must still clear the stale flag before its own click is evaluated.
+			window.dispatchEvent(new PointerEvent('pointerdown', { pointerId: POINTER_ID + 1 }));
+
+			expect(handlers.consumePostDragClick()).toBe(false);
+		});
+
+		it('still lets the immediate post-drag row click consume the flag', () => {
+			const handlers = createFileListPointerReorder(
+				() => {},
+				() => ({ index: 1, edge: 'top' }),
+			);
+
+			handlers.onGripPointerDown(0, gripPointerDown());
+			firePointer('pointermove', { clientX: 0, clientY: 24 });
+			firePointer('pointerup', {});
+
+			// The pointerup that armed suppression is not itself a pointerdown, so
+			// the very next row click (calling consumePostDragClick synchronously)
+			// still observes the flag armed.
+			expect(handlers.consumePostDragClick()).toBe(true);
+			expect(handlers.consumePostDragClick()).toBe(false);
+		});
+	});
+
+	describe('lostpointercapture listener leak (F18b)', () => {
+		it('removes the lostpointercapture listener on reset so a stale, delayed event cannot cancel a later drag with a reused pointer id', () => {
+			const states: Array<{ draggedIndex: number | null }> = [];
+			const handlers = createFileListPointerReorder(
+				(state) => states.push(state),
+				() => ({ index: 1, edge: 'top' }),
+			);
+
+			const firstGrip = document.createElement('span');
+			Object.assign(firstGrip, { setPointerCapture: vi.fn() });
+			handlers.onGripPointerDown(0, {
+				pointerId: POINTER_ID,
+				button: 0,
+				clientX: 0,
+				clientY: 0,
+				preventDefault: vi.fn(),
+				currentTarget: firstGrip,
+			} as unknown as PointerEvent);
+			firePointer('pointermove', { clientX: 0, clientY: 24 });
+			firePointer('pointerup', {});
+			vi.mocked(reorderFiles).mockClear();
+
+			// Start a second drag reusing the same pointer id (mouse pointer ids
+			// are recycled), then let the first grip's stale lostpointercapture
+			// arrive late.
+			const secondGrip = document.createElement('span');
+			Object.assign(secondGrip, { setPointerCapture: vi.fn() });
+			handlers.onGripPointerDown(2, {
+				pointerId: POINTER_ID,
+				button: 0,
+				clientX: 0,
+				clientY: 0,
+				preventDefault: vi.fn(),
+				currentTarget: secondGrip,
+			} as unknown as PointerEvent);
+			firePointer('pointermove', { clientX: 0, clientY: 24 });
+
+			firstGrip.dispatchEvent(new PointerEvent('lostpointercapture', { pointerId: POINTER_ID }));
+
+			// The stray event must not have cancelled the in-progress second drag.
+			expect(states[states.length - 1]?.draggedIndex).toBe(2);
+
+			firePointer('pointerup', {});
+			expect(reorderFiles).toHaveBeenCalledWith(2, 1);
+		});
 	});
 });

--- a/src/ui/fileList/events.ts
+++ b/src/ui/fileList/events.ts
@@ -23,9 +23,13 @@ import {
 export type FileListDragState = {
 	draggedIndex: number | null;
 	hoveredIndex: number | null;
+	hoveredEdge: 'top' | 'bottom' | null;
 };
 
-export type FileListRowHitTest = (clientX: number, clientY: number) => number | null;
+/** A hovered row plus which half of it the pointer is over. */
+export type FileListRowHit = { index: number; edge: 'top' | 'bottom' };
+
+export type FileListRowHitTest = (clientX: number, clientY: number) => FileListRowHit | null;
 
 export type FileListPointerReorderHandlers = {
 	onGripPointerDown: (index: number, event: PointerEvent) => void;
@@ -36,16 +40,21 @@ export type FileListPointerReorderHandlers = {
 const REORDER_DRAG_THRESHOLD_PX = 4;
 
 /**
- * Default hit test: the row index under the pointer. jsdom has no layout, so
- * tests inject their own hit test instead of stubbing elementFromPoint.
+ * Default hit test: the row under the pointer plus which half it's in. jsdom
+ * has no layout, so tests inject their own hit test instead of stubbing
+ * elementFromPoint/getBoundingClientRect.
  */
-export function fileListRowIndexFromPoint(clientX: number, clientY: number): number | null {
+export function fileListRowHitFromPoint(clientX: number, clientY: number): FileListRowHit | null {
 	if (typeof document.elementFromPoint !== 'function') return null;
 	const row = document
 		.elementFromPoint(clientX, clientY)
 		?.closest<HTMLElement>('tr[data-file-index]');
-	const index = row ? Number.parseInt(row.dataset.fileIndex ?? '', 10) : Number.NaN;
-	return Number.isInteger(index) ? index : null;
+	if (!row) return null;
+	const index = Number.parseInt(row.dataset.fileIndex ?? '', 10);
+	if (!Number.isInteger(index)) return null;
+	const rect = row.getBoundingClientRect();
+	const edge = clientY < rect.top + rect.height / 2 ? 'top' : 'bottom';
+	return { index, edge };
 }
 
 /**
@@ -55,7 +64,7 @@ export function fileListRowIndexFromPoint(clientX: number, clientY: number): num
  */
 export function createFileListPointerReorder(
 	setDragState: (state: FileListDragState) => void,
-	hitTest: FileListRowHitTest = fileListRowIndexFromPoint,
+	hitTest: FileListRowHitTest = fileListRowHitFromPoint,
 ): FileListPointerReorderHandlers {
 	let pressedIndex: number | null = null;
 	let pressedPointerId: number | null = null;
@@ -64,12 +73,35 @@ export function createFileListPointerReorder(
 	let dragEngaged = false;
 	let draggedIndex: number | null = null;
 	let hoveredIndex: number | null = null;
+	let hoveredEdge: 'top' | 'bottom' | null = null;
 	let suppressPostDragClick = false;
+	let pressedGrip: Element | null = null;
+	let lostPointerCaptureListener: ((event: Event) => void) | null = null;
 
 	function detachWindowListeners(): void {
 		window.removeEventListener('pointermove', handlePointerMove);
 		window.removeEventListener('pointerup', handlePointerUp);
 		window.removeEventListener('pointercancel', handlePointerCancel);
+	}
+
+	function detachLostPointerCaptureListener(): void {
+		if (pressedGrip && lostPointerCaptureListener) {
+			pressedGrip.removeEventListener('lostpointercapture', lostPointerCaptureListener);
+		}
+		pressedGrip = null;
+		lostPointerCaptureListener = null;
+	}
+
+	function disarmPostDragClickSuppression(): void {
+		suppressPostDragClick = false;
+		window.removeEventListener('pointerdown', disarmPostDragClickSuppression, true);
+	}
+
+	function armPostDragClickSuppression(): void {
+		suppressPostDragClick = true;
+		// The immediate post-drag click (if any) fires before the user's next
+		// pointerdown, so this only ever disarms a click that never arrived.
+		window.addEventListener('pointerdown', disarmPostDragClickSuppression, true);
 	}
 
 	function resetDragState(): void {
@@ -78,8 +110,10 @@ export function createFileListPointerReorder(
 		dragEngaged = false;
 		draggedIndex = null;
 		hoveredIndex = null;
+		hoveredEdge = null;
 		detachWindowListeners();
-		setDragState({ draggedIndex: null, hoveredIndex: null });
+		detachLostPointerCaptureListener();
+		setDragState({ draggedIndex: null, hoveredIndex: null, hoveredEdge: null });
 	}
 
 	function handlePointerMove(event: PointerEvent): void {
@@ -96,12 +130,15 @@ export function createFileListPointerReorder(
 			draggedIndex = pressedIndex;
 		}
 
-		const targetIndex = hitTest(event.clientX, event.clientY);
-		hoveredIndex =
-			targetIndex !== null && targetIndex !== draggedIndex && hasValidIndex(targetIndex)
-				? targetIndex
-				: null;
-		setDragState({ draggedIndex, hoveredIndex });
+		const hit = hitTest(event.clientX, event.clientY);
+		if (hit !== null && hit.index !== draggedIndex && hasValidIndex(hit.index)) {
+			hoveredIndex = hit.index;
+			hoveredEdge = hit.edge;
+		} else {
+			hoveredIndex = null;
+			hoveredEdge = null;
+		}
+		setDragState({ draggedIndex, hoveredIndex, hoveredEdge });
 	}
 
 	function handlePointerUp(event: PointerEvent): void {
@@ -109,17 +146,21 @@ export function createFileListPointerReorder(
 
 		if (dragEngaged) {
 			// Only an engaged drag suppresses the click that follows pointerup.
-			suppressPostDragClick = true;
+			armPostDragClickSuppression();
 			const from = draggedIndex;
-			const to = hoveredIndex;
 			if (
 				from !== null &&
-				to !== null &&
-				from !== to &&
+				hoveredIndex !== null &&
+				hoveredEdge !== null &&
 				!get(metadataSaveInProgress) &&
 				!isOrderLocked()
 			) {
-				reorderFiles(from, to);
+				// The indicator promises "insert above" (top) or "insert below"
+				// (bottom) of the hovered row; compensate for reorderFiles'
+				// remove-then-insert splice so the drop lands where it's shown.
+				const insertIndex = hoveredEdge === 'top' ? hoveredIndex : hoveredIndex + 1;
+				const to = from < insertIndex ? insertIndex - 1 : insertIndex;
+				if (to !== from) reorderFiles(from, to);
 			}
 		}
 		resetDragState();
@@ -151,11 +192,14 @@ export function createFileListPointerReorder(
 					// Losing capture mid-drag (e.g. the grip unmounting) abandons the
 					// drag like a cancel. On a normal pointerup this fires after state
 					// is already reset, so the pointer-id guard makes it a no-op.
-					grip.addEventListener(
-						'lostpointercapture',
-						(lostEvent) => handlePointerCancel(lostEvent as PointerEvent),
-						{ once: true },
-					);
+					// Tracked so resetDragState can remove it if it never fires,
+					// avoiding a stale listener surviving pointer-id reuse.
+					lostPointerCaptureListener = (lostEvent) =>
+						handlePointerCancel(lostEvent as PointerEvent);
+					pressedGrip = grip;
+					grip.addEventListener('lostpointercapture', lostPointerCaptureListener, {
+						once: true,
+					});
 				} catch {
 					// Capture is best-effort; window listeners carry the drag regardless.
 				}
@@ -166,7 +210,7 @@ export function createFileListPointerReorder(
 		},
 		consumePostDragClick() {
 			const shouldSuppress = suppressPostDragClick;
-			suppressPostDragClick = false;
+			if (shouldSuppress) disarmPostDragClickSuppression();
 			return shouldSuppress;
 		},
 	};

--- a/src/ui/metadataSurface/MetadataSurfaceIsland.svelte
+++ b/src/ui/metadataSurface/MetadataSurfaceIsland.svelte
@@ -49,6 +49,15 @@
 		}
 	}
 
+	// The list scrolls in a nested container, so a bubbling window listener
+	// would miss it; capture phase sees every scroll on the way down. Dismiss
+	// rather than reposition — the popover has no live anchor-tracking loop.
+	function handleScrollOrResizeDismiss(event: Event): void {
+		if (!popover.isOpen) return;
+		const target = event.target;
+		if (target instanceof Node && panel?.contains(target)) return;
+		void requestDismissal({ restoreFocus: false });
+	}
 
 	const railPresentation: Presentation = {
 		open: () => {},
@@ -87,6 +96,8 @@
 			void requestDismissal({ restoreFocus: false });
 		}
 	}}
+	onscrollcapture={handleScrollOrResizeDismiss}
+	onresize={handleScrollOrResizeDismiss}
 />
 
 <div class="metadata-surface-host" bind:this={host}>


### PR DESCRIPTION
Slice A of the #425 hardening roadmap (tracker: #426).

## What

- **F1** — drag-reorder drop now matches the indicator: midpoint hit-testing (upper half → insert above with `border-top`, lower half → insert below with `border-bottom`), with removal-first splice compensation in the drop handler. Downward drags no longer land one slot below the promise; append-after-last works via the last row's lower half. `reorderFiles` semantics unchanged.
- **F18a** — `suppressPostDragClick` disarms on the next global (capture-phase) pointerdown, so an interrupted drag can't eat the next intentional click. Normal post-drag consume path unchanged.
- **F18b** — the per-drag `lostpointercapture` listener is tracked and removed in `resetDragState`, closing the pointer-id-reuse race.
- **F3** — metadata popover dismisses on outside scroll (capture-phase, nested list container) and window resize via the existing draft-preserving `requestDismissal` path; scroll inside the popover is ignored. Dismissal chosen over live repositioning by owner decision.

## Proof

- `tsc --noEmit` clean · `svelte-check` 810 files, 0 errors/0 warnings
- Touched suites: drag-handlers + metadataSurface-lifecycle, 18 tests passing (incl. all four compensation traces and the last-row append)
- Full fileList + metadataSurface suites: 12 files, 103 tests passing

## Merge gate

Owner drag smoke: verify drag feel in the running app — downward drags, drop-below-last, and that a drag interrupted mid-gesture doesn't swallow the next click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)