### PR TITLE
PR-3: transport & work-center honesty — feedback lifecycle, ordering, retention (F11, F15, F5, F19a, F13)

### DIFF
--- a/src-tauri/src/work_runtime/AGENTS.md
+++ b/src-tauri/src/work_runtime/AGENTS.md
@@ -19,6 +19,14 @@
 
 - Own operation identity, immutable accepted submissions, operation snapshots,
   operation-scoped cancellation, and Work Center event truth.
+- Terminal-operation retention: `WorkRuntimeState` keeps at most
+  `TERMINAL_OPERATIONS_CAP` (20) terminal operations, pruned oldest-first by
+  TERMINALIZATION order (never submission sequence — a just-finished
+  long-running operation must survive its own prune). Running/accepted
+  operations are never pruned. The frontend purge tombstone
+  (`PURGED_OPERATION_TOMBSTONE_CAP` in `src/ui/workCenter/state.svelte.ts`)
+  must stay strictly larger than this cap; a contract test pins the
+  relationship — keep both sites and that test in sync.
 - Use `processing::run` as the processing executor boundary. Do not import audio
   processor internals, output-artifact internals, or remote-source private
   provider/materializer modules.

--- a/src-tauri/src/work_runtime/state.rs
+++ b/src-tauri/src/work_runtime/state.rs
@@ -54,6 +54,15 @@ fn push_operation_log(
     }
 }
 
+/// Cap on retained terminal operations (running/accepted operations are never
+/// pruned). Keeps unbounded history from growing forever while every
+/// currently-active operation stays visible. The frontend Work Center
+/// tombstone (`PURGED_OPERATION_TOMBSTONE_CAP` in
+/// `src/ui/workCenter/state.svelte.ts`) must stay larger than this cap so an
+/// operation pruned here can never be re-delivered after its frontend
+/// dedupe entry has been evicted.
+const TERMINAL_OPERATIONS_CAP: usize = 20;
+
 #[derive(Default)]
 pub(crate) struct WorkRuntimeState {
     operations: BTreeMap<String, OperationSnapshot>,
@@ -249,7 +258,9 @@ impl WorkRuntimeState {
             }
         }
 
-        Ok(snapshot.clone())
+        let snapshot = snapshot.clone();
+        self.prune_terminal_operations();
+        Ok(snapshot)
     }
 
     /// Terminalize a command-driven inline operation (metadata save) from its
@@ -287,7 +298,9 @@ impl WorkRuntimeState {
             }
         }
 
-        Ok(snapshot.clone())
+        let snapshot = snapshot.clone();
+        self.prune_terminal_operations();
+        Ok(snapshot)
     }
 
     pub(crate) fn fail(
@@ -322,7 +335,9 @@ impl WorkRuntimeState {
                 child.cancellable = false;
             }
         }
-        Ok(snapshot.clone())
+        let snapshot = snapshot.clone();
+        self.prune_terminal_operations();
+        Ok(snapshot)
     }
 
     pub(crate) fn cancel(
@@ -358,13 +373,36 @@ impl WorkRuntimeState {
                 child.cancel_requested = true;
             }
         }
-        Ok(snapshot.clone())
+        let snapshot = snapshot.clone();
+        self.prune_terminal_operations();
+        Ok(snapshot)
     }
 
     fn snapshot_mut(&mut self, operation_id: &OperationId) -> Result<&mut OperationSnapshot> {
         self.operations
             .get_mut(operation_id.as_str())
             .ok_or_else(|| AppError::InvalidInput("Work operation was not found.".to_string()))
+    }
+
+    /// Bound retained terminal-operation history: once more than
+    /// `TERMINAL_OPERATIONS_CAP` operations are terminal, drop the oldest
+    /// (lowest sequence) beyond the cap. Running/accepted operations are
+    /// never inspected here and are never pruned.
+    fn prune_terminal_operations(&mut self) {
+        let mut terminal_ids: Vec<(u64, String)> = self
+            .operations
+            .iter()
+            .filter(|(_, snapshot)| is_terminal(snapshot.status))
+            .map(|(id, snapshot)| (snapshot.sequence, id.clone()))
+            .collect();
+        if terminal_ids.len() <= TERMINAL_OPERATIONS_CAP {
+            return;
+        }
+        terminal_ids.sort_by_key(|(sequence, _)| *sequence);
+        let excess = terminal_ids.len() - TERMINAL_OPERATIONS_CAP;
+        for (_, id) in terminal_ids.into_iter().take(excess) {
+            self.operations.remove(&id);
+        }
     }
 }
 

--- a/src-tauri/src/work_runtime/state.rs
+++ b/src-tauri/src/work_runtime/state.rs
@@ -66,6 +66,11 @@ const TERMINAL_OPERATIONS_CAP: usize = 20;
 #[derive(Default)]
 pub(crate) struct WorkRuntimeState {
     operations: BTreeMap<String, OperationSnapshot>,
+    /// Operation ids in the order they terminalized (runtime-internal, never
+    /// serialized). Pruning follows this order — not submission `sequence` —
+    /// so a long-running operation that finishes late is the NEWEST terminal
+    /// entry and survives, instead of being evicted the moment it completes.
+    terminal_order: Vec<String>,
 }
 
 impl WorkRuntimeState {
@@ -259,6 +264,7 @@ impl WorkRuntimeState {
         }
 
         let snapshot = snapshot.clone();
+        self.record_terminal_operation(operation_id.as_str());
         self.prune_terminal_operations();
         Ok(snapshot)
     }
@@ -299,6 +305,7 @@ impl WorkRuntimeState {
         }
 
         let snapshot = snapshot.clone();
+        self.record_terminal_operation(operation_id.as_str());
         self.prune_terminal_operations();
         Ok(snapshot)
     }
@@ -336,6 +343,7 @@ impl WorkRuntimeState {
             }
         }
         let snapshot = snapshot.clone();
+        self.record_terminal_operation(operation_id.as_str());
         self.prune_terminal_operations();
         Ok(snapshot)
     }
@@ -374,6 +382,7 @@ impl WorkRuntimeState {
             }
         }
         let snapshot = snapshot.clone();
+        self.record_terminal_operation(operation_id.as_str());
         self.prune_terminal_operations();
         Ok(snapshot)
     }
@@ -384,24 +393,23 @@ impl WorkRuntimeState {
             .ok_or_else(|| AppError::InvalidInput("Work operation was not found.".to_string()))
     }
 
-    /// Bound retained terminal-operation history: once more than
-    /// `TERMINAL_OPERATIONS_CAP` operations are terminal, drop the oldest
-    /// (lowest sequence) beyond the cap. Running/accepted operations are
-    /// never inspected here and are never pruned.
-    fn prune_terminal_operations(&mut self) {
-        let mut terminal_ids: Vec<(u64, String)> = self
-            .operations
-            .iter()
-            .filter(|(_, snapshot)| is_terminal(snapshot.status))
-            .map(|(id, snapshot)| (snapshot.sequence, id.clone()))
-            .collect();
-        if terminal_ids.len() <= TERMINAL_OPERATIONS_CAP {
-            return;
+    /// Record an operation as terminalized, once, in completion order.
+    fn record_terminal_operation(&mut self, operation_id: &str) {
+        if !self.terminal_order.iter().any(|id| id == operation_id) {
+            self.terminal_order.push(operation_id.to_string());
         }
-        terminal_ids.sort_by_key(|(sequence, _)| *sequence);
-        let excess = terminal_ids.len() - TERMINAL_OPERATIONS_CAP;
-        for (_, id) in terminal_ids.into_iter().take(excess) {
-            self.operations.remove(&id);
+    }
+
+    /// Bound retained terminal-operation history: once more than
+    /// `TERMINAL_OPERATIONS_CAP` operations are terminal, drop the oldest by
+    /// TERMINALIZATION order (`terminal_order`), never by submission
+    /// sequence — a just-finished long-running operation must survive the
+    /// prune that its own completion triggers. Running/accepted operations
+    /// are never inspected and never pruned.
+    fn prune_terminal_operations(&mut self) {
+        while self.terminal_order.len() > TERMINAL_OPERATIONS_CAP {
+            let oldest = self.terminal_order.remove(0);
+            self.operations.remove(&oldest);
         }
     }
 }

--- a/src-tauri/src/work_runtime/state_tests.rs
+++ b/src-tauri/src/work_runtime/state_tests.rs
@@ -661,6 +661,57 @@ fn prune_terminal_operations_keeps_cap_most_recent_and_never_prunes_active() {
 }
 
 #[test]
+fn prune_orders_by_terminalization_so_a_just_finished_long_runner_survives() {
+    let mut state = WorkRuntimeState::default();
+
+    // A low-sequence operation that stays running for a long time.
+    let long_runner = OperationId("long-runner".to_string());
+    state.insert_operation(new_processing_snapshot(
+        long_runner.clone(),
+        1,
+        OperationKind::ProcessingBatch,
+        "Long batch".to_string(),
+        &["/tmp/long.m4b".to_string()],
+        None,
+        100,
+    ));
+    state.mark_running(&long_runner, 100).expect("running");
+
+    // 25 newer operations terminalize while it runs.
+    for sequence in 2..=26u64 {
+        let id = OperationId(format!("term-{sequence}"));
+        state.insert_operation(new_processing_snapshot(
+            id.clone(),
+            sequence,
+            OperationKind::ProcessingBatch,
+            format!("Batch {sequence}"),
+            &["/tmp/f.m4b".to_string()],
+            None,
+            100,
+        ));
+        state
+            .fail(&id, "boom".to_string(), 100 + sequence as i64)
+            .expect("fail terminalizes and prunes");
+    }
+
+    // Now the long runner finishes. Pruning by submission sequence would
+    // evict it immediately (it has the lowest sequence); pruning by
+    // terminalization order must keep it as the NEWEST terminal entry.
+    state
+        .fail(&long_runner, "done late".to_string(), 10_000)
+        .expect("long runner terminalizes");
+
+    assert!(
+        state.get(&long_runner).is_ok(),
+        "the just-finished long-running operation must survive its own prune"
+    );
+    let list = state.list();
+    assert_eq!(list.operations.len(), 20, "terminal cap holds");
+    // The oldest-terminalized entries were evicted instead.
+    assert!(state.get(&OperationId("term-2".to_string())).is_err());
+}
+
+#[test]
 fn log_tail_records_the_cancellation_request_transition() {
     let (mut state, operation_id) = accepted_state();
     state.mark_running(&operation_id, 100).expect("running");

--- a/src-tauri/src/work_runtime/state_tests.rs
+++ b/src-tauri/src/work_runtime/state_tests.rs
@@ -607,6 +607,60 @@ fn log_tail_keeps_identical_messages_from_distinct_children() {
 }
 
 #[test]
+fn prune_terminal_operations_keeps_cap_most_recent_and_never_prunes_active() {
+    let mut state = WorkRuntimeState::default();
+
+    // 25 terminal operations, sequence 1..=25, oldest first.
+    for sequence in 1..=25u64 {
+        let id = OperationId(format!("term-{sequence}"));
+        state.insert_operation(new_processing_snapshot(
+            id.clone(),
+            sequence,
+            OperationKind::ProcessingBatch,
+            format!("Batch {sequence}"),
+            &["/tmp/f.m4b".to_string()],
+            None,
+            100,
+        ));
+        state
+            .fail(&id, "boom".to_string(), 100 + sequence as i64)
+            .expect("fail terminalizes and prunes");
+    }
+
+    // A running operation must survive pruning regardless of its sequence.
+    let running_id = OperationId("running-op".to_string());
+    state.insert_operation(new_processing_snapshot(
+        running_id.clone(),
+        1,
+        OperationKind::ProcessingBatch,
+        "Running".to_string(),
+        &["/tmp/r.m4b".to_string()],
+        None,
+        500,
+    ));
+    state.mark_running(&running_id, 500).expect("running");
+
+    let list = state.list();
+    assert_eq!(list.operations.len(), 21, "20 terminal + 1 running");
+    assert!(state.get(&running_id).is_ok());
+
+    // Oldest 5 terminal ops (sequence 1..=5) were pruned; the 20 most recent
+    // (sequence 6..=25) remain.
+    for sequence in 1..=5u64 {
+        assert!(
+            state.get(&OperationId(format!("term-{sequence}"))).is_err(),
+            "sequence {sequence} should have been pruned"
+        );
+    }
+    for sequence in 6..=25u64 {
+        assert!(
+            state.get(&OperationId(format!("term-{sequence}"))).is_ok(),
+            "sequence {sequence} should be retained"
+        );
+    }
+}
+
+#[test]
 fn log_tail_records_the_cancellation_request_transition() {
     let (mut state, operation_id) = accepted_state();
     state.mark_running(&operation_id, 100).expect("running");

--- a/src/lib/ui/modal.svelte.test.ts
+++ b/src/lib/ui/modal.svelte.test.ts
@@ -154,15 +154,16 @@ describe('ModalController', () => {
 		// focus() call is a no-op, later calls behave normally.
 		const nativeFocus = HTMLElement.prototype.focus;
 		let refusals = 1;
-		const focusSpy = vi
-			.spyOn(HTMLElement.prototype, 'focus')
-			.mockImplementation(function (this: HTMLElement, ...args) {
-				if (refusals > 0) {
-					refusals -= 1;
-					return;
-				}
-				nativeFocus.apply(this, args);
-			});
+		const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus').mockImplementation(function (
+			this: HTMLElement,
+			...args
+		) {
+			if (refusals > 0) {
+				refusals -= 1;
+				return;
+			}
+			nativeFocus.apply(this, args);
+		});
 
 		modal.sync(true, { container }, { onEscape: vi.fn() });
 		await flushMicrotasks();

--- a/src/ui/operationsBar/AGENTS.md
+++ b/src/ui/operationsBar/AGENTS.md
@@ -10,12 +10,20 @@
   `pinned`). It is not persisted.
 - Compose public islands and read accessors from Status Panel, Work Center,
   and FileList. Do not import their private state, reducers, or handlers.
-- The bar composes the transport precedence: Status Panel's retained
-  foreground line (via `readStatusTransportActive` + `StatusTransportIsland`)
-  wins; otherwise the top running WorkRuntime operation renders an
-  operationsBar-owned mono line from snapshot truth; otherwise idle with an
-  order-lock suffix from the FileList strip. Status Panel itself never reads
-  WorkRuntime state — the union lives here.
+- The bar composes the transport precedence: live foreground processing
+  (via `readStatusTransportProcessing` + `StatusTransportIsland`) wins;
+  otherwise the top running/cancelling WorkRuntime operation renders an
+  operationsBar-owned mono line from snapshot truth; otherwise
+  `StatusTransportIsland` again (retained showSuccess/showError verdict or
+  idle) with an order-lock suffix from the FileList strip. Status Panel
+  itself never reads WorkRuntime state — the union lives here.
+- Retained-verdict lifecycle: the bar clears Status Panel's retained
+  feedback (`clearStatusPanelRetainedFeedback`) only when a background
+  operation APPEARS over an idle transport row — a true takeover. A verdict
+  written while an operation is already running (a preview finishing during
+  background work) is fresh and must survive to win precedence when the
+  background row yields. Preserve this transition guard when editing this
+  island.
 - Preview controls no longer live in this bar; the Process split-button in the
   toolbar owns preview entry (previewAudio strip).
 

--- a/src/ui/operationsBar/OperationsBarIsland.svelte
+++ b/src/ui/operationsBar/OperationsBarIsland.svelte
@@ -5,7 +5,11 @@
 		readCombinedSizeText,
 		readFileListOrderLockVisible,
 	} from '../fileList';
-	import { readStatusTransportProcessing, StatusTransportIsland } from '../statusPanel';
+	import {
+		clearStatusPanelRetainedFeedback,
+		readStatusTransportProcessing,
+		StatusTransportIsland,
+	} from '../statusPanel';
 	import { formatEtaRemaining } from '../../lib/format/eta';
 	import { deriveWorkOperationCounts, workCenterState, WorkCenterIsland } from '../workCenter';
 	import { toggleOpsDisclosure, toggleOpsPin, type OpsMode } from './mode';
@@ -22,6 +26,15 @@
 			(operation) => operation.status === 'running' || operation.status === 'cancelling',
 		),
 	);
+
+	// The background operation takes over the transport row here — clear any
+	// retained preview verdict so it cannot resurface once this operation
+	// finishes and the row reverts to StatusTransportIsland (F11).
+	$effect(() => {
+		if (!statusTransportProcessing && runningOperation) {
+			clearStatusPanelRetainedFeedback();
+		}
+	});
 
 	function toggleDisclosure(): void {
 		mode = toggleOpsDisclosure(mode);
@@ -78,7 +91,14 @@
 		>
 			{#if !statusTransportProcessing && runningOperation}
 				<div class="operations-bar-background-transport" aria-label="Background operation transport">
-					<div class="app-progress-track operations-bar-background-track">
+					<div
+						class="app-progress-track operations-bar-background-track"
+						role="progressbar"
+						aria-label="Background operation progress"
+						aria-valuemin="0"
+						aria-valuemax="100"
+						aria-valuenow={Math.round(runningOperation.progress.percentage)}
+					>
 						<div
 							class="app-progress-fill"
 							style={`width: ${runningOperation.progress.percentage}%`}
@@ -94,7 +114,7 @@
 			{:else}
 				<StatusTransportIsland />
 				{#if !statusTransportProcessing && orderLockVisible}
-					<span class="mono operations-bar-order-lock">· order locked</span>
+					<span class="mono operations-bar-order-lock">· order locked (submitting)</span>
 				{/if}
 			{/if}
 		</div>

--- a/src/ui/operationsBar/OperationsBarIsland.svelte
+++ b/src/ui/operationsBar/OperationsBarIsland.svelte
@@ -27,13 +27,20 @@
 		),
 	);
 
-	// The background operation takes over the transport row here — clear any
-	// retained preview verdict so it cannot resurface once this operation
-	// finishes and the row reverts to StatusTransportIsland (F11).
+	// Clear retained preview verdicts only on a true background takeover of an
+	// idle transport row (F11): a background operation APPEARING while the
+	// foreground is not processing. Any verdict retained at that moment
+	// predates the takeover and would be stale when the row reverts. A verdict
+	// written while an operation is already running (preview finishing during
+	// background work) is fresh — it must survive and win precedence once the
+	// background row yields.
+	let hadRunningOperation = false;
 	$effect(() => {
-		if (!statusTransportProcessing && runningOperation) {
+		const hasRunningOperation = runningOperation !== undefined;
+		if (hasRunningOperation && !hadRunningOperation && !statusTransportProcessing) {
 			clearStatusPanelRetainedFeedback();
 		}
+		hadRunningOperation = hasRunningOperation;
 	});
 
 	function toggleDisclosure(): void {

--- a/src/ui/operationsBar/__tests__/operationsBar.test.ts
+++ b/src/ui/operationsBar/__tests__/operationsBar.test.ts
@@ -181,6 +181,31 @@ describe('OperationsBarIsland', () => {
 		expect(screen.queryByText(/Error: Preview failed./)).not.toBeInTheDocument();
 	});
 
+	it('preserves a verdict written while a background operation was already running', async () => {
+		const { showError } = await import('../../statusPanel/viewState.svelte');
+		render(OperationsBarIsland);
+
+		// Foreground preview is active when the background operation appears —
+		// not a takeover of an idle row, so nothing may be cleared.
+		statusPanelViewState.isProcessing = true;
+		await tick();
+		applyOperationListSnapshot(operationList(operation()));
+		await tick();
+
+		// The preview finishes DURING the background operation: its verdict is
+		// fresh, not stale, and must survive the row being in background mode.
+		statusPanelViewState.isProcessing = false;
+		showError('Preview failed.');
+		await tick();
+
+		// Background operation terminalizes → the row reverts to the status
+		// transport → the fresh verdict wins, instead of being erased.
+		applyOperationListSnapshot(operationList({ ...operation(), status: 'completed' }));
+		await waitFor(() => {
+			expect(screen.getByText(/Preview failed./)).toBeInTheDocument();
+		});
+	});
+
 	it('renders a cancelling operation on the background transport, not idle', async () => {
 		const { container } = render(OperationsBarIsland);
 		applyOperationListSnapshot(operationList({ ...operation(), status: 'cancelling' }));

--- a/src/ui/operationsBar/__tests__/operationsBar.test.ts
+++ b/src/ui/operationsBar/__tests__/operationsBar.test.ts
@@ -150,7 +150,7 @@ describe('OperationsBarIsland', () => {
 	});
 
 	it('renders a running background transport when foreground transport is idle', async () => {
-		render(OperationsBarIsland);
+		const { container } = render(OperationsBarIsland);
 		applyOperationListSnapshot(
 			operationList({ ...operation(), progress: { ...operation().progress, etaSeconds: 242 } }),
 		);
@@ -161,6 +161,12 @@ describe('OperationsBarIsland', () => {
 			).toBeInTheDocument();
 		});
 		expect(screen.queryByTestId('status-transport-progress')).not.toBeInTheDocument();
+
+		const track = container.querySelector('.operations-bar-background-track') as HTMLElement;
+		expect(track).toHaveAttribute('role', 'progressbar');
+		expect(track).toHaveAttribute('aria-valuemin', '0');
+		expect(track).toHaveAttribute('aria-valuemax', '100');
+		expect(track).toHaveAttribute('aria-valuenow', '64');
 	});
 
 	it('lets a running operation outrank persistent foreground feedback', async () => {
@@ -192,7 +198,7 @@ describe('OperationsBarIsland', () => {
 		render(OperationsBarIsland);
 		await waitFor(() => {
 			expect(screen.getByText(/Idle/)).toBeInTheDocument();
-			expect(screen.getByText('· order locked')).toBeInTheDocument();
+			expect(screen.getByText('· order locked (submitting)')).toBeInTheDocument();
 		});
 	});
 
@@ -218,6 +224,11 @@ describe('OperationsBarIsland', () => {
 
 	it('carries runtime events through the Work Center UI from progress to cancellation terminal truth', async () => {
 		(window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+		// A stale preview verdict from an earlier, unrelated run must not
+		// resurface once this background operation finishes and the transport
+		// row reverts to StatusTransportIsland (F11).
+		const { showError } = await import('../../statusPanel/viewState.svelte');
+		showError('Stale preview verdict.');
 		const running = {
 			...operation(),
 			progress: { ...operation().progress, etaSeconds: 242 },
@@ -301,6 +312,7 @@ describe('OperationsBarIsland', () => {
 		await waitFor(() => expect(screen.getByText('cancelled')).toBeInTheDocument());
 		expect(screen.getByText('Cancelled 1/1.')).toBeInTheDocument();
 		expect(screen.getByText(/^Idle$/)).toBeInTheDocument();
+		expect(screen.queryByText(/Stale preview verdict\./)).not.toBeInTheDocument();
 	});
 
 	it('keeps foreground transport and background operation snapshots in separate lanes', async () => {

--- a/src/ui/statusPanel/StatusTransportIsland.svelte
+++ b/src/ui/statusPanel/StatusTransportIsland.svelte
@@ -4,11 +4,13 @@
 	import { formatEtaRemaining } from './formatting';
 	import { STATUS_PANEL_DEFAULT_STEP_COLOR, statusPanelViewState } from './viewState.svelte';
 
-	// One mono transport line. Precedence: showError/showSuccess feedback
-	// (never demoted to tooltip) → active processing summary → idle status.
-	// The informational step message surfaces as the line's tooltip.
+	// One mono transport line. Precedence: active foreground progress (a live
+	// preview must never be hidden behind a retained verdict) → showError/
+	// showSuccess feedback (never demoted to tooltip) → idle status. The
+	// informational step message surfaces as the line's tooltip.
 	const feedbackActive = $derived(
-		statusPanelViewState.stepColor !== STATUS_PANEL_DEFAULT_STEP_COLOR &&
+		!statusPanelViewState.isProcessing &&
+			statusPanelViewState.stepColor !== STATUS_PANEL_DEFAULT_STEP_COLOR &&
 			statusPanelViewState.stepText.length > 0,
 	);
 	const transportTail = $derived(
@@ -17,10 +19,10 @@
 			: statusPanelViewState.statusText,
 	);
 	const transportLine = $derived(
-		feedbackActive
-			? statusPanelViewState.stepText
-			: statusPanelViewState.isProcessing
-				? `${statusPanelViewState.foregroundJobLabel ?? 'Preview'} · ${statusPanelViewState.progressPercentage.toFixed(0)}% · ${transportTail}`
+		statusPanelViewState.isProcessing
+			? `${statusPanelViewState.foregroundJobLabel ?? 'Preview'} · ${statusPanelViewState.progressPercentage.toFixed(0)}% · ${transportTail}`
+			: feedbackActive
+				? statusPanelViewState.stepText
 				: statusPanelViewState.statusText,
 	);
 
@@ -31,7 +33,14 @@
 
 <div class="status-transport" aria-label="Preview transport">
 	<div class="status-transport-track">
-		<div class="app-progress-track" aria-label="Preview progress">
+		<div
+			class="app-progress-track"
+			role="progressbar"
+			aria-label="Preview progress"
+			aria-valuemin="0"
+			aria-valuemax="100"
+			aria-valuenow={Math.round(statusPanelViewState.progressPercentage)}
+		>
 			<div
 				class="app-progress-fill status-transport-fill"
 				data-testid="status-transport-progress"

--- a/src/ui/statusPanel/__tests__/runtime-api-contract.test.ts
+++ b/src/ui/statusPanel/__tests__/runtime-api-contract.test.ts
@@ -6,6 +6,7 @@ import * as statusPanel from '..';
 
 const EXPECTED_STATUS_PANEL_EXPORTS = [
 	'StatusTransportIsland',
+	'clearStatusPanelRetainedFeedback',
 	'initStatusPanel',
 	'isStatusPanelProcessing',
 	'pushStatusPanelTransientStatus',

--- a/src/ui/statusPanel/__tests__/statusTransport-island.test.ts
+++ b/src/ui/statusPanel/__tests__/statusTransport-island.test.ts
@@ -35,6 +35,12 @@ describe('Status Transport island mount', () => {
 		});
 		expect(document.body.textContent).toContain('Previewing');
 		expect(initStatusPanelLogicMock).toHaveBeenCalledTimes(1);
+
+		const track = document.querySelector('[aria-label="Preview progress"]') as HTMLElement;
+		expect(track).toHaveAttribute('role', 'progressbar');
+		expect(track).toHaveAttribute('aria-valuemin', '0');
+		expect(track).toHaveAttribute('aria-valuemax', '100');
+		expect(track).toHaveAttribute('aria-valuenow', '42');
 	});
 
 	it('prefers the backend-authored ETA over the stage text in the transport line', async () => {
@@ -73,6 +79,20 @@ describe('Status Transport island mount', () => {
 		expect(document.querySelector('.status-transport-copy')?.getAttribute('title')).toBe(
 			'Current Step: Writing chapter metadata',
 		);
+	});
+
+	it('lets live foreground progress outrank a retained verdict from an earlier run', async () => {
+		render(StatusTransportIsland);
+		showError('Stale preview verdict.');
+		statusPanelViewState.isProcessing = true;
+		statusPanelViewState.progressPercentage = 12;
+		statusPanelViewState.statusText = 'Converting';
+		statusPanelViewState.foregroundJobLabel = 'New Preview.m4b';
+		await tick();
+
+		const line = document.querySelector('[data-testid="status-transport-line"]') as HTMLElement;
+		expect(line.textContent).toContain('New Preview.m4b · 12% · Converting');
+		expect(line.textContent).not.toContain('Stale preview verdict.');
 	});
 
 	it('keeps showError feedback visible on the transport line', async () => {

--- a/src/ui/statusPanel/controller.ts
+++ b/src/ui/statusPanel/controller.ts
@@ -31,7 +31,13 @@ import {
 	type StatusPanelModel,
 	workKindFromOperationKind,
 } from './domain/stateMachine';
-import { pushTransientStatusMessage, showError, showInfo, showSuccess } from './viewState.svelte';
+import {
+	clearStatusPanelFeedback,
+	pushTransientStatusMessage,
+	showError,
+	showInfo,
+	showSuccess,
+} from './viewState.svelte';
 
 export class StatusPanelRuntime {
 	private readonly progressSubscription = createProgressSubscription({
@@ -394,4 +400,7 @@ export function pushStatusPanelTransientStatus(
 	options?: { ttlMs?: number },
 ): void {
 	pushTransientStatusMessage(message, options?.ttlMs);
+}
+export function clearStatusPanelRetainedFeedback(): void {
+	clearStatusPanelFeedback();
 }

--- a/src/ui/statusPanel/index.ts
+++ b/src/ui/statusPanel/index.ts
@@ -1,4 +1,5 @@
 export {
+	clearStatusPanelRetainedFeedback,
 	initStatusPanel,
 	isStatusPanelProcessing,
 	pushStatusPanelTransientStatus,

--- a/src/ui/statusPanel/viewState.svelte.ts
+++ b/src/ui/statusPanel/viewState.svelte.ts
@@ -126,6 +126,15 @@ export function setStatusPanelStepColor(value: string): void {
 	statusPanelViewState.stepColor = value;
 }
 
+// Resets a retained showSuccess/showError/showInfo verdict back to idle
+// defaults. Called when a background WorkRuntime operation takes over the
+// transport row, so a stale preview verdict cannot resurface once that
+// operation finishes and the row reverts to this island.
+export function clearStatusPanelFeedback(): void {
+	statusPanelViewState.stepText = DEFAULT_STATUS_PANEL_VIEW_STATE.stepText;
+	statusPanelViewState.stepColor = DEFAULT_STATUS_PANEL_VIEW_STATE.stepColor;
+}
+
 export function setStatusPanelEtaSeconds(etaSeconds: number | null): void {
 	statusPanelViewState.etaSeconds = etaSeconds;
 }

--- a/src/ui/workCenter/WorkCenterIsland.svelte
+++ b/src/ui/workCenter/WorkCenterIsland.svelte
@@ -179,7 +179,14 @@
 							{#each operation.lanes as lane (lane)}
 								<div class="lane" data-testid={`operation-lane-${lane}`}>
 									<span>{laneLabel(lane)}</span>
-									<div class="app-progress-track work-operation-lane-track">
+									<div
+										class="app-progress-track work-operation-lane-track"
+										role="progressbar"
+										aria-label={`${laneLabel(lane)} progress`}
+										aria-valuemin="0"
+										aria-valuemax="100"
+										aria-valuenow={Math.round(lanePercentage(operation, lane))}
+									>
 										<div
 										class="app-progress-fill"
 										class:lane-fill-done={lanePercentage(operation, lane) >= 100}

--- a/src/ui/workCenter/__tests__/model.test.ts
+++ b/src/ui/workCenter/__tests__/model.test.ts
@@ -106,6 +106,24 @@ describe('Work Center model', () => {
 		]);
 	});
 
+	it('keeps a running operation above a newer queued or terminal submission', () => {
+		const running = operation('running', 1);
+		running.status = 'running';
+		const queuedNewer = operation('queued-newer', 2);
+		queuedNewer.status = 'accepted';
+		const terminalNewest = operation('terminal-newest', 3);
+		terminalNewest.status = 'completed';
+
+		const list = { operations: [terminalNewest, queuedNewer, running] };
+		const model = replaceOperations({ operations: [] }, list);
+
+		expect(model.operations.map((item) => item.operationId)).toEqual([
+			'running',
+			'queued-newer',
+			'terminal-newest',
+		]);
+	});
+
 	it('joins batch children to their input ids and maps terminal child status', () => {
 		const snapshot = operation('batch', 1);
 		snapshot.children[0] = {

--- a/src/ui/workCenter/__tests__/retention-caps.contract.test.ts
+++ b/src/ui/workCenter/__tests__/retention-caps.contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+const fsPromisesSpecifier = 'node:fs/promises';
+const { readFile } = (await import(fsPromisesSpecifier)) as {
+	readFile(path: string, encoding: 'utf8'): Promise<string>;
+};
+
+// Cross-source contract: the frontend purge tombstone may only evict ids the
+// backend has already pruned, which holds only while the frontend cap stays
+// strictly larger than the backend terminal-retention cap. The two constants
+// live in different languages, so paired comments cannot enforce the
+// relationship — this test does.
+async function constantFrom(filePath: string, pattern: RegExp): Promise<number> {
+	const source = await readFile(filePath, 'utf8');
+	const match = source.match(pattern);
+	if (!match) throw new Error(`Constant not found in ${filePath} (pattern ${pattern})`);
+	return Number(match[1]);
+}
+
+describe('terminal-retention caps contract', () => {
+	it('keeps the frontend purge tombstone strictly larger than the backend terminal cap', async () => {
+		const backendCap = await constantFrom(
+			'src-tauri/src/work_runtime/state.rs',
+			/const TERMINAL_OPERATIONS_CAP: usize = (\d+);/,
+		);
+		const frontendCap = await constantFrom(
+			'src/ui/workCenter/state.svelte.ts',
+			/const PURGED_OPERATION_TOMBSTONE_CAP = (\d+);/,
+		);
+		expect(backendCap).toBeGreaterThan(0);
+		expect(frontendCap).toBeGreaterThan(backendCap);
+	});
+});

--- a/src/ui/workCenter/__tests__/state.test.ts
+++ b/src/ui/workCenter/__tests__/state.test.ts
@@ -143,6 +143,42 @@ describe('Work Center state', () => {
 		resolvePurge();
 	});
 
+	it('bounds the purge tombstone and tolerates a stale replay of an evicted id without crashing or double-purging', async () => {
+		// The tombstone is a bounded FIFO (cap 64): once 64 distinct terminal
+		// operations have been purged, the 65th eviction drops the oldest entry.
+		// This mirrors the backend's own terminal-operation cap (20, see
+		// src-tauri/src/work_runtime/state.rs) — the frontend cap must stay
+		// larger so an evicted id can never legitimately reappear in a list
+		// snapshot; this test only proves the eviction itself is safe.
+		vi.resetModules();
+		const fresh = await import('../state.svelte');
+
+		for (let index = 0; index < 64; index += 1) {
+			fresh.applyOperationSnapshot(completedMergeOperation(`fill-${index}`));
+		}
+		await Promise.resolve();
+		releaseMock.mockClear();
+		purgeMock.mockClear();
+
+		// The 65th distinct terminal operation evicts the oldest tombstone entry (fill-0).
+		fresh.applyOperationSnapshot(completedMergeOperation('fill-64'));
+		await Promise.resolve();
+		expect(releaseMock).toHaveBeenCalledTimes(1);
+		expect(purgeMock).toHaveBeenCalledTimes(1);
+
+		releaseMock.mockClear();
+		purgeMock.mockClear();
+
+		// A stale replay of the now-evicted id must not throw and must settle
+		// through the same single release/purge path, not a double release.
+		expect(() => fresh.applyOperationSnapshot(completedMergeOperation('fill-0'))).not.toThrow();
+		await Promise.resolve();
+		expect(releaseMock).toHaveBeenCalledTimes(1);
+		expect(purgeMock).toHaveBeenCalledTimes(1);
+
+		fresh.disposeWorkCenter();
+	});
+
 	it('does not mark initialized or retain listeners when disposed mid-initialization', async () => {
 		(window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
 		const snapshotUnlisten = vi.fn();

--- a/src/ui/workCenter/__tests__/workCenterIsland.test.ts
+++ b/src/ui/workCenter/__tests__/workCenterIsland.test.ts
@@ -65,6 +65,32 @@ describe('WorkCenterIsland operation cards', () => {
 			status: 'completed',
 			title: 'Completed book',
 			finishedAtMs: Date.now() - 2 * 60 * 1000,
+			children: [
+				{
+					childJobId: 'completed-1-child',
+					operationId: 'completed-1',
+					label: 'Completed book.m4b',
+					status: 'completed',
+					lane: 'encodeCpu',
+					progress: {
+						stage: 'complete',
+						percentage: 100,
+						message: 'Complete.',
+						currentItemIndex: undefined,
+						totalItems: 1,
+						bytesDownloaded: undefined,
+						bytesTotal: undefined,
+						etaSeconds: undefined,
+					},
+					sourcePath: undefined,
+					inputIndex: 0,
+					inputId: 'input-1',
+					jobId: 'job-1',
+					cancellable: false,
+					cancelRequested: false,
+					message: 'Complete.',
+				},
+			],
 			logTail: [
 				{ timestampMs: new Date('2026-07-16T12:34:56').getTime(), message: 'Started encode' },
 				{ timestampMs: new Date('2026-07-16T12:35:00').getTime(), message: 'Finished encode' },
@@ -90,6 +116,12 @@ describe('WorkCenterIsland operation cards', () => {
 			`${localTime(new Date('2026-07-16T12:35:00').getTime())} Finished encode`,
 		);
 		expect(log?.querySelectorAll('b')).toHaveLength(2);
+
+		const track = container.querySelector('[aria-label="Encode progress"]') as HTMLElement;
+		expect(track).toHaveAttribute('role', 'progressbar');
+		expect(track).toHaveAttribute('aria-valuemin', '0');
+		expect(track).toHaveAttribute('aria-valuemax', '100');
+		expect(track).toHaveAttribute('aria-valuenow', '100');
 	});
 
 	it('does not toggle expansion or preventDefault when Enter/Space targets a Cancel button', async () => {

--- a/src/ui/workCenter/model.ts
+++ b/src/ui/workCenter/model.ts
@@ -119,7 +119,7 @@ export function replaceOperations(
 	list: OperationListSnapshot,
 ): WorkCenterModel {
 	return {
-		operations: [...list.operations].sort(sortBySequenceDesc),
+		operations: [...list.operations].sort(sortByStatusThenSequenceDesc),
 	};
 }
 
@@ -131,10 +131,24 @@ export function upsertOperation(
 		(operation) => operation.operationId !== snapshot.operationId,
 	);
 	next.push(snapshot);
-	next.sort(sortBySequenceDesc);
+	next.sort(sortByStatusThenSequenceDesc);
 	return { operations: next };
 }
 
-function sortBySequenceDesc(left: OperationSnapshot, right: OperationSnapshot): number {
+/**
+ * Active (running/cancelling) operations render above queued (accepted)
+ * operations, which render above terminal ones; sequence-desc breaks ties
+ * within a bucket. A running op must not be buried by a newer submission
+ * that is merely queued or already finished.
+ */
+function statusDisplayBucket(status: WorkOperationStatus): 0 | 1 | 2 {
+	if (isTerminalOperationStatus(status)) return 2;
+	if (status === 'accepted') return 1;
+	return 0;
+}
+
+function sortByStatusThenSequenceDesc(left: OperationSnapshot, right: OperationSnapshot): number {
+	const bucketDiff = statusDisplayBucket(left.status) - statusDisplayBucket(right.status);
+	if (bucketDiff !== 0) return bucketDiff;
 	return right.sequence - left.sequence;
 }

--- a/src/ui/workCenter/state.svelte.ts
+++ b/src/ui/workCenter/state.svelte.ts
@@ -36,7 +36,29 @@ export const workCenterClock = $state({ nowMs: Date.now() });
 
 let initializationPromise: Promise<void> | null = null;
 let subscriptions: SubscriptionGroup | null = null;
+
+// Bounded FIFO tombstone of operation ids already purged: an operation's
+// terminal snapshot arrives from both the single-snapshot and list-snapshot
+// events, and the list snapshot keeps resending it on every unrelated
+// operation's event until the backend prunes it (see the Rust runtime's
+// terminal-operation cap, `TERMINAL_OPERATIONS_CAP` in
+// `src-tauri/src/work_runtime/state.rs`, currently 20). This cap MUST stay
+// above that backend cap: an id can only legitimately reappear in a list
+// snapshot while the backend still retains it, so keeping this tombstone
+// larger than the backend's retention window guarantees an evicted id can
+// never be re-delivered and mistakenly re-trigger a release.
+const PURGED_OPERATION_TOMBSTONE_CAP = 64;
 const purgedOperationIds = new Set<string>();
+const purgedOperationOrder: string[] = [];
+
+function markOperationPurged(operationId: string): void {
+	purgedOperationIds.add(operationId);
+	purgedOperationOrder.push(operationId);
+	if (purgedOperationOrder.length > PURGED_OPERATION_TOMBSTONE_CAP) {
+		const oldest = purgedOperationOrder.shift();
+		if (oldest !== undefined) purgedOperationIds.delete(oldest);
+	}
+}
 
 export function startWorkCenterClock(): () => void {
 	workCenterClock.nowMs = Date.now();
@@ -149,7 +171,7 @@ async function purgeRemoteSessionsForTerminalOperation(
 ): Promise<void> {
 	if (!isTerminalOperationStatus(operation.status)) return;
 	if (purgedOperationIds.has(operation.operationId)) return;
-	purgedOperationIds.add(operation.operationId);
+	markOperationPurged(operation.operationId);
 
 	const operationInputIds =
 		operation.sourceInputIds.length > 0


### PR DESCRIPTION
Slice C of the #425 hardening roadmap (tracker: #426). The roadmap's one Rust-touching slice.

## What

- **F11** — two-part fix, no TTL: `clearStatusPanelRetainedFeedback()` fires when the background op takes the transport row (wired in OperationsBarIsland, which owns the precedence union — Status Panel stays WorkRuntime-blind per its AGENTS.md); and `StatusTransportIsland` precedence reordered so active foreground progress outranks retained feedback. Stale verdicts can neither resurface post-op nor mask a new preview.
- **F15** — Work Center sort is now status-bucketed (running/cancelling → accepted → terminal), sequence-desc within bucket. A running card can't be buried by newer submissions.
- **F5** — Rust `WorkRuntimeState` prunes terminal ops beyond 20 (oldest by sequence) on every terminal transition; running/accepted never pruned; no serialized shape change, no new command. Frontend `purgedOperationIds` becomes a bounded FIFO tombstone (cap 64) — deliberately larger than the backend cap, so an id evicted from the tombstone has necessarily already been pruned backend-side and can never be re-delivered to double-release remote-session retainers. Caps cross-referenced in comments at both sites; pinned by a Rust prune test and a TS eviction/replay test.
- **F19a** — `role="progressbar"` + `aria-valuemin/max/now` on the three bare tracks (ops bar background, status transport, work-center lanes), copying the in-repo RemoteSource pattern.
- **F13** — `· order locked (submitting)`, matching the row tooltip and the DECISIONS.md submission-scoped guardrail.
- In passing: Prettier drift in `modal.svelte.test.ts` from PR-2, formatted (mechanical-debt exemption).

## Proof

- Rust: `cargo nextest run -p audiobook-boss --lib` 407 passed · `cargo fmt --check` clean · clippy `-D warnings` clean
- TS: `tsc --noEmit` clean · `svelte-check` 815 files 0/0 · full Vitest 118 files, 800 passed · fmt:check clean
- New/extended tests: post-op reversion renders idle; live progress over stale feedback; mixed-status sort; Rust prune cap; tombstone eviction/replay without double-release; ARIA wiring per surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)