### PR TITLE
PR-6: lab interaction proofs — drag drop-position and modal Escape (jsdom-blind classes)

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -82,6 +82,18 @@ commands over invoking internals directly.
   `labFixtures.ts` adapters and stay fixture-only: adding media synthesis,
   screenshot-diff baselines, or a default-path/CI hook is an owner decision
   (same pattern as the media lane), not a default.
+  - Also runs two browser-only interaction proofs, on their own dedicated
+    pages so they never mutate a screenshot page's state: (1) a real pointer
+    drag on the `chapter-queue` scenario asserting the drop lands exactly
+    where the `drag-over`/`drag-over-bottom` indicator promised, including
+    append-after-last (pins the F1 drop-position fix); (2) Escape through the
+    real `ModalController`/CSS visibility transition on the lab-local
+    `modal-escape` scenario (no owner fixture file, same pattern as
+    `modal-short`), asserting Escape closes the dialog regardless of focus
+    timing (pins the PR-2 Escape fix). Chromium cannot reproduce the exact
+    WebKit focus-refusal timing the fix addresses; the proof verifies the
+    invariant instead. Both stay manual-invocation only, same scope boundary
+    as the rest of this command.
 - IPC/generated binding changes:
   `bash scripts/check-generated-bindings.sh --mode local`, then the contract
   Vitest files: `bun run test -- src/lib/tauri-public-api.contract.test.ts

--- a/scripts/lab-shots.ts
+++ b/scripts/lab-shots.ts
@@ -1,13 +1,18 @@
 /**
- * Lab scenario screenshots + the one browser-level layout assertion.
+ * Lab scenario screenshots + browser-level interaction/layout assertions.
  *
  * Usage: `bun run lab:shots`
  *
  * Starts the Vite dev server, opens each lab scenario in headless Chromium,
- * saves screenshots to .artifacts/lab-shots/ (gitignored), and asserts the
- * short-window modal scenario keeps its footer actions reachable while the
- * body scrolls — the layout proof jsdom cannot provide (LabIsland.test.ts
- * pins markup only).
+ * saves screenshots to .artifacts/lab-shots/ (gitignored), and asserts:
+ * - the short-window modal scenario keeps its footer actions reachable while
+ *   the body scrolls — the layout proof jsdom cannot provide (LabIsland.test.ts
+ *   pins markup only).
+ * - the chapter-queue drag reorder lands where the drag-over indicator
+ *   promised (pins the F1 fix) — real pointer drag, not simulable in jsdom.
+ * - the modal-escape scenario's Escape key closes the dialog through the real
+ *   visibility-transition window regardless of focus (pins the PR-2 Escape
+ *   fix) — jsdom has no CSS transitions or WebKit-style focus timing.
  *
  * Prerequisite (one-time per machine): a Playwright Chromium matching the
  * pinned `playwright` devDependency — `bunx playwright install chromium`.
@@ -66,6 +71,157 @@ async function assertShortModalUsable(page: import('playwright').Page): Promise<
 	}
 }
 
+/** Reads the visible row order (title text) from the chapter-queue table, top to bottom. */
+async function readQueueRowTitles(page: import('playwright').Page): Promise<string[]> {
+	return page
+		.locator('tr[data-file-index]')
+		.evaluateAll((rows) =>
+			rows.map((row) => row.querySelector('.file-list-file-name')?.textContent?.trim() ?? ''),
+		);
+}
+
+/** Presses the grip past the reorder threshold, then moves to a target row's edge. */
+async function dragGripTo(
+	page: import('playwright').Page,
+	fromIndex: number,
+	target: { x: number; y: number },
+): Promise<void> {
+	const gripBox = await page
+		.locator(`tr[data-file-index="${fromIndex}"] .file-list-reorder-grip`)
+		.boundingBox();
+	if (!gripBox) throw new Error(`queue-drag: grip for row ${fromIndex} has no layout box.`);
+	const gripX = gripBox.x + gripBox.width / 2;
+	const gripY = gripBox.y + gripBox.height / 2;
+
+	await page.mouse.move(gripX, gripY);
+	await page.mouse.down();
+	// Move past the 4px engage threshold before hit-testing the target row.
+	await page.mouse.move(gripX, gripY + 10, { steps: 3 });
+	await page.mouse.move(target.x, target.y, { steps: 5 });
+}
+
+/**
+ * Drives a real pointer drag on the chapter-queue scenario and asserts the
+ * drop lands exactly where the drag-over indicator promised — pins the F1
+ * fix (drop-position truth). The drag implementation is pointer-events-based
+ * (src/ui/fileList/events.ts, midpoint hit-testing via getBoundingClientRect),
+ * so Playwright mouse.down/move/up drives it directly; no OS drag layer.
+ */
+async function assertQueueDragLandsAtIndicator(page: import('playwright').Page): Promise<void> {
+	const initialTitles = await readQueueRowTitles(page);
+	if (initialTitles.length === 0) {
+		throw new Error('queue-drag: chapter-queue scenario rendered no rows.');
+	}
+
+	const targetIndex = 3;
+	const targetBox = await page.locator(`tr[data-file-index="${targetIndex}"]`).boundingBox();
+	if (!targetBox) throw new Error(`queue-drag: target row ${targetIndex} has no layout box.`);
+	const targetX = targetBox.x + targetBox.width / 2;
+	const targetUpperY = targetBox.y + targetBox.height * 0.25;
+	const targetLowerY = targetBox.y + targetBox.height * 0.75;
+
+	await dragGripTo(page, 0, { x: targetX, y: targetUpperY });
+	const targetRow = page.locator(`tr[data-file-index="${targetIndex}"]`);
+	const hasTopIndicator = await targetRow.evaluate((row) => row.classList.contains('drag-over'));
+	if (!hasTopIndicator) {
+		throw new Error('queue-drag: expected drag-over (top indicator) while hovering the upper half.');
+	}
+
+	await page.mouse.move(targetX, targetLowerY, { steps: 5 });
+	const hasBottomIndicator = await targetRow.evaluate((row) =>
+		row.classList.contains('drag-over-bottom'),
+	);
+	if (!hasBottomIndicator) {
+		throw new Error('queue-drag: expected drag-over-bottom while hovering the lower half.');
+	}
+
+	await page.mouse.up();
+
+	const finalTitles = await readQueueRowTitles(page);
+	const expectedTitles = [...initialTitles];
+	const [moved] = expectedTitles.splice(0, 1);
+	expectedTitles.splice(targetIndex, 0, moved);
+	if (JSON.stringify(finalTitles) !== JSON.stringify(expectedTitles)) {
+		throw new Error(
+			`queue-drag: final order did not match the indicator's promise.\nexpected: ${expectedTitles.join(' | ')}\nactual:   ${finalTitles.join(' | ')}`,
+		);
+	}
+}
+
+/** Dropping on the lower half of the last row must append the dragged row at the end. */
+async function assertQueueDragAppendsAfterLast(page: import('playwright').Page): Promise<void> {
+	const initialTitles = await readQueueRowTitles(page);
+	const lastIndex = initialTitles.length - 1;
+	if (lastIndex < 1) throw new Error('queue-drag: not enough rows to prove append-after-last.');
+
+	const lastBox = await page.locator(`tr[data-file-index="${lastIndex}"]`).boundingBox();
+	if (!lastBox) throw new Error(`queue-drag: last row ${lastIndex} has no layout box.`);
+	const lastX = lastBox.x + lastBox.width / 2;
+	const lastLowerY = lastBox.y + lastBox.height * 0.75;
+
+	await dragGripTo(page, 0, { x: lastX, y: lastLowerY });
+	await page.mouse.up();
+
+	const finalTitles = await readQueueRowTitles(page);
+	if (finalTitles.length !== initialTitles.length || finalTitles[finalTitles.length - 1] !== initialTitles[0]) {
+		throw new Error(
+			`queue-drag: expected the dragged row last.\nexpected last: ${initialTitles[0]}\nactual last:   ${finalTitles[finalTitles.length - 1]}`,
+		);
+	}
+}
+
+async function waitForModalEscapeOpenState(
+	page: import('playwright').Page,
+	open: boolean,
+): Promise<void> {
+	await page.waitForFunction(
+		(wantOpen) =>
+			document.querySelector('[data-testid="modal-escape-backdrop"]')?.classList.contains('open') ===
+			wantOpen,
+		open,
+		{ timeout: 2_000 },
+	);
+}
+
+/**
+ * Drives Escape through the real ModalController/CSS visibility transition
+ * on the modal-escape scenario — pins the PR-2 fix that Escape works
+ * regardless of where focus sits (document-level, capture-phase handling in
+ * src/lib/ui/modal.svelte.ts). Chromium cannot reproduce the exact WebKit
+ * focus-refusal timing this fix addresses; that's accepted — the proof
+ * verifies the invariant the fix guarantees, not the original repro.
+ */
+async function assertModalEscapeClosesRegardlessOfFocus(
+	page: import('playwright').Page,
+): Promise<void> {
+	// Case 1: open, then press Escape immediately with no waits in between —
+	// drives the keypress through the visibility-transition window.
+	await page.getByTestId('modal-escape-open').click();
+	await page.keyboard.press('Escape');
+	await waitForModalEscapeOpenState(page, false);
+
+	// Case 2: reopen, click a non-focusable area inside the dialog, then Escape.
+	await page.getByTestId('modal-escape-open').click();
+	await waitForModalEscapeOpenState(page, true);
+	await page.getByTestId('modal-escape-heading').click();
+	await page.keyboard.press('Escape');
+	await waitForModalEscapeOpenState(page, false);
+
+	// Case 3: reopen, press Tab — focus must land/stay inside the dialog.
+	await page.getByTestId('modal-escape-open').click();
+	await waitForModalEscapeOpenState(page, true);
+	await page.keyboard.press('Tab');
+	const focusInsideDialog = await page
+		.getByTestId('modal-escape-dialog')
+		.evaluate((dialog) => dialog.contains(document.activeElement));
+	if (!focusInsideDialog) {
+		throw new Error('modal-escape: focus left the dialog after Tab.');
+	}
+
+	await page.getByTestId('modal-escape-close').click();
+	await waitForModalEscapeOpenState(page, false);
+}
+
 async function main(): Promise<void> {
 	mkdirSync(OUT_DIR, { recursive: true });
 
@@ -100,10 +256,45 @@ async function main(): Promise<void> {
 				console.log(`shot: ${shotPath}`);
 				await page.close();
 			}
+
+			// Interaction proofs run on their own fresh pages (dedicated navigations,
+			// not the screenshot pages above) so mutating drag/keyboard state cannot
+			// bleed into the chapter-queue or modal-short screenshots.
+			const queueDragPage = await browser.newPage({
+				viewport: { width: 1440, height: 900 },
+				colorScheme: 'dark',
+			});
+			await queueDragPage.goto(`${BASE_URL}?scenario=chapter-queue`);
+			await queueDragPage.getByTestId('lab-scenario-stage').waitFor({ timeout: 10_000 });
+			await assertQueueDragLandsAtIndicator(queueDragPage);
+			console.log('proof: chapter-queue drag lands at the indicator (F1)');
+			await queueDragPage.close();
+
+			const queueDragAppendPage = await browser.newPage({
+				viewport: { width: 1440, height: 900 },
+				colorScheme: 'dark',
+			});
+			await queueDragAppendPage.goto(`${BASE_URL}?scenario=chapter-queue`);
+			await queueDragAppendPage.getByTestId('lab-scenario-stage').waitFor({ timeout: 10_000 });
+			await assertQueueDragAppendsAfterLast(queueDragAppendPage);
+			console.log('proof: chapter-queue drag appends after the last row (F1)');
+			await queueDragAppendPage.close();
+
+			const modalEscapePage = await browser.newPage({
+				viewport: { width: 1440, height: 900 },
+				colorScheme: 'dark',
+			});
+			await modalEscapePage.goto(`${BASE_URL}?scenario=modal-escape`);
+			await modalEscapePage.getByTestId('lab-scenario-stage').waitFor({ timeout: 10_000 });
+			await assertModalEscapeClosesRegardlessOfFocus(modalEscapePage);
+			console.log('proof: modal-escape closes regardless of focus (PR-2)');
+			await modalEscapePage.close();
 		} finally {
 			await browser.close();
 		}
-		console.log('lab:shots OK — all scenarios rendered; modal-short layout assertion passed.');
+		console.log(
+			'lab:shots OK — all scenarios rendered; modal-short layout, queue-drag, and modal-escape assertions passed.',
+		);
 	} finally {
 		vite.kill();
 	}

--- a/scripts/lab-shots.ts
+++ b/scripts/lab-shots.ts
@@ -200,10 +200,23 @@ async function assertModalEscapeClosesRegardlessOfFocus(
 	await page.keyboard.press('Escape');
 	await waitForModalEscapeOpenState(page, false);
 
-	// Case 2: reopen, click a non-focusable area inside the dialog, then Escape.
+	// Case 2: reopen, force focus OUTSIDE the dialog, then Escape. A click on
+	// a non-focusable area is not guaranteed to move focus out in Chromium,
+	// which would let this proof pass against a container-scoped listener —
+	// the exact design this proof exists to reject. Blur explicitly and
+	// assert focus really is outside before pressing the key.
 	await page.getByTestId('modal-escape-open').click();
 	await waitForModalEscapeOpenState(page, true);
 	await page.getByTestId('modal-escape-heading').click();
+	await page.evaluate(() => {
+		(document.activeElement as HTMLElement | null)?.blur();
+	});
+	const focusOutsideDialog = await page
+		.getByTestId('modal-escape-dialog')
+		.evaluate((dialog) => !dialog.contains(document.activeElement));
+	if (!focusOutsideDialog) {
+		throw new Error('modal-escape: could not move focus outside the dialog for case 2.');
+	}
 	await page.keyboard.press('Escape');
 	await waitForModalEscapeOpenState(page, false);
 

--- a/src/lab/LabIsland.svelte
+++ b/src/lab/LabIsland.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { PopoverController } from '../lib/ui/popover.svelte';
+	import { ModalController } from '../lib/ui/modal.svelte';
 	import {
 		MetadataFormFieldsIsland,
 		onMetadataFormActionSelectChange,
@@ -25,6 +26,11 @@
 			: new URLSearchParams(window.location.search).get('scenario');
 	const fileListScenario = isFileListLabScenarioId(scenarioParam) ? scenarioParam : null;
 	const modalShortScenario = scenarioParam === 'modal-short';
+	// Lab-only interaction-proof stage (no owner fixture file — same pattern as
+	// modal-short): exercises the REAL ModalController/CSS transition so
+	// scripts/lab-shots.ts can pin the Escape-regardless-of-focus guarantee in
+	// a real browser (jsdom cannot see focus/visibility-transition timing).
+	const modalEscapeScenario = scenarioParam === 'modal-escape';
 
 	if (fileListScenario) {
 		applyFileListLabScenario(fileListScenario);
@@ -44,6 +50,27 @@
 			container: popoverContainer,
 			panel: popoverPanel,
 		});
+	});
+
+	let modalEscapeOpen = $state(false);
+	let modalEscapeDialogEl = $state<HTMLElement | null>(null);
+	const modalEscapeModal = new ModalController();
+
+	function closeModalEscape(): void {
+		modalEscapeOpen = false;
+	}
+
+	$effect(() => {
+		if (!modalEscapeScenario) return;
+		modalEscapeModal.sync(
+			modalEscapeOpen,
+			{ container: modalEscapeDialogEl },
+			{ onEscape: closeModalEscape },
+		);
+	});
+
+	onDestroy(() => {
+		if (modalEscapeScenario) modalEscapeModal.destroy();
 	});
 
 	function setDensity(next: 'comfortable' | 'compact'): void {
@@ -192,6 +219,62 @@
 			<div class="lab-modal-footer" data-testid="modal-scenario-footer">
 				<button class="pill pill-ghost" type="button">Cancel</button>
 				<button class="pill pill-primary" type="button">Apply</button>
+			</div>
+		</div>
+	</div>
+{:else if modalEscapeScenario}
+	<div
+		class="lab-scenario-stage"
+		data-testid="lab-scenario-stage"
+		data-scenario="modal-escape"
+	>
+		<button
+			class="pill pill-primary"
+			type="button"
+			data-testid="modal-escape-open"
+			onclick={() => {
+				modalEscapeOpen = true;
+			}}
+		>
+			Open dialog
+		</button>
+		<div
+			class="app-modal-backdrop"
+			class:open={modalEscapeOpen}
+			data-testid="modal-escape-backdrop"
+			aria-hidden={!modalEscapeOpen}
+		>
+			<div
+				class="app-modal-dialog"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="modal-escape-title"
+				data-testid="modal-escape-dialog"
+				bind:this={modalEscapeDialogEl}
+			>
+				<div class="app-modal-header">
+					<h4 id="modal-escape-title" data-testid="modal-escape-heading">Escape proof dialog</h4>
+				</div>
+				<div class="app-modal-body">
+					<div class="field">
+						<label for="modal-escape-field-1">First field</label>
+						<input id="modal-escape-field-1" type="text" data-testid="modal-escape-field-1" />
+					</div>
+					<div class="field">
+						<label for="modal-escape-field-2">Second field</label>
+						<input id="modal-escape-field-2" type="text" data-testid="modal-escape-field-2" />
+					</div>
+				</div>
+				<div class="lab-modal-footer">
+					<button
+						class="pill pill-ghost"
+						type="button"
+						data-testid="modal-escape-close"
+						onclick={closeModalEscape}
+					>
+						Close
+					</button>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Slice PR-6 of the #425 hardening roadmap (tracker: #426), pulled forward from the deferred ledger by owner decision after both live bugs on this branch (F1 drag off-by-one, PR-2's dead Escape) landed in the jsdom-blind class.

## What

- **Proof A (pins F1):** on the existing `chapter-queue` scenario, a real Playwright pointer drag asserts the upper-half `drag-over` / lower-half `drag-over-bottom` indicators and that the released row lands at the exact position the indicator promised — plus an append-after-last case. Each proof runs on a fresh page so mutations can't contaminate other assertions or screenshots.
- **Proof B (pins PR-2's bug class):** new lab-local `modal-escape` stage using the real `ModalController` and real `.app-modal-backdrop`/`.open` CSS: Escape immediately after open (through the visibility-transition window), Escape after clicking a non-focusable area, and Tab containment. Chromium can't reproduce WebKit's exact focus refusal — the proof pins the design invariant instead: modal keys work regardless of where focus sits.
- Charter unchanged: proofs run inside `bun run lab:shots`, manual invocation, fixture-only, no CI hook. `scripts/AGENTS.md` documents them.

## Proof

Full harness run (via the documented `ABB_LAB_CHROMIUM` escape hatch — the pinned Playwright's Chromium 1194 isn't cached on this machine):
all 4 scenario screenshots render, modal-short layout assertion + all three new interaction proofs pass. `tsc --noEmit` clean · `svelte-check` 815 files 0/0.

Note: branched off base, disjoint from PR-3 (#429) — mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)