### PR TITLE
PR-4: presentation calm — empty state, idle badges, cover states, invalid rows, overlay title bar (F4, F6, F8, F12, F14, F7)

### DIFF
--- a/scripts/lab-shots.ts
+++ b/scripts/lab-shots.ts
@@ -124,7 +124,9 @@ async function assertQueueDragLandsAtIndicator(page: import('playwright').Page):
 	const targetRow = page.locator(`tr[data-file-index="${targetIndex}"]`);
 	const hasTopIndicator = await targetRow.evaluate((row) => row.classList.contains('drag-over'));
 	if (!hasTopIndicator) {
-		throw new Error('queue-drag: expected drag-over (top indicator) while hovering the upper half.');
+		throw new Error(
+			'queue-drag: expected drag-over (top indicator) while hovering the upper half.',
+		);
 	}
 
 	await page.mouse.move(targetX, targetLowerY, { steps: 5 });
@@ -163,7 +165,10 @@ async function assertQueueDragAppendsAfterLast(page: import('playwright').Page):
 	await page.mouse.up();
 
 	const finalTitles = await readQueueRowTitles(page);
-	if (finalTitles.length !== initialTitles.length || finalTitles[finalTitles.length - 1] !== initialTitles[0]) {
+	if (
+		finalTitles.length !== initialTitles.length ||
+		finalTitles[finalTitles.length - 1] !== initialTitles[0]
+	) {
 		throw new Error(
 			`queue-drag: expected the dragged row last.\nexpected last: ${initialTitles[0]}\nactual last:   ${finalTitles[finalTitles.length - 1]}`,
 		);
@@ -176,8 +181,9 @@ async function waitForModalEscapeOpenState(
 ): Promise<void> {
 	await page.waitForFunction(
 		(wantOpen) =>
-			document.querySelector('[data-testid="modal-escape-backdrop"]')?.classList.contains('open') ===
-			wantOpen,
+			document
+				.querySelector('[data-testid="modal-escape-backdrop"]')
+				?.classList.contains('open') === wantOpen,
 		open,
 		{ timeout: 2_000 },
 	);

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "core:window:allow-start-dragging",
+    "core:window:allow-internal-toggle-maximize",
     "dialog:allow-open",
     "opener:allow-open-path",
     {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,9 @@
         "minWidth": 1440,
         "minHeight": 900,
         "center": true,
-        "preventOverflow": true
+        "preventOverflow": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/src/ui/__tests__/coverArt-island.test.ts
+++ b/src/ui/__tests__/coverArt-island.test.ts
@@ -129,6 +129,27 @@ describe('CoverArt island mount + clear behavior', () => {
 		expect(document.body.textContent).toContain('Only HTTPS URLs are supported.');
 	});
 
+	it('keeps the multi-select gate error when a URL load is reverted, not a success message', async () => {
+		setCurrentFileList({
+			files: [
+				{ path: '/books/a.m4b', isValid: true, inputId: 'a' } as AudioFile,
+				{ path: '/books/b.m4b', isValid: true, inputId: 'b' } as AudioFile,
+			],
+			validCount: 2,
+			invalidCount: 0,
+			totalDuration: 0,
+			totalSize: 0,
+		} as FileListInfo);
+		setSelectedFileIndices([0, 1]);
+		setSelectedIndex(0);
+		loadCoverArtFromUrlMock.mockResolvedValue([0x89, 0x50, 0x4e, 0x47]);
+
+		await onLoadCoverArtFromInput('https://example.com/cover.png');
+
+		expect(document.body.textContent).toContain('Select exactly one file to set its cover.');
+		expect(document.body.textContent).not.toContain('Cover art loaded from URL.');
+	});
+
 	it('shows sanitized backend cover-art validation errors', async () => {
 		openFileMock.mockResolvedValue('/Users/example/private/cover.gif');
 		loadCoverArtFileMock.mockRejectedValue({

--- a/src/ui/__tests__/coverArt-owner-integration.test.ts
+++ b/src/ui/__tests__/coverArt-owner-integration.test.ts
@@ -7,6 +7,7 @@ import {
 	refreshCoverArtDisplay,
 	setCustomCoverArt,
 } from '../coverArt';
+import { coverArtUiState } from '../coverArt/state.svelte';
 import { jobControlsState } from '../jobControls/state.svelte';
 import {
 	setCurrentFileList,
@@ -72,6 +73,18 @@ describe('coverArt owner integration', () => {
 		expect(getMetadataIntentPatchForFile('/books/b.m4b')?.cover_art).toBeUndefined();
 		expect(getCurrentCoverArt()).toBeNull();
 		expect(getHasCustomCoverArt()).toBe(false);
+	});
+
+	it('surfaces a status message when the batch multi-select gate reverts a cover commit', () => {
+		setSelectedFileIndices([0, 1]);
+		setSelectedIndex(0);
+
+		setCustomCoverArt([7, 8, 9]);
+
+		expect(coverArtUiState.message).toEqual({
+			kind: 'error',
+			text: 'Select exactly one file to set its cover.',
+		});
 	});
 
 	it('commits merge cover art to the first valid file regardless of selection', () => {

--- a/src/ui/appShell/AppShellIsland.svelte
+++ b/src/ui/appShell/AppShellIsland.svelte
@@ -155,21 +155,20 @@ let { children, overlay, rail }: Props = $props();
 <svelte:window onclick={handleWindowClick} />
 
 <div class="app-shell" bind:this={popoverContainer}>
-	<!-- data-tauri-drag-region: with titleBarStyle Overlay the appbar is the
-	     window's drag surface (drag fires only on direct hits, so nested
-	     buttons/tabs keep their own clicks). -->
-	<header class="app-shell-appbar" data-testid="app-shell-appbar" data-tauri-drag-region>
-		<!-- The drag attribute fires on direct hits only, so it must also sit
-		     on the non-button surfaces inside the bar (title, strip/group
-		     backgrounds) or the draggable area shrinks to padding slivers. -->
-		<span class="app-shell-title" data-tauri-drag-region>Audiobook Boss</span>
-		<div class="tab-strip" data-tauri-drag-region>
+	<!-- data-tauri-drag-region="deep": with titleBarStyle Overlay the appbar
+	     is the window's drag surface. "deep" makes the whole subtree drag
+	     (tauri's drag.js walks the event path and lets clickable elements —
+	     buttons, inputs — block dragging on their own), so nested tabs and
+	     controls keep their clicks without per-element attributes. -->
+	<header class="app-shell-appbar" data-testid="app-shell-appbar" data-tauri-drag-region="deep">
+		<span class="app-shell-title">Audiobook Boss</span>
+		<div class="tab-strip">
 			<button type="button" class="tab on" aria-current="page">Process</button>
 			<button type="button" class="tab" onclick={() => void openAppSettingsDialog()}>
 				Settings
 			</button>
 		</div>
-		<div class="segmented" role="group" aria-label="Density" data-tauri-drag-region>
+		<div class="segmented" role="group" aria-label="Density">
 			<button
 				type="button"
 				aria-pressed={densityState.preference === 'comfortable'}

--- a/src/ui/appShell/AppShellIsland.svelte
+++ b/src/ui/appShell/AppShellIsland.svelte
@@ -159,14 +159,17 @@ let { children, overlay, rail }: Props = $props();
 	     window's drag surface (drag fires only on direct hits, so nested
 	     buttons/tabs keep their own clicks). -->
 	<header class="app-shell-appbar" data-testid="app-shell-appbar" data-tauri-drag-region>
-		<span class="app-shell-title">Audiobook Boss</span>
-		<div class="tab-strip">
+		<!-- The drag attribute fires on direct hits only, so it must also sit
+		     on the non-button surfaces inside the bar (title, strip/group
+		     backgrounds) or the draggable area shrinks to padding slivers. -->
+		<span class="app-shell-title" data-tauri-drag-region>Audiobook Boss</span>
+		<div class="tab-strip" data-tauri-drag-region>
 			<button type="button" class="tab on" aria-current="page">Process</button>
 			<button type="button" class="tab" onclick={() => void openAppSettingsDialog()}>
 				Settings
 			</button>
 		</div>
-		<div class="segmented" role="group" aria-label="Density">
+		<div class="segmented" role="group" aria-label="Density" data-tauri-drag-region>
 			<button
 				type="button"
 				aria-pressed={densityState.preference === 'comfortable'}

--- a/src/ui/appShell/AppShellIsland.svelte
+++ b/src/ui/appShell/AppShellIsland.svelte
@@ -380,7 +380,13 @@ let { children, overlay, rail }: Props = $props();
 	.app-shell-appbar {
 		height: var(--appbar-h);
 		gap: var(--space-2);
-		padding: 0 var(--density-pad);
+		/* Left padding reserves space for macOS's overlay-titlebar traffic
+		   lights (tauri.conf.json `titleBarStyle: "Overlay"`). Frontend code
+		   has no platform read today, so this is unconditional; the config
+		   flag only takes effect on macOS (tauri-runtime-wry gates it behind
+		   `cfg(target_os = "macos")`), so this is dead space elsewhere. The
+		   planned Linux port keeps native decorations and can drop this then. */
+		padding: 0 var(--density-pad) 0 4.875rem;
 		border-bottom: 1px solid var(--border-primary);
 		background: var(--bg-main);
 		flex-shrink: 0;

--- a/src/ui/appShell/AppShellIsland.svelte
+++ b/src/ui/appShell/AppShellIsland.svelte
@@ -155,7 +155,10 @@ let { children, overlay, rail }: Props = $props();
 <svelte:window onclick={handleWindowClick} />
 
 <div class="app-shell" bind:this={popoverContainer}>
-	<header class="app-shell-appbar" data-testid="app-shell-appbar">
+	<!-- data-tauri-drag-region: with titleBarStyle Overlay the appbar is the
+	     window's drag surface (drag fires only on direct hits, so nested
+	     buttons/tabs keep their own clicks). -->
+	<header class="app-shell-appbar" data-testid="app-shell-appbar" data-tauri-drag-region>
 		<span class="app-shell-title">Audiobook Boss</span>
 		<div class="tab-strip">
 			<button type="button" class="tab on" aria-current="page">Process</button>

--- a/src/ui/coverArt/index.ts
+++ b/src/ui/coverArt/index.ts
@@ -287,6 +287,7 @@ export function setCustomCoverArt(coverArtBytes: number[] | null): void {
 		setHasCustomCoverArt(false);
 		setCoverArtRemovalRequested(false);
 		refreshCoverArtDisplay();
+		showCoverArtMessage('Select exactly one file to set its cover.', 'error');
 		return;
 	}
 	setCoverArtSession(coverArtBytes);

--- a/src/ui/coverArt/index.ts
+++ b/src/ui/coverArt/index.ts
@@ -141,7 +141,7 @@ async function loadCoverArtFile(filePath: string): Promise<void> {
 	try {
 		const imageData = await tauriClient.loadCoverArtFile(filePath);
 
-		applyLoadedCoverArt(imageData);
+		if (!applyLoadedCoverArt(imageData)) return;
 
 		console.log('Cover art loaded:', filePath);
 	} catch (error) {
@@ -156,7 +156,9 @@ async function loadCoverArtFromUrl(url: string): Promise<void> {
 		clearCoverArtMessage();
 		const imageData = await tauriClient.loadCoverArtFromUrl(url);
 
-		applyLoadedCoverArt(imageData);
+		// A gated revert already showed its own error — do not overwrite it
+		// with a success message for a cover that was never staged.
+		if (!applyLoadedCoverArt(imageData)) return;
 		showCoverArtMessage('Cover art loaded from URL.', 'success');
 	} catch (error) {
 		console.error('Failed to load cover art URL:', error);
@@ -166,8 +168,8 @@ async function loadCoverArtFromUrl(url: string): Promise<void> {
 	}
 }
 
-function applyLoadedCoverArt(imageData: number[]): void {
-	setCustomCoverArt(imageData);
+function applyLoadedCoverArt(imageData: number[]): boolean {
+	return setCustomCoverArt(imageData);
 }
 
 export { coverArtBytesToDataUrl };
@@ -275,10 +277,14 @@ export function setCoverArt(coverArtBytes: number[] | null): void {
 	displayCoverArt(coverArtBytes);
 }
 
-export function setCustomCoverArt(coverArtBytes: number[] | null): void {
+/**
+ * Returns false when the commit was gated to a single owner and reverted
+ * (batch multi-select) — callers must not report success in that case.
+ */
+export function setCustomCoverArt(coverArtBytes: number[] | null): boolean {
 	if (!coverArtBytes || coverArtBytes.length === 0) {
 		clearCoverArt({ markRemoval: true });
-		return;
+		return true;
 	}
 
 	const committed = commitCoverArtToOwners(coverArtBytes, false);
@@ -288,12 +294,13 @@ export function setCustomCoverArt(coverArtBytes: number[] | null): void {
 		setCoverArtRemovalRequested(false);
 		refreshCoverArtDisplay();
 		showCoverArtMessage('Select exactly one file to set its cover.', 'error');
-		return;
+		return false;
 	}
 	setCoverArtSession(coverArtBytes);
 	setHasCustomCoverArt(true);
 	setCoverArtRemovalRequested(false);
 	refreshCoverArtDisplay();
+	return true;
 }
 
 export function clearCoverArt(options?: { markRemoval?: boolean }): void {

--- a/src/ui/fileList/FileListIsland.svelte
+++ b/src/ui/fileList/FileListIsland.svelte
@@ -129,19 +129,44 @@
 		return title && title !== getFileName(file) ? title : null;
 	}
 
-	function getCoverDataUrl(file: (typeof files)[number]): string | null {
+	type CoverCellState =
+		| { kind: 'image'; url: string }
+		| { kind: 'placeholder' }
+		| { kind: 'loading' }
+		| { kind: 'error' };
+
+	function getCoverCellState(file: (typeof files)[number]): CoverCellState {
+		// Intent and loaded metadata are authoritative: an explicit clear or a
+		// metadata load that answers "no cover" must never be overdrawn by
+		// stale thumbnail-cache state (queued/loading/error). Only the
+		// fallthrough — metadata not yet loaded — consults the thumbnail cache.
 		const coverIntent = getMetadataIntentPatchForFile(file.path)?.cover_art;
-		if (coverIntent?.op === 'clear') return null;
-		if (coverIntent?.op === 'set') return coverArtBytesToDataUrl(coverIntent.value);
+		if (coverIntent?.op === 'clear') return { kind: 'placeholder' };
+		if (coverIntent?.op === 'set') {
+			return { kind: 'image', url: coverArtBytesToDataUrl(coverIntent.value) };
+		}
 
 		const metadata = getMetadataForFile(file.path);
 		if (metadata !== undefined) {
 			const coverArt = metadata.cover_art;
-			return coverArt && coverArt.length > 0 ? coverArtBytesToDataUrl(coverArt) : null;
+			return coverArt && coverArt.length > 0
+				? { kind: 'image', url: coverArtBytesToDataUrl(coverArt) }
+				: { kind: 'placeholder' };
 		}
 
 		const thumbnail = getFileListCoverThumbnailState(file.path);
-		return thumbnail.status === 'ready' ? thumbnail.dataUrl : null;
+		switch (thumbnail.status) {
+			case 'ready':
+				return { kind: 'image', url: thumbnail.dataUrl };
+			case 'queued':
+			case 'loading':
+				return { kind: 'loading' };
+			case 'error':
+				return { kind: 'error' };
+			case 'idle':
+			case 'absent':
+				return { kind: 'placeholder' };
+		}
 	}
 </script>
 
@@ -162,11 +187,10 @@
 			onclick={() => onHeaderClick?.()}
 			onkeydown={(event) => onHeaderKeydown?.(event)}
 		>
-			<p class="text-sm muted-text">Drop files or folders here, click to choose files, or use Add Folder</p>
+			<p class="text-sm muted-text">Drop files or folders here, or use ＋ Import above to add Files… or a Folder…</p>
 			<p class="text-xs muted-text mt-1">{supportText}</p>
 		</div>
-	{/if}
-
+	{:else}
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex, a11y_no_noninteractive_element_interactions -->
 	<div
 		class="file-list-content"
@@ -233,7 +257,7 @@
 					{@const selected = selectedIndices.includes(index)}
 					{@const active = index === getSelectedFileIndex()}
 					{@const badge = readFileListStatusBadge(file, readWorkActivityByInputId)}
-					{@const coverDataUrl = getCoverDataUrl(file)}
+					{@const coverState = getCoverCellState(file)}
 					{@const fileName = getFileName(file)}
 					{@const secondaryTitle = getSecondaryTitle(file)}
 					<tr
@@ -270,8 +294,18 @@
 						</td>
 						<td class="file-list-cover-cell">
 							<div class="app-cover-thumb file-list-cover">
-								{#if coverDataUrl}
-									<img src={coverDataUrl} alt="" />
+								{#if coverState.kind === 'image'}
+									<img src={coverState.url} alt="" />
+								{:else if coverState.kind === 'loading'}
+									<span class="file-list-cover-loading" aria-hidden="true"></span>
+								{:else if coverState.kind === 'error'}
+									<span
+										class="file-list-cover-error"
+										aria-hidden="true"
+										title="Cover art failed to load"
+									>
+										!
+									</span>
 								{:else}
 									<span aria-hidden="true">—</span>
 								{/if}
@@ -311,6 +345,7 @@
 			</tbody>
 		</table>
 	</div>
+	{/if}
 </div>
 
 <style>
@@ -338,11 +373,15 @@
 	.file-list-table tbody tr.drag-over { border-top: 2px solid var(--accent-primary); }
 	.file-list-table tbody tr.drag-over-bottom { border-bottom: 2px solid var(--accent-primary); }
 	.file-list-table tbody tr.order-locked { cursor: default; }
+	.file-list-table tbody tr.invalid .file-list-file-name { color: var(--text-error); opacity: 0.85; }
 	.file-list-reorder-cell { width: 1.5rem; padding-right: 0 !important; padding-left: var(--space-2) !important; text-align: center !important; }
 	.file-list-reorder-grip { display: inline-flex; align-items: center; justify-content: center; width: 1rem; color: var(--text-muted); cursor: grab; font-size: 0.875rem; line-height: 1; user-select: none; touch-action: none; }
 	.file-list-table tbody tr.order-locked .file-list-reorder-grip { cursor: not-allowed; opacity: 0.65; }
 	.file-list-cover-cell { width: 2.25rem; padding-right: 0 !important; }
 	.file-list-cover { --cover-thumb-size: 1.625rem; border: none; }
+	.file-list-cover-loading { display: inline-block; width: 60%; height: 60%; border-radius: var(--radius-sm); background: var(--bg-hover); animation: file-list-cover-pulse 1.2s ease-in-out infinite; }
+	.file-list-cover-error { color: var(--text-error); font-size: var(--text-sm); font-weight: 700; }
+	@keyframes file-list-cover-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 0.85; } }
 	.file-list-order-controls { display: inline-flex; align-items: baseline; gap: var(--space-1); }
 	.file-list-sort-header { padding: 0; border: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; letter-spacing: inherit; text-transform: inherit; }
 	.file-list-sort-direction { margin-left: 0.25rem; color: var(--text-muted); }

--- a/src/ui/fileList/__tests__/book-table.test.ts
+++ b/src/ui/fileList/__tests__/book-table.test.ts
@@ -509,6 +509,63 @@ describe('v3 book table', () => {
 		expect(openMetadataSurface).not.toHaveBeenCalled();
 	});
 
+	it('renders only the drop zone, with no table header, when the queue is empty', () => {
+		setCurrentFileList(fileList());
+		const screen = render(FileListIsland);
+
+		expect(screen.getByRole('button', { name: 'Add audio files' })).toBeInTheDocument();
+		expect(screen.queryByTestId('book-table')).not.toBeInTheDocument();
+		expect(screen.queryByText('Status')).not.toBeInTheDocument();
+	});
+
+	it('marks invalid rows with the invalid class for at-a-glance styling', () => {
+		const screen = render(FileListIsland);
+
+		expect(rowFor(screen, 'ready.m4b')).toHaveClass('valid');
+		expect(rowFor(screen, 'bad.m4b')).toHaveClass('invalid');
+	});
+
+	it('renders distinct cover-cell states for loading, absent, and error thumbnails', async () => {
+		let resolveLoading!: (value: number[] | null) => void;
+		const loadingPromise = new Promise<number[] | null>((resolve) => {
+			resolveLoading = resolve;
+		});
+		vi.spyOn(tauriClient, 'readAudioCoverThumbnail').mockImplementation(async (path: string) => {
+			if (path.endsWith('loading.m4b')) return loadingPromise;
+			if (path.endsWith('absent.m4b')) return null;
+			throw new Error('unreadable cover');
+		});
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		setCurrentFileList(
+			fileList(
+				file('/books/loading.m4b', 'loading'),
+				file('/books/absent.m4b', 'absent'),
+				file('/books/broken.m4b', 'broken'),
+			),
+		);
+		const screen = render(FileListIsland);
+
+		await waitFor(() => {
+			expect(
+				rowFor(screen, 'loading.m4b').querySelector('.file-list-cover-loading'),
+			).toBeInTheDocument();
+		});
+		await waitFor(() => {
+			expect(rowFor(screen, 'absent.m4b').querySelector('.file-list-cover-cell')).toHaveTextContent(
+				'—',
+			);
+		});
+		await waitFor(() => {
+			expect(
+				rowFor(screen, 'broken.m4b').querySelector('.file-list-cover-error'),
+			).toBeInTheDocument();
+		});
+
+		warn.mockRestore();
+		resolveLoading(null);
+	});
+
 	it('preserves selected identities and suppresses row activation after a rendered drag reorder', async () => {
 		setCurrentFileList(
 			fileList(

--- a/src/ui/operationsBar/OperationsBarIsland.svelte
+++ b/src/ui/operationsBar/OperationsBarIsland.svelte
@@ -127,9 +127,11 @@
 		</div>
 
 		<div class="operations-bar-meta">
-			<span class="app-badge app-badge-info">{counts.running} running</span>
-			<span class="app-badge app-badge-muted">{counts.queued} queued</span>
-			<span class="app-badge app-badge-ok">{counts.done} done</span>
+			{#if counts.running > 0 || counts.queued > 0 || counts.done > 0}
+				<span class="app-badge app-badge-info">{counts.running} running</span>
+				<span class="app-badge app-badge-muted">{counts.queued} queued</span>
+				<span class="app-badge app-badge-ok">{counts.done} done</span>
+			{/if}
 			<span class="operations-bar-info" aria-label="File totals">
 				{fileCount}
 				{fileCount === 1 ? 'book' : 'books'} · <span class="mono">{durationText} · {sizeText}</span>

--- a/src/ui/operationsBar/__tests__/operationsBar.test.ts
+++ b/src/ui/operationsBar/__tests__/operationsBar.test.ts
@@ -140,6 +140,21 @@ describe('OperationsBarIsland', () => {
 		expect(disclosure).toHaveAttribute('aria-expanded', 'false');
 	});
 
+	it('hides the running/queued/done badge cluster at idle 0/0/0 and shows it once a count is non-zero', async () => {
+		const { container } = render(OperationsBarIsland);
+
+		expect(container.querySelector('.app-badge-info')).not.toBeInTheDocument();
+		expect(container.querySelector('.app-badge-muted')).not.toBeInTheDocument();
+		expect(container.querySelector('.app-badge-ok')).not.toBeInTheDocument();
+
+		applyOperationListSnapshot(operationList(operation()));
+		await waitFor(() => {
+			expect(container.querySelector('.app-badge-info')).toHaveTextContent('1 running');
+		});
+		expect(container.querySelector('.app-badge-muted')).toHaveTextContent('0 queued');
+		expect(container.querySelector('.app-badge-ok')).toHaveTextContent('0 done');
+	});
+
 	it('uses book totals and flips the visible pin label', async () => {
 		render(OperationsBarIsland);
 		expect(screen.getByLabelText('File totals')).toHaveTextContent('1 book');


### PR DESCRIPTION
Slice D of the #425 hardening roadmap (tracker: #426). Two commits: the calm items, then F7 (overlay title bar) alone so it can be assessed/reverted independently.

## Commit 1 — calm items

- **F4** — empty queue: drop zone owns the whole area (no header-only table skeleton); copy names the actual `＋ Import → Files…/Folder…` affordance.
- **F6** — the `0 running / 0 queued / 0 done` badge cluster hides when all zero. The PR-3 takeover-transition feedback guard in this component is untouched (per its AGENTS.md contract).
- **F8** — gated cover commits in batch multi-select now surface "Select exactly one file to set its cover." on the revert path; the single-owner gating itself is unchanged.
- **F12** — cover cells surface the thumbnail state union (pulsing load, quiet absent, error glyph + tooltip). Metadata-intent authority preserved: intent-clear/set and loaded-no-cover branches unchanged; only the metadata-not-yet-loaded fallthrough expanded.
- **F14** — invalid rows tint the filename beside the ERROR badge.
- In passing: Biome format drift in `scripts/lab-shots.ts` (mechanical debt from PR-6).

## Commit 2 — F7 overlay title bar (merge gate: owner smoke)

`titleBarStyle: "Overlay"` + `hiddenTitle: true`; appbar reserves 78px left for traffic lights. Platform behavior verified from `tauri-runtime-wry 2.11.2` **source** (not docs): both fields apply only under `#[cfg(target_os = "macos")]` — schema-valid, genuine no-op on Linux/Windows, so the planned Linux port keeps native decorations. `productName`/window `title` untouched (release-artifact identity).

## Proof

- `tsc --noEmit` clean · `svelte-check` 816 files 0/0 · full Vitest 119 files, 807 passed · fmt/lint clean (6 pre-existing styles.css warnings remain)
- Lab harness before/after: all 4 screenshots + all 3 interaction proofs pass, no selector changes. `empty-queue.png` shows the new single-owner empty state; `chapter-queue.png` shows the invalid-row tint and cover-cell error glyphs (the fixture has no Tauri backend, so every thumbnail fetch genuinely errors — previously collapsed to silent dashes, now truthfully surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)