### PR TITLE
bld: align Tauri and adopt Specta RC25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,9 +4560,9 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f320c7dd82008b6958f43f6257c95319c407d1c17ade43686e50ea520c28bb26"
+checksum = "38f9a30cbcbb7011f1da7d73483983bf838af123883e45f2b36ed76328df9c50"
 dependencies = [
  "paste",
  "rustc_version",
@@ -4571,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153f185d0051a64d81977bab5012809d5c9d9db8792406a0997352e05494f711"
+checksum = "2ce14957ecc2897f1f848b8255b6531d13ddf49cbcf506b7c2c9fb1d005593bb"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -4583,30 +4583,28 @@ dependencies = [
 
 [[package]]
 name = "specta-serde"
-version = "0.0.11"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a46349e2c3fb3f3de4b78daa19632c32813262e1ab0966896b64ca91e0926e"
+checksum = "ee8a72b755ddb8949fd8f17c5db43f0e8a806ea587d9bc602ee3f73240c00029"
 dependencies = [
  "specta",
  "specta-macros",
 ]
 
 [[package]]
-name = "specta-tags"
-version = "0.0.0"
+name = "specta-typescript"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3026b7e2f8c76dcab90ec27b7f3e6a0b7d646501a3a8aa5d739d09cb9ee59871"
+checksum = "639404ee95557f2f8b7e4cb773ffefd45304c7ab8ba21ac83b69051595e083c0"
 dependencies = [
- "serde",
- "serde_json",
  "specta",
 ]
 
 [[package]]
-name = "specta-typescript"
-version = "0.0.11"
+name = "specta-util"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea586e1709619c9f4cb0c9115ff29c278f331c0450aff266c2913c639708b299"
+checksum = "29b1fc02b446f7244a92924fe68c0555921209f1d342990cd1539e9138e69502"
 dependencies = [
  "specta",
 ]
@@ -5059,17 +5057,17 @@ dependencies = [
 
 [[package]]
 name = "tauri-specta"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9191951c8d3aefce8fb9818271545c61b441a3c1095d8443637b36572e0346e4"
+checksum = "ee080f36d2ac17ce2f3a82fb53f02d664e8345457de51b56dad3c394dacc41a2"
 dependencies = [
  "heck 0.5.0",
  "serde",
  "serde_json",
  "specta",
  "specta-serde",
- "specta-tags",
  "specta-typescript",
+ "specta-util",
  "tauri",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4814,9 +4814,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.2"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4866,9 +4866,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4887,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4914,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4944,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -5008,9 +5008,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -5033,9 +5033,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.2"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -5076,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
@@ -5501,9 +5501,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
+ "specta-typescript",
 ]
 
 [[package]]

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "audiobook-boss",
       "dependencies": {
-        "@tauri-apps/api": "^2.11.0",
-        "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/api": "^2.11.1",
+        "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "effect": "^3.21.3",
       },
@@ -14,7 +14,7 @@
         "@biomejs/biome": "^2.5.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/vite": "^4.3.1",
-        "@tauri-apps/cli": "^2.11.2",
+        "@tauri-apps/cli": "^2.11.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -31,6 +31,7 @@
     },
   },
   "overrides": {
+    "@tauri-apps/api": "2.11.1",
     "undici": "^7.28.0",
   },
   "packages": {
@@ -174,33 +175,33 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.1", "", { "dependencies": { "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "tailwindcss": "4.3.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
-    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.2", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.2", "@tauri-apps/cli-darwin-x64": "2.11.2", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2", "@tauri-apps/cli-linux-arm64-gnu": "2.11.2", "@tauri-apps/cli-linux-arm64-musl": "2.11.2", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-musl": "2.11.2", "@tauri-apps/cli-win32-arm64-msvc": "2.11.2", "@tauri-apps/cli-win32-ia32-msvc": "2.11.2", "@tauri-apps/cli-win32-x64-msvc": "2.11.2" }, "bin": { "tauri": "tauri.js" } }, "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw=="],
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.4", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.4", "@tauri-apps/cli-darwin-x64": "2.11.4", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4", "@tauri-apps/cli-linux-arm64-gnu": "2.11.4", "@tauri-apps/cli-linux-arm64-musl": "2.11.4", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-musl": "2.11.4", "@tauri-apps/cli-win32-arm64-msvc": "2.11.4", "@tauri-apps/cli-win32-ia32-msvc": "2.11.4", "@tauri-apps/cli-win32-x64-msvc": "2.11.4" }, "bin": { "tauri": "tauri.js" } }, "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ=="],
 
-    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w=="],
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ=="],
 
-    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg=="],
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A=="],
 
-    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.2", "", { "os": "linux", "cpu": "arm" }, "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA=="],
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.4", "", { "os": "linux", "cpu": "arm" }, "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ=="],
 
-    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw=="],
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA=="],
 
-    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw=="],
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw=="],
 
-    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.2", "", { "os": "linux", "cpu": "none" }, "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ=="],
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.4", "", { "os": "linux", "cpu": "none" }, "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ=="],
 
-    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw=="],
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ=="],
 
-    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw=="],
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A=="],
 
-    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA=="],
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ=="],
 
-    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA=="],
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA=="],
 
-    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
-    "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ=="],
+    "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.2", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 

--- a/crates/abb-media-core/Cargo.toml
+++ b/crates/abb-media-core/Cargo.toml
@@ -8,7 +8,7 @@ doctest = false
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
-specta = { version = "=2.0.0-rc.24", features = ["derive"] }
+specta = { version = "=2.0.0-rc.25", features = ["derive"] }
 sha2 = "0.10.9"
 
 [lints]

--- a/crates/abb-metadata-core/Cargo.toml
+++ b/crates/abb-metadata-core/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
-specta = { version = "=2.0.0-rc.24", features = ["derive"] }
+specta = { version = "=2.0.0-rc.25", features = ["derive"] }
 thiserror = "2.0.18"
 
 [lints]

--- a/crates/abb-output-artifact-core/Cargo.toml
+++ b/crates/abb-output-artifact-core/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 abb-metadata-core = { path = "../abb-metadata-core" }
 serde = { version = "1.0.228", features = ["derive"] }
-specta = { version = "=2.0.0-rc.24", features = ["derive"] }
+specta = { version = "=2.0.0-rc.25", features = ["derive"] }
 thiserror = "2.0.18"
 
 [lints]

--- a/crates/abb-processing-core/Cargo.toml
+++ b/crates/abb-processing-core/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
-specta = { version = "=2.0.0-rc.24", features = ["derive"] }
+specta = { version = "=2.0.0-rc.25", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/abb-remote-source-core/Cargo.toml
+++ b/crates/abb-remote-source-core/Cargo.toml
@@ -12,6 +12,7 @@ abb-media-core = { path = "../abb-media-core" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 specta = { version = "=2.0.0-rc.25", features = ["derive"] }
+specta-typescript = "=0.0.12"
 
 [lints]
 workspace = true

--- a/crates/abb-remote-source-core/Cargo.toml
+++ b/crates/abb-remote-source-core/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 abb-media-core = { path = "../abb-media-core" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-specta = { version = "=2.0.0-rc.24", features = ["derive"] }
+specta = { version = "=2.0.0-rc.25", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/abb-remote-source-core/src/lib.rs
+++ b/crates/abb-remote-source-core/src/lib.rs
@@ -169,7 +169,10 @@ pub fn acquisition_progress(
     bytes_downloaded: Option<u64>,
     bytes_total: Option<u64>,
 ) -> AcquisitionProgress {
-    let fraction = fraction.unwrap_or(0.0).clamp(0.0, 1.0);
+    let fraction = fraction
+        .filter(|value| value.is_finite())
+        .unwrap_or(0.0)
+        .clamp(0.0, 1.0);
     let (start, end, message, terminal) = match stage {
         AcquisitionStage::Auth => (0.0, 5.0, "Preparing account session.", false),
         AcquisitionStage::Library => (0.0, 5.0, "Loading remote library.", false),
@@ -468,5 +471,13 @@ mod tests {
         assert_eq!(scoped_progress.current_item_index, Some(2));
         assert_eq!(scoped_progress.total_items, Some(3));
         assert_eq!(scoped_progress.stage, AcquisitionStage::Download);
+    }
+
+    #[test]
+    fn progress_plan_rejects_non_finite_fraction_at_its_owner() {
+        let progress = acquisition_progress(AcquisitionStage::Download, Some(f32::NAN), None, None);
+
+        assert_eq!(progress.percentage, 15.0);
+        assert!(progress.percentage.is_finite());
     }
 }

--- a/crates/abb-remote-source-core/src/lib.rs
+++ b/crates/abb-remote-source-core/src/lib.rs
@@ -60,6 +60,7 @@ pub enum AcquisitionStrategy {
 #[serde(rename_all = "camelCase")]
 pub struct AcquisitionProgress {
     pub stage: AcquisitionStage,
+    #[specta(type = specta_typescript::Number)]
     pub percentage: f32,
     pub message: String,
     pub bytes_downloaded: Option<u64>,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -13,10 +13,12 @@
   `src-tauri/src/ipc_contract.rs` owns the integer policy;
   `src/lib/tauri-client.generated-event-bindings.test.ts` pins representative
   numeric shapes; focused Rust tests pin non-finite progress normalization.
-- Guardrail: do not introduce JavaScript `bigint`, lossless-float semantic
-  transforms, or per-core-crate TypeScript annotations without a concrete
-  payload that can exceed JavaScript's exact integer range or must preserve
-  non-finite floats end to end.
+- Guardrail: do not introduce JavaScript `bigint` or lossless-float semantic
+  transforms without a concrete payload that needs those runtime semantics.
+  An owner-local `specta-typescript::Number` annotation is allowed only when
+  the Rust owner normalizes the value to a finite number and the established
+  wire contract must remain non-nullable; keep focused owner and generated-type
+  proof beside that exception.
 
 ## 2026-08-09 - FFmpeg 9 Uses a Minimal Source-Provenance Vendor (#441)
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,23 @@
 # Decisions
 
+## 2026-08-10 - Specta RC25 Keeps ABB's Numeric IPC Contract (#448)
+
+- Outcome: ABB adopts Specta/tauri-specta RC25 and keeps bounded byte sizes,
+  timestamps, counts, indices, and sequence values as TypeScript `number` at
+  the Tauri IPC boundary. The exporter opts into the RC25 integer remapper at
+  that boundary; pure domain crates retain their Rust-owned integer types.
+  Float fields used for progress and file totals stay numeric only where their
+  Rust owners normalize non-finite values before serialization.
+- Evidence: RC25 binding generation rejects wide integers without an explicit
+  policy and represents potentially non-finite floats as `number | null`.
+  `src-tauri/src/ipc_contract.rs` owns the integer policy;
+  `src/lib/tauri-client.generated-event-bindings.test.ts` pins representative
+  numeric shapes; focused Rust tests pin non-finite progress normalization.
+- Guardrail: do not introduce JavaScript `bigint`, lossless-float semantic
+  transforms, or per-core-crate TypeScript annotations without a concrete
+  payload that can exceed JavaScript's exact integer range or must preserve
+  non-finite floats end to end.
+
 ## 2026-08-09 - FFmpeg 9 Uses a Minimal Source-Provenance Vendor (#441)
 
 - Outcome: ABB moves `ffmpeg-next` and `ffmpeg-sys-next` together to 9.0.0 and

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@tauri-apps/api": "^2.11.0",
-		"@tauri-apps/plugin-dialog": "^2.7.1",
+		"@tauri-apps/api": "^2.11.1",
+		"@tauri-apps/plugin-dialog": "^2.7.2",
 		"@tauri-apps/plugin-opener": "^2.5.4",
 		"effect": "^3.21.3"
 	},
@@ -42,7 +42,7 @@
 		"@biomejs/biome": "^2.5.0",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
 		"@tailwindcss/vite": "^4.3.1",
-		"@tauri-apps/cli": "^2.11.2",
+		"@tauri-apps/cli": "^2.11.4",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
 		"@testing-library/user-event": "^14.6.1",
@@ -57,6 +57,7 @@
 		"vitest": "^4.1.9"
 	},
 	"overrides": {
+		"@tauri-apps/api": "2.11.1",
 		"undici": "^7.28.0"
 	}
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 doctest = false
 
 [build-dependencies]
-tauri-build = { version = "2.6.2", features = [] }
+tauri-build = { version = "2.6.3", features = [] }
 
 [dependencies]
 abb-audible-core = { path = "../crates/abb-audible-core" }
@@ -31,9 +31,9 @@ abb-metadata-core = { path = "../crates/abb-metadata-core" }
 abb-output-artifact-core = { path = "../crates/abb-output-artifact-core" }
 abb-processing-core = { path = "../crates/abb-processing-core" }
 abb-remote-source-core = { path = "../crates/abb-remote-source-core" }
-tauri = { version = "2.11.2", features = [] }
+tauri = { version = "2.11.5", features = [] }
 tauri-plugin-opener = "2.5.4"
-tauri-plugin-dialog = "2.7.1"
+tauri-plugin-dialog = "2.7.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -90,7 +90,7 @@ bundled-ffmpeg-portable = [
 
 [dev-dependencies]
 tempfile = "3.27.0"
-tauri = { version = "2.11.2", features = ["test"] }
+tauri = { version = "2.11.5", features = ["test"] }
 base64 = "0.22.1"
 # Media-lane fixture synthesis (e.g. MP3 via libmp3lame). Same version as the
 # main dependency, so this adds zero extra compilation.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,9 +50,9 @@ reqwest = { version = "0.13.4", default-features = false, features = ["rustls", 
 audible-reqwest = { package = "reqwest", version = "0.12.28", features = ["json"] }
 mp4ameta = "0.13.0"
 bogon = "0.3"
-specta = "=2.0.0-rc.24"
-specta-typescript = "=0.0.11"
-tauri-specta = { version = "=2.0.0-rc.24", features = ["typescript"] }
+specta = "=2.0.0-rc.25"
+specta-typescript = "=0.0.12"
+tauri-specta = { version = "=2.0.0-rc.25", features = ["typescript"] }
 keyring-core = "1.0.0"
 secrecy = "0.10.3"
 sha2 = "0.10.9"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,7 +7,14 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "dialog:allow-open",
-    "opener:allow-open-path",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$TEMP/**" },
+        { "path": "/Volumes/**" }
+      ]
+    },
     {
       "identifier": "opener:allow-open-url",
       "allow": [{ "url": "https://*" }]

--- a/src-tauri/src/audio/file_list.rs
+++ b/src-tauri/src/audio/file_list.rs
@@ -15,8 +15,10 @@ pub struct FileListInfo {
     /// Stable decoder identities aligned by index with `files`.
     pub selected_decoders: Vec<Option<DecoderSelection>>,
     /// Total duration in seconds
+    #[specta(type = specta_typescript::Number)]
     pub total_duration: f64,
     /// Total size in bytes
+    #[specta(type = specta_typescript::Number)]
     pub total_size: f64,
     /// Number of valid files
     pub valid_count: usize,
@@ -211,8 +213,11 @@ pub fn get_file_list_info<P: AsRef<Path>>(file_paths: &[P]) -> Result<FileListIn
 
     for file in &files {
         if file.is_valid {
-            total_duration += file.duration.unwrap_or(0.0);
-            total_size += file.size.unwrap_or(0.0);
+            total_duration += file
+                .duration
+                .filter(|value| value.is_finite())
+                .unwrap_or(0.0);
+            total_size += file.size.filter(|value| value.is_finite()).unwrap_or(0.0);
             valid_count += 1;
         } else {
             invalid_count += 1;

--- a/src-tauri/src/ipc_contract.rs
+++ b/src-tauri/src/ipc_contract.rs
@@ -54,6 +54,10 @@ pub fn builder() -> Builder<tauri::Wry> {
             crate::work_runtime::WorkOperationListSnapshotEvent
         ])
         .error_handling(ErrorHandlingMode::Result)
+        // ABB's JSON IPC contract uses numbers for bounded byte sizes, timestamps,
+        // counts, indices, and sequence values. They remain below JavaScript's exact
+        // integer range, and frontend consumers intentionally perform number arithmetic.
+        .dangerously_cast_bigints_to_number()
 }
 
 pub fn default_typescript_output_path() -> PathBuf {

--- a/src-tauri/src/processing/progress/emitter.rs
+++ b/src-tauri/src/processing/progress/emitter.rs
@@ -225,6 +225,11 @@ impl ProgressEmitter {
         current_file: Option<String>,
         eta_seconds: Option<f64>,
     ) {
+        let percentage = if percentage.is_finite() {
+            percentage.clamp(0.0, 100.0)
+        } else {
+            0.0
+        };
         let event = ProgressEvent {
             operation_kind: self.operation_kind,
             stage: EventStage::from(&stage),
@@ -289,5 +294,39 @@ mod tests {
         assert_eq!(failed.eta_seconds, None);
         assert_eq!(cancelled.eta_seconds, None);
         assert_eq!(skipped.eta_seconds, None);
+    }
+
+    #[test]
+    fn emitted_progress_normalizes_non_finite_percentage() {
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let listener_capture = Arc::clone(&captured);
+        let listener: ProgressListener = Arc::new(move |event| {
+            *listener_capture.lock().expect("capture progress event") = Some(event.clone());
+        });
+        let emitter = ProgressEmitter::with_context(
+            None,
+            EmitContext {
+                operation_kind: OperationKind::ProcessingBatch,
+                job_id: None,
+                input_index: None,
+            },
+        )
+        .with_progress_listener(Some(listener));
+
+        emitter.emit_custom(
+            ProcessingStage::Converting,
+            f32::NAN,
+            "Encoding",
+            None,
+            None,
+        );
+
+        let event = captured
+            .lock()
+            .expect("read progress event")
+            .clone()
+            .expect("progress event was emitted");
+        assert_eq!(event.percentage, 0.0);
+        assert!(event.percentage.is_finite());
     }
 }

--- a/src-tauri/src/processing/progress/mod.rs
+++ b/src-tauri/src/processing/progress/mod.rs
@@ -96,6 +96,7 @@ pub struct ProgressEvent {
     /// Current processing stage
     pub stage: EventStage,
     /// Progress percentage (0-100)
+    #[specta(type = specta_typescript::Number)]
     pub percentage: f32,
     /// Human-readable status message
     pub message: String,

--- a/src-tauri/src/work_runtime/state.rs
+++ b/src-tauri/src/work_runtime/state.rs
@@ -152,7 +152,7 @@ impl WorkRuntimeState {
             }
             child.status = child_status;
             child.progress.stage = work_stage_from_event_stage(event.stage);
-            child.progress.percentage = event.percentage.clamp(0.0, 100.0);
+            child.progress.percentage = finite_percentage(event.percentage);
             child.progress.message = event.message.clone();
             child.progress.eta_seconds = event.eta_seconds;
             child.cancellable =
@@ -176,7 +176,7 @@ impl WorkRuntimeState {
         snapshot.progress.percentage = if child_scoped_batch_event {
             aggregate_child_progress(&snapshot.children)
         } else {
-            event.percentage.clamp(0.0, 100.0)
+            finite_percentage(event.percentage)
         };
         snapshot.progress.message = event.message.clone();
         // A multi-child batch event carries one child's ETA, which does not
@@ -411,6 +411,14 @@ impl WorkRuntimeState {
             let oldest = self.terminal_order.remove(0);
             self.operations.remove(&oldest);
         }
+    }
+}
+
+fn finite_percentage(percentage: f32) -> f32 {
+    if percentage.is_finite() {
+        percentage.clamp(0.0, 100.0)
+    } else {
+        0.0
     }
 }
 

--- a/src-tauri/src/work_runtime/types.rs
+++ b/src-tauri/src/work_runtime/types.rs
@@ -85,6 +85,7 @@ pub enum ResourceLane {
 #[serde(rename_all = "camelCase")]
 pub struct ProgressSnapshot {
     pub stage: WorkProgressStage,
+    #[specta(type = specta_typescript::Number)]
     pub percentage: f32,
     pub message: String,
     pub current_item_index: Option<usize>,

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -149,7 +149,7 @@ export type AcquisitionPlan = {
 
 export type AcquisitionProgress = {
 	stage: AcquisitionStage,
-	percentage: number | null,
+	percentage: number,
 	message: string,
 	bytesDownloaded: number | null,
 	bytesTotal: number | null,

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -34,9 +34,9 @@ export const commands = {
 	 *  Includes SSRF protection: blocks requests to private/loopback/link-local IPs.
 	 */
 	loadCoverArtFromUrl: (url: string) => typedError<number[], AppErrorEnvelope>(__TAURI_INVOKE("load_cover_art_from_url", { url })),
-	// Reads an audio file's embedded cover as a bounded JPEG thumbnail.
+	/**  Reads an audio file's embedded cover as a bounded JPEG thumbnail. */
 	readAudioCoverThumbnail: (filePath: string) => typedError<number[] | null, AppErrorEnvelope>(__TAURI_INVOKE("read_audio_cover_thumbnail", { filePath })),
-	// Validates and normalizes metadata intent without writing files.
+	/**  Validates and normalizes metadata intent without writing files. */
 	validateMetadataIntentPatch: (metadataPatch: MetadataIntentPatch) => typedError<MetadataIntentValidationResult, AppErrorEnvelope>(__TAURI_INVOKE("validate_metadata_intent_patch", { metadataPatch })),
 	/**
 	 *  Saves metadata to an audio file using explicit write intent (metadata-only editing)
@@ -54,11 +54,11 @@ export const commands = {
 	 *  Returns comprehensive file information including duration and size
 	 */
 	analyzeAudioFiles: (filePaths: string[]) => typedError<FileListInfo, AppErrorEnvelope>(__TAURI_INVOKE("analyze_audio_files", { filePaths })),
-	// Returns backend-owned supported local audio import metadata for picker UI.
+	/**  Returns backend-owned supported local audio import metadata for picker UI. */
 	getSupportedAudioImportMetadata: () => typedError<SupportedAudioImportMetadata, AppErrorEnvelope>(__TAURI_INVOKE("get_supported_audio_import_metadata")),
-	// Recursively discovers supported local audio files from files and directories.
+	/**  Recursively discovers supported local audio files from files and directories. */
 	discoverAudioImportPaths: (inputPaths: string[]) => typedError<string[], AppErrorEnvelope>(__TAURI_INVOKE("discover_audio_import_paths", { inputPaths })),
-	// Drains local audio paths opened by the OS before the frontend was ready.
+	/**  Drains local audio paths opened by the OS before the frontend was ready. */
 	takeOpenedAudioFiles: () => typedError<string[], AppErrorEnvelope>(__TAURI_INVOKE("take_opened_audio_files")),
 	listRemoteSourceProviders: () => typedError<RemoteSourceProviderCapabilities[], AppErrorEnvelope>(__TAURI_INVOKE("list_remote_source_providers")),
 	getRemoteSourceAccountState: (providerId: ProviderId) => typedError<RemoteSourceAccountState, AppErrorEnvelope>(__TAURI_INVOKE("get_remote_source_account_state", { providerId })),
@@ -70,11 +70,11 @@ export const commands = {
 	getRemoteSourceAcquisitionStatus: (jobId: string) => typedError<AcquisitionJob, AppErrorEnvelope>(__TAURI_INVOKE("get_remote_source_acquisition_status", { jobId })),
 	cancelRemoteSourceAcquisition: (jobId: string) => typedError<AcquisitionJob, AppErrorEnvelope>(__TAURI_INVOKE("cancel_remote_source_acquisition", { jobId })),
 	purgeRemoteSourceSession: (jobId: string) => typedError<null, AppErrorEnvelope>(__TAURI_INVOKE("purge_remote_source_session", { jobId })),
-	// Validates encoder settings (no side effects)
+	/**  Validates encoder settings (no side effects) */
 	validateEncoderSettings: (settings: EncoderSettings) => typedError<string, AppErrorEnvelope>(__TAURI_INVOKE("validate_encoder_settings", { settings })),
-	// Returns backend-owned runtime settings capabilities for UI controls.
+	/**  Returns backend-owned runtime settings capabilities for UI controls. */
 	getRuntimeSettingsCapabilities: () => typedError<RuntimeSettingsCapabilities, AppErrorEnvelope>(__TAURI_INVOKE("get_runtime_settings_capabilities")),
-	// Builds an output path preview using backend naming rules without collision suffixing.
+	/**  Builds an output path preview using backend naming rules without collision suffixing. */
 	previewOutputPath: (outputDir: string, metadata: {
 	title: string | null,
 	artist: string | null,
@@ -98,9 +98,9 @@ export const commands = {
 	customTemplate: string | null,
 } | null, sourcePath: string | null, outputKind: "final" | "preview" | null) => typedError<string, AppErrorEnvelope>(__TAURI_INVOKE("preview_output_path", { outputDir, metadata, outputNaming, sourcePath, outputKind })),
 	preflightProcessingPlan: (payload: ProcessPayload, metadata: { [key in string]: MetadataIntentPatch } | null, previewSeconds: number | null) => typedError<ProcessingPreflightPlan, AppErrorEnvelope>(__TAURI_INVOKE("preflight_processing_plan", { payload, metadata, previewSeconds })),
-	// Returns the current maximum concurrent jobs setting
+	/**  Returns the current maximum concurrent jobs setting */
 	getMaxConcurrentJobs: () => __TAURI_INVOKE<number>("get_max_concurrent_jobs"),
-	// Updates the maximum concurrent jobs setting (requires idle state)
+	/**  Updates the maximum concurrent jobs setting (requires idle state) */
 	setMaxConcurrentJobs: (maxConcurrent: number | null) => typedError<number, AppErrorEnvelope>(__TAURI_INVOKE("set_max_concurrent_jobs", { maxConcurrent })),
 	/**
 	 *  Processes audiobook files with configurable encoder settings.
@@ -119,7 +119,7 @@ export const commands = {
 /** Events */
 export const events = {
 	openedAudioFiles: makeEvent<OpenedAudioFilesEvent>("opened-audio-files"),
-	processingProgress: makeEvent<ProgressEvent>("processing-progress"),
+	processingProgress: makeEvent<ProgressEvent_Deserialize>("processing-progress"),
 	processingQueue: makeEvent<QueueEvent>("processing-queue"),
 	workOperationListSnapshot: makeEvent<WorkOperationListSnapshotEvent>("work-operation-list-snapshot"),
 	workOperationSnapshot: makeEvent<WorkOperationSnapshotEvent>("work-operation-snapshot"),
@@ -149,7 +149,7 @@ export type AcquisitionPlan = {
 
 export type AcquisitionProgress = {
 	stage: AcquisitionStage,
-	percentage: number,
+	percentage: number | null,
 	message: string,
 	bytesDownloaded: number | null,
 	bytesTotal: number | null,
@@ -201,47 +201,47 @@ export type AppSettingsPatch = {
 	pinnedDefaults: PinnedDefaults | null,
 };
 
-// Read-only chapter facts discovered while analyzing one audio file.
+/**  Read-only chapter facts discovered while analyzing one audio file. */
 export type AudioChapter = {
-	// Embedded chapter title, when present in the source container.
+	/**  Embedded chapter title, when present in the source container. */
 	title: string | null,
-	// Chapter start in milliseconds from the beginning of this file.
+	/**  Chapter start in milliseconds from the beginning of this file. */
 	startMs: number,
-	// Chapter end in milliseconds from the beginning of this file.
+	/**  Chapter end in milliseconds from the beginning of this file. */
 	endMs: number,
 };
 
-// Represents an audio file with metadata
+/**  Represents an audio file with metadata */
 export type AudioFile = {
-	// Stable workbench/session identity for joins that must survive reorder/remove operations.
+	/**  Stable workbench/session identity for joins that must survive reorder/remove operations. */
 	inputId: string,
-	// File path
+	/**  File path */
 	path: string,
-	// File size in bytes (None if unavailable)
+	/**  File size in bytes (None if unavailable) */
 	size: number | null,
-	// Duration in seconds (None if unavailable)
+	/**  Duration in seconds (None if unavailable) */
 	duration: number | null,
-	// Audio format (None if unavailable)
+	/**  Audio format (None if unavailable) */
 	format: string | null,
-	// Bitrate in kbps (None if unavailable)
+	/**  Bitrate in kbps (None if unavailable) */
 	bitrate: number | null,
-	// Sample rate in Hz (None if unavailable)
+	/**  Sample rate in Hz (None if unavailable) */
 	sampleRate: number | null,
-	// Number of channels (None if unavailable)
+	/**  Number of channels (None if unavailable) */
 	channels: number | null,
-	// Friendly codec label for display (None if unavailable)
+	/**  Friendly codec label for display (None if unavailable) */
 	codecLabel: string | null,
-	// Friendly selected decoder label for display only (None if unavailable)
+	/**  Friendly selected decoder label for display only (None if unavailable) */
 	selectedDecoder: string | null,
-	// Title tag discovered during input analysis (None if unavailable)
+	/**  Title tag discovered during input analysis (None if unavailable) */
 	tagTitle: string | null,
-	// Artist tag discovered during input analysis (None if unavailable)
+	/**  Artist tag discovered during input analysis (None if unavailable) */
 	tagArtist: string | null,
-	// Chapters embedded in this individual source file, normalized to milliseconds.
+	/**  Chapters embedded in this individual source file, normalized to milliseconds. */
 	chapters?: AudioChapter[],
-	// Validation status
+	/**  Validation status */
 	isValid: boolean,
-	// Error message if validation failed
+	/**  Error message if validation failed */
 	error: string | null,
 };
 
@@ -264,13 +264,13 @@ export type AudiobookMetadata = {
 	cover_art: number[] | null,
 };
 
-// Bitrate/quality control mode per encoder
+/**  Bitrate/quality control mode per encoder */
 export type BitrateMode = { mode: "cbr" } | { mode: "cvbr" } | { mode: "vbr"; value: number };
 
-// Bitrate mode capability without encoder-specific values.
+/**  Bitrate mode capability without encoder-specific values. */
 export type BitrateModeKind = "cbr" | "cvbr" | "vbr";
 
-// Channel selection strategy
+/**  Channel selection strategy */
 export type ChannelConfig = "auto" | "mono" | "stereo";
 
 export type ChildJobSnapshot = {
@@ -295,11 +295,11 @@ export type CollisionPolicy = "fail" | "replace_existing" | "rename_new" | "skip
 
 export type ConcurrencyPreference = { mode: "auto" } | { mode: "fixed"; value: number };
 
-// Machine-readable decoder identity paired with the friendly display label.
+/**  Machine-readable decoder identity paired with the friendly display label. */
 export type DecoderSelection = {
-	// Stable decoder identifier used for routing and comparisons.
+	/**  Stable decoder identifier used for routing and comparisons. */
 	decoderId: string,
-	// Friendly decoder label used for display only.
+	/**  Friendly decoder label used for display only. */
 	decoderLabel: string,
 };
 
@@ -320,7 +320,7 @@ export type EncoderBitrateModeCapability = {
 };
 
 export type EncoderCapabilitySource = "none" | "detected" |
-// Validated from the user-configured FFmpeg path in App Settings.
+/**  Validated from the user-configured FFmpeg path in App Settings. */
 "user_configured";
 
 export type EncoderDefaults = {
@@ -344,7 +344,7 @@ export type EncoderSettings = {
 	bitrateKbps: number,
 	bitrateMode: BitrateMode,
 	channels: ChannelConfig,
-	// Applies to FDK encoder only
+	/**  Applies to FDK encoder only */
 	afterburner: boolean,
 };
 
@@ -362,15 +362,15 @@ export type EncoderSettingsCapabilities = {
 	channelOptions: ChannelConfig[],
 };
 
-// Supported encoder types for audiobooks
+/**  Supported encoder types for audiobooks */
 export type EncoderType =
-// Auto-detect best available (FDK > Apple > Native AAC)
+/**  Auto-detect best available (FDK > Apple > Native AAC) */
 "auto" |
-// FDK HE-AAC VBR (libfdk_aac)
+/**  FDK HE-AAC VBR (libfdk_aac) */
 "fdk_he_aac" |
-// Apple AAC (AudioToolbox), macOS-only
+/**  Apple AAC (AudioToolbox), macOS-only */
 "aac_at" |
-// Native FFmpeg AAC encoder (aac)
+/**  Native FFmpeg AAC encoder (aac) */
 "native_aac";
 
 /**
@@ -384,19 +384,19 @@ export type EncoderType =
  */
 export type EventStage = "analyzing" | "converting" | "writing" | "completed" | "skipped" | "failed" | "cancelled";
 
-// Summary information for a file list
+/**  Summary information for a file list */
 export type FileListInfo = {
-	// List of validated audio files
+	/**  List of validated audio files */
 	files: AudioFile[],
-	// Stable decoder identities aligned by index with `files`.
+	/**  Stable decoder identities aligned by index with `files`. */
 	selectedDecoders: (DecoderSelection | null)[],
-	// Total duration in seconds
+	/**  Total duration in seconds */
 	totalDuration: number,
-	// Total size in bytes
+	/**  Total size in bytes */
 	totalSize: number,
-	// Number of valid files
+	/**  Number of valid files */
 	validCount: number,
-	// Number of invalid files
+	/**  Number of invalid files */
 	invalidCount: number,
 };
 
@@ -603,7 +603,7 @@ export type OutputReviewRequirement = {
 
 export type PatchOp<T> = { op: "set"; value: T } | { op: "clear" } | { op: "noop" };
 
-// A deliberately captured snapshot of the panel-owned durable preferences.
+/**  A deliberately captured snapshot of the panel-owned durable preferences. */
 export type PinnedDefaults = {
 	maxConcurrentJobs: ConcurrencyPreference,
 	encoderDefaults: EncoderDefaults,
@@ -644,14 +644,14 @@ export type ProcessPayload = {
 	inputIds: (string | null)[] | null,
 	outputDir: string,
 	settings: EncoderSettings,
-	// Sample rate from frontend (optional, defaults to Auto)
+	/**  Sample rate from frontend (optional, defaults to Auto) */
 	sampleRate: SampleRateConfig | null,
 	jobType: JobType | null,
-	// Output naming configuration (defaults to ABS-compatible)
+	/**  Output naming configuration (defaults to ABS-compatible) */
 	outputNaming: OutputNamingConfig | null,
-	// Explicit collision policy selected by the user after preflight review.
+	/**  Explicit collision policy selected by the user after preflight review. */
 	collisionPolicy: CollisionPolicy | null,
-	// Signature returned by preflight so execution can reject stale destination assumptions.
+	/**  Signature returned by preflight so execution can reject stale destination assumptions. */
 	preflightSignature: string | null,
 	/**
 	 *  Supplemental assets keyed by input id. These are committed only after a
@@ -680,46 +680,46 @@ export type ProcessingPreflightPlan = {
 	outputs: PlannedOutput[],
 };
 
-// Progress event structure for frontend communication
+/**  Progress event structure for frontend communication */
 export type ProgressEvent = ProgressEvent_Serialize | ProgressEvent_Deserialize;
 
-// Progress event structure for frontend communication
+/**  Progress event structure for frontend communication */
 export type ProgressEvent_Deserialize = {
-	// Backend operation family that emitted this event
+	/**  Backend operation family that emitted this event */
 	operation_kind: OperationKind,
-	// Current processing stage
+	/**  Current processing stage */
 	stage: EventStage,
-	// Progress percentage (0-100)
+	/**  Progress percentage (0-100) */
 	percentage: number,
-	// Human-readable status message
+	/**  Human-readable status message */
 	message: string,
-	// Currently processing file (if applicable)
+	/**  Currently processing file (if applicable) */
 	current_file: string | null,
-	// Estimated time remaining in seconds
+	/**  Estimated time remaining in seconds */
 	eta_seconds: number | null,
-	// Job identifier when this event is tied to a registered job
+	/**  Job identifier when this event is tied to a registered job */
 	job_id: string | null,
-	// Original input index when this event maps to one selected input
+	/**  Original input index when this event maps to one selected input */
 	input_index: number | null,
 };
 
-// Progress event structure for frontend communication
+/**  Progress event structure for frontend communication */
 export type ProgressEvent_Serialize = {
-	// Backend operation family that emitted this event
+	/**  Backend operation family that emitted this event */
 	operation_kind: OperationKind,
-	// Current processing stage
+	/**  Current processing stage */
 	stage: EventStage,
-	// Progress percentage (0-100)
+	/**  Progress percentage (0-100) */
 	percentage: number,
-	// Human-readable status message
+	/**  Human-readable status message */
 	message: string,
-	// Currently processing file (if applicable)
+	/**  Currently processing file (if applicable) */
 	current_file: string | null,
-	// Estimated time remaining in seconds
+	/**  Estimated time remaining in seconds */
 	eta_seconds: number | null,
-	// Job identifier when this event is tied to a registered job
+	/**  Job identifier when this event is tied to a registered job */
 	job_id?: string | null,
-	// Original input index when this event maps to one selected input
+	/**  Original input index when this event maps to one selected input */
 	input_index?: number | null,
 };
 
@@ -736,14 +736,14 @@ export type ProgressSnapshot = {
 
 export type ProviderId = "audible";
 
-// Batch queue snapshot for frontend communication
+/**  Batch queue snapshot for frontend communication */
 export type QueueEvent = {
 	operation_kind: OperationKind,
 	items: QueueItem[],
 	max_concurrent: number,
 };
 
-// Single queued item in a batch run
+/**  Single queued item in a batch run */
 export type QueueItem = {
 	input_index: number,
 	file_path: string,
@@ -840,11 +840,11 @@ export type RuntimeSettingsCapabilities = {
 	maxConcurrentJobs: MaxConcurrentJobsCapabilities,
 };
 
-// Sample rate configuration options
+/**  Sample rate configuration options */
 export type SampleRateConfig =
-// Automatically detect from input files
+/**  Automatically detect from input files */
 "auto" |
-// Explicit sample rate in Hz
+/**  Explicit sample rate in Hz */
 { explicit: number };
 
 /**
@@ -853,7 +853,7 @@ export type SampleRateConfig =
  *  hydration source.
  */
 export type StartupBehavior =
-// Today's behavior: reopen with whatever the panels last persisted.
+/**  Today's behavior: reopen with whatever the panels last persisted. */
 "rememberLastState" |
 /**
  *  Reopen with the user-pinned defaults; in-flight panel tweaks are
@@ -905,7 +905,7 @@ export type SupportedAudioImportMetadata = {
  *  owner probes and validates the path before any runtime use.
  */
 export type ToolchainPreferences = {
-	// User-selected external FFmpeg binary expected to expose `libfdk_aac`.
+	/**  User-selected external FFmpeg binary expected to expose `libfdk_aac`. */
 	externalFfmpegPath: string | null,
 };
 
@@ -936,17 +936,22 @@ async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; dat
     }
 }
 
-function makeEvent<T>(name: string) {
+type EventEmit<T> = [T] extends [null] ? () => Promise<void> : (payload: T) => Promise<void>;
+
+function makeEvent<T>(name: string, serialize?: (payload: T) => unknown, deserialize?: (payload: any) => T) {
+    const mapEvent = (cb: __TAURI_EVENT.EventCallback<T>) => (event: __TAURI_EVENT.Event<any>) => cb({ ...event, payload: deserialize ? deserialize(event.payload) : event.payload });
+    const mapPayload = (payload: T) => serialize ? serialize(payload) : payload;
+
     const base = {
-        listen: (cb: __TAURI_EVENT.EventCallback<T>) => __TAURI_EVENT.listen(name, cb),
-        once: (cb: __TAURI_EVENT.EventCallback<T>) => __TAURI_EVENT.once(name, cb),
-        emit: ((payload: T) => __TAURI_EVENT.emit(name, payload) as unknown) as (T extends null ? () => Promise<void> : (payload: T) => Promise<void>)
+        listen: (cb: __TAURI_EVENT.EventCallback<T>) => __TAURI_EVENT.listen(name, mapEvent(cb)),
+        once: (cb: __TAURI_EVENT.EventCallback<T>) => __TAURI_EVENT.once(name, mapEvent(cb)),
+        emit: ((payload: T) => __TAURI_EVENT.emit(name, mapPayload(payload)) as unknown) as EventEmit<T>
     };
 
     const fn = (target: import("@tauri-apps/api/webview").Webview | import("@tauri-apps/api/window").Window) => ({
-        listen: (cb: __TAURI_EVENT.EventCallback<T>) => target.listen(name, cb),
-        once: (cb: __TAURI_EVENT.EventCallback<T>) => target.once(name, cb),
-        emit: ((payload: T) => target.emit(name, payload) as unknown) as (T extends null ? () => Promise<void> : (payload: T) => Promise<void>)
+        listen: (cb: __TAURI_EVENT.EventCallback<T>) => target.listen(name, mapEvent(cb)),
+        once: (cb: __TAURI_EVENT.EventCallback<T>) => target.once(name, mapEvent(cb)),
+        emit: ((payload: T) => target.emit(name, mapPayload(payload)) as unknown) as EventEmit<T>
     });
 
     return Object.assign(fn, base);

--- a/src/lib/tauri-client.generated-event-bindings.test.ts
+++ b/src/lib/tauri-client.generated-event-bindings.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { EVENTS } from '../types/events';
 import type {
+	AcquisitionProgress,
 	AudioChapter,
 	FileListInfo,
 	MaterializedSourceFile,
@@ -57,6 +58,7 @@ describe('tauriClient generated event bindings', () => {
 	});
 
 	it('keeps bounded wide Rust values in the numeric IPC contract', () => {
+		expectTypeOf<AcquisitionProgress['percentage']>().toEqualTypeOf<number>();
 		expectTypeOf<AudioChapter['startMs']>().toEqualTypeOf<number>();
 		expectTypeOf<MaterializedSourceFile['sizeBytes']>().toEqualTypeOf<number>();
 		expectTypeOf<MetadataSaveResultEntry['inputIndex']>().toEqualTypeOf<number>();

--- a/src/lib/tauri-client.generated-event-bindings.test.ts
+++ b/src/lib/tauri-client.generated-event-bindings.test.ts
@@ -1,6 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { EVENTS } from '../types/events';
+import type {
+	AudioChapter,
+	FileListInfo,
+	MaterializedSourceFile,
+	MaxConcurrentJobsCapabilities,
+	MetadataSaveResultEntry,
+	OperationSnapshot,
+	ProgressEvent,
+	ProgressSnapshot,
+} from './generated/tauri';
 
 describe('tauriClient generated event bindings', () => {
 	beforeEach(() => {
@@ -44,5 +54,17 @@ describe('tauriClient generated event bindings', () => {
 			expect.any(Function),
 		);
 		expect(tauriListen).toHaveBeenCalledTimes(5);
+	});
+
+	it('keeps bounded wide Rust values in the numeric IPC contract', () => {
+		expectTypeOf<AudioChapter['startMs']>().toEqualTypeOf<number>();
+		expectTypeOf<MaterializedSourceFile['sizeBytes']>().toEqualTypeOf<number>();
+		expectTypeOf<MetadataSaveResultEntry['inputIndex']>().toEqualTypeOf<number>();
+		expectTypeOf<OperationSnapshot['sequence']>().toEqualTypeOf<number>();
+		expectTypeOf<FileListInfo['totalDuration']>().toEqualTypeOf<number>();
+		expectTypeOf<ProgressEvent['percentage']>().toEqualTypeOf<number>();
+		expectTypeOf<ProgressSnapshot['percentage']>().toEqualTypeOf<number>();
+		expectTypeOf<ProgressSnapshot['bytesDownloaded']>().toEqualTypeOf<number | null>();
+		expectTypeOf<MaxConcurrentJobsCapabilities['fixedMax']>().toEqualTypeOf<number>();
 	});
 });

--- a/src/lib/tauri-client.test.ts
+++ b/src/lib/tauri-client.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultEncoderSettings, type EncoderSettings } from '../types/audio';
 import type { ProcessingProgressEvent } from '../types/events';
 import { runtimeSettingsCapabilitiesFixture } from '../test/fixtures/runtimeSettingsCapabilities';
+import mainWindowCapability from '../../src-tauri/capabilities/default.json';
 
 // Note: Tauri APIs are auto-mocked by src/test/setup.ts
 
@@ -57,6 +58,18 @@ describe('tauriClient', () => {
 	});
 
 	describe('opener helpers', () => {
+		it('limits source and preview opening to user-owned or mounted paths', () => {
+			const openPathPermission = mainWindowCapability.permissions.find(
+				(permission) =>
+					typeof permission === 'object' && permission.identifier === 'opener:allow-open-path',
+			);
+
+			expect(openPathPermission).toEqual({
+				identifier: 'opener:allow-open-path',
+				allow: [{ path: '$HOME/**' }, { path: '$TEMP/**' }, { path: '/Volumes/**' }],
+			});
+		});
+
 		it('routes paths and URLs to distinct Tauri opener commands', async () => {
 			const { openPath, openUrl } = await import('@tauri-apps/plugin-opener');
 			const mockOpenPath = vi.mocked(openPath);

--- a/src/ui/workCenter/__tests__/state.test.ts
+++ b/src/ui/workCenter/__tests__/state.test.ts
@@ -12,7 +12,12 @@ vi.mock('../../remoteSource/sessionAssets.svelte', () => ({
 	releaseRemoteSourceSessionRetainers: releaseMock,
 }));
 
-import { applyOperationSnapshot, disposeWorkCenter, initializeWorkCenter } from '../state.svelte';
+import {
+	applyOperationSnapshot,
+	disposeWorkCenter,
+	initializeWorkCenter,
+	openChildSource,
+} from '../state.svelte';
 import { workCenterState } from '../state.svelte';
 
 function createDeferred<T>() {
@@ -94,6 +99,7 @@ describe('Work Center state', () => {
 		releaseMock.mockReset();
 		releaseMock.mockReturnValue([]);
 		disposeWorkCenter();
+		workCenterState.errorMessage = null;
 	});
 
 	afterEach(() => {
@@ -141,6 +147,16 @@ describe('Work Center state', () => {
 		expect(releaseMock).toHaveBeenCalledTimes(1);
 		expect(purgeMock).toHaveBeenCalledTimes(1);
 		resolvePurge();
+	});
+
+	it('surfaces source-open rejection without leaving an unhandled promise', async () => {
+		vi.spyOn(tauriClient, 'openPath').mockRejectedValueOnce('source application unavailable');
+
+		await expect(openChildSource({ sourcePath: '/tmp/book.m4b' })).resolves.toBeUndefined();
+
+		expect(workCenterState.errorMessage).toBe(
+			'Failed to open source file: source application unavailable',
+		);
 	});
 
 	it('does not mark initialized or retain listeners when disposed mid-initialization', async () => {

--- a/src/ui/workCenter/state.svelte.ts
+++ b/src/ui/workCenter/state.svelte.ts
@@ -137,7 +137,11 @@ export async function cancelWorkOperation(operationId: OperationId): Promise<voi
 
 export async function openChildSource(child: { sourcePath?: string | null }): Promise<void> {
 	if (!child.sourcePath) return;
-	await tauriClient.openPath(child.sourcePath);
+	try {
+		await tauriClient.openPath(child.sourcePath);
+	} catch (error) {
+		workCenterState.errorMessage = `Failed to open source file: ${toUserMessage(error)}`;
+	}
 }
 
 async function purgeRemoteSessionsForTerminalOperation(


### PR DESCRIPTION
Tracks #448. Close it manually only after owner-approved merge and terminal validation.

## What changed

- aligned the Rust and JavaScript Tauri patch family, including one resolved `@tauri-apps/api` 2.11.1 install across the root and opener dependency
- adopted `specta` and `tauri-specta` RC25 with `specta-typescript` 0.0.12 across the runtime and five core crates
- regenerated the command/event bindings and accepted RC25's phase-aware event helper output
- made ABB's existing numeric IPC contract explicit at the Tauri boundary: bounded byte sizes, timestamps, counts, indices, and sequence values remain TypeScript `number`
- hardened Rust progress and file-total owners so non-finite floats cannot become unexpected JSON `null` values where the UI requires numeric arithmetic
- recorded the durable IPC decision and added representative generated-type and non-finite-value regression proof
- restored Work Center source and automatic preview opening for user-owned, temporary, and mounted-volume paths; denied paths now surface truthful Work Center feedback instead of an unhandled rejection

No visual UI, metadata policy, codec policy, or FFmpeg posture changed. The only workflow correction is restoring the existing source/preview opener action under an explicit least-privilege path scope.

## Why

Tauri 2.11.3-2.11.5 carries runtime and packaged-protocol corrections relevant to ABB's desktop shell. Specta RC25 makes wide-integer and non-finite-float serialization choices explicit instead of silently preserving RC24's generated shapes. This PR adopts the current stacks while keeping ABB's domain-appropriate JSON contract intentional and testable.

## Validation

- frozen Bun install resolves `@tauri-apps/api` 2.11.1 only; no stale nested 2.11.0 dependency
- Vitest: 106 files / 664 tests passed
- all six `abb-*-core` Nextest packages passed (80 tests total)
- bundled runtime library: 423 passed / 4 skipped
- runtime integration and real-media lane: 65 passed
- generated bindings: local generation and release-critical verify both clean
- Tauri runtime-boundary check passed
- TypeScript typecheck, Svelte diagnostics (0 errors / 0 warnings), Biome lint/format, Prettier, Cargo fmt, and production web build passed
- owner run `20260810T230001Z-9832`: all 8 jobs and 3 WorkRuntime operations completed; its sole degraded signal was traced exactly to the previously empty opener path scope
- controlled `app:dev:log` run `20260811T000621Z-19195`: clean start/stop with zero diagnostics, proving generic shutdown did not cause the owner-run rejection
- portable DMG built and passed `hdiutil verify`; a copied artifact reported version 1.3.2, stayed running, and exposed an on-screen `AudioBook Boss` window
- packaged web shape: one JavaScript entry bundle; no `modulepreload` or `crossorigin` drift

## Accepted residual

Strict workspace Clippy reaches one unchanged pre-existing warning: `read_id3_cover` is 124 lines against the configured 100-line limit. It is a maintainability finding in the security-sensitive embedded-cover parser, not a compile/runtime regression or part of the Tauri/Specta blast radius; this PR does not refactor that parser merely to make the unrelated lint green.

