### PR TITLE
bld: make release packaging and hosted proof deterministic

### DIFF
--- a/.agents/skills/release/references/execution.md
+++ b/.agents/skills/release/references/execution.md
@@ -105,6 +105,10 @@ tagging or publishing.
 
    ```bash
    gh release create v<x.y.z> "<resolved-dmg-path>" --title "AudioBook Boss v<x.y.z>" --notes-file <notes-file>
+   gh release verify-asset v<x.y.z> "<resolved-dmg-path>"
    gh release view v<x.y.z>
    gh release list --limit 5
    ```
+
+   `verify-asset` must succeed for the exact local DMG that passed `hdiutil
+   verify`; it confirms the GitHub asset is byte-for-byte the tested file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
     name: Typecheck + svelte-check (clean install)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,25 @@
-name: tripwire
+name: frontend clean-install alarm
 
-# Narrow app-correctness tripwire (issue #341 / roadmap #407 Slice 1).
-# Deliberately NOT a broad app gate: typecheck + clean-install svelte-check,
-# generated-binding drift, and core-crate Nextest only. Widen only with
-# repo-owner sign-off recorded in docs/DECISIONS.md.
+# Clean-runner check for frontend dependency and type drift that a warm local
+# checkout can conceal. This is an alarm after relevant main pushes, not a PR
+# gate or a broad test route.
 
 on:
   push:
     branches: [main]
+    paths:
+      - .github/workflows/ci.yml
+      - src/**
+      - package.json
+      - bun.lock
+      - bunfig.toml
+      - svelte.config.js
+      - tsconfig.json
+      - vite.config.ts
   workflow_dispatch:
 
 concurrency:
-  group: tripwire-${{ github.ref }}
+  group: frontend-clean-install-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,47 +34,3 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run check:svelte
-
-  rust-core:
-    name: Core-crate Nextest
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.95"
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-      - run: >-
-          cargo nextest run
-          -p abb-audible-core
-          -p abb-media-core
-          -p abb-metadata-core
-          -p abb-output-artifact-core
-          -p abb-processing-core
-          -p abb-remote-source-core
-
-  bindings:
-    name: Generated-binding drift
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.95"
-      - uses: Swatinem/rust-cache@v2
-      # Binding export uses ABB's pinned bundled FFmpeg for release-artifact
-      # parity; system FFmpeg remains a fast local diagnostic route only.
-      - run: brew install pkg-config
-      # tauri-build requires the AAXClean sidecar resource to exist; binding
-      # generation never executes it, so a stub keeps .NET out of this lane.
-      - run: |
-          mkdir -p src-tauri/binaries
-          touch src-tauri/binaries/abb-aaxclean-helper-aarch64-apple-darwin
-          chmod +x src-tauri/binaries/abb-aaxclean-helper-aarch64-apple-darwin
-      - run: bash scripts/check-generated-bindings.sh --mode verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to AudioBook Boss™ will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Release packaging is now deterministic: Cargo binary discovery is explicit,
+  bundle verification rejects any unexpected executable next to the app and
+  AAXClean helper, and both shipped executables are checked for architecture
+  and external library links.
+- Public DMG builds always rebuild the AAXClean helper from current source
+  instead of reusing machine-history output; developer builds keep fast reuse.
+- Formal releases now verify the uploaded GitHub asset is byte-for-byte the
+  locally validated DMG (`gh release verify-asset`).
+
 ## [1.3.3] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to AudioBook Boss™ will be documented in this file.
   and external library links.
 - Public DMG builds always rebuild the AAXClean helper from current source
   instead of reusing machine-history output; developer builds keep fast reuse.
+  A failed or interrupted helper publish no longer copies leftover output.
 - Formal releases now verify the uploaded GitHub asset is byte-for-byte the
   locally validated DMG (`gh release verify-asset`).
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ default broad review route.
   generated bindings or Tauri runtime boundaries directly.
 - Dependency hygiene: `bun run audit`
   It is not part of the normal review path.
-- CI: a narrow tripwire workflow runs on push to `main` (clean-install
-  typecheck/svelte-check, binding drift, core-crate Nextest). It is an alarm,
-  not a gate; local commands above are the evidence trail.
+- CI: GitHub automatically runs Pages for `site/**` and a path-narrowed
+  frontend clean-install alarm (frozen install, typecheck, svelte-check) after
+  relevant `main` pushes. It is an alarm, not a PR gate. Rust tests and
+  generated-binding checks stay local or release-owned; an empty PR check list
+  does not mean those proofs ran on GitHub.
 - Tooling policy: Bun is the package manager/script runner/test runner.
   Keep Vite scripts on the standard Vite CLI unless a validated tooling
   decision changes that.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,17 @@
 # Decisions
 
+## 2026-08-11 - Hosted Proof Is One Clean-Frontend Alarm (#450)
+
+- Outcome: GitHub automatically runs only Pages publication and a
+  path-narrowed frontend frozen-install/type/Svelte alarm. Rust tests and
+  generated-binding verification stay explicit local or release checks.
+- Evidence: the clean frontend runner caught an undeclared `@types/node`
+  dependency hidden by a warm checkout; hosted core tests had no unique catch,
+  and the binding job's only catch was a trailing newline after compiling the
+  FFmpeg-linked runtime.
+- Guardrail: automatic hosted work needs a demonstrated clean-runner or
+  publication outcome that local/release proof does not already own.
+
 ## 2026-08-10 - Specta RC25 Keeps ABB's Numeric IPC Contract (#448)
 
 - Outcome: ABB adopts Specta/tauri-specta RC25 and keeps bounded byte sizes,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"app:dev:log": "bash scripts/dev-tauri-log.sh",
 		"aaxclean-helper:publish": "bun scripts/publish-aaxclean-helper.ts",
 		"app:build": "bun scripts/build-app.ts --bundles app",
-		"app:build:dmg": "bun scripts/build-app.ts --bundles dmg",
+		"app:build:dmg": "bun scripts/build-app.ts --bundles app,dmg",
 		"app:build:all": "bun scripts/build-app.ts --bundles all",
 		"app:install-local": "bun scripts/install-local-app.ts",
 		"app:install-local:existing": "bun scripts/install-local-app.ts --skip-build",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -7,11 +7,11 @@ commands over invoking internals directly.
 ## Public Entrypoints
 
 - Convenience commands: `package.json` scripts.
-- CI tripwire (`.github/workflows/ci.yml`) runs on push to `main` only:
-  clean-install typecheck + `check:svelte`, generated-binding drift, and
-  core-crate Nextest. It is a narrow post-push alarm, not a gate; local
-  commands below remain the default evidence trail. Widening it requires a
-  repo-owner decision (see `docs/DECISIONS.md` 2026-07-01).
+- Frontend clean-install alarm (`.github/workflows/ci.yml`) runs after relevant
+  frontend/dependency/config pushes to `main`: frozen install, typecheck, and
+  `check:svelte`. It catches undeclared dependencies that a warm checkout can
+  conceal; it is not a PR gate or broad test route. Rust and generated-binding
+  proof stay local/release-owned through the commands below.
 - There is no repo-owned verification runner and no default broad review route.
   Run native commands directly, one at a time, only for the touched owner or
   explicit risk surface. Report the command, elapsed time when meaningful, exit
@@ -99,7 +99,11 @@ commands over invoking internals directly.
 - `check-tauri-runtime-boundary.ts`: generated command/event import boundary
   plus raw Tauri invoke bypass protection.
 - `build-app.ts`, `install-local-app.ts`, `resolve-release-dmg.ts`,
-  `bump-version.ts`: build/release utilities.
+  `bump-version.ts`: build/release utilities. Public DMG builds always publish
+  the AAXClean helper from current source and retain the matching portable app
+  long enough to verify it; local app builds may reuse a fresh helper sidecar.
+  Bundle verification accepts exactly the app and helper executables and
+  inspects both.
 - `analyze_code_lines.py`: optional human "Commander View" source-size
   diagnostic, not proof.
 - `*.test.ts`: Vitest coverage for script helpers.

--- a/scripts/build-app.test.ts
+++ b/scripts/build-app.test.ts
@@ -16,6 +16,7 @@ import {
 	pruneLocalInstallArtifacts,
 	resolveRequestedBundles,
 	resolveMacOsBundlePaths,
+	verifyMacOsBundle,
 	verifyDmgBundle,
 } from './build-app';
 
@@ -104,6 +105,58 @@ describe('findForbiddenLinkedLibraries', () => {
 			'/opt/homebrew/opt/ffmpeg/lib/libavcodec.62.dylib',
 			'/usr/local/opt/libx11/lib/libX11.6.dylib',
 		]);
+	});
+});
+
+describe('verifyMacOsBundle', () => {
+	function createPackagedAppFixture(): {
+		commandRunner: typeof spawnSync;
+		paths: ReturnType<typeof resolveMacOsBundlePaths>;
+		toolCalls: Array<{ args: string[]; command: string }>;
+	} {
+		const { applicationsDir, repoRoot } = createRepoFixture();
+		const paths = resolveMacOsBundlePaths(repoRoot, applicationsDir);
+		const macOsDir = path.dirname(paths.executablePath);
+		mkdirSync(macOsDir, { recursive: true });
+		writeFileSync(paths.executablePath, 'app');
+		writeFileSync(paths.helperExecutablePath, 'helper');
+
+		const toolCalls: Array<{ args: string[]; command: string }> = [];
+		const commandRunner = ((command: string, args: string[]) => {
+			toolCalls.push({ command, args });
+			return {
+				status: 0,
+				stderr: '',
+				stdout:
+					command === 'lipo'
+						? 'arm64\n'
+						: `${args[1]}:\n\t/System/Library/Frameworks/Foundation.framework/Foundation\n`,
+			};
+		}) as typeof spawnSync;
+
+		return { commandRunner, paths, toolCalls };
+	}
+
+	it('accepts exactly the app and helper and inspects both executables', () => {
+		const { commandRunner, paths, toolCalls } = createPackagedAppFixture();
+
+		expect(() => verifyMacOsBundle(paths, commandRunner)).not.toThrow();
+		expect(toolCalls).toEqual([
+			{ command: 'lipo', args: ['-archs', paths.executablePath] },
+			{ command: 'lipo', args: ['-archs', paths.helperExecutablePath] },
+			{ command: 'otool', args: ['-L', paths.executablePath] },
+			{ command: 'otool', args: ['-L', paths.helperExecutablePath] },
+		]);
+	});
+
+	it('rejects an unexpected executable before inspecting the bundle', () => {
+		const { commandRunner, paths, toolCalls } = createPackagedAppFixture();
+		writeFileSync(path.join(path.dirname(paths.executablePath), 'export_bindings'), 'unexpected');
+
+		expect(() => verifyMacOsBundle(paths, commandRunner)).toThrow(
+			'Packaged app contains unexpected executables',
+		);
+		expect(toolCalls).toEqual([]);
 	});
 });
 
@@ -293,6 +346,12 @@ describe('addAaxcleanHelperConfigArg', () => {
 describe('buildTauriApp', () => {
 	it('forces noninteractive Finder-free DMG packaging when requested', () => {
 		const { repoRoot } = createRepoFixture();
+		const sidecarDir = path.join(repoRoot, 'src-tauri/binaries');
+		mkdirSync(sidecarDir, { recursive: true });
+		writeFileSync(
+			path.join(sidecarDir, 'abb-aaxclean-helper-aarch64-apple-darwin'),
+			'existing helper',
+		);
 		const calls: Array<{
 			args: string[];
 			command: string;
@@ -341,6 +400,12 @@ describe('buildTauriApp', () => {
 
 	it('leaves CI value untouched for non-DMG app builds', () => {
 		const { repoRoot } = createRepoFixture();
+		const sidecarDir = path.join(repoRoot, 'src-tauri/binaries');
+		mkdirSync(sidecarDir, { recursive: true });
+		writeFileSync(
+			path.join(sidecarDir, 'abb-aaxclean-helper-aarch64-apple-darwin'),
+			'existing helper',
+		);
 		const calls: Array<{ env?: NodeJS.ProcessEnv }> = [];
 		const commandRunner = ((
 			command: string,
@@ -362,8 +427,9 @@ describe('buildTauriApp', () => {
 			nonInteractiveDmg: false,
 		});
 
-		expect(calls[1]?.env?.CI).toBe(process.env.CI);
-		expect(calls[1]?.env).toBe(process.env);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.env?.CI).toBe(process.env.CI);
+		expect(calls[0]?.env).toBe(process.env);
 	});
 });
 

--- a/scripts/build-app.ts
+++ b/scripts/build-app.ts
@@ -177,7 +177,11 @@ export function buildTauriApp(
 	buildArgs: string[],
 	options: BuildTauriAppOptions = {},
 ): void {
-	publishAaxcleanHelper(repoRoot, options.commandRunner);
+	const requestedBundles = resolveRequestedBundles(buildArgs);
+	publishAaxcleanHelper(repoRoot, {
+		commandRunner: options.commandRunner,
+		force: requestedBundles.has('dmg'),
+	});
 	verifyAaxcleanHelperSidecar(repoRoot);
 
 	const ffmpegFeature = bundledFfmpegFeatureForBuild(buildArgs);
@@ -235,7 +239,10 @@ export function addAaxcleanHelperConfigArg(args: string[]): string[] {
 	];
 }
 
-export function verifyMacOsBundle(paths: BundlePaths): void {
+export function verifyMacOsBundle(
+	paths: BundlePaths,
+	commandRunner: typeof spawnSync = spawnSync,
+): void {
 	if (!existsSync(paths.canonicalAppPath)) {
 		throw new Error(`Expected canonical app bundle at ${paths.canonicalAppPath}`);
 	}
@@ -248,25 +255,45 @@ export function verifyMacOsBundle(paths: BundlePaths): void {
 		throw new Error(`Expected AAXClean helper executable at ${paths.helperExecutablePath}`);
 	}
 
-	verifyMacOsExecutableArchitecture(paths.executablePath);
-	verifyMacOsExecutableArchitecture(paths.helperExecutablePath);
+	const macOsDir = path.dirname(paths.executablePath);
+	const expectedExecutables = new Set([
+		path.basename(paths.executablePath),
+		path.basename(paths.helperExecutablePath),
+	]);
+	const unexpectedExecutables = readdirSync(macOsDir).filter(
+		(entry) => !expectedExecutables.has(entry),
+	);
+	if (unexpectedExecutables.length > 0) {
+		throw new Error(
+			[
+				`Packaged app contains unexpected executables under ${macOsDir}:`,
+				...unexpectedExecutables.sort(),
+			].join('\n'),
+		);
+	}
 
-	const result = spawnSync('otool', ['-L', paths.executablePath], {
+	verifyMacOsExecutableArchitecture(paths.executablePath, commandRunner);
+	verifyMacOsExecutableArchitecture(paths.helperExecutablePath, commandRunner);
+	verifyMacOsExecutableLinks(paths.executablePath, commandRunner);
+	verifyMacOsExecutableLinks(paths.helperExecutablePath, commandRunner);
+}
+
+function verifyMacOsExecutableLinks(executablePath: string, commandRunner: typeof spawnSync): void {
+	const result = commandRunner('otool', ['-L', executablePath], {
 		encoding: 'utf8',
 	});
 
 	if (result.status !== 0) {
-		throw new Error(result.stderr.trim() || `otool failed for ${paths.executablePath}`);
+		throw new Error(result.stderr.trim() || `otool failed for ${executablePath}`);
 	}
 
 	const forbiddenMatches = findForbiddenLinkedLibraries(result.stdout);
 
 	if (forbiddenMatches.length > 0) {
 		throw new Error(
-			[
-				`Packaged app still links external libraries: ${paths.executablePath}`,
-				...forbiddenMatches,
-			].join('\n'),
+			[`Packaged app still links external libraries: ${executablePath}`, ...forbiddenMatches].join(
+				'\n',
+			),
 		);
 	}
 }
@@ -282,8 +309,11 @@ export function verifyDmgBundle(paths: BundlePaths): void {
 	}
 }
 
-function verifyMacOsExecutableArchitecture(executablePath: string): void {
-	const result = spawnSync('lipo', ['-archs', executablePath], {
+function verifyMacOsExecutableArchitecture(
+	executablePath: string,
+	commandRunner: typeof spawnSync,
+): void {
+	const result = commandRunner('lipo', ['-archs', executablePath], {
 		encoding: 'utf8',
 	});
 
@@ -398,7 +428,7 @@ function main(): void {
 	}
 
 	const bundlePaths = resolveMacOsBundlePaths(repoRoot);
-	if (requestedBundles.has('app')) {
+	if (requestedBundles.has('app') || requestedBundles.has('dmg')) {
 		verifyMacOsBundle(bundlePaths);
 	}
 

--- a/scripts/publish-aaxclean-helper.test.ts
+++ b/scripts/publish-aaxclean-helper.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import type { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+	aaxcleanHelperBaseName,
+	aaxcleanHelperTargetTriple,
+	publishAaxcleanHelper,
+	resolveAaxcleanHelperPaths,
+} from './publish-aaxclean-helper';
+
+const tempRoots: string[] = [];
+
+function createHelperRepoFixture(): string {
+	const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'abb-aaxclean-publish-'));
+	tempRoots.push(repoRoot);
+	mkdirSync(path.join(repoRoot, 'tools/abb-aaxclean-helper/src/AbbAaxcleanHelper'), {
+		recursive: true,
+	});
+	writeFileSync(
+		path.join(repoRoot, 'tools/abb-aaxclean-helper/src/AbbAaxcleanHelper/Program.cs'),
+		'// helper source fixture',
+	);
+	writeFileSync(
+		path.join(repoRoot, 'tools/abb-aaxclean-helper/src/AbbAaxcleanHelper/AbbAaxcleanHelper.csproj'),
+		'<Project />',
+	);
+	return repoRoot;
+}
+
+afterAll(() => {
+	for (const tempRoot of tempRoots.splice(0, tempRoots.length)) {
+		rmSync(tempRoot, { force: true, recursive: true });
+	}
+});
+
+describe('publishAaxcleanHelper', () => {
+	it('rejects a signal-terminated publish and does not copy leftover output', () => {
+		const repoRoot = createHelperRepoFixture();
+		const paths = resolveAaxcleanHelperPaths(repoRoot);
+		mkdirSync(paths.publishDir, { recursive: true });
+		writeFileSync(paths.publishedExecutablePath, 'old leftover helper');
+		mkdirSync(paths.sidecarDir, { recursive: true });
+		writeFileSync(paths.sidecarPath, 'previous sidecar');
+
+		const commandRunner = (() => ({
+			status: null,
+			signal: 'SIGTERM',
+		})) as typeof spawnSync;
+
+		expect(() => publishAaxcleanHelper(repoRoot, { commandRunner, force: true })).toThrow(
+			'AAXClean helper publish failed (signal SIGTERM)',
+		);
+		expect(existsSync(paths.publishedExecutablePath)).toBe(false);
+		expect(readFileSync(paths.sidecarPath, 'utf8')).toBe('previous sidecar');
+	});
+
+	it('copies only a helper recreated by a successful publish', () => {
+		const repoRoot = createHelperRepoFixture();
+		const paths = resolveAaxcleanHelperPaths(repoRoot);
+		mkdirSync(paths.publishDir, { recursive: true });
+		writeFileSync(paths.publishedExecutablePath, 'old leftover helper');
+
+		const commandRunner = ((command: string, args: string[]) => {
+			expect(command).toContain('dotnet');
+			expect(args[0]).toBe('publish');
+			expect(existsSync(paths.publishedExecutablePath)).toBe(false);
+			writeFileSync(paths.publishedExecutablePath, 'fresh helper');
+			return { status: 0 };
+		}) as typeof spawnSync;
+
+		expect(publishAaxcleanHelper(repoRoot, { commandRunner, force: true })).toBe(paths.sidecarPath);
+		expect(readFileSync(paths.sidecarPath, 'utf8')).toBe('fresh helper');
+		expect(path.basename(paths.sidecarPath)).toBe(
+			`${aaxcleanHelperBaseName}-${aaxcleanHelperTargetTriple}`,
+		);
+	});
+});

--- a/scripts/publish-aaxclean-helper.ts
+++ b/scripts/publish-aaxclean-helper.ts
@@ -14,6 +14,11 @@ interface AaxcleanHelperPaths {
 	sidecarPath: string;
 }
 
+interface PublishAaxcleanHelperOptions {
+	commandRunner?: typeof spawnSync;
+	force?: boolean;
+}
+
 export function resolveDotnetCommand(): string {
 	if (process.env.DOTNET_CLI && process.env.DOTNET_CLI.length > 0) {
 		return process.env.DOTNET_CLI;
@@ -45,16 +50,16 @@ export function resolveAaxcleanHelperPaths(repoRoot: string): AaxcleanHelperPath
 
 export function publishAaxcleanHelper(
 	repoRoot: string,
-	commandRunner: typeof spawnSync = spawnSync,
+	options: PublishAaxcleanHelperOptions = {},
 ): string {
 	const paths = resolveAaxcleanHelperPaths(repoRoot);
-	if (helperSidecarIsFresh(repoRoot, paths.sidecarPath)) {
+	if (!options.force && helperSidecarIsFresh(repoRoot, paths.sidecarPath)) {
 		console.log(`[aaxclean-helper] Using existing ${paths.sidecarPath}`);
 		return paths.sidecarPath;
 	}
 
 	const dotnet = resolveDotnetCommand();
-	const result = commandRunner(
+	const result = (options.commandRunner ?? spawnSync)(
 		dotnet,
 		[
 			'publish',

--- a/scripts/publish-aaxclean-helper.ts
+++ b/scripts/publish-aaxclean-helper.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	statSync,
+	unlinkSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -58,6 +66,10 @@ export function publishAaxcleanHelper(
 		return paths.sidecarPath;
 	}
 
+	if (existsSync(paths.publishedExecutablePath)) {
+		unlinkSync(paths.publishedExecutablePath);
+	}
+
 	const dotnet = resolveDotnetCommand();
 	const result = (options.commandRunner ?? spawnSync)(
 		dotnet,
@@ -83,11 +95,17 @@ export function publishAaxcleanHelper(
 		},
 	);
 
-	if (typeof result.status === 'number' && result.status !== 0) {
-		process.exit(result.status);
-	}
 	if (result.error) {
 		throw result.error;
+	}
+	if (result.status !== 0) {
+		const detail =
+			typeof result.status === 'number'
+				? `status ${result.status}`
+				: result.signal
+					? `signal ${result.signal}`
+					: 'no successful exit status';
+		throw new Error(`AAXClean helper publish failed (${detail})`);
 	}
 	if (!existsSync(paths.publishedExecutablePath)) {
 		throw new Error(`Expected published AAXClean helper at ${paths.publishedExecutablePath}`);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,11 @@ description = "AudioBook Boss™ — Batch audiobook processing and metadata man
 authors = ["JStar"]
 edition = "2021"
 default-run = "audiobook-boss"
+autobins = false
+
+[[bin]]
+name = "audiobook-boss"
+path = "src/main.rs"
 
 [[bin]]
 name = "export_bindings"


### PR DESCRIPTION
Tracks #450. This implements only the essential, evidence-backed subset agreed in the issue; the parked optimization experiments remain out of scope.

## Outcomes

- make Cargo binary discovery explicit and fail release verification if anything besides the ABB app and AAXClean helper enters Contents/MacOS
- force public DMG builds to publish AAXClean from current source instead of reusing machine-history output
- verify the uploaded GitHub Release asset is byte-for-byte the local DMG that passed release validation
- retain one hosted clean-install frontend alarm, narrowly triggered by frontend/build-input changes
- remove automatic hosted Rust and generated-binding jobs; those proofs remain local and release-owned
- pin the retained workflow actions to reviewed commit SHAs (checkout reuses the pages.yml pin) and record the packaging/verification changes in the unreleased changelog

## Why

This closes observed defects and friction: developer binaries previously entered a release bundle, public packaging could inherit a stale helper, unrelated pushes triggered slow hosted jobs, and the release procedure did not explicitly compare the uploaded asset with the validated local file.

## Independent pre-flight audit

A read-only audit reviewed the first three commits against the #450 adjudication and confirmed the implementation, including the forced-rebuild interaction with the `beforeBuildCommand` re-publish (fresh sidecar is reused, not rebuilt twice) and both `publishAaxcleanHelper` call sites. It found two adopted-but-missing items, now fixed in the fourth commit:

1. the surviving frontend-alarm job still referenced `actions/checkout@v6` and `oven-sh/setup-bun@v2` by tag; both are now pinned to full commit SHAs
2. the repo-convention CHANGELOG entry was absent; the unreleased section now records the packaging and release-verification changes

## Deliberate non-goals

No AAXClean trimming, FFmpeg feature reduction, binding-export redesign, cache identity framework, NuGet lockfile work, repository-wide Action policy, or new CI framework.

## Validation

- bun run test -- scripts/build-app.test.ts — 28 passed (re-run after audit fixes)
- bun run typecheck
- bun run check:svelte — 0 errors, 0 warnings for the app
- bun run fmt:check
- bun run lint:check
- git diff --check (re-run after audit fixes)
- parsed both workflow YAML files (re-parsed ci.yml after pinning)
- verified Cargo exposes exactly the main binary plus the two feature-gated developer binaries
- bun run app:build:dmg completed a fresh portable release build
- retained app Contents/MacOS contained exactly audiobook-boss and abb-aaxclean-helper
- hdiutil verify passed for the resulting DMG
- gh release verify-asset was live-proven against v1.3.3