### PR TITLE
test(audio): pin SampleAccumulator channel/silence/tail invariants

### DIFF
--- a/src-tauri/src/audio/buffer.rs
+++ b/src-tauri/src/audio/buffer.rs
@@ -407,3 +407,7 @@ impl SampleAccumulator {
         self.consumed_samples = 0;
     }
 }
+
+#[cfg(test)]
+#[path = "buffer_tests.rs"]
+mod buffer_tests;

--- a/src-tauri/src/audio/buffer_tests.rs
+++ b/src-tauri/src/audio/buffer_tests.rs
@@ -1,0 +1,273 @@
+use super::*;
+use ffmpeg_next as ff;
+
+const SAMPLE_RATE: u32 = 44_100;
+const FRAME_SIZE: usize = 8;
+
+fn init_ffmpeg() {
+    ff::init().expect("ffmpeg init");
+}
+
+fn f32_planar() -> ff::format::Sample {
+    ff::format::Sample::F32(ff::format::sample::Type::Planar)
+}
+
+fn i16_packed() -> ff::format::Sample {
+    ff::format::Sample::I16(ff::format::sample::Type::Packed)
+}
+
+fn layout(channels: i32) -> ff::channel_layout::ChannelLayout {
+    ff::channel_layout::ChannelLayout::default(channels)
+}
+
+fn new_accumulator(
+    channels: usize,
+    frame_size: usize,
+    format: ff::format::Sample,
+) -> SampleAccumulator {
+    SampleAccumulator::new(
+        channels,
+        frame_size,
+        SAMPLE_RATE,
+        layout(channels as i32),
+        format,
+    )
+    .expect("supported SampleAccumulator config")
+}
+
+fn alloc_audio_frame(
+    format: ff::format::Sample,
+    channels: i32,
+    samples: usize,
+) -> ff::frame::Audio {
+    let channel_layout = layout(channels);
+    let mut frame = ff::frame::Audio::empty();
+    frame.set_format(format);
+    frame.set_channel_layout(channel_layout);
+    frame.set_rate(SAMPLE_RATE);
+    frame.set_samples(samples);
+    unsafe {
+        frame.alloc(format, samples, channel_layout);
+    }
+    frame
+}
+
+fn fill_f32_plane(frame: &mut ff::frame::Audio, channel: usize, values: &[f32]) {
+    let plane = frame.plane_mut::<f32>(channel);
+    assert!(
+        plane.len() >= values.len(),
+        "typed plane {channel} is shorter than the values being written"
+    );
+    plane[..values.len()].copy_from_slice(values);
+}
+
+fn f32_plane_samples(frame: &ff::frame::Audio, channel: usize) -> Vec<f32> {
+    let take = frame.samples();
+    let plane = frame.plane::<f32>(channel);
+    assert!(
+        plane.len() >= take,
+        "typed plane {channel} is shorter than the reported sample count"
+    );
+    plane[..take].to_vec()
+}
+
+fn fill_i16_packed(frame: &mut ff::frame::Audio, interleaved: &[i16]) {
+    let plane = frame.data_mut(0);
+    let needed_bytes = interleaved.len() * std::mem::size_of::<i16>();
+    assert!(
+        plane.len() >= needed_bytes,
+        "packed I16 frame data(0) is shorter than the interleaved payload"
+    );
+    // SAFETY: `data_mut(0)` is the allocated packed S16 plane; we only view the
+    // native-endian sample payload (`interleaved.len()` values), not linesize padding.
+    let dst = unsafe {
+        std::slice::from_raw_parts_mut(plane.as_mut_ptr() as *mut i16, interleaved.len())
+    };
+    dst.copy_from_slice(interleaved);
+}
+
+fn i16_packed_samples(frame: &ff::frame::Audio, channels: usize) -> Vec<i16> {
+    let take_total = frame.samples() * channels;
+    let plane = frame.data(0);
+    let needed_bytes = take_total * std::mem::size_of::<i16>();
+    assert!(
+        plane.len() >= needed_bytes,
+        "packed I16 drain must expose samples through data(0)"
+    );
+    // SAFETY: production `drain_one_s16_packed` writes native-endian i16 into
+    // `data_mut(0)`; this read uses the same plane and sample count.
+    let src = unsafe { std::slice::from_raw_parts(plane.as_ptr() as *const i16, take_total) };
+    src.to_vec()
+}
+
+/// Catches a silent/dropped right plane if `push_frame` only copies channel 0
+/// and `drain_one` still reports a stereo frame.
+#[test]
+fn f32_planar_stereo_push_then_drain_keeps_both_planes_and_matching_sample_counts() {
+    init_ffmpeg();
+    let left = [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80];
+    let right = [-0.15, -0.25, -0.35, -0.45, -0.55, -0.65, -0.75, -0.85];
+
+    let mut input = alloc_audio_frame(f32_planar(), 2, FRAME_SIZE);
+    fill_f32_plane(&mut input, 0, &left);
+    fill_f32_plane(&mut input, 1, &right);
+
+    let mut accumulator = new_accumulator(2, FRAME_SIZE, f32_planar());
+    let drained = accumulator.push_frame(&input);
+    assert_eq!(
+        drained.len(),
+        1,
+        "one exact encoder frame should drain from a full stereo push"
+    );
+
+    let out = &drained[0];
+    assert_eq!(out.samples(), FRAME_SIZE);
+    assert_eq!(out.planes(), 2, "drained frame must keep a right plane");
+    assert_eq!(
+        f32_plane_samples(out, 0),
+        left,
+        "left plane must survive push_frame -> drain_one"
+    );
+    assert_eq!(
+        f32_plane_samples(out, 1),
+        right,
+        "right plane must survive push_frame -> drain_one (not silence)"
+    );
+}
+
+/// Policy: silence-pad channel `ch > 0` only when typed `frame.planes()` omits
+/// that channel (`ch >= planes`). Do not treat `data(ch)` / byte linesize as
+/// missing-plane truth, and do not copy or drop the present plane.
+#[test]
+fn missing_plane_ch_gt_0_pads_silence_only_when_frame_planes_omits_that_channel() {
+    init_ffmpeg();
+    let left = [0.11, 0.22, 0.33, 0.44, 0.55, 0.66, 0.77, 0.88];
+
+    let mut mono = alloc_audio_frame(f32_planar(), 1, FRAME_SIZE);
+    assert_eq!(
+        mono.planes(),
+        1,
+        "precondition: mono planar input reports one typed plane"
+    );
+    fill_f32_plane(&mut mono, 0, &left);
+
+    let mut accumulator = new_accumulator(2, FRAME_SIZE, f32_planar());
+    let drained = accumulator.push_frame(&mono);
+    assert_eq!(drained.len(), 1);
+
+    let out = &drained[0];
+    assert_eq!(out.samples(), FRAME_SIZE);
+    assert_eq!(
+        f32_plane_samples(out, 0),
+        left,
+        "present plane 0 must be copied, not replaced with silence"
+    );
+    assert_eq!(
+        f32_plane_samples(out, 1),
+        [0.0; FRAME_SIZE],
+        "channel 1 is absent from frame.planes() so only that plane is silence-padded"
+    );
+}
+
+/// Catches flush(true) inventing extra full frames of silence, or flush(false)
+/// padding a leftover tail up to `frame_size`.
+#[test]
+fn flush_tail_true_pads_exactly_one_short_frame_false_does_not_invent_a_full_frame() {
+    init_ffmpeg();
+    let tail = [0.31, -0.42, 0.53];
+    assert!(tail.len() < FRAME_SIZE);
+
+    let mut short = alloc_audio_frame(f32_planar(), 2, tail.len());
+    fill_f32_plane(&mut short, 0, &tail);
+    fill_f32_plane(&mut short, 1, &tail);
+
+    let mut pad_on = new_accumulator(2, FRAME_SIZE, f32_planar());
+    assert!(
+        pad_on.push_frame(&short).is_empty(),
+        "a short push must not drain a full frame"
+    );
+    let padded = pad_on
+        .flush_tail(true)
+        .expect("flush_tail(true) must emit the padded leftover");
+    assert_eq!(
+        padded.samples(),
+        FRAME_SIZE,
+        "flush_tail(true) pads exactly one short leftover to one encoder frame"
+    );
+    let mut expected = tail.to_vec();
+    expected.extend(std::iter::repeat_n(0.0f32, FRAME_SIZE - tail.len()));
+    assert_eq!(f32_plane_samples(&padded, 0), expected);
+    assert_eq!(f32_plane_samples(&padded, 1), expected);
+    assert!(
+        pad_on.flush_tail(true).is_none(),
+        "flush_tail(true) must not invent a second full frame after the leftover"
+    );
+
+    let mut pad_off = new_accumulator(2, FRAME_SIZE, f32_planar());
+    assert!(pad_off.push_frame(&short).is_empty());
+    let unpadded = pad_off
+        .flush_tail(false)
+        .expect("flush_tail(false) still drains the leftover samples");
+    assert_eq!(
+        unpadded.samples(),
+        tail.len(),
+        "flush_tail(false) must not invent a full encoder frame"
+    );
+    assert_eq!(f32_plane_samples(&unpadded, 0), tail);
+    assert_eq!(f32_plane_samples(&unpadded, 1), tail);
+}
+
+/// Catches L/R swap or planar indexing on the Apple AAC packed-I16 `data_mut(0)`
+/// path. Host-testable without AudioToolbox encode.
+#[test]
+fn i16_packed_drain_preserves_interleaved_lr_order_through_data_mut_0() {
+    init_ffmpeg();
+    // Distinct L/R magnitudes so a channel swap is obvious: L negative, R positive.
+    let interleaved = [-1000i16, 2000, -3000, 4000, -5000, 6000, -7000, 8000];
+    assert_eq!(interleaved.len(), FRAME_SIZE * 2);
+
+    let mut input = alloc_audio_frame(i16_packed(), 2, FRAME_SIZE);
+    fill_i16_packed(&mut input, &interleaved);
+
+    let mut accumulator = new_accumulator(2, FRAME_SIZE, i16_packed());
+    let drained = accumulator.push_frame(&input);
+    assert_eq!(drained.len(), 1);
+
+    let out = &drained[0];
+    assert_eq!(out.samples(), FRAME_SIZE);
+    assert_eq!(
+        i16_packed_samples(out, 2),
+        interleaved,
+        "packed drain must keep interleaved L/R order through data(0)"
+    );
+}
+
+/// Catches constructing a storage/format mismatch (or a zero-sized frame plan)
+/// that would later truncate or silently corrupt encoder bytes.
+#[test]
+fn construct_rejects_zero_frame_size_and_unsupported_formats_as_anti_corruption_guard() {
+    init_ffmpeg();
+    let stereo = layout(2);
+
+    let zero = SampleAccumulator::new(2, 0, SAMPLE_RATE, stereo, f32_planar())
+        .expect_err("frame_size == 0 must fail closed");
+    assert!(
+        zero.to_string().contains("frame_size=0"),
+        "zero frame_size error should name the anti-corruption guard, got {zero}"
+    );
+
+    let unsupported = [
+        ff::format::Sample::F32(ff::format::sample::Type::Packed),
+        ff::format::Sample::I16(ff::format::sample::Type::Planar),
+        ff::format::Sample::U8(ff::format::sample::Type::Packed),
+    ];
+    for format in unsupported {
+        let err = SampleAccumulator::new(2, FRAME_SIZE, SAMPLE_RATE, stereo, format)
+            .expect_err("unsupported formats must fail closed");
+        let message = err.to_string();
+        assert!(
+            message.contains("Unsupported encoder sample format"),
+            "unsupported format {format:?} should fail as the anti-corruption guard, got {message}"
+        );
+    }
+}

--- a/src-tauri/src/audio/buffer_tests.rs
+++ b/src-tauri/src/audio/buffer_tests.rs
@@ -249,8 +249,9 @@ fn construct_rejects_zero_frame_size_and_unsupported_formats_as_anti_corruption_
     init_ffmpeg();
     let stereo = layout(2);
 
-    let zero = SampleAccumulator::new(2, 0, SAMPLE_RATE, stereo, f32_planar())
-        .expect_err("frame_size == 0 must fail closed");
+    let Err(zero) = SampleAccumulator::new(2, 0, SAMPLE_RATE, stereo, f32_planar()) else {
+        panic!("frame_size == 0 must fail closed");
+    };
     assert!(
         zero.to_string().contains("frame_size=0"),
         "zero frame_size error should name the anti-corruption guard, got {zero}"
@@ -262,8 +263,9 @@ fn construct_rejects_zero_frame_size_and_unsupported_formats_as_anti_corruption_
         ff::format::Sample::U8(ff::format::sample::Type::Packed),
     ];
     for format in unsupported {
-        let err = SampleAccumulator::new(2, FRAME_SIZE, SAMPLE_RATE, stereo, format)
-            .expect_err("unsupported formats must fail closed");
+        let Err(err) = SampleAccumulator::new(2, FRAME_SIZE, SAMPLE_RATE, stereo, format) else {
+            panic!("unsupported format {format:?} must fail closed");
+        };
         let message = err.to_string();
         assert!(
             message.contains("Unsupported encoder sample format"),

--- a/src-tauri/src/audio/buffer_tests.rs
+++ b/src-tauri/src/audio/buffer_tests.rs
@@ -73,7 +73,7 @@ fn f32_plane_samples(frame: &ff::frame::Audio, channel: usize) -> Vec<f32> {
 
 fn fill_i16_packed(frame: &mut ff::frame::Audio, interleaved: &[i16]) {
     let plane = frame.data_mut(0);
-    let needed_bytes = interleaved.len() * std::mem::size_of::<i16>();
+    let needed_bytes = std::mem::size_of_val(interleaved);
     assert!(
         plane.len() >= needed_bytes,
         "packed I16 frame data(0) is shorter than the interleaved payload"

--- a/src-tauri/src/audio/buffer_tests.rs
+++ b/src-tauri/src/audio/buffer_tests.rs
@@ -224,17 +224,17 @@ fn i16_packed_drain_preserves_interleaved_lr_order_through_data_mut_0() {
     init_ffmpeg();
     // Distinct L/R magnitudes so a channel swap is obvious: L negative, R positive.
     let interleaved = [-1000i16, 2000, -3000, 4000, -5000, 6000, -7000, 8000];
-    assert_eq!(interleaved.len(), FRAME_SIZE * 2);
+    let frame_size = interleaved.len() / 2;
 
-    let mut input = alloc_audio_frame(i16_packed(), 2, FRAME_SIZE);
+    let mut input = alloc_audio_frame(i16_packed(), 2, frame_size);
     fill_i16_packed(&mut input, &interleaved);
 
-    let mut accumulator = new_accumulator(2, FRAME_SIZE, i16_packed());
+    let mut accumulator = new_accumulator(2, frame_size, i16_packed());
     let drained = accumulator.push_frame(&input);
     assert_eq!(drained.len(), 1);
 
     let out = &drained[0];
-    assert_eq!(out.samples(), FRAME_SIZE);
+    assert_eq!(out.samples(), frame_size);
     assert_eq!(
         i16_packed_samples(out, 2),
         interleaved,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses F1 in #454. Remaining CRAP findings (F2–F8) stay open on that issue.

## Why
`SampleAccumulator` owns planar/packed copy, missing-plane silence padding, short-frame tail pad, and the Apple AAC packed-I16 `data_mut(0)` path. `src-tauri/src/audio/AGENTS.md` already requires regression coverage for silence-padding and sample-buffer/channel/tail changes; the accumulator had none.

## Five earns-keep cases
Colocated in `src-tauri/src/audio/buffer_tests.rs` (declared from `buffer.rs`, not the public-strip `contract_tests.rs`):

1. **F32 planar stereo** — both planes survive `push_frame` → `drain_one` with matching sample counts (catches a silent/dropped right channel).
2. **Missing plane `ch > 0`** — pads silence **only** when typed `frame.planes()` omits that channel (`ch >= planes`). Present plane 0 is copied; channel 1 is zeros. Does not treat `data(ch)` / byte linesize as missing-plane truth.
3. **`flush_tail(true)`** pads exactly one short leftover to one encoder frame; **`flush_tail(false)`** drains the leftover sample count and does not invent a full frame.
4. **I16 packed** — interleaved L/R order is preserved through `data(0)` / `data_mut(0)`. Host-testable; does not require AudioToolbox encode.
5. **Construct-fail** — `frame_size == 0` and unsupported sample formats (`F32` packed, `I16` planar, `U8` packed) fail closed as the anti-corruption guard.

No `SampleAccumulator` move into `abb-media-core`. No `setup_encoder` / remux / finalize / plan.rs / RemoteSource work.

## How to run
From the repo root, smallest owner proof:

```bash
cargo nextest run -p audiobook-boss --features bundled-ffmpeg --lib -- buffer
```

Equivalent lib filter if nextest is unavailable:

```bash
cargo test -p audiobook-boss --features bundled-ffmpeg --lib -- buffer
```

## Verification
Linux cloud VM, after installing GTK/WebKit/OpenSSL/nasm (not in the snapshot) and a gitignored AAXClean helper stub:

```
cargo test -p audiobook-boss --features bundled-ffmpeg --lib -- buffer
```

Result: **5 passed / 0 failed** (`audio::buffer::buffer_tests::*`). Clippy on the new file is clean after a `size_of_val` lint fix. Pre-existing `lib.rs` / macOS-only toolchain warnings were not touched.

## Environment limits
This PR was authored on a Linux cloud VM. It does **not** run the media-execution lane and cannot prove Apple AAC / AudioToolbox encode quality (macOS-gated by design). The packed-I16 test pins accumulator byte order only. External FDK remains env-gated and is out of scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-305e4325-6a2f-4298-9b0b-6784f052a2b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-305e4325-6a2f-4298-9b0b-6784f052a2b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

