### PR TITLE
bld: adopt TypeScript 7 and Effect 4 RC

### DIFF
--- a/.agents/skills/abb-library-research/references/effect.md
+++ b/.agents/skills/abb-library-research/references/effect.md
@@ -14,14 +14,14 @@ Resolve the installed version from `bun.lock` (do not cache it here).
 
 ## Installed / registry entrypoints
 
-- `node_modules/effect/dist/dts/index.d.ts`
-- `node_modules/effect/dist/dts/Effect.d.ts`
-- `node_modules/effect/dist/dts/Context.d.ts`
-- `node_modules/effect/dist/dts/Layer.d.ts`
-- `node_modules/effect/dist/dts/Scope.d.ts`
-- `node_modules/effect/dist/dts/Schema.d.ts`
-- `node_modules/effect/dist/dts/Stream.d.ts`
-- `node_modules/effect/dist/dts/Schedule.d.ts`
+- `node_modules/effect/dist/index.d.ts`
+- `node_modules/effect/dist/Effect.d.ts`
+- `node_modules/effect/dist/Context.d.ts`
+- `node_modules/effect/dist/Layer.d.ts`
+- `node_modules/effect/dist/Scope.d.ts`
+- `node_modules/effect/dist/Schema.d.ts`
+- `node_modules/effect/dist/Stream.d.ts`
+- `node_modules/effect/dist/Schedule.d.ts`
 - npm/unpkg: `effect` at the lockfile version (`packages/effect` in the
   upstream monorepo)
 

--- a/.agents/skills/abb-library-research/references/effect.md
+++ b/.agents/skills/abb-library-research/references/effect.md
@@ -36,11 +36,13 @@ Resolve the installed version from `bun.lock` (do not cache it here).
 - Import the installed `effect` package, not unpublished monorepo paths.
 - Do not copy internal helpers from `src/internal` unless an exported installed
   API proves the same capability exists.
-- Do not treat Effect v4 notes as ABB truth unless ABB has adopted that version.
 - Effect `llms.txt` is current documentation, not versioned evidence.
 
 ## ABB Reconciliation
 
+- ABB is on Effect 4 (exact pin in `package.json`). Reconcile docs against
+  `bun.lock`. Workflow owners import Effect only through
+  `src/lib/effect/appEffect.ts`.
 - Check `package.json` and `bun.lock` for the resolved `effect` version.
 - Prefer installed TypeScript declarations and exported APIs over source-only
   internals.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run check:svelte

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.svelte-check/
 dist
 dist-ssr
 *.local

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Convert, tag, and organize your audiobook library with metadata that works every
 ## Quick start
 
 ```bash
-# JS/TS dependencies (Bun 1.3.14; see package.json packageManager)
+# JS/TS dependencies (Bun 1.4.0; see package.json packageManager)
 bun install
 
 # First run publishes the AAXClean sidecar (.NET 8 SDK required)
@@ -25,7 +25,7 @@ bun install
 bun run app:dev:log
 ```
 
-Requires: macOS (Apple Silicon), Bun 1.3.14, Rust, and a .NET 8 SDK for the sidecar. App, test, and release builds use **bundled FFmpeg** — Homebrew `ffmpeg` is not required to run the app. Install it only for the real-media test lane (fixture/readback) or an optional external-FDK encoder.
+Requires: macOS (Apple Silicon), Bun 1.4.0, Rust, and a .NET 8 SDK for the sidecar. App, test, and release builds use **bundled FFmpeg** — Homebrew `ffmpeg` is not required to run the app. Install it only for the real-media test lane (fixture/readback) or an optional external-FDK encoder.
 
 **AAC runtime contract**: output encoder and input decoder are separate. Normal processing uses in-process `ffmpeg-next`. FDK HE-AAC output uses an external FFmpeg/`libfdk_aac` adapter and may force `aac_at` or `libfdk_aac` when the default decoder cannot handle the source.
 
@@ -33,7 +33,7 @@ Requires: macOS (Apple Silicon), Bun 1.3.14, Rust, and a .NET 8 SDK for the side
 
 ## Toolchain
 
-- Package manager: **Bun 1.3.14**, pinned by `package.json` `packageManager`.
+- Package manager: **Bun 1.4.0**, pinned by `package.json` `packageManager`.
 - Verify Bun or frontend changes with the commands below; use `.agents/skills/release`
   for packaging and GitHub Release work.
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.112",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.9",
@@ -18,13 +18,14 @@
         "@testing-library/jest-dom": "^6.10.0",
         "@testing-library/svelte": "^5.4.2",
         "@testing-library/user-event": "^14.6.5",
+        "@typescript/native": "npm:typescript@7.0.2",
         "jsdom": "^29.1.1",
         "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^3.5.2",
         "svelte": "^5.56.9",
         "svelte-check": "^4.7.6",
         "tailwindcss": "^4.3.3",
-        "typescript": "^6.0.3",
+        "typescript": "npm:@typescript/typescript6@6.0.2",
         "vite": "^8.2.2",
         "vitest": "^4.1.11",
       },
@@ -95,6 +96,18 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
 
@@ -218,6 +231,50 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@typescript/native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "@typescript/old": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
@@ -272,7 +329,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-    "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
@@ -288,7 +345,7 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
-    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -348,7 +405,13 @@
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
+    "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -370,7 +433,7 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -422,7 +485,7 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,15 +2,18 @@
 
 ## 2026-08-27 - TypeScript 7 / Effect 4 Frontend Toolchain (#462)
 
-- Outcome: ABB's frontend compiler is TypeScript 7 via `@typescript/native`;
-  the `typescript` package slot stays `@typescript/typescript6` so tools that
-  `require('typescript')` still get a 6.x API. `svelte-check` runs with
-  `--tsgo`. Bun is `1.4.0` because `1.3.14` cannot resolve that nested alias
-  graph. Effect is an exact v4 RC pin (`4.0.0-rc.112` at landing), not a
-  range. Workflow owners consume Effect only through `src/lib/effect/appEffect.ts`.
-- Evidence: `package.json`, `bun.lock`, `.github/workflows/ci.yml`.
-- Guardrail: do not put TypeScript 7 in the `typescript` package slot; that
-  breaks svelte-check's TypeScript 6 peer and the compiler API.
+- Outcome: ABB's frontend compiler is TypeScript 7 via `@typescript/native`.
+  The `typescript` package slot is `@typescript/typescript6` only because
+  `svelte-check@4.7.6` still `require()`s a TypeScript 6 compiler API even
+  with `--tsgo`. ABB-owned code does not import `typescript`. Bun is `1.4.0`
+  because `1.3.14` cannot resolve that nested alias graph. Effect is an exact
+  v4 RC pin (`4.0.0-rc.112` at landing), not a range. Workflow owners consume
+  Effect only through `src/lib/effect/appEffect.ts`.
+- Evidence: `package.json`, `bun.lock`, `.github/workflows/ci.yml`,
+  `scripts/check-tauri-runtime-boundary.ts`.
+- Guardrail: drop the TypeScript 6 shim when svelte-check can type `.svelte`
+  files against TypeScript 7 alone. Do not put TypeScript 7 in the
+  `typescript` slot before that; `svelte-check` will refuse to start.
 
 ## 2026-08-27 - Dependency Resolution And Release-Age Policy
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -13,7 +13,11 @@
   `scripts/check-tauri-runtime-boundary.ts`.
 - Guardrail: drop the TypeScript 6 shim when svelte-check can type `.svelte`
   files against TypeScript 7 alone. Do not put TypeScript 7 in the
-  `typescript` slot before that; `svelte-check` will refuse to start.
+  `typescript` slot before that; `svelte-check` will refuse to start. The
+  runtime-boundary check is a text scan for this window, not an AST
+  parser. Replace it when TypeScript 7.1's programmatic API and a svelte-check
+  that types `.svelte` on that API exist. Do not grow it toward AST
+  completeness in the meantime.
 
 ## 2026-08-27 - Dependency Resolution And Release-Age Policy
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,17 @@
 # Decisions
 
+## 2026-08-27 - TypeScript 7 / Effect 4 Frontend Toolchain (#462)
+
+- Outcome: ABB's frontend compiler is TypeScript 7 via `@typescript/native`;
+  the `typescript` package slot stays `@typescript/typescript6` so tools that
+  `require('typescript')` still get a 6.x API. `svelte-check` runs with
+  `--tsgo`. Bun is `1.4.0` because `1.3.14` cannot resolve that nested alias
+  graph. Effect is an exact v4 RC pin (`4.0.0-rc.112` at landing), not a
+  range. Workflow owners consume Effect only through `src/lib/effect/appEffect.ts`.
+- Evidence: `package.json`, `bun.lock`, `.github/workflows/ci.yml`.
+- Guardrail: do not put TypeScript 7 in the `typescript` package slot; that
+  breaks svelte-check's TypeScript 6 peer and the compiler API.
+
 ## 2026-08-27 - Dependency Resolution And Release-Age Policy
 
 - Outcome: `Cargo.lock` and `bun.lock` are committed resolution truth; any CI

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "AudioBook Boss™ — Batch audiobook processing and metadata management",
 	"version": "1.3.5",
 	"type": "module",
-	"packageManager": "bun@1.3.14",
+	"packageManager": "bun@1.4.0",
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc && vite build",
@@ -13,7 +13,7 @@
 		"fmt:check": "bunx @biomejs/biome format --no-errors-on-unmatched . && bunx prettier --check \"src/**/*.svelte\"",
 		"fmt:changed": "bunx @biomejs/biome format --write --changed --no-errors-on-unmatched && bunx prettier --write \"src/**/*.svelte\"",
 		"lint:check": "bunx @biomejs/biome lint --no-errors-on-unmatched .",
-		"check:svelte": "svelte-check --tsconfig ./tsconfig.json",
+		"check:svelte": "svelte-check --tsconfig ./tsconfig.json --tsgo",
 		"audit:rust": "cargo audit -D warnings",
 		"audit:js": "bun audit",
 		"audit": "bun run --sequential --no-exit-on-error audit:rust audit:js",
@@ -39,7 +39,7 @@
 		"@tauri-apps/api": "^2.11.1",
 		"@tauri-apps/plugin-dialog": "^2.7.2",
 		"@tauri-apps/plugin-opener": "^2.5.4",
-		"effect": "^3.22.1"
+		"effect": "4.0.0-rc.112"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.9",
@@ -49,13 +49,14 @@
 		"@testing-library/jest-dom": "^6.10.0",
 		"@testing-library/svelte": "^5.4.2",
 		"@testing-library/user-event": "^14.6.5",
+		"@typescript/native": "npm:typescript@7.0.2",
 		"jsdom": "^29.1.1",
 		"prettier": "^3.9.6",
 		"prettier-plugin-svelte": "^3.5.2",
 		"svelte": "^5.56.9",
 		"svelte-check": "^4.7.6",
 		"tailwindcss": "^4.3.3",
-		"typescript": "^6.0.3",
+		"typescript": "npm:@typescript/typescript6@6.0.2",
 		"vite": "^8.2.2",
 		"vitest": "^4.1.11"
 	},

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -120,11 +120,17 @@ commands over invoking internals directly.
 - TypeScript 7 lives in `@typescript/native`; the `typescript` slot stays the
   TypeScript 6 `require()` shim for `svelte-check --tsgo`. Do not collapse
   them, and do not import `typescript` from ABB `src/` or `scripts/` (parse
-  without the compiler API). Rationale: `docs/DECISIONS.md` 2026-08-27
+  without the compiler API). The runtime-boundary text scanner is for this
+  window only. Replace it when TypeScript 7.1's API and svelte-check can type
+  `.svelte` files without the TypeScript 6 shim. Do not grow it toward AST
+  completeness. Rationale: `docs/DECISIONS.md` 2026-08-27
   TypeScript 7 / Effect 4. Proof:
   `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
-  The no-import tripwire matches `from 'typescript'` so ordinary multiline
-  named imports count; do not require the binding list to sit on one line.
+  The no-import tripwires match `from 'typescript'` / `from 'effect'` so
+  ordinary multiline named imports count; do not require the binding list
+  to sit on one line. Effect imports are allowed only in
+  `src/lib/effect/appEffect.ts`. The tripwire stays in `scripts/` so it does
+  not pull Node types into the frontend `tsconfig`.
 - Bun version truth is `package.json#packageManager`. When it changes, set
   `.github/workflows/ci.yml` `bun-version` and
   `scripts/setup-codex-agent-env.sh` to that same field. Setup must install

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -125,8 +125,9 @@ commands over invoking internals directly.
   `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
 - Bun version truth is `package.json#packageManager`. When it changes, set
   `.github/workflows/ci.yml` `bun-version` and
-  `scripts/setup-codex-agent-env.sh` to that same field. Do not copy the
-  version from the 2026-05-28 DECISIONS entry.
+  `scripts/setup-codex-agent-env.sh` to that same field. Setup must install
+  that version or exit; do not warn-and-continue. Do not copy the version
+  from the 2026-05-28 DECISIONS entry.
 
 ## Linux Agent Environment (media lane)
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -123,6 +123,8 @@ commands over invoking internals directly.
   without the compiler API). Rationale: `docs/DECISIONS.md` 2026-08-27
   TypeScript 7 / Effect 4. Proof:
   `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
+  The no-import tripwire matches `from 'typescript'` so ordinary multiline
+  named imports count; do not require the binding list to sit on one line.
 - Bun version truth is `package.json#packageManager`. When it changes, set
   `.github/workflows/ci.yml` `bun-version` and
   `scripts/setup-codex-agent-env.sh` to that same field. Setup must install

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -117,6 +117,16 @@ commands over invoking internals directly.
   domain logic through filtered broad-crate tests when a core crate can own it.
 - Do not recreate custom runner aliases without explicit repo-owner approval.
 - New scripts need an obvious public command, package script, or usage header.
+- TypeScript 7 lives in `@typescript/native`; the `typescript` slot stays the
+  TypeScript 6 `require()` shim for `svelte-check --tsgo`. Do not collapse
+  them, and do not import `typescript` from ABB `src/` or `scripts/` (parse
+  without the compiler API). Rationale: `docs/DECISIONS.md` 2026-08-27
+  TypeScript 7 / Effect 4. Proof:
+  `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
+- Bun version truth is `package.json#packageManager`. When it changes, set
+  `.github/workflows/ci.yml` `bun-version` and
+  `scripts/setup-codex-agent-env.sh` to that same field. Do not copy the
+  version from the 2026-05-28 DECISIONS entry.
 
 ## Linux Agent Environment (media lane)
 

--- a/scripts/check-tauri-runtime-boundary.test.ts
+++ b/scripts/check-tauri-runtime-boundary.test.ts
@@ -263,4 +263,54 @@ describe('check-tauri-runtime-boundary.ts', () => {
 			rmSync(repoRoot, { force: true, recursive: true });
 		}
 	});
+
+	it('rejects raw __TAURI_INVOKE usage inside template interpolations', () => {
+		const repoRoot = createFixtureRepo();
+		try {
+			writeFileSync(
+				path.join(repoRoot, 'src/ui/templateInvoke.ts'),
+				'`${window.__TAURI_INVOKE("process_audiobook_files")}`;\n',
+			);
+
+			const result = runTauriBoundaryCheck(repoRoot);
+			expectStatus(result, 1);
+			expect(result.stderr).toContain('raw __TAURI_INVOKE usage');
+			expect(result.stderr).toContain('src/ui/templateInvoke.ts');
+		} finally {
+			rmSync(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it('ignores generated-import text inside string literals', () => {
+		const repoRoot = createFixtureRepo();
+		try {
+			writeFileSync(
+				path.join(repoRoot, 'src/ui/helpText.ts'),
+				'const help = "import { commands } from \'../lib/generated/tauri\'";\nexport const ok = help;\n',
+			);
+
+			const result = runTauriBoundaryCheck(repoRoot);
+			expectStatus(result, 0);
+			expect(result.stdout).toContain('[check-tauri-runtime-boundary] OK');
+		} finally {
+			rmSync(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it('allows a type-only generated re-export after a side-effect import', () => {
+		const repoRoot = createFixtureRepo();
+		try {
+			writeFileSync(
+				path.join(repoRoot, 'src/ui/types.ts'),
+				"import './setup';\nexport type { commands } from '../lib/generated/tauri';\n",
+			);
+			writeFileSync(path.join(repoRoot, 'src/ui/setup.ts'), 'export {};\n');
+
+			const result = runTauriBoundaryCheck(repoRoot);
+			expectStatus(result, 0);
+			expect(result.stdout).toContain('[check-tauri-runtime-boundary] OK');
+		} finally {
+			rmSync(repoRoot, { force: true, recursive: true });
+		}
+	});
 });

--- a/scripts/check-tauri-runtime-boundary.ts
+++ b/scripts/check-tauri-runtime-boundary.ts
@@ -1,6 +1,5 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
-import ts from 'typescript';
 
 const repoRoot = process.cwd();
 const generatedModulePath = path.join(repoRoot, 'src/lib/generated/tauri');
@@ -13,6 +12,21 @@ type Violation = {
 	file: string;
 	line: number;
 	message: string;
+};
+
+type NamedBinding = {
+	name: string;
+	typeOnly: boolean;
+};
+
+type ModuleStatement = {
+	kind: 'import' | 'export';
+	index: number;
+	typeOnly: boolean;
+	hasDefault: boolean;
+	hasNamespace: boolean;
+	names: NamedBinding[];
+	source: string;
 };
 
 const sourceFiles = collectSourceFiles(path.join(repoRoot, 'src'));
@@ -56,73 +70,38 @@ function checkFile(file: string): void {
 }
 
 function checkSourceBlock(file: string, fullContent: string, block: SourceBlock): void {
-	const sourceFile = ts.createSourceFile(file, block.content, ts.ScriptTarget.Latest, true);
-	for (const statement of sourceFile.statements) {
-		if (ts.isImportDeclaration(statement)) {
-			checkImportDeclaration(file, fullContent, block, sourceFile, statement);
-		} else if (ts.isExportDeclaration(statement)) {
-			checkExportDeclaration(file, fullContent, block, sourceFile, statement);
-		}
+	const code = blankComments(block.content);
+	for (const statement of parseModuleStatements(code)) {
+		checkModuleStatement(file, fullContent, block, statement);
 	}
-
 	if (!allowsRawTauriCore(file)) {
-		checkRawTauriInvokeUsage(file, fullContent, block, sourceFile);
+		checkRawTauriInvokeUsage(file, fullContent, block, code);
 	}
 }
 
-function checkImportDeclaration(
+function checkModuleStatement(
 	file: string,
 	fullContent: string,
 	block: SourceBlock,
-	sourceFile: ts.SourceFile,
-	statement: ts.ImportDeclaration,
+	statement: ModuleStatement,
 ): void {
-	const source = moduleSpecifierText(statement.moduleSpecifier);
-	const importClause = statement.importClause;
-	if (!source || !importClause || importClause.isTypeOnly) {
+	const line = lineNumberAt(fullContent, block.start + statement.index);
+	if (statement.source === '@tauri-apps/api/core' && !allowsRawTauriCore(file)) {
+		pushRawTauriCoreImportViolations(file, line, statement);
 		return;
 	}
 
-	const line = lineNumberAt(fullContent, block.start + statement.getStart(sourceFile));
-	if (source === '@tauri-apps/api/core' && !allowsRawTauriCore(file)) {
-		pushRawTauriCoreImportViolations(file, line, importClause);
+	if (statement.typeOnly || !isGeneratedTauriImport(file, statement.source)) {
 		return;
 	}
 
-	if (!isGeneratedTauriImport(file, source)) {
-		return;
-	}
+	pushNamedValueViolations(
+		file,
+		line,
+		new Set(statement.names.filter((binding) => !binding.typeOnly).map((binding) => binding.name)),
+	);
 
-	const namedImports = importNamedValues(importClause);
-	const hasValueNamespaceImport =
-		importClause.namedBindings !== undefined && ts.isNamespaceImport(importClause.namedBindings);
-	pushNamedValueViolations(file, line, namedImports);
-
-	if (hasValueNamespaceImport) {
-		violations.push({
-			file: displayPath(file),
-			line,
-			message:
-				'generated Tauri namespace value imports are not allowed; import commands or events through the owning boundary file',
-		});
-	}
-}
-
-function checkExportDeclaration(
-	file: string,
-	fullContent: string,
-	block: SourceBlock,
-	sourceFile: ts.SourceFile,
-	statement: ts.ExportDeclaration,
-): void {
-	const source = moduleSpecifierText(statement.moduleSpecifier);
-	if (!source || statement.isTypeOnly || !isGeneratedTauriImport(file, source)) {
-		return;
-	}
-
-	const line = lineNumberAt(fullContent, block.start + statement.getStart(sourceFile));
-	const exportClause = statement.exportClause;
-	if (!exportClause || ts.isNamespaceExport(exportClause)) {
+	if (statement.kind === 'export' && (statement.hasNamespace || statement.names.length === 0)) {
 		violations.push({
 			file: displayPath(file),
 			line,
@@ -132,48 +111,48 @@ function checkExportDeclaration(
 		return;
 	}
 
-	pushNamedValueViolations(file, line, namedExports(exportClause));
+	if (statement.hasNamespace) {
+		violations.push({
+			file: displayPath(file),
+			line,
+			message:
+				'generated Tauri namespace value imports are not allowed; import commands or events through the owning boundary file',
+		});
+	}
 }
 
 function checkRawTauriInvokeUsage(
 	file: string,
 	fullContent: string,
 	block: SourceBlock,
-	sourceFile: ts.SourceFile,
+	code: string,
 ): void {
-	function visit(node: ts.Node): void {
-		if (ts.isIdentifier(node) && node.text === '__TAURI_INVOKE') {
-			violations.push({
-				file: displayPath(file),
-				line: lineNumberAt(fullContent, block.start + node.getStart(sourceFile)),
-				message: 'raw __TAURI_INVOKE usage must stay out of runtime app code; use tauriClient',
-			});
-		}
-		ts.forEachChild(node, visit);
+	const searchable = blankQuoted(code);
+	for (const match of searchable.matchAll(/\b__TAURI_INVOKE\b/g)) {
+		violations.push({
+			file: displayPath(file),
+			line: lineNumberAt(fullContent, block.start + (match.index ?? 0)),
+			message: 'raw __TAURI_INVOKE usage must stay out of runtime app code; use tauriClient',
+		});
 	}
-
-	visit(sourceFile);
 }
 
 function pushRawTauriCoreImportViolations(
 	file: string,
 	line: number,
-	importClause: ts.ImportClause,
+	statement: ModuleStatement,
 ): void {
-	if (importClause.name) {
+	if (statement.typeOnly) {
+		return;
+	}
+	if (statement.hasDefault) {
 		violations.push({
 			file: displayPath(file),
 			line,
 			message: 'raw Tauri core default imports must stay out of runtime app code; use tauriClient',
 		});
 	}
-
-	const namedBindings = importClause.namedBindings;
-	if (!namedBindings) {
-		return;
-	}
-
-	if (ts.isNamespaceImport(namedBindings)) {
+	if (statement.hasNamespace) {
 		violations.push({
 			file: displayPath(file),
 			line,
@@ -182,19 +161,12 @@ function pushRawTauriCoreImportViolations(
 		});
 		return;
 	}
-
-	for (const specifier of namedBindings.elements) {
-		if (specifier.isTypeOnly) {
-			continue;
-		}
-		const name = specifier.propertyName?.text ?? specifier.name.text;
-		if (name === 'invoke') {
-			violations.push({
-				file: displayPath(file),
-				line,
-				message: "raw Tauri 'invoke' imports must stay out of runtime app code; use tauriClient",
-			});
-		}
+	if (statement.names.some((binding) => !binding.typeOnly && binding.name === 'invoke')) {
+		violations.push({
+			file: displayPath(file),
+			line,
+			message: "raw Tauri 'invoke' imports must stay out of runtime app code; use tauriClient",
+		});
 	}
 }
 
@@ -217,38 +189,227 @@ function sourceBlocks(file: string, content: string): SourceBlock[] {
 	return blocks;
 }
 
-function moduleSpecifierText(moduleSpecifier: ts.Expression | undefined): string | null {
-	if (!moduleSpecifier || !ts.isStringLiteral(moduleSpecifier)) {
+function parseModuleStatements(source: string): ModuleStatement[] {
+	const statements: ModuleStatement[] = [];
+	const keyword = /\b(import|export)\b/g;
+	let match = keyword.exec(source);
+	while (match) {
+		const kind = match[1] as 'import' | 'export';
+		const start = match.index;
+		if (kind === 'import' && source[start + 6] === '(') {
+			match = keyword.exec(source);
+			continue;
+		}
+		const parsed = parseModuleStatement(kind, source.slice(start));
+		if (!parsed) {
+			match = keyword.exec(source);
+			continue;
+		}
+		const { consumed, ...statement } = parsed;
+		statements.push({ ...statement, kind, index: start });
+		keyword.lastIndex = start + consumed;
+		match = keyword.exec(source);
+	}
+	return statements;
+}
+
+function parseModuleStatement(
+	kind: 'import' | 'export',
+	text: string,
+): (Omit<ModuleStatement, 'kind' | 'index'> & { consumed: number }) | null {
+	const prefix = kind === 'import' ? /^import\s+/ : /^export\s+/;
+	const afterKeyword = text.match(prefix);
+	if (!afterKeyword) {
 		return null;
 	}
-	return moduleSpecifier.text;
+
+	let cursor = afterKeyword[0].length;
+	const typeOnly = /^(type\s+)(?!as\b)/.test(text.slice(cursor));
+	if (typeOnly) {
+		cursor += text.slice(cursor).match(/^type\s+/)?.[0].length ?? 0;
+	}
+
+	const fromMatch = findFromClause(text.slice(cursor));
+	if (!fromMatch) {
+		return null;
+	}
+
+	const bindings = text.slice(cursor, cursor + fromMatch.bindingsEnd).trim();
+	const source = fromMatch.source;
+	const consumed = cursor + fromMatch.consumed;
+	if (bindings === '*') {
+		return {
+			typeOnly,
+			hasDefault: false,
+			hasNamespace: true,
+			names: [],
+			source,
+			consumed,
+		};
+	}
+
+	return {
+		typeOnly,
+		...parseBindings(bindings),
+		source,
+		consumed,
+	};
 }
 
-function importNamedValues(importClause: ts.ImportClause): Set<string> {
-	const namedBindings = importClause.namedBindings;
-	if (!namedBindings || !ts.isNamedImports(namedBindings)) {
-		return new Set();
-	}
-
-	const names = new Set<string>();
-	for (const specifier of namedBindings.elements) {
-		if (specifier.isTypeOnly) {
+function findFromClause(
+	text: string,
+): { bindingsEnd: number; source: string; consumed: number } | null {
+	let depth = 0;
+	for (let index = 0; index < text.length; index += 1) {
+		const character = text[index];
+		if (character === '{' || character === '(') {
+			depth += 1;
 			continue;
 		}
-		names.add(specifier.propertyName?.text ?? specifier.name.text);
+		if (character === '}' || character === ')') {
+			depth = Math.max(0, depth - 1);
+			continue;
+		}
+		if (depth !== 0 || !text.startsWith('from', index) || /\S/.test(text[index - 1] ?? ' ')) {
+			continue;
+		}
+		const specifier = text.slice(index + 4).match(/^\s*(['"])([^'"]+)\1/);
+		if (!specifier) {
+			return null;
+		}
+		return {
+			bindingsEnd: index,
+			source: specifier[2] ?? '',
+			consumed: index + 4 + specifier[0].length,
+		};
 	}
-	return names;
+	return null;
 }
 
-function namedExports(exportClause: ts.NamedExports): Set<string> {
-	const names = new Set<string>();
-	for (const specifier of exportClause.elements) {
-		if (specifier.isTypeOnly) {
+function parseBindings(
+	bindings: string,
+): Pick<ModuleStatement, 'hasDefault' | 'hasNamespace' | 'names'> {
+	const hasNamespace = /(?:^|,)\s*\*(?:\s+as\s+[A-Za-z_$][\w$]*)?/.test(bindings);
+	const hasDefault = /^[A-Za-z_$][\w$]*\s*(,|$)/.test(bindings);
+	const named = bindings.match(/\{([\s\S]*)\}/);
+	if (!named) {
+		return { hasDefault, hasNamespace, names: [] };
+	}
+
+	const names: NamedBinding[] = [];
+	for (const raw of splitBindingList(named[1] ?? '')) {
+		const specifier = raw.trim();
+		if (!specifier) {
 			continue;
 		}
-		names.add(specifier.propertyName?.text ?? specifier.name.text);
+		const typeOnly = /^type\s+/.test(specifier);
+		const rest = typeOnly ? specifier.slice(5).trim() : specifier;
+		const name = rest.split(/\s+as\s+/)[0]?.trim();
+		if (name) {
+			names.push({ name, typeOnly });
+		}
 	}
-	return names;
+	return { hasDefault, hasNamespace, names };
+}
+
+function splitBindingList(list: string): string[] {
+	const parts: string[] = [];
+	let current = '';
+	let depth = 0;
+	for (const character of list) {
+		if (character === '{' || character === '(') {
+			depth += 1;
+		} else if (character === '}' || character === ')') {
+			depth = Math.max(0, depth - 1);
+		}
+		if (character === ',' && depth === 0) {
+			parts.push(current);
+			current = '';
+			continue;
+		}
+		current += character;
+	}
+	if (current.trim()) {
+		parts.push(current);
+	}
+	return parts;
+}
+
+function blankComments(source: string): string {
+	let output = '';
+	let index = 0;
+	let quote: "'" | '"' | '`' | null = null;
+	while (index < source.length) {
+		const character = source[index] ?? '';
+		const next = source[index + 1] ?? '';
+		if (quote) {
+			output += character;
+			if (character === '\\' && quote !== '`') {
+				output += next;
+				index += 2;
+				continue;
+			}
+			if (character === quote) {
+				quote = null;
+			}
+			index += 1;
+			continue;
+		}
+		if (character === '/' && next === '/') {
+			const end = source.indexOf('\n', index);
+			const length = (end === -1 ? source.length : end) - index;
+			output += ' '.repeat(length);
+			index += length;
+			continue;
+		}
+		if (character === '/' && next === '*') {
+			const end = source.indexOf('*/', index + 2);
+			const close = end === -1 ? source.length : end + 2;
+			output += source.slice(index, close).replace(/[^\n]/g, ' ');
+			index = close;
+			continue;
+		}
+		if (character === "'" || character === '"' || character === '`') {
+			quote = character;
+		}
+		output += character;
+		index += 1;
+	}
+	return output;
+}
+
+function blankQuoted(source: string): string {
+	let output = '';
+	let index = 0;
+	let quote: "'" | '"' | '`' | null = null;
+	while (index < source.length) {
+		const character = source[index] ?? '';
+		if (quote) {
+			if (character === '\\' && quote !== '`') {
+				output += '  ';
+				index += 2;
+				continue;
+			}
+			if (character === quote) {
+				output += character;
+				quote = null;
+				index += 1;
+				continue;
+			}
+			output += character === '\n' ? '\n' : ' ';
+			index += 1;
+			continue;
+		}
+		if (character === "'" || character === '"' || character === '`') {
+			quote = character;
+			output += character;
+			index += 1;
+			continue;
+		}
+		output += character;
+		index += 1;
+	}
+	return output;
 }
 
 function pushNamedValueViolations(file: string, line: number, names: Set<string>): void {

--- a/scripts/check-tauri-runtime-boundary.ts
+++ b/scripts/check-tauri-runtime-boundary.ts
@@ -191,24 +191,52 @@ function sourceBlocks(file: string, content: string): SourceBlock[] {
 
 function parseModuleStatements(source: string): ModuleStatement[] {
 	const statements: ModuleStatement[] = [];
-	const keyword = /\b(import|export)\b/g;
-	let match = keyword.exec(source);
-	while (match) {
-		const kind = match[1] as 'import' | 'export';
-		const start = match.index;
-		if (kind === 'import' && source[start + 6] === '(') {
-			match = keyword.exec(source);
+	let index = 0;
+	let quote: "'" | '"' | '`' | null = null;
+	while (index < source.length) {
+		const character = source[index] ?? '';
+		const next = source[index + 1] ?? '';
+		if (quote) {
+			if (character === '\\' && quote !== '`') {
+				index += 2;
+				continue;
+			}
+			if (character === quote) {
+				quote = null;
+			}
+			index += 1;
 			continue;
 		}
-		const parsed = parseModuleStatement(kind, source.slice(start));
+		if (character === "'" || character === '"' || character === '`') {
+			quote = character;
+			index += 1;
+			continue;
+		}
+		if (character === '/' && next === '/') {
+			const end = source.indexOf('\n', index);
+			index = end === -1 ? source.length : end;
+			continue;
+		}
+		if (character === '/' && next === '*') {
+			const end = source.indexOf('*/', index + 2);
+			index = end === -1 ? source.length : end + 2;
+			continue;
+		}
+		const remaining = source.slice(index);
+		const keyword = remaining.match(/^(import|export)\b/);
+		if (!keyword || (keyword[1] === 'import' && remaining[6] === '(')) {
+			index += 1;
+			continue;
+		}
+		const kind = keyword[1] as 'import' | 'export';
+		const parsed = parseModuleStatement(kind, remaining);
 		if (!parsed) {
-			match = keyword.exec(source);
+			index += keyword[0].length;
 			continue;
 		}
 		const { consumed, ...statement } = parsed;
-		statements.push({ ...statement, kind, index: start });
-		keyword.lastIndex = start + consumed;
-		match = keyword.exec(source);
+		statements.push({ ...statement, kind, index });
+		index += consumed;
 	}
 	return statements;
 }
@@ -227,6 +255,18 @@ function parseModuleStatement(
 	const typeOnly = /^(type\s+)(?!as\b)/.test(text.slice(cursor));
 	if (typeOnly) {
 		cursor += text.slice(cursor).match(/^type\s+/)?.[0].length ?? 0;
+	}
+
+	const sideEffect = text.slice(cursor).match(/^(['"])([^'"]+)\1\s*;?/);
+	if (kind === 'import' && sideEffect) {
+		return {
+			typeOnly,
+			hasDefault: false,
+			hasNamespace: false,
+			names: [],
+			source: sideEffect[2] ?? '',
+			consumed: cursor + sideEffect[0].length,
+		};
 	}
 
 	const fromMatch = findFromClause(text.slice(cursor));
@@ -260,8 +300,23 @@ function findFromClause(
 	text: string,
 ): { bindingsEnd: number; source: string; consumed: number } | null {
 	let depth = 0;
+	let quote: "'" | '"' | '`' | null = null;
 	for (let index = 0; index < text.length; index += 1) {
-		const character = text[index];
+		const character = text[index] ?? '';
+		if (quote) {
+			if (character === '\\' && quote !== '`') {
+				index += 1;
+				continue;
+			}
+			if (character === quote) {
+				quote = null;
+			}
+			continue;
+		}
+		if (character === "'" || character === '"' || character === '`') {
+			quote = character;
+			continue;
+		}
 		if (character === '{' || character === '(') {
 			depth += 1;
 			continue;
@@ -269,6 +324,9 @@ function findFromClause(
 		if (character === '}' || character === ')') {
 			depth = Math.max(0, depth - 1);
 			continue;
+		}
+		if (depth === 0 && character === ';') {
+			return null;
 		}
 		if (depth !== 0 || !text.startsWith('from', index) || /\S/.test(text[index - 1] ?? ' ')) {
 			continue;
@@ -384,7 +442,45 @@ function blankQuoted(source: string): string {
 	let quote: "'" | '"' | '`' | null = null;
 	while (index < source.length) {
 		const character = source[index] ?? '';
+		const next = source[index + 1] ?? '';
 		if (quote) {
+			if (quote === '`' && character === '$' && next === '{') {
+				output += '${';
+				index += 2;
+				let depth = 1;
+				let innerQuote: "'" | '"' | '`' | null = null;
+				while (index < source.length && depth > 0) {
+					const inner = source[index] ?? '';
+					const innerNext = source[index + 1] ?? '';
+					if (innerQuote) {
+						output += inner;
+						if (inner === '\\' && innerQuote !== '`') {
+							output += innerNext;
+							index += 2;
+							continue;
+						}
+						if (inner === innerQuote) {
+							innerQuote = null;
+						}
+						index += 1;
+						continue;
+					}
+					if (inner === "'" || inner === '"' || inner === '`') {
+						innerQuote = inner;
+						output += inner;
+						index += 1;
+						continue;
+					}
+					if (inner === '{') {
+						depth += 1;
+					} else if (inner === '}') {
+						depth -= 1;
+					}
+					output += inner;
+					index += 1;
+				}
+				continue;
+			}
 			if (character === '\\' && quote !== '`') {
 				output += '  ';
 				index += 2;

--- a/scripts/frontend-toolchain-layout.test.ts
+++ b/scripts/frontend-toolchain-layout.test.ts
@@ -46,68 +46,21 @@ function collectSourceFiles(root: string): string[] {
 	return files;
 }
 
-function blankComments(source: string): string {
-	let output = '';
-	let index = 0;
-	let quote: "'" | '"' | '`' | null = null;
-	while (index < source.length) {
-		const character = source[index] ?? '';
-		const next = source[index + 1] ?? '';
-		if (quote) {
-			output += character;
-			if (character === '\\' && quote !== '`') {
-				output += next;
-				index += 2;
-				continue;
-			}
-			if (character === quote) {
-				quote = null;
-			}
-			index += 1;
-			continue;
-		}
-		if (character === '/' && next === '/') {
-			const end = source.indexOf('\n', index);
-			const length = (end === -1 ? source.length : end) - index;
-			output += ' '.repeat(length);
-			index += length;
-			continue;
-		}
-		if (character === '/' && next === '*') {
-			const end = source.indexOf('*/', index + 2);
-			const close = end === -1 ? source.length : end + 2;
-			output += source.slice(index, close).replace(/[^\n]/g, ' ');
-			index = close;
-			continue;
-		}
-		if (character === "'" || character === '"' || character === '`') {
-			quote = character;
-		}
-		output += character;
-		index += 1;
-	}
-	return output;
-}
-
-function moduleSpecifiers(source: string): string[] {
-	const code = blankComments(source);
-	const specifiers: string[] = [];
-	const pattern =
-		/\b(?:import\s*\(\s*|require\s*\(\s*|(?:import|export)(?:\s+type)?\s+(?:[^'"\n]*?\sfrom\s*)?)['"]([^'"]+)['"]/g;
-	for (const match of code.matchAll(pattern)) {
-		if (match[1]) {
-			specifiers.push(match[1]);
-		}
-	}
-	return specifiers;
+function importsTypescriptPackage(source: string): boolean {
+	return /\b(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]typescript['"]/.test(
+		source,
+	);
 }
 
 function typescriptImportHits(): string[] {
+	const self = path.normalize(fileURLToPath(import.meta.url));
 	const hits: string[] = [];
 	for (const root of ['src', 'scripts']) {
 		for (const file of collectSourceFiles(path.join(repoRoot, root))) {
-			const specifiers = moduleSpecifiers(readFileSync(file, 'utf8'));
-			if (specifiers.includes('typescript')) {
+			if (path.normalize(file) === self) {
+				continue;
+			}
+			if (importsTypescriptPackage(readFileSync(file, 'utf8'))) {
 				hits.push(path.relative(repoRoot, file));
 			}
 		}
@@ -138,5 +91,14 @@ describe('frontend toolchain layout', () => {
 
 	it('does not import the typescript package from ABB src/ or scripts/', () => {
 		expect(typescriptImportHits()).toEqual([]);
+	});
+
+	it('records typescript specifiers from multiline named imports', () => {
+		expect(
+			importsTypescriptPackage("import {\n\tcreateSourceFile,\n} from 'typescript';\n"),
+		).toBe(true);
+		expect(importsTypescriptPackage("import { createSourceFile } from './typescript';\n")).toBe(
+			false,
+		);
 	});
 });

--- a/scripts/frontend-toolchain-layout.test.ts
+++ b/scripts/frontend-toolchain-layout.test.ts
@@ -47,20 +47,28 @@ function collectSourceFiles(root: string): string[] {
 }
 
 function importsTypescriptPackage(source: string): boolean {
-	return /\b(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]typescript['"]/.test(
+	return /\b(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]typescript['"]/.test(source);
+}
+
+function importsEffectPackage(source: string): boolean {
+	return /\b(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]effect(?:\/[^'"]*)?['"]/.test(
 		source,
 	);
 }
 
-function typescriptImportHits(): string[] {
+function packageImportHits(
+	matches: (source: string) => boolean,
+	skip: ReadonlySet<string> = new Set(),
+): string[] {
 	const self = path.normalize(fileURLToPath(import.meta.url));
 	const hits: string[] = [];
 	for (const root of ['src', 'scripts']) {
 		for (const file of collectSourceFiles(path.join(repoRoot, root))) {
-			if (path.normalize(file) === self) {
+			const normalized = path.normalize(file);
+			if (normalized === self || skip.has(normalized)) {
 				continue;
 			}
-			if (importsTypescriptPackage(readFileSync(file, 'utf8'))) {
+			if (matches(readFileSync(file, 'utf8'))) {
 				hits.push(path.relative(repoRoot, file));
 			}
 		}
@@ -90,15 +98,37 @@ describe('frontend toolchain layout', () => {
 	});
 
 	it('does not import the typescript package from ABB src/ or scripts/', () => {
-		expect(typescriptImportHits()).toEqual([]);
+		expect(packageImportHits(importsTypescriptPackage)).toEqual([]);
 	});
 
 	it('records typescript specifiers from multiline named imports', () => {
-		expect(
-			importsTypescriptPackage("import {\n\tcreateSourceFile,\n} from 'typescript';\n"),
-		).toBe(true);
+		expect(importsTypescriptPackage("import {\n\tcreateSourceFile,\n} from 'typescript';\n")).toBe(
+			true,
+		);
 		expect(importsTypescriptPackage("import { createSourceFile } from './typescript';\n")).toBe(
 			false,
 		);
+	});
+
+	it('keeps bun.lock @typescript/old on real TypeScript 6, not the wrapper', () => {
+		const lock = readFileSync(path.join(repoRoot, 'bun.lock'), 'utf8');
+		expect(lock).toContain('"@typescript/old": ["typescript@6.');
+		expect(lock).not.toMatch(/"@typescript\/old": \["@typescript\/typescript6/);
+	});
+
+	it('lets only appEffect.ts import the effect package', () => {
+		const allowed = path.normalize(path.join(repoRoot, 'src/lib/effect/appEffect.ts'));
+		expect(packageImportHits(importsEffectPackage, new Set([allowed]))).toEqual([]);
+	});
+
+	it('treats Effect package root and subpath specifiers as the same boundary', () => {
+		expect(importsEffectPackage("import { Effect } from 'effect'")).toBe(true);
+		expect(importsEffectPackage("import { Effect } from 'effect/Effect'")).toBe(true);
+		expect(importsEffectPackage("import { something } from './effect'")).toBe(false);
+	});
+
+	it('records effect specifiers from multiline named imports', () => {
+		expect(importsEffectPackage("import {\n\tEffect,\n} from 'effect';\n")).toBe(true);
+		expect(importsEffectPackage("import { Effect } from './effect';\n")).toBe(false);
 	});
 });

--- a/scripts/frontend-toolchain-layout.test.ts
+++ b/scripts/frontend-toolchain-layout.test.ts
@@ -1,0 +1,140 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+type PackageManifest = {
+	packageManager: string;
+	scripts: Record<string, string>;
+	devDependencies: Record<string, string>;
+};
+
+function readPackageManifest(): PackageManifest {
+	return JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as PackageManifest;
+}
+
+function bunVersionFromPackageManager(packageManager: string): string {
+	const match = /^bun@(.+)$/.exec(packageManager);
+	if (!match?.[1]) {
+		throw new Error(`packageManager is not a bun pin: ${packageManager}`);
+	}
+	return match[1];
+}
+
+function collectSourceFiles(root: string): string[] {
+	const files: string[] = [];
+	const skipDirs = new Set(['node_modules', 'dist', '.git', '.svelte-check', 'coverage']);
+
+	const walk = (dir: string): void => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (entry.isDirectory()) {
+				if (skipDirs.has(entry.name)) {
+					continue;
+				}
+				walk(path.join(dir, entry.name));
+				continue;
+			}
+			if (/\.(?:[cm]?tsx?|mjs|cjs|svelte)$/.test(entry.name)) {
+				files.push(path.join(dir, entry.name));
+			}
+		}
+	};
+
+	walk(root);
+	return files;
+}
+
+function blankComments(source: string): string {
+	let output = '';
+	let index = 0;
+	let quote: "'" | '"' | '`' | null = null;
+	while (index < source.length) {
+		const character = source[index] ?? '';
+		const next = source[index + 1] ?? '';
+		if (quote) {
+			output += character;
+			if (character === '\\' && quote !== '`') {
+				output += next;
+				index += 2;
+				continue;
+			}
+			if (character === quote) {
+				quote = null;
+			}
+			index += 1;
+			continue;
+		}
+		if (character === '/' && next === '/') {
+			const end = source.indexOf('\n', index);
+			const length = (end === -1 ? source.length : end) - index;
+			output += ' '.repeat(length);
+			index += length;
+			continue;
+		}
+		if (character === '/' && next === '*') {
+			const end = source.indexOf('*/', index + 2);
+			const close = end === -1 ? source.length : end + 2;
+			output += source.slice(index, close).replace(/[^\n]/g, ' ');
+			index = close;
+			continue;
+		}
+		if (character === "'" || character === '"' || character === '`') {
+			quote = character;
+		}
+		output += character;
+		index += 1;
+	}
+	return output;
+}
+
+function moduleSpecifiers(source: string): string[] {
+	const code = blankComments(source);
+	const specifiers: string[] = [];
+	const pattern =
+		/\b(?:import\s*\(\s*|require\s*\(\s*|(?:import|export)(?:\s+type)?\s+(?:[^'"\n]*?\sfrom\s*)?)['"]([^'"]+)['"]/g;
+	for (const match of code.matchAll(pattern)) {
+		if (match[1]) {
+			specifiers.push(match[1]);
+		}
+	}
+	return specifiers;
+}
+
+function typescriptImportHits(): string[] {
+	const hits: string[] = [];
+	for (const root of ['src', 'scripts']) {
+		for (const file of collectSourceFiles(path.join(repoRoot, root))) {
+			const specifiers = moduleSpecifiers(readFileSync(file, 'utf8'));
+			if (specifiers.includes('typescript')) {
+				hits.push(path.relative(repoRoot, file));
+			}
+		}
+	}
+	return hits;
+}
+
+describe('frontend toolchain layout', () => {
+	it('keeps TypeScript 7 in @typescript/native and the 6.x require() shim in the typescript slot', () => {
+		const pkg = readPackageManifest();
+		expect(pkg.devDependencies['@typescript/native']).toMatch(/^npm:typescript@/);
+		expect(pkg.devDependencies.typescript).toMatch(/^npm:@typescript\/typescript6@/);
+		expect(pkg.scripts['check:svelte']).toContain('--tsgo');
+	});
+
+	it('keeps CI and Codex Bun pins locked to package.json packageManager', () => {
+		const bunVersion = bunVersionFromPackageManager(readPackageManifest().packageManager);
+		const ciYml = readFileSync(path.join(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+		const setupScript = readFileSync(
+			path.join(repoRoot, 'scripts/setup-codex-agent-env.sh'),
+			'utf8',
+		);
+		expect(ciYml).toContain(`bun-version: ${bunVersion}`);
+		expect(setupScript).toContain(`required_bun_version="${bunVersion}"`);
+	});
+
+	it('does not import the typescript package from ABB src/ or scripts/', () => {
+		expect(typescriptImportHits()).toEqual([]);
+	});
+});

--- a/scripts/frontend-toolchain-layout.test.ts
+++ b/scripts/frontend-toolchain-layout.test.ts
@@ -118,7 +118,7 @@ function typescriptImportHits(): string[] {
 describe('frontend toolchain layout', () => {
 	it('keeps TypeScript 7 in @typescript/native and the 6.x require() shim in the typescript slot', () => {
 		const pkg = readPackageManifest();
-		expect(pkg.devDependencies['@typescript/native']).toMatch(/^npm:typescript@/);
+		expect(pkg.devDependencies['@typescript/native']).toMatch(/^npm:typescript@7\./);
 		expect(pkg.devDependencies.typescript).toMatch(/^npm:@typescript\/typescript6@/);
 		expect(pkg.scripts['check:svelte']).toContain('--tsgo');
 	});
@@ -132,6 +132,8 @@ describe('frontend toolchain layout', () => {
 		);
 		expect(ciYml).toContain(`bun-version: ${bunVersion}`);
 		expect(setupScript).toContain(`required_bun_version="${bunVersion}"`);
+		expect(setupScript).toContain(`BUN_VERSION="\${required_bun_version}"`);
+		expect(setupScript).toContain('error: need Bun');
 	});
 
 	it('does not import the typescript package from ABB src/ or scripts/', () => {

--- a/scripts/setup-codex-agent-env.sh
+++ b/scripts/setup-codex-agent-env.sh
@@ -77,25 +77,27 @@ ensure_rust_toolchain() {
 }
 
 ensure_bun() {
-	if have bun; then
-		log "Using existing Bun $(bun --version)"
-		if [ "$(bun --version)" != "${required_bun_version}" ]; then
-			warn "repo packageManager pins Bun ${required_bun_version}; prefer setting that version in Codex environment settings"
-		fi
+	if have bun && [ "$(bun --version)" = "${required_bun_version}" ]; then
+		log "Using Bun ${required_bun_version}"
 		return
 	fi
 
 	if ! have curl; then
-		warn "curl not found; cannot install Bun automatically"
-		return
+		printf 'error: need Bun %s (found %s) and curl is missing\n' \
+			"${required_bun_version}" \
+			"$(bun --version 2>/dev/null || printf 'missing')" >&2
+		exit 1
 	fi
 
-	log "Installing Bun for frontend dependency setup"
-	curl -fsSL https://bun.sh/install | bash
+	log "Installing Bun ${required_bun_version}"
+	curl -fsSL https://bun.sh/install | BUN_VERSION="${required_bun_version}" bash
 	export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
 	export PATH="${BUN_INSTALL}/bin:${PATH}"
-	if have bun && [ "$(bun --version)" != "${required_bun_version}" ]; then
-		warn "installed Bun $(bun --version); repo packageManager pins ${required_bun_version}"
+	if ! have bun || [ "$(bun --version)" != "${required_bun_version}" ]; then
+		printf 'error: need Bun %s; found %s\n' \
+			"${required_bun_version}" \
+			"$(bun --version 2>/dev/null || printf 'missing')" >&2
+		exit 1
 	fi
 }
 

--- a/scripts/setup-codex-agent-env.sh
+++ b/scripts/setup-codex-agent-env.sh
@@ -15,7 +15,7 @@ ffmpeg_commit="${ABB_CODEX_FFMPEG_COMMIT:-d32b387f2b0a484599d4587d651891f0c63c42
 ffmpeg_prefix="${ABB_CODEX_FFMPEG_PREFIX:-/opt/ffmpeg90}"
 ffmpeg_src="${ABB_CODEX_FFMPEG_SRC:-/opt/ffmpeg-src}"
 local_env_file="${repo_root}/.codex/agent-env.local.sh"
-required_bun_version="1.3.14"
+required_bun_version="1.4.0"
 
 log() {
 	printf '\n==> %s\n' "$*"

--- a/src-tauri/src/audio/toolchain/tests.rs
+++ b/src-tauri/src/audio/toolchain/tests.rs
@@ -121,6 +121,31 @@ fn no_fdk_found_returns_none_with_status_message() {
     );
 }
 
+/// Homebrew's ffmpeg can sit on PATH and still fail `-version` (missing dylib).
+/// Every other fake here exits 0 on `-version`, so that hole was untested.
+#[cfg(unix)]
+#[test]
+fn nonstarting_ffmpeg_candidate_is_not_fdk_available() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let ffmpeg_path = write_nonstarting_ffmpeg(temp_dir.path());
+
+    let resolution = resolve_external_toolchain_with_candidates(None, vec![ffmpeg_path]);
+
+    assert!(resolution.validated.is_none());
+    assert_eq!(resolution.fdk_source, EncoderCapabilitySource::None);
+    assert!(
+        resolution.status_message.contains("could not start"),
+        "status must name the start failure: {}",
+        resolution.status_message
+    );
+    assert!(
+        !resolution.status_message.contains("FDK AAC detected")
+            && !resolution.status_message.contains("FDK AAC ready"),
+        "status must not claim FDK is ready: {}",
+        resolution.status_message
+    );
+}
+
 #[test]
 fn toolchain_validation_captures_decoder_capabilities() {
     let temp_dir = TempDir::new().expect("temp dir");
@@ -218,6 +243,19 @@ fn write_fake_ffmpeg_decoy_encoder(root: &Path) -> PathBuf {
         "echo ' V..... someaac          AAC (libfdk_aac wrapper)'",
         "echo ' V..... aac'",
     )
+}
+
+fn write_nonstarting_ffmpeg(root: &Path) -> PathBuf {
+    std::fs::create_dir_all(root).expect("create fake ffmpeg root");
+    let script_path = root.join("fake-ffmpeg");
+    let script = "#!/bin/sh\nfor arg in \"$@\"; do\n  if [ \"$arg\" = \"-version\" ]; then\n    echo 'dyld[1]: Library not loaded: /opt/homebrew/opt/x265/lib/libx265.216.dylib' >&2\n    exit 1\n  fi\ndone\nexit 1\n";
+    write(&script_path, script).expect("write nonstarting ffmpeg");
+    let mut permissions = std::fs::metadata(&script_path)
+        .expect("metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    set_permissions(&script_path, permissions).expect("chmod nonstarting ffmpeg");
+    script_path
 }
 
 fn write_fake_ffmpeg_script(root: &Path, encoder_line: &str, decoder_lines: &str) -> PathBuf {

--- a/src-tauri/src/metadata/cover_art/embedding.rs
+++ b/src-tauri/src/metadata/cover_art/embedding.rs
@@ -132,8 +132,11 @@ fn configure_cover_art_stream_parameters(
         .open_as(codec)
         .map_err(|e| AppError::General(format!("Failed to open cover art encoder: {}", e)))?;
 
-    // Set the stream parameters from the encoder context
+    // Parameters first, then the stream time_base. An unset cover time_base
+    // (num=0) makes the ipod muxer default the stream to 1/90000, LCM with
+    // audio 1/44100 into movie timescale 4410000, and overflow QT chapter packets.
     stream.set_parameters(&encoder);
+    stream.set_time_base(ff::Rational(1, 1));
 
     log::debug!(
         "Configured cover art stream parameters for {:?} format ({}x{})",

--- a/src-tauri/tests/cases/integration_media_execution_tests.rs
+++ b/src-tauri/tests/cases/integration_media_execution_tests.rs
@@ -570,6 +570,112 @@ fn chapters_of(path: &Path) -> Vec<(Option<String>, i64, i64)> {
         .collect()
 }
 
+/// Apple Books reads the QuickTime `text` trak, not Nero `chpl`.
+/// FFmpeg's chapter API only sees `chpl`, so a green chpl probe does not prove
+/// the player-visible track. Walk the `text` handler's `mdhd`.
+fn timed_text_chapter_track(path: &Path) -> (f64, u32, u32) {
+    let bytes = fs::read(path).expect("read artifact for timed-text atom probe");
+    let moov = find_atom(&bytes, 0, bytes.len(), *b"moov").expect("moov atom");
+    let mut offset = moov.0;
+    let end = moov.1;
+    let mut audio_timescale = None;
+    let mut text = None;
+    while offset + 8 <= end {
+        let (trak_start, trak_end, size) = match next_atom(&bytes, offset, end) {
+            Some(atom) => atom,
+            None => break,
+        };
+        offset += size;
+        if bytes[trak_start + 4..trak_start + 8] != *b"trak" {
+            continue;
+        }
+        let Some(mdia) = find_atom(&bytes, trak_start + 8, trak_end, *b"mdia") else {
+            continue;
+        };
+        let Some(hdlr) = find_atom(&bytes, mdia.0, mdia.1, *b"hdlr") else {
+            continue;
+        };
+        // hdlr payload: version/flags (4) + component type (4) + handler (4)
+        let subtype_at = hdlr.0 + 8;
+        if subtype_at + 4 > hdlr.1 {
+            continue;
+        }
+        let handler = &bytes[subtype_at..subtype_at + 4];
+        let Some(mdhd) = find_atom(&bytes, mdia.0, mdia.1, *b"mdhd") else {
+            continue;
+        };
+        let (timescale, duration) = parse_mdhd(&bytes, mdhd.0, mdhd.1);
+        if handler == b"soun" {
+            audio_timescale = Some(timescale);
+        } else if handler == b"text" {
+            assert!(timescale > 0, "text trak timescale is zero");
+            text = Some((duration as f64 / f64::from(timescale), timescale));
+        }
+    }
+    let (duration_secs, text_timescale) =
+        text.expect("QuickTime timed-text chapter trak not found");
+    (
+        duration_secs,
+        text_timescale,
+        audio_timescale.expect("audio trak timescale"),
+    )
+}
+
+fn next_atom(bytes: &[u8], start: usize, end: usize) -> Option<(usize, usize, usize)> {
+    if start + 8 > end {
+        return None;
+    }
+    let mut size = u32::from_be_bytes(bytes[start..start + 4].try_into().ok()?) as usize;
+    let mut header = 8;
+    if size == 1 {
+        if start + 16 > end {
+            return None;
+        }
+        size = u64::from_be_bytes(bytes[start + 8..start + 16].try_into().ok()?) as usize;
+        header = 16;
+    } else if size == 0 {
+        size = end - start;
+    }
+    if size < header || start + size > end {
+        return None;
+    }
+    Some((start, start + size, size))
+}
+
+fn find_atom(bytes: &[u8], start: usize, end: usize, fourcc: [u8; 4]) -> Option<(usize, usize)> {
+    let mut offset = start;
+    while offset + 8 <= end {
+        let (atom_start, atom_end, size) = next_atom(bytes, offset, end)?;
+        if bytes[atom_start + 4..atom_start + 8] == fourcc {
+            let header =
+                if u32::from_be_bytes(bytes[atom_start..atom_start + 4].try_into().ok()?) == 1 {
+                    16
+                } else {
+                    8
+                };
+            return Some((atom_start + header, atom_end));
+        }
+        offset += size;
+    }
+    None
+}
+
+fn parse_mdhd(bytes: &[u8], start: usize, end: usize) -> (u32, u64) {
+    assert!(start + 4 <= end, "mdhd too small");
+    let version = bytes[start];
+    if version == 1 {
+        assert!(start + 28 <= end, "mdhd v1 too small");
+        let timescale = u32::from_be_bytes(bytes[start + 20..start + 24].try_into().unwrap());
+        let duration = u64::from_be_bytes(bytes[start + 24..start + 32].try_into().unwrap());
+        (timescale, duration)
+    } else {
+        assert!(start + 20 <= end, "mdhd v0 too small");
+        let timescale = u32::from_be_bytes(bytes[start + 12..start + 16].try_into().unwrap());
+        let duration = u32::from_be_bytes(bytes[start + 16..start + 20].try_into().unwrap()) as u64;
+        (timescale, duration)
+    }
+}
+
 /// The user's dominant real input is M4B, not WAV. Two-pass: the engine's own
 /// committed output becomes the single input for a second run — exercising
 /// AAC decode → encode and the MP4 tag read path with no committed media.
@@ -697,6 +803,36 @@ async fn chapters_synthesize_on_merge_and_survive_reprocessing() {
     assert!(
         (preserved_boundary - boundary).abs() < 200,
         "preserved chapter boundary {preserved_boundary}ms should match the source's {boundary}ms"
+    );
+}
+
+/// Cover art is a second output stream. If its time_base stays 0/0, FFmpeg's
+/// ipod muxer defaults it to 1/90000, LCMs with audio 1/44100 into movie
+/// timescale 4410000, and the QuickTime chapter packets overflow. Apple Books
+/// reads that broken timed-text track; Nero `chpl` stays correct. Cover art is
+/// the reproducing trigger, not a decoration.
+#[tokio::test]
+async fn qt_chapter_track_times_span_the_book_when_cover_art_is_muxed() {
+    let lane = MediaLane::with_fixtures(&[1.5, 1.0]);
+    let mut metadata = AudiobookMetadata::new();
+    metadata.cover_art = Some(minimal_jpg_bytes());
+    let output = lane.process(Some(metadata)).await;
+
+    let chpl = chapters_of(&output);
+    assert_eq!(
+        chpl.len(),
+        2,
+        "Nero chpl still synthesizes one chapter per input"
+    );
+
+    let (qt_duration, text_timescale, audio_timescale) = timed_text_chapter_track(&output);
+    assert_eq!(
+        text_timescale, audio_timescale,
+        "timed-text timescale {text_timescale} must match audio {audio_timescale}; 4410000 is the 44100×90000 LCM from an unset cover-art time_base"
+    );
+    assert!(
+        (qt_duration - 2.5).abs() < 0.75,
+        "timed-text track duration {qt_duration}s must span the whole book (~2.5s), not only the last chapter"
     );
 }
 

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -13,6 +13,9 @@ multi-service orchestration.
 
 Keep Effect private to workflow owners:
 
+- Only `src/lib/effect/appEffect.ts` imports the `effect` package. Owners and
+  tests import `Effect`, `Context`, `Data`, and `Layer` from that file. Proof:
+  `bun run test -- src/lib/effect/appEffect.test.ts`.
 - Public UI/runtime entrypoints expose Promise-returning functions or existing
   synchronous wrappers where callers already rely on them.
 - Workflow owners expose a local service interface, service tag, live layer

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -15,9 +15,10 @@ Keep Effect private to workflow owners:
 
 - Only `src/lib/effect/appEffect.ts` imports the `effect` package. Owners and
   tests import `Effect`, `Context`, `Data`, and `Layer` from that file. Proof:
-  `bun run test -- src/lib/effect/appEffect.test.ts`. The tripwire matches
-  `from 'effect'` and `from 'effect/...'` so ordinary multiline named imports
-  count; do not require the binding list to sit on one line.
+  `bun run test -- scripts/frontend-toolchain-layout.test.ts`. The tripwire
+  lives in scripts so the frontend `tsconfig` stays Vite/Svelte types. It
+  matches `from 'effect'` and `from 'effect/...'` so ordinary multiline named
+  imports count; do not require the binding list to sit on one line.
 - Public UI/runtime entrypoints expose Promise-returning functions or existing
   synchronous wrappers where callers already rely on them.
 - Workflow owners expose a local service interface, service tag, live layer

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -15,7 +15,9 @@ Keep Effect private to workflow owners:
 
 - Only `src/lib/effect/appEffect.ts` imports the `effect` package. Owners and
   tests import `Effect`, `Context`, `Data`, and `Layer` from that file. Proof:
-  `bun run test -- src/lib/effect/appEffect.test.ts`.
+  `bun run test -- src/lib/effect/appEffect.test.ts`. The tripwire matches
+  `from 'effect'` and `from 'effect/...'` so ordinary multiline named imports
+  count; do not require the binding list to sit on one line.
 - Public UI/runtime entrypoints expose Promise-returning functions or existing
   synchronous wrappers where callers already rely on them.
 - Workflow owners expose a local service interface, service tag, live layer

--- a/src/lib/effect/appEffect.test.ts
+++ b/src/lib/effect/appEffect.test.ts
@@ -138,12 +138,22 @@ describe('makeWorkflowKit (#389 spike acceptance)', () => {
 	});
 });
 
+const EFFECT_PACKAGE_IMPORT =
+	/\b(?:import\s*\(\s*|require\s*\(\s*|(?:import|export)(?:\s+type)?\s+(?:[^'"\n]*?\sfrom\s*)?)['"]effect(?:\/[^'"]*)?['"]/;
+
 describe('Effect package import boundary', () => {
 	const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 	const allowed = path.normalize(path.join(srcRoot, 'lib/effect/appEffect.ts'));
 
+	it('treats Effect package root and subpath specifiers as the same boundary', () => {
+		expect(EFFECT_PACKAGE_IMPORT.test("import { Effect } from 'effect'")).toBe(true);
+		expect(EFFECT_PACKAGE_IMPORT.test("import { Effect } from 'effect/Effect'")).toBe(true);
+		expect(EFFECT_PACKAGE_IMPORT.test("import { something } from './effect'")).toBe(false);
+	});
+
 	it('lets only appEffect.ts import the effect package', () => {
 		const hits: string[] = [];
+		const self = path.normalize(fileURLToPath(import.meta.url));
 		const walk = (dir: string): void => {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				const fullPath = path.join(dir, entry.name);
@@ -157,15 +167,11 @@ describe('Effect package import boundary', () => {
 				if (!/\.(?:[cm]?tsx?|mjs|svelte)$/.test(entry.name)) {
 					continue;
 				}
-				if (path.normalize(fullPath) === allowed) {
+				if (path.normalize(fullPath) === allowed || path.normalize(fullPath) === self) {
 					continue;
 				}
 				const source = readFileSync(fullPath, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
-				if (
-					/\b(?:import\s*\(\s*|require\s*\(\s*|(?:import|export)(?:\s+type)?\s+(?:[^'"\n]*?\sfrom\s*)?)['"]effect['"]/.test(
-						source,
-					)
-				) {
+				if (EFFECT_PACKAGE_IMPORT.test(source)) {
 					hits.push(path.relative(srcRoot, fullPath));
 				}
 			}

--- a/src/lib/effect/appEffect.test.ts
+++ b/src/lib/effect/appEffect.test.ts
@@ -138,17 +138,25 @@ describe('makeWorkflowKit (#389 spike acceptance)', () => {
 	});
 });
 
-const EFFECT_PACKAGE_IMPORT =
-	/\b(?:import\s*\(\s*|require\s*\(\s*|(?:import|export)(?:\s+type)?\s+(?:[^'"\n]*?\sfrom\s*)?)['"]effect(?:\/[^'"]*)?['"]/;
+function importsEffectPackage(source: string): boolean {
+	return /\b(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]effect(?:\/[^'"]*)?['"]/.test(
+		source,
+	);
+}
 
 describe('Effect package import boundary', () => {
 	const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 	const allowed = path.normalize(path.join(srcRoot, 'lib/effect/appEffect.ts'));
 
 	it('treats Effect package root and subpath specifiers as the same boundary', () => {
-		expect(EFFECT_PACKAGE_IMPORT.test("import { Effect } from 'effect'")).toBe(true);
-		expect(EFFECT_PACKAGE_IMPORT.test("import { Effect } from 'effect/Effect'")).toBe(true);
-		expect(EFFECT_PACKAGE_IMPORT.test("import { something } from './effect'")).toBe(false);
+		expect(importsEffectPackage("import { Effect } from 'effect'")).toBe(true);
+		expect(importsEffectPackage("import { Effect } from 'effect/Effect'")).toBe(true);
+		expect(importsEffectPackage("import { something } from './effect'")).toBe(false);
+	});
+
+	it('records effect specifiers from multiline named imports', () => {
+		expect(importsEffectPackage("import {\n\tEffect,\n} from 'effect';\n")).toBe(true);
+		expect(importsEffectPackage("import { Effect } from './effect';\n")).toBe(false);
 	});
 
 	it('lets only appEffect.ts import the effect package', () => {
@@ -171,7 +179,7 @@ describe('Effect package import boundary', () => {
 					continue;
 				}
 				const source = readFileSync(fullPath, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
-				if (EFFECT_PACKAGE_IMPORT.test(source)) {
+				if (importsEffectPackage(source)) {
 					hits.push(path.relative(srcRoot, fullPath));
 				}
 			}

--- a/src/lib/effect/appEffect.test.ts
+++ b/src/lib/effect/appEffect.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { Data } from './appEffect';
 import {
@@ -132,5 +135,42 @@ describe('makeWorkflowKit (#389 spike acceptance)', () => {
 		);
 
 		expect(result).toBe('alpha-live');
+	});
+});
+
+describe('Effect package import boundary', () => {
+	const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+	const allowed = path.normalize(path.join(srcRoot, 'lib/effect/appEffect.ts'));
+
+	it('lets only appEffect.ts import the effect package', () => {
+		const hits: string[] = [];
+		const walk = (dir: string): void => {
+			for (const entry of readdirSync(dir, { withFileTypes: true })) {
+				const fullPath = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					if (entry.name === 'node_modules' || entry.name === 'dist') {
+						continue;
+					}
+					walk(fullPath);
+					continue;
+				}
+				if (!/\.(?:[cm]?tsx?|mjs|svelte)$/.test(entry.name)) {
+					continue;
+				}
+				if (path.normalize(fullPath) === allowed) {
+					continue;
+				}
+				const source = readFileSync(fullPath, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+				if (
+					/\b(?:import\s*\(\s*|require\s*\(\s*|(?:import|export)(?:\s+type)?\s+(?:[^'"\n]*?\sfrom\s*)?)['"]effect['"]/.test(
+						source,
+					)
+				) {
+					hits.push(path.relative(srcRoot, fullPath));
+				}
+			}
+		};
+		walk(srcRoot);
+		expect(hits).toEqual([]);
 	});
 });

--- a/src/lib/effect/appEffect.test.ts
+++ b/src/lib/effect/appEffect.test.ts
@@ -1,6 +1,3 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { Data } from './appEffect';
 import {
@@ -135,56 +132,5 @@ describe('makeWorkflowKit (#389 spike acceptance)', () => {
 		);
 
 		expect(result).toBe('alpha-live');
-	});
-});
-
-function importsEffectPackage(source: string): boolean {
-	return /\b(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]effect(?:\/[^'"]*)?['"]/.test(
-		source,
-	);
-}
-
-describe('Effect package import boundary', () => {
-	const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-	const allowed = path.normalize(path.join(srcRoot, 'lib/effect/appEffect.ts'));
-
-	it('treats Effect package root and subpath specifiers as the same boundary', () => {
-		expect(importsEffectPackage("import { Effect } from 'effect'")).toBe(true);
-		expect(importsEffectPackage("import { Effect } from 'effect/Effect'")).toBe(true);
-		expect(importsEffectPackage("import { something } from './effect'")).toBe(false);
-	});
-
-	it('records effect specifiers from multiline named imports', () => {
-		expect(importsEffectPackage("import {\n\tEffect,\n} from 'effect';\n")).toBe(true);
-		expect(importsEffectPackage("import { Effect } from './effect';\n")).toBe(false);
-	});
-
-	it('lets only appEffect.ts import the effect package', () => {
-		const hits: string[] = [];
-		const self = path.normalize(fileURLToPath(import.meta.url));
-		const walk = (dir: string): void => {
-			for (const entry of readdirSync(dir, { withFileTypes: true })) {
-				const fullPath = path.join(dir, entry.name);
-				if (entry.isDirectory()) {
-					if (entry.name === 'node_modules' || entry.name === 'dist') {
-						continue;
-					}
-					walk(fullPath);
-					continue;
-				}
-				if (!/\.(?:[cm]?tsx?|mjs|svelte)$/.test(entry.name)) {
-					continue;
-				}
-				if (path.normalize(fullPath) === allowed || path.normalize(fullPath) === self) {
-					continue;
-				}
-				const source = readFileSync(fullPath, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
-				if (importsEffectPackage(source)) {
-					hits.push(path.relative(srcRoot, fullPath));
-				}
-			}
-		};
-		walk(srcRoot);
-		expect(hits).toEqual([]);
 	});
 });

--- a/src/lib/effect/appEffect.test.ts
+++ b/src/lib/effect/appEffect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Data } from 'effect';
+import { Data } from './appEffect';
 import {
 	type AppEffect,
 	Effect,

--- a/src/lib/effect/appEffect.ts
+++ b/src/lib/effect/appEffect.ts
@@ -4,12 +4,12 @@ export { Context, Data, Effect, Layer };
 
 export type AppEffect<A, E = never, R = never> = Effect.Effect<A, E, R>;
 export type AppLayer<ROut, E = never, RIn = never> = Layer.Layer<ROut, E, RIn>;
-export type AppServiceTag<Identifier, Service> = Context.Tag<Identifier, Service>;
+export type AppServiceTag<Identifier, Service> = Context.Service<Identifier, Service>;
 
 export function makeWorkflowServiceTag<Identifier extends string, Service>(
 	identifier: Identifier,
 ): AppServiceTag<Identifier, Service> {
-	return Context.GenericTag<Identifier, Service>(`abb/${identifier}`);
+	return Context.Service<Identifier, Service>(`abb/${identifier}`);
 }
 
 export function makeWorkflowLayer<Identifier, Service>(

--- a/src/ui/fileImport/importAnalysisWorkflow.ts
+++ b/src/ui/fileImport/importAnalysisWorkflow.ts
@@ -141,7 +141,7 @@ function analyzeFileListInfo(
 	evaluate: () => ReturnType<ImportAnalysisWorkflowServices['analyzeAudioFiles']>,
 ): AppEffect<FileListInfo | null, never> {
 	return workflowPromise(evaluate, 'Failed to analyze files.').pipe(
-		Effect.catchAll((error) =>
+		Effect.catch((error) =>
 			Effect.sync(() => {
 				return reportAnalysisFailure(services, error.cause);
 			}),
@@ -156,7 +156,7 @@ function stagePendingMetadataDrafts(
 		() => services.persistPendingMetadataDraftsForCurrentSelection(),
 		'Failed to stage metadata drafts before import.',
 	).pipe(
-		Effect.catchAll((error) =>
+		Effect.catch((error) =>
 			Effect.sync(() => {
 				return reportMetadataStagingFailure(services, error.cause);
 			}),
@@ -226,7 +226,7 @@ function reportUnsupportedImport(
 			() => services.getSupportedAudioImportMetadata(),
 			'Failed to load supported audio import metadata.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					return reportImportMetadataFailure(services, error.cause);
 				}),
@@ -267,7 +267,7 @@ function discoverAndProcessPaths(
 			() => services.discoverAudioImportPaths(paths),
 			'Failed to discover audio files.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					return reportImportDiscoveryFailure(services, error.cause);
 				}),
@@ -307,7 +307,7 @@ function processSelectedFiles(
 			evaluateSelectedPaths,
 			'Failed to open file dialog.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					return reportOpenFileDialogFailure(services, error.cause);
 				}),
@@ -331,7 +331,7 @@ function processSelectedFolder(
 			evaluateSelectedPath,
 			'Failed to open folder dialog.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					return reportOpenFolderDialogFailure(services, error.cause);
 				}),
@@ -380,7 +380,7 @@ function importPathsFromPrepared(
 			() => preparedEntry.discoveredPaths,
 			'Failed to discover audio files.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					return reportImportDiscoveryFailure(services, error.cause);
 				}),

--- a/src/ui/metadataLookup/metadataLookupWorkflow.ts
+++ b/src/ui/metadataLookup/metadataLookupWorkflow.ts
@@ -465,7 +465,7 @@ export function metadataLookupWorkflowProgram(
 	action: MetadataLookupWorkflowAction,
 ): AppEffect<void, never, MetadataLookupWorkflowServicesId> {
 	return metadataLookupWorkflowBody(action).pipe(
-		Effect.catchAll((error) =>
+		Effect.catch((error) =>
 			Effect.gen(function* () {
 				const services = yield* MetadataLookupWorkflowServicesTag;
 				yield* reportWorkflowFailure(services, error);

--- a/src/ui/metadataSession/saveWorkflow.ts
+++ b/src/ui/metadataSession/saveWorkflow.ts
@@ -309,7 +309,7 @@ export function metadataSaveWorkflowProgram(
 ): AppEffect<void, never, MetadataSaveWorkflowServicesId> {
 	const state = { enteredSave: preparedEntry !== undefined };
 	return metadataSaveWorkflowBody(state, preparedEntry).pipe(
-		Effect.catchAll((error) =>
+		Effect.catch((error) =>
 			Effect.gen(function* () {
 				const services = yield* MetadataSaveWorkflowServicesTag;
 				yield* reportWorkflowFailure(services, error);

--- a/src/ui/outputPanel/outputPlanWorkflow.ts
+++ b/src/ui/outputPanel/outputPlanWorkflow.ts
@@ -129,7 +129,7 @@ export function outputPathPreviewBody(
 			() => services.updateMetadataIntentWarnings(previewMetadataDraft),
 			'Failed to validate metadata intent for output preview.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					services.console.error('Metadata preview validation failed:', error.cause);
 					services.showOutputError('Failed to validate metadata preview.');
@@ -156,7 +156,7 @@ export function outputPathPreviewBody(
 				}),
 			'Output preview failed.',
 		).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.sync(() => {
 					if (!services.isLatestOutputPreviewRequest(requestId)) {
 						return null;

--- a/src/ui/statusPanel/__tests__/progressAggregator.test.ts
+++ b/src/ui/statusPanel/__tests__/progressAggregator.test.ts
@@ -125,48 +125,46 @@ describe('StatusPanel aggregate progress', () => {
 	// fields are type-level impossible on terminal variants; this test pins the
 	// runtime behavior so a future regression (e.g. someone reintroduces the
 	// copy-unconditional pattern behind a cast) fails loudly.
-	it.each([
-		STAGES.completed,
-		STAGES.skipped,
-		STAGES.failed,
-		STAGES.cancelled,
-	])('does not leak stale currentFile/etaSeconds onto terminal aggregates for %s', (terminalStage) => {
-		const controller = new StatusPanelRuntime();
-		const snapshot: ProcessingQueueEvent = {
-			operation_kind: 'processingBatch',
-			items: [{ input_index: 0, file_path: '/books/alpha.m4b' }],
-			max_concurrent: 1,
-		};
+	it.each([STAGES.completed, STAGES.skipped, STAGES.failed, STAGES.cancelled])(
+		'does not leak stale currentFile/etaSeconds onto terminal aggregates for %s',
+		(terminalStage) => {
+			const controller = new StatusPanelRuntime();
+			const snapshot: ProcessingQueueEvent = {
+				operation_kind: 'processingBatch',
+				items: [{ input_index: 0, file_path: '/books/alpha.m4b' }],
+				max_concurrent: 1,
+			};
 
-		controller.applyQueueSnapshot(snapshot);
+			controller.applyQueueSnapshot(snapshot);
 
-		// Active progress populates `latestProgressEvent` with active-stage
-		// fields; a careless flushRender would preserve these onto the terminal
-		// status that follows.
-		controller.applyProgress({
-			operation_kind: 'processingBatch',
-			input_index: 0,
-			stage: 'converting',
-			percentage: 80,
-			message: 'Working',
-			current_file: '/books/alpha.m4b',
-			eta_seconds: 42,
-		});
+			// Active progress populates `latestProgressEvent` with active-stage
+			// fields; a careless flushRender would preserve these onto the terminal
+			// status that follows.
+			controller.applyProgress({
+				operation_kind: 'processingBatch',
+				input_index: 0,
+				stage: 'converting',
+				percentage: 80,
+				message: 'Working',
+				current_file: '/books/alpha.m4b',
+				eta_seconds: 42,
+			});
 
-		controller.applyProgress({
-			operation_kind: 'processingBatch',
-			input_index: 0,
-			stage: terminalStage,
-			percentage: 100,
-			message: 'Done',
-		});
-		vi.advanceTimersByTime(20);
+			controller.applyProgress({
+				operation_kind: 'processingBatch',
+				input_index: 0,
+				stage: terminalStage,
+				percentage: 100,
+				message: 'Done',
+			});
+			vi.advanceTimersByTime(20);
 
-		const status = controller.getCurrentStatus();
-		expect(status).toMatchObject({
-			stage: terminalStage === STAGES.skipped ? 'completed' : terminalStage,
-		});
-		expect(status).not.toHaveProperty('currentFile');
-		expect(status).not.toHaveProperty('etaSeconds');
-	});
+			const status = controller.getCurrentStatus();
+			expect(status).toMatchObject({
+				stage: terminalStage === STAGES.skipped ? 'completed' : terminalStage,
+			});
+			expect(status).not.toHaveProperty('currentFile');
+			expect(status).not.toHaveProperty('etaSeconds');
+		},
+	);
 });

--- a/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
+++ b/src/ui/statusPanel/__tests__/statusPanel-lifecycle.test.ts
@@ -256,95 +256,98 @@ describe('StatusPanel lifecycle', () => {
 			expectedMessage: 'One or more files failed to process.',
 			expectedStepText: 'Error: One or more files failed to process.',
 		},
-	])('applies batch terminal lifecycle reset after 2s when %s', ({
-		terminalStages,
-		terminalClass,
-		summary,
-		resultStatuses,
-		expectedMethod,
-		expectedMessage,
-		expectedStepText,
-	}) => {
-		const controller = new StatusPanelRuntime();
-		seedDisabledControls();
-
-		const showSuccessSpy = vi.spyOn(viewState, 'showSuccess');
-		const showErrorSpy = vi.spyOn(viewState, 'showError');
-		const showInfoSpy = vi.spyOn(viewState, 'showInfo');
-
-		controller.applyQueueSnapshot({
-			operation_kind: 'processingBatch',
-			items: [
-				{ input_index: 0, file_path: '/books/alpha.m4b' },
-				{ input_index: 1, file_path: '/books/beta.m4b' },
-			],
-			max_concurrent: 2,
-		});
-
-		controller.applyProgress({
-			operation_kind: 'processingBatch',
-			input_index: 0,
-			stage: terminalStages[0],
-			percentage: 100,
-			message: 'terminal-0',
-		});
-		controller.applyProgress({
-			operation_kind: 'processingBatch',
-			input_index: 1,
-			stage: terminalStages[1],
-			percentage: 100,
-			message: 'terminal-1',
-		});
-
-		// The terminal verdict is backend-owned: reconcile the run result so the
-		// completion toast renders `terminalClass`, not a TS re-classification.
-		controller.reconcileProcessResult({
-			jobType: 'batch',
-			summary,
+	])(
+		'applies batch terminal lifecycle reset after 2s when %s',
+		({
+			terminalStages,
 			terminalClass,
-			results: resultStatuses.map((status, index) => ({
-				inputIndex: index,
-				status,
-				message: `terminal-${index}`,
-			})),
-		});
+			summary,
+			resultStatuses,
+			expectedMethod,
+			expectedMessage,
+			expectedStepText,
+		}) => {
+			const controller = new StatusPanelRuntime();
+			seedDisabledControls();
 
-		expect(controller.isCurrentlyProcessing).toBe(true);
-		expect(getJobRows()).toHaveLength(2);
-		assertControlsDisabled();
+			const showSuccessSpy = vi.spyOn(viewState, 'showSuccess');
+			const showErrorSpy = vi.spyOn(viewState, 'showError');
+			const showInfoSpy = vi.spyOn(viewState, 'showInfo');
 
-		vi.advanceTimersByTime(1999);
-		expect(controller.isCurrentlyProcessing).toBe(true);
+			controller.applyQueueSnapshot({
+				operation_kind: 'processingBatch',
+				items: [
+					{ input_index: 0, file_path: '/books/alpha.m4b' },
+					{ input_index: 1, file_path: '/books/beta.m4b' },
+				],
+				max_concurrent: 2,
+			});
 
-		vi.advanceTimersByTime(1);
+			controller.applyProgress({
+				operation_kind: 'processingBatch',
+				input_index: 0,
+				stage: terminalStages[0],
+				percentage: 100,
+				message: 'terminal-0',
+			});
+			controller.applyProgress({
+				operation_kind: 'processingBatch',
+				input_index: 1,
+				stage: terminalStages[1],
+				percentage: 100,
+				message: 'terminal-1',
+			});
 
-		assertControlsEnabled();
-		expect(controller.isCurrentlyProcessing).toBe(false);
-		const idleStatus = controller.getCurrentStatus();
-		expect(idleStatus).toEqual({
-			stage: 'idle',
-			percentage: 0,
-			message: 'Ready to process audiobook',
-		});
-		expect(idleStatus).not.toHaveProperty('currentFile');
-		expect(idleStatus).not.toHaveProperty('etaSeconds');
-		expect(statusPanelViewState.jobItems).toHaveLength(0);
-		expect(getStepText()).toBe(expectedStepText);
+			// The terminal verdict is backend-owned: reconcile the run result so the
+			// completion toast renders `terminalClass`, not a TS re-classification.
+			controller.reconcileProcessResult({
+				jobType: 'batch',
+				summary,
+				terminalClass,
+				results: resultStatuses.map((status, index) => ({
+					inputIndex: index,
+					status,
+					message: `terminal-${index}`,
+				})),
+			});
 
-		const toastSpies = {
-			showSuccess: showSuccessSpy,
-			showError: showErrorSpy,
-			showInfo: showInfoSpy,
-		};
-		const expectedSpy = toastSpies[expectedMethod];
-		expect(expectedSpy).toHaveBeenCalledTimes(1);
-		expect(expectedSpy).toHaveBeenCalledWith(expectedMessage);
-		for (const [method, spy] of Object.entries(toastSpies)) {
-			if (method !== expectedMethod) {
-				expect(spy).not.toHaveBeenCalled();
+			expect(controller.isCurrentlyProcessing).toBe(true);
+			expect(getJobRows()).toHaveLength(2);
+			assertControlsDisabled();
+
+			vi.advanceTimersByTime(1999);
+			expect(controller.isCurrentlyProcessing).toBe(true);
+
+			vi.advanceTimersByTime(1);
+
+			assertControlsEnabled();
+			expect(controller.isCurrentlyProcessing).toBe(false);
+			const idleStatus = controller.getCurrentStatus();
+			expect(idleStatus).toEqual({
+				stage: 'idle',
+				percentage: 0,
+				message: 'Ready to process audiobook',
+			});
+			expect(idleStatus).not.toHaveProperty('currentFile');
+			expect(idleStatus).not.toHaveProperty('etaSeconds');
+			expect(statusPanelViewState.jobItems).toHaveLength(0);
+			expect(getStepText()).toBe(expectedStepText);
+
+			const toastSpies = {
+				showSuccess: showSuccessSpy,
+				showError: showErrorSpy,
+				showInfo: showInfoSpy,
+			};
+			const expectedSpy = toastSpies[expectedMethod];
+			expect(expectedSpy).toHaveBeenCalledTimes(1);
+			expect(expectedSpy).toHaveBeenCalledWith(expectedMessage);
+			for (const [method, spy] of Object.entries(toastSpies)) {
+				if (method !== expectedMethod) {
+					expect(spy).not.toHaveBeenCalled();
+				}
 			}
-		}
-	});
+		},
+	);
 
 	it('reconciles merge skip_existing results back to idle and unlocks controls', () => {
 		const controller = new StatusPanelRuntime();
@@ -569,52 +572,51 @@ describe('StatusPanel lifecycle', () => {
 			message: 'Processing was cancelled.',
 			method: 'showInfo' as const,
 		},
-	])('applies single-job terminal lifecycle reset after 2s when %s', ({
-		stage,
-		message,
-		method,
-	}) => {
-		const controller = new StatusPanelRuntime();
-		seedDisabledControls();
+	])(
+		'applies single-job terminal lifecycle reset after 2s when %s',
+		({ stage, message, method }) => {
+			const controller = new StatusPanelRuntime();
+			seedDisabledControls();
 
-		const showSuccessSpy = vi.spyOn(viewState, 'showSuccess');
-		const showErrorSpy = vi.spyOn(viewState, 'showError');
-		const showInfoSpy = vi.spyOn(viewState, 'showInfo');
+			const showSuccessSpy = vi.spyOn(viewState, 'showSuccess');
+			const showErrorSpy = vi.spyOn(viewState, 'showError');
+			const showInfoSpy = vi.spyOn(viewState, 'showInfo');
 
-		controller.applyProgress({
-			operation_kind: 'processingBatch',
-			job_id: 'job-1',
-			stage,
-			percentage: 100,
-			message,
-		});
+			controller.applyProgress({
+				operation_kind: 'processingBatch',
+				job_id: 'job-1',
+				stage,
+				percentage: 100,
+				message,
+			});
 
-		expect(controller.isCurrentlyProcessing).toBe(true);
-		expect(getJobRows()).toHaveLength(1);
-		assertControlsDisabled();
+			expect(controller.isCurrentlyProcessing).toBe(true);
+			expect(getJobRows()).toHaveLength(1);
+			assertControlsDisabled();
 
-		vi.advanceTimersByTime(1999);
-		vi.advanceTimersByTime(1);
+			vi.advanceTimersByTime(1999);
+			vi.advanceTimersByTime(1);
 
-		const expectedSpy =
-			method === 'showSuccess'
-				? showSuccessSpy
-				: method === 'showError'
-					? showErrorSpy
-					: showInfoSpy;
-		expect(expectedSpy).toHaveBeenCalledWith(message);
-		assertControlsEnabled();
-		const idleStatus = controller.getCurrentStatus();
-		expect(idleStatus).toEqual({
-			stage: 'idle',
-			percentage: 0,
-			message: 'Ready to process audiobook',
-		});
-		expect(idleStatus).not.toHaveProperty('currentFile');
-		expect(idleStatus).not.toHaveProperty('etaSeconds');
-		expect(statusPanelViewState.jobItems).toHaveLength(0);
-		expect(getStepText()).toBe(method === 'showError' ? `Error: ${message}` : message);
-	});
+			const expectedSpy =
+				method === 'showSuccess'
+					? showSuccessSpy
+					: method === 'showError'
+						? showErrorSpy
+						: showInfoSpy;
+			expect(expectedSpy).toHaveBeenCalledWith(message);
+			assertControlsEnabled();
+			const idleStatus = controller.getCurrentStatus();
+			expect(idleStatus).toEqual({
+				stage: 'idle',
+				percentage: 0,
+				message: 'Ready to process audiobook',
+			});
+			expect(idleStatus).not.toHaveProperty('currentFile');
+			expect(idleStatus).not.toHaveProperty('etaSeconds');
+			expect(statusPanelViewState.jobItems).toHaveLength(0);
+			expect(getStepText()).toBe(method === 'showError' ? `Error: ${message}` : message);
+		},
+	);
 
 	it('prevents stale single-job completion timeout from resetting a newer active run', () => {
 		const controller = new StatusPanelRuntime();

--- a/src/ui/statusPanel/processingWorkflow.ts
+++ b/src/ui/statusPanel/processingWorkflow.ts
@@ -263,7 +263,7 @@ function submitRetainedProcessingCommand(
 	return Effect.gen(function* () {
 		yield* Effect.sync(() => retainRemoteSourceSessionsForInputIds(request.inputIds));
 		return yield* submitProcessingCommand(services, request).pipe(
-			Effect.catchAll((error) =>
+			Effect.catch((error) =>
 				Effect.tryPromise({
 					try: async () => {
 						const pendingPurgeInputIds = releaseRemoteSourceSessionRetainers(request.inputIds);
@@ -273,7 +273,7 @@ function submitRetainedProcessingCommand(
 					},
 					catch: () => undefined,
 				}).pipe(
-					Effect.catchAll(() => Effect.succeed(undefined)),
+					Effect.catch(() => Effect.succeed(undefined)),
 					Effect.flatMap(() => Effect.fail(error)),
 				),
 			),
@@ -288,7 +288,7 @@ function readProcessingConfig(
 		try: () => services.readProcessingRequestConfig(),
 		catch: (cause) => cause,
 	}).pipe(
-		Effect.catchAll((error) =>
+		Effect.catch((error) =>
 			Effect.sync(() => {
 				services.console.log('StatusPanel: Settings validation failed:', error);
 				services.feedback.showError(`Settings validation failed: ${errorDisplayText(error)}`);
@@ -491,7 +491,7 @@ export function processingWorkflowProgram(
 		});
 		yield* completeAcceptedSubmission(services, context, accepted);
 	}).pipe(
-		Effect.catchAll((error) =>
+		Effect.catch((error) =>
 			Effect.gen(function* () {
 				const services = yield* ProcessingWorkflowServicesTag;
 				yield* handleWorkflowError(services, context, error);


### PR DESCRIPTION
## Current state

Landed on `upgrade/ts7-effect4`. Frontend compiler is TypeScript 7, Effect is exact `4.0.0-rc.112`, Bun is `1.4.0`. Promise-facing UI and Tauri IPC contracts are unchanged.

ABB-owned code does not import `typescript`. The TypeScript 6 shim exists only because `svelte-check@4.7.6` still `require()`s a 6.x compiler API, including under `--tsgo`. That is upstream, not an ABB choice. Do not flatten the dual layout until svelte-check can type `.svelte` files on TypeScript 7 alone.

**Next action:** GUI click-through of the Effect-owned paths below. Automated proof already ran on this branch.

Closes #462

## Dual TypeScript layout (svelte-check only)

- `@typescript/native` → `typescript@7.0.2` supplies `tsc`
- `typescript` → `@typescript/typescript6@6.0.2` is the svelte-check shim (wrapper 6.0.2; nested `@typescript/old` is real `typescript@6.0.3`)

`svelte-check` peers `typescript` `^5 || ^6` and refuses to start if that slot is 7. Bun `1.4.0` is required so `@typescript/old` resolves to real TypeScript 6, not back onto the wrapper.

Proof:

- `./node_modules/.bin/tsc --version` → `7.0.2`
- `./node_modules/.bin/tsc6 --version` → `6.0.3`
- `require('typescript')` → `6.0.3 object`
- `bun.lock` `@typescript/old` → `typescript@6.0.3`

Upstream svelte-check README still mentions `@typescript/native-preview`. Installed `4.7.6 --tsgo` works with `@typescript/native`. Do not add `native-preview`.

## Implementation notes for reviewing agents

- Dist-tags at branch start still matched #462 (`typescript@latest` 7.0.2, `effect@rc` 4.0.0-rc.112). Effect port was `Context.Tag`/`GenericTag` → `Context.Service` plus `Effect.catchAll` → `Effect.catch` at 15 workflow call sites. Typecheck passed immediately.
- `scripts/check-tauri-runtime-boundary.ts` no longer uses the TypeScript compiler API. It scans import/export text. Focused test: `bun run test -- scripts/check-tauri-runtime-boundary.test.ts` (10 passed) plus `bun scripts/check-tauri-runtime-boundary.ts` on this tree.
- `bunfig.toml` 10-day `minimumReleaseAge` blocks the Effect RC on a fresh resolve. This branch used `bun install --minimum-release-age=0` once; frozen installs after that need no exception.
- `bun.lock` growth is TS7 platform packages plus Effect 4 deps (`fast-check` 4, `msgpackr`).
- #462 named `packageManager` and CI for Bun `1.4.0` but not the other live pins. This PR also updates `scripts/setup-codex-agent-env.sh` and the README Bun lines.
- `/.svelte-check/` is gitignored. Biome already has `vcs.useIgnoreFile`.
- The two Status Panel test diffs are formatter-only; they were pre-existing `fmt:check` failures on `main`.
- `bun run app:dev:log` opened the native window. A normal browser on `http://localhost:1420` throws `invoke` / `transformCallback` because Tauri IPC is absent there. Not an Effect 4 regression.

## Remaining

Human GUI smoke in the native app: file import, metadata lookup/apply, output-path preview/collision review, metadata save, processing submit/complete, local cancel/cleanup.

## Automated verification already run

```text
bun install --frozen-lockfile
./node_modules/.bin/tsc --version
./node_modules/.bin/tsc6 --version
node -e "const ts=require('typescript'); console.log(ts.version, typeof ts.sys)"
bun run typecheck
bun run check:svelte
bun run lint:check
bun run fmt:check
bun run test -- scripts/check-tauri-runtime-boundary.test.ts
bun scripts/check-tauri-runtime-boundary.ts
bun run test -- src/lib/effect/appEffect.test.ts src/ui/fileImport/__tests__/importAnalysisWorkflow.test.ts src/ui/statusPanel/__tests__/processingWorkflow.test.ts src/ui/outputPanel/__tests__/outputPlanWorkflow.test.ts src/ui/metadataSession/__tests__/saveWorkflow.test.ts src/ui/metadataLookup/__tests__/metadataLookupWorkflow.test.ts
bun run test
bun run build
bun run audit:js
```