### PR TITLE
spike(ui): File List Solid 1.9 island on atom-solid

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -67,7 +67,7 @@
 			}
 		},
 		{
-			"includes": ["src/**/*.test.ts", "src/test/**/*.ts"],
+			"includes": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*.ts"],
 			"linter": {
 				"rules": {
 					"style": {

--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,16 @@
     "": {
       "name": "audiobook-boss",
       "dependencies": {
+        "@effect/atom-solid": "4.0.0-rc.110",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "effect": "4.0.0-rc.112",
+        "solid-js": "1.9.15",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.9",
+        "@solidjs/testing-library": "0.8.10",
         "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@tailwindcss/vite": "^4.3.3",
         "@tauri-apps/cli": "^2.11.4",
@@ -27,6 +30,7 @@
         "tailwindcss": "^4.3.3",
         "typescript": "npm:@typescript/typescript6@6.0.2",
         "vite": "^8.2.2",
+        "vite-plugin-solid": "2.11.14",
         "vitest": "^4.1.11",
       },
     },
@@ -49,9 +53,41 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.5.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.9", "@biomejs/cli-darwin-x64": "2.5.9", "@biomejs/cli-linux-arm64": "2.5.9", "@biomejs/cli-linux-arm64-musl": "2.5.9", "@biomejs/cli-linux-x64": "2.5.9", "@biomejs/cli-linux-x64-musl": "2.5.9", "@biomejs/cli-win32-arm64": "2.5.9", "@biomejs/cli-win32-x64": "2.5.9" }, "bin": { "biome": "bin/biome" } }, "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g=="],
 
@@ -84,6 +120,8 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@effect/atom-solid": ["@effect/atom-solid@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110", "solid-js": ">=1.9.14 <2.0.0" } }, "sha512-2oa5ny4VEZqXHPz3nlEXfn0M1ceHJ2puqDi+U0jwx8rh5APiToUOACT/k0mLqRvvNvSY13TsETvGr+PwXVDiwQ=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
@@ -142,6 +180,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@solidjs/testing-library": ["@solidjs/testing-library@0.8.10", "", { "dependencies": { "@testing-library/dom": "^10.4.0" }, "peerDependencies": { "@solidjs/router": ">=0.9.0", "solid-js": ">=1.0.0" }, "optionalPeers": ["@solidjs/router"] }, "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -223,6 +263,14 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -301,7 +349,17 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.10", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-lxve6Y02YiZTldB7efKpnbf1BH00XCFZNYYW235jSGsYaJNFtHrYlKV6/O+miHbjqpIr9FTe5+0no4hofAMbfA=="],
+
+    "babel-preset-solid": ["babel-preset-solid@1.9.15", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.10" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.15" }, "optionalPeers": ["solid-js"] }, "sha512-GBmg1OiPb+OwcH51XbDAKPtvrPfQW7rCJTJxcp8+yhtWwN+kqnbEJk2SgVybd+uhTxTKAvjaFyiQSr/eUZBwzg=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.15", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA=="],
+
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -315,7 +373,11 @@
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -331,11 +393,15 @@
 
     "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.409", "", {}, "sha512-ChI4N44d0B4A6C8prnNjMOaGgE59fUyEVYcRYm2XEXIjMbbvF5i9UL1cblDbpGqiU0uS8FE8UcKxqZqTXdmzbQ=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
     "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
@@ -351,9 +417,13 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -361,11 +431,17 @@
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
+    "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
@@ -401,9 +477,13 @@
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
+    "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
 
@@ -412,6 +492,8 @@
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -449,7 +531,17 @@
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "solid-js": ["solid-js@1.9.15", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg=="],
+
+    "solid-refresh": ["solid-refresh@0.6.3", "", { "dependencies": { "@babel/generator": "^7.23.6", "@babel/helper-module-imports": "^7.22.15", "@babel/types": "^7.23.6" }, "peerDependencies": { "solid-js": "^1.3" } }, "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -489,7 +581,11 @@
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
+
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
+
+    "vite-plugin-solid": ["vite-plugin-solid@2.11.14", "", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-7ZVBt8rpoyqmlwin2kRIUveaHoF6/kulY7gsnD+qFh4nS29V4OPAnw+ojoAspXIjObiL9o1xh9a/nTuYHm02Rw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
@@ -509,7 +605,21 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -535,6 +645,10 @@
 
     "@vitest/snapshot/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
+
+    "babel-plugin-jsx-dom-expressions/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "data-urls/whatwg-url": ["whatwg-url@16.0.0", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ=="],
 
     "html-encoding-sniffer/@exodus/bytes": ["@exodus/bytes@1.11.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA=="],
@@ -546,6 +660,12 @@
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
@@ -570,6 +690,8 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "babel-plugin-jsx-dom-expressions/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "data-urls/whatwg-url/@exodus/bytes": ["@exodus/bytes@1.11.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA=="],
   }

--- a/file-list-solid.html
+++ b/file-list-solid.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>ABB File List Solid spike</title>
+	</head>
+	<body class="p-4">
+		<div id="file-list-solid"></div>
+		<script type="module" src="/src/ui/fileList/solid/main.ts"></script>
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -36,13 +36,16 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@effect/atom-solid": "4.0.0-rc.110",
 		"@tauri-apps/api": "^2.11.1",
 		"@tauri-apps/plugin-dialog": "^2.7.2",
 		"@tauri-apps/plugin-opener": "^2.5.4",
-		"effect": "4.0.0-rc.112"
+		"effect": "4.0.0-rc.112",
+		"solid-js": "1.9.15"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.9",
+		"@solidjs/testing-library": "0.8.10",
 		"@sveltejs/vite-plugin-svelte": "^7.3.0",
 		"@tailwindcss/vite": "^4.3.3",
 		"@tauri-apps/cli": "^2.11.4",
@@ -58,6 +61,7 @@
 		"tailwindcss": "^4.3.3",
 		"typescript": "npm:@typescript/typescript6@6.0.2",
 		"vite": "^8.2.2",
+		"vite-plugin-solid": "2.11.14",
 		"vitest": "^4.1.11"
 	},
 	"overrides": {

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -14,13 +14,17 @@ multi-service orchestration.
 Keep Effect private to workflow owners:
 
 - Only `src/lib/effect/appEffect.ts` imports the `effect` package. Owners and
-  tests import `Effect`, `Context`, `Data`, and `Layer` from that file. Proof:
+  tests import `Effect`, `Context`, `Data`, `Layer`, `Atom`, `AtomRegistry`,
+  and `AsyncResult` from that file. Proof:
   `bun run test -- scripts/frontend-toolchain-layout.test.ts`. The tripwire
   lives in scripts so the frontend `tsconfig` stays Vite/Svelte types. It
   matches `from 'effect'` and `from 'effect/...'` so ordinary multiline named
   imports count; do not require the binding list to sit on one line.
 - Public UI/runtime entrypoints expose Promise-returning functions or existing
-  synchronous wrappers where callers already rely on them.
+  synchronous wrappers where callers already rely on them. Exception: the File
+  List `solid/` spike (#464) has no `runAppEffect` and no Promise workflow
+  façade; clicks write atoms, Effects run in the Atom registry, and Solid
+  reads Atom/AsyncResult. That exception does not apply to other islands.
 - Workflow owners expose a local service interface, service tag, live layer
   (co-located in the workflow file with `satisfies`), typed errors, program,
   and Promise bridge. `ProcessingWorkflow` keeps live deps in

--- a/src/lib/effect/appEffect.ts
+++ b/src/lib/effect/appEffect.ts
@@ -1,6 +1,7 @@
 import { Context, Data, Effect, Layer } from 'effect';
+import { Atom, AtomRegistry, AsyncResult } from 'effect/unstable/reactivity';
 
-export { Context, Data, Effect, Layer };
+export { Atom, AtomRegistry, AsyncResult, Context, Data, Effect, Layer };
 
 export type AppEffect<A, E = never, R = never> = Effect.Effect<A, E, R>;
 export type AppLayer<ROut, E = never, RIn = never> = Layer.Layer<ROut, E, RIn>;

--- a/src/ui/fileList/AGENTS.md
+++ b/src/ui/fileList/AGENTS.md
@@ -24,6 +24,12 @@
   `viewState.svelte.ts`, `events.ts`, `selection.ts`,
   `metadataStaging.ts`, `metadataPanel.ts`, `appendResult.ts`,
   `inspectorState.svelte.ts`, `keyboardNavigation.ts`, `__tests__/`.
+- Spike (issue #464 lock 1, not the live runtime strip): `solid/` — Solid 1.9
+  island on official `@effect/atom-solid`. Public spike strip = `solid/index.ts`
+  (atoms + sync actions only). Do not import `FileListIsland.tsx`,
+  `mount.tsx`, or `@effect/atom-solid` from outside `solid/`. Do not grow
+  `index.ts` with this spike. No `runAppEffect` on this island; Atoms run
+  Effects and the TSX reads Atom/AsyncResult.
 
 ## Preferred Path
 

--- a/src/ui/fileList/solid/FileListIsland.css
+++ b/src/ui/fileList/solid/FileListIsland.css
@@ -1,0 +1,123 @@
+.file-management-container {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-height: 8rem;
+	overflow: hidden;
+	border: 1px solid var(--border-primary);
+	border-radius: 0.375rem;
+	background-color: var(--bg-input);
+}
+
+.file-list-content {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.file-list-content:focus-visible {
+	outline: 2px solid var(--border-focus);
+	outline-offset: -2px;
+}
+
+.drop-zone-header[data-has-files="false"] {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 2rem 1rem;
+	border: 2px dashed var(--border-secondary);
+	background-color: var(--bg-drag-area);
+	cursor: pointer;
+}
+
+.drop-zone-header[data-has-files="true"] {
+	flex-shrink: 0;
+	min-height: 2.5rem;
+	padding: 0.5rem 1rem;
+	border-bottom: 1px solid var(--border-primary);
+	cursor: pointer;
+}
+
+.file-list-item {
+	padding: 0.75rem;
+	border-bottom: 1px solid var(--border-primary);
+	cursor: pointer;
+	user-select: none;
+}
+
+.file-list-item.selected {
+	background-color: var(--accent-primary);
+	color: var(--text-inverse);
+}
+
+.file-item-content {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	min-width: 0;
+}
+
+.file-cover-thumbnail {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	flex: 0 0 2rem;
+	overflow: hidden;
+	border-radius: 0.25rem;
+	background: var(--bg-drag-area);
+	font-size: 0.625rem;
+}
+
+.file-cover-thumbnail img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.file-info {
+	flex: 1;
+	min-width: 0;
+}
+
+.file-name-row {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	min-width: 0;
+}
+
+.file-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.875rem;
+	font-weight: 500;
+}
+
+.file-details {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.75rem;
+}
+
+.remove-file-btn,
+.move-up-btn,
+.move-down-btn {
+	width: 1.5rem;
+	height: 1.5rem;
+	border: none;
+	background: none;
+	cursor: pointer;
+}
+
+.move-up-btn:disabled,
+.move-down-btn:disabled,
+.remove-file-btn:disabled {
+	opacity: 0.3;
+	cursor: not-allowed;
+}

--- a/src/ui/fileList/solid/FileListIsland.tsx
+++ b/src/ui/fileList/solid/FileListIsland.tsx
@@ -1,0 +1,292 @@
+import { RegistryContext, useAtomValue } from '@effect/atom-solid';
+import { For, Show } from 'solid-js';
+import { pathBasename } from '../../../lib/path/basename';
+import { formatDuration, formatFileSize, type AudioFile } from '../../../types/audio';
+import { AsyncResult } from '../../../lib/effect/appEffect';
+import { hasSupplementalAssetsForInputId } from '../../remoteSource';
+import {
+	fileListNavigationCommandFromKey,
+	resolveFileListNavigationTarget,
+} from '../keyboardNavigation';
+import {
+	clearFiles,
+	clearSelection,
+	fileListRegistry,
+	moveFile,
+	removeFile,
+	restoreImportOrder,
+	selectAll,
+	selectFile,
+	toggleSort,
+} from './session';
+import { displayedArtistForFile, displayedTitleForFile, fileListViewAtom } from './view';
+import { coverThumbnailAtom } from './thumbnails';
+import './FileListIsland.css';
+
+export type FileListIslandProps = {
+	isDragOver?: boolean;
+	supportText?: string;
+	onHeaderClick?: () => void;
+	onHeaderKeydown?: (event: KeyboardEvent) => void;
+};
+
+function fileDetails(file: AudioFile): string {
+	const artist = displayedArtistForFile(file);
+	const artistPrefix = artist ? `${artist} • ` : '';
+	const chapterSuffix = file.chapters?.length
+		? ` • ${file.chapters.length} chapter${file.chapters.length === 1 ? '' : 's'}`
+		: '';
+	if (file.isValid && file.duration && file.size) {
+		return `${artistPrefix}${formatDuration(file.duration)} • ${formatFileSize(file.size)} • ${file.format}${chapterSuffix}`;
+	}
+	return `Error: ${file.error || 'Invalid file'}`;
+}
+
+function CoverThumb(props: { path: string }) {
+	const thumbnail = useAtomValue(() => coverThumbnailAtom(props.path));
+	const dataUrl = () => {
+		const result = thumbnail();
+		return AsyncResult.isSuccess(result) ? result.value : null;
+	};
+	return (
+		<div class="file-cover-thumbnail" aria-hidden="true">
+			<Show when={dataUrl()} fallback={<span>Art</span>}>
+				<img src={dataUrl() ?? ''} alt="" />
+			</Show>
+		</div>
+	);
+}
+
+function FileRow(props: {
+	file: AudioFile;
+	index: number;
+	selected: boolean;
+	fileCount: number;
+	orderLocked: boolean;
+}) {
+	const name = () => pathBasename(props.file.path, { fallback: 'path' });
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: listbox owns keyboard navigation for options
+		<div
+			data-file-index={props.index}
+			class="file-list-item"
+			classList={{
+				valid: props.file.isValid,
+				invalid: !props.file.isValid,
+				selected: props.selected,
+			}}
+			role="option"
+			aria-selected={props.selected}
+			aria-label={name()}
+			tabIndex={-1}
+			onClick={(event) => {
+				if (event.shiftKey) window.getSelection()?.removeAllRanges();
+				selectFile(props.index, {
+					multi: event.ctrlKey || event.metaKey,
+					range: event.shiftKey,
+				});
+			}}
+		>
+			<div class="file-item-content">
+				<CoverThumb path={props.file.path} />
+				<div class={`file-status ${props.file.isValid ? 'text-green-500' : 'text-red-500'}`}>
+					{props.file.isValid ? '✓' : '✗'}
+				</div>
+				<div class="file-info">
+					<div class="file-name-row">
+						<div class="file-name">{displayedTitleForFile(props.file)}</div>
+						<Show when={hasSupplementalAssetsForInputId(props.file.inputId)}>
+							<span class="companion-chip" title="Supplemental PDF attached">
+								PDF
+							</span>
+						</Show>
+					</div>
+					<div class="file-details">{fileDetails(props.file)}</div>
+				</div>
+				<button
+					type="button"
+					class="move-up-btn"
+					disabled={props.index === 0 || props.orderLocked}
+					onClick={(event) => {
+						event.stopPropagation();
+						moveFile(props.index, -1);
+					}}
+				>
+					▲
+				</button>
+				<button
+					type="button"
+					class="move-down-btn"
+					disabled={props.index === props.fileCount - 1 || props.orderLocked}
+					onClick={(event) => {
+						event.stopPropagation();
+						moveFile(props.index, 1);
+					}}
+				>
+					▼
+				</button>
+				<button
+					type="button"
+					class="remove-file-btn"
+					disabled={props.orderLocked}
+					onClick={(event) => {
+						event.stopPropagation();
+						removeFile(props.index);
+					}}
+				>
+					×
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function FileListView(props: FileListIslandProps) {
+	const view = useAtomValue(() => fileListViewAtom);
+
+	function onKeyDown(event: KeyboardEvent) {
+		const current = view();
+		if (!current.files.length) return;
+		const target = event.target;
+		if (target instanceof HTMLElement) {
+			const tag = target.tagName.toLowerCase();
+			if (tag === 'input' || tag === 'textarea') return;
+		}
+		const command = fileListNavigationCommandFromKey(event);
+		if (command) {
+			const targetIndex = resolveFileListNavigationTarget({
+				command,
+				fileCount: current.files.length,
+				selectedIndex: current.selectedIndices[current.selectedIndices.length - 1] ?? -1,
+			});
+			if (targetIndex === null) return;
+			event.preventDefault();
+			if (current.selectedIndices.length === 1 && current.selectedIndices[0] === targetIndex) {
+				return;
+			}
+			selectFile(targetIndex, { multi: false, range: false });
+			return;
+		}
+		const key = event.key.toLowerCase();
+		if ((event.metaKey || event.ctrlKey) && key === 'a') {
+			event.preventDefault();
+			selectAll();
+		} else if (key === 'escape') {
+			event.preventDefault();
+			clearSelection();
+		}
+	}
+
+	return (
+		<>
+			<div class="flex flex-col gap-2 mb-2">
+				<div class="flex items-center justify-end gap-2">
+					<div class="flex items-center gap-2 mr-auto self-center pl-1">
+						<span class="text-xs muted-text italic" id="file-count-display">
+							{view().files.length} {view().files.length === 1 ? 'file' : 'files'}
+						</span>
+						<span
+							class="text-xs muted-text italic"
+							id="file-order-lock"
+							data-testid="file-order-lock"
+							style={{ display: view().orderLockVisible ? 'inline' : 'none' }}
+						>
+							Order locked while processing
+						</span>
+					</div>
+					<button
+						type="button"
+						id="sort-toggle-btn"
+						class="btn-pill btn-pill-secondary"
+						style={{ display: view().showSortButton ? 'block' : 'none' }}
+						disabled={view().sortDisabled}
+						aria-label={`Sort files ${view().sortState === 'ascending' ? 'descending' : 'ascending'}`}
+						aria-describedby="file-sort-status"
+						onClick={() => toggleSort()}
+					>
+						{view().sortLabel}
+					</button>
+					<span id="file-sort-status" class="sr-only" aria-live="polite">
+						{view().sortState === 'ascending'
+							? 'Files sorted from A to Z.'
+							: view().sortState === 'descending'
+								? 'Files sorted from Z to A.'
+								: 'Files are in import order.'}
+					</span>
+					<button
+						type="button"
+						id="restore-import-order-btn"
+						class="btn-pill btn-pill-secondary"
+						style={{ display: view().orderDiffersFromImport ? 'block' : 'none' }}
+						disabled={view().sortDisabled}
+						onClick={() => restoreImportOrder()}
+					>
+						Restore import order
+					</button>
+					<button
+						type="button"
+						id="clear-files-btn"
+						class="btn-pill btn-pill-secondary"
+						style={{ display: view().showClearButton ? 'block' : 'none' }}
+						disabled={view().clearDisabled}
+						onClick={() => clearFiles()}
+					>
+						Clear
+					</button>
+				</div>
+			</div>
+			<section class="file-management-container mb-3" aria-label="File list">
+				{/* biome-ignore lint/a11y/useSemanticElements: drop zone is a clickable region, not a form button */}
+				<div
+					class="drop-zone-header"
+					classList={{ 'drag-over': Boolean(props.isDragOver) }}
+					data-has-files={String(view().files.length > 0)}
+					role="button"
+					aria-label="Add audio files"
+					tabIndex={0}
+					onClick={() => props.onHeaderClick?.()}
+					onKeyDown={(event) => props.onHeaderKeydown?.(event)}
+				>
+					<p class="text-sm muted-text">
+						Drop files or folders here, click to choose files, or use Add Folder
+					</p>
+					<p class="text-xs muted-text mt-1">{props.supportText ?? ''}</p>
+				</div>
+				<div
+					class="file-list-content"
+					role="listbox"
+					aria-label="Audio files"
+					aria-multiselectable="true"
+					tabIndex={0}
+					onKeyDown={onKeyDown}
+				>
+					<For each={view().files}>
+						{(file, index) => (
+							<FileRow
+								file={file}
+								index={index()}
+								selected={view().selectedIndices.includes(index())}
+								fileCount={view().files.length}
+								orderLocked={view().orderLockVisible}
+							/>
+						)}
+					</For>
+				</div>
+			</section>
+			<aside data-testid="file-list-inspector" aria-label="Selected file inspector">
+				<p data-testid="inspector-context">{view().inspector.contextText}</p>
+				<p data-testid="inspector-detail">{view().inspector.contextDetail}</p>
+				<p data-testid="inspector-size">{view().inspector.fileSizeText}</p>
+				<p data-testid="inspector-combined">{view().combinedSizeText}</p>
+			</aside>
+		</>
+	);
+}
+
+export function FileListIsland(props: FileListIslandProps) {
+	return (
+		<RegistryContext.Provider value={fileListRegistry}>
+			<FileListView {...props} />
+		</RegistryContext.Provider>
+	);
+}

--- a/src/ui/fileList/solid/__tests__/FileListIsland.test.tsx
+++ b/src/ui/fileList/solid/__tests__/FileListIsland.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import { FileListIsland } from '../FileListIsland';
+import { loadFileList, resetFileList, selectFile, setOrderLocked } from '..';
+
+function makeFileList(): FileListInfo {
+	const files: AudioFile[] = [
+		{ path: '/books/alpha.m4b', isValid: true, duration: 60, size: 1024, format: 'm4b' },
+		{ path: '/books/bravo.m4b', isValid: true, duration: 60, size: 2048, format: 'm4b' },
+	];
+	return {
+		files,
+		selectedDecoders: files.map(() => null),
+		totalDuration: 120,
+		totalSize: 3072,
+		validCount: files.length,
+		invalidCount: 0,
+	};
+}
+
+describe('Solid File List island', () => {
+	beforeEach(() => {
+		resetFileList();
+		loadFileList(makeFileList());
+	});
+
+	afterEach(() => {
+		cleanup();
+		resetFileList();
+	});
+
+	it('handles keyboard actions only from the focusable FileList region', async () => {
+		render(() => <FileListIsland />);
+		const listbox = screen.getByRole('listbox', { name: 'Audio files' });
+
+		await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+		expect(screen.getByRole('option', { name: 'alpha.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+
+		await fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+		await fireEvent.keyDown(window, { key: 'ArrowDown' });
+		expect(screen.getByRole('option', { name: 'bravo.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'false',
+		);
+
+		await fireEvent.keyDown(listbox, { key: 'a', ctrlKey: true });
+		expect(screen.getByRole('option', { name: 'alpha.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+		expect(screen.getByRole('option', { name: 'bravo.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+	});
+
+	it('paints inspector and sort from the Atom view', async () => {
+		selectFile(0);
+		render(() => <FileListIsland />);
+		expect(screen.getByTestId('inspector-context')).toHaveTextContent('alpha.m4b');
+		expect(screen.getByTestId('inspector-detail')).toHaveTextContent('1 of 2');
+		expect(screen.getByTestId('file-order-lock')).not.toBeVisible();
+
+		await fireEvent.click(screen.getByRole('button', { name: /Sort files/ }));
+		expect(screen.getByLabelText(/Sort files descending/)).toHaveTextContent('Sort: A-Z');
+
+		setOrderLocked(true);
+		expect(screen.getByTestId('file-order-lock')).toBeVisible();
+		expect(screen.getByRole('button', { name: 'Clear' })).toBeDisabled();
+	});
+});

--- a/src/ui/fileList/solid/__tests__/coverThumbnails.test.ts
+++ b/src/ui/fileList/solid/__tests__/coverThumbnails.test.ts
@@ -53,30 +53,16 @@ describe('Solid File List cover thumbnail atoms', () => {
 		expect(AsyncResult.isSuccess(thumbnail('/a'))).toBe(true);
 	});
 
-	it('ignores stale completion after reset and re-mount', async () => {
-		const stale = deferred<number[]>();
-		const fresh = deferred<number[]>();
-		const load = vi.fn().mockReturnValueOnce(stale.promise).mockReturnValueOnce(fresh.promise);
-		setCoverThumbnailLoader(load);
-		const unmount = fileListRegistry.mount(coverThumbnailAtom('/book'));
-		await flush();
-		unmount();
-		resetFileList();
+	it('exposes a successful cover as AsyncResult success', async () => {
+		const load = vi.fn().mockResolvedValueOnce([1]);
 		setCoverThumbnailLoader(load);
 		fileListRegistry.mount(coverThumbnailAtom('/book'));
 		await flush();
-		stale.resolve([1]);
-		await flush();
-		expect(AsyncResult.isSuccess(thumbnail('/book')) && thumbnail('/book').waiting).toBeFalsy();
-		expect(
-			AsyncResult.isWaiting(thumbnail('/book')) || AsyncResult.isInitial(thumbnail('/book')),
-		).toBe(true);
-		fresh.resolve([2]);
-		await flush();
+		expect(load).toHaveBeenCalledTimes(1);
 		const result = thumbnail('/book');
 		expect(AsyncResult.isSuccess(result)).toBe(true);
 		if (AsyncResult.isSuccess(result)) {
-			expect(result.value).toBe('data:image/jpeg;base64,Ag==');
+			expect(result.value).toBe('data:image/jpeg;base64,AQ==');
 		}
 	});
 });

--- a/src/ui/fileList/solid/__tests__/coverThumbnails.test.ts
+++ b/src/ui/fileList/solid/__tests__/coverThumbnails.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AsyncResult } from '../../../../lib/effect/appEffect';
+import { FILE_LIST_COVER_THUMBNAIL_CONCURRENCY } from '../thumbnails';
+import { fileListRegistry } from '../session';
+import { coverThumbnailAtom, resetFileList, setCoverThumbnailLoader } from '..';
+
+type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void };
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+	for (let i = 0; i < 20; i += 1) await Promise.resolve();
+}
+
+function thumbnail(path: string) {
+	return fileListRegistry.get(coverThumbnailAtom(path));
+}
+
+describe('Solid File List cover thumbnail atoms', () => {
+	beforeEach(() => {
+		resetFileList();
+	});
+
+	it('bounds loading to two paths and dedupes duplicate family mounts', async () => {
+		const requests: Array<Deferred<number[] | null>> = [];
+		const load = vi.fn((_path: string, _signal: AbortSignal) => {
+			const request = deferred<number[] | null>();
+			requests.push(request);
+			return request.promise;
+		});
+		setCoverThumbnailLoader(load);
+		fileListRegistry.mount(coverThumbnailAtom('/a'));
+		fileListRegistry.mount(coverThumbnailAtom('/a'));
+		fileListRegistry.mount(coverThumbnailAtom('/b'));
+		fileListRegistry.mount(coverThumbnailAtom('/c'));
+		await flush();
+		expect(load).toHaveBeenCalledTimes(FILE_LIST_COVER_THUMBNAIL_CONCURRENCY);
+		expect(AsyncResult.isWaiting(thumbnail('/c')) || AsyncResult.isInitial(thumbnail('/c'))).toBe(
+			true,
+		);
+		requests[0]?.resolve([1]);
+		await flush();
+		expect(load).toHaveBeenCalledTimes(3);
+		requests[1]?.resolve([2]);
+		requests[2]?.resolve([3]);
+		await flush();
+		expect(AsyncResult.isSuccess(thumbnail('/a'))).toBe(true);
+	});
+
+	it('ignores stale completion after reset and re-mount', async () => {
+		const stale = deferred<number[]>();
+		const fresh = deferred<number[]>();
+		const load = vi.fn().mockReturnValueOnce(stale.promise).mockReturnValueOnce(fresh.promise);
+		setCoverThumbnailLoader(load);
+		const unmount = fileListRegistry.mount(coverThumbnailAtom('/book'));
+		await flush();
+		unmount();
+		resetFileList();
+		setCoverThumbnailLoader(load);
+		fileListRegistry.mount(coverThumbnailAtom('/book'));
+		await flush();
+		stale.resolve([1]);
+		await flush();
+		expect(AsyncResult.isSuccess(thumbnail('/book')) && thumbnail('/book').waiting).toBeFalsy();
+		expect(
+			AsyncResult.isWaiting(thumbnail('/book')) || AsyncResult.isInitial(thumbnail('/book')),
+		).toBe(true);
+		fresh.resolve([2]);
+		await flush();
+		const result = thumbnail('/book');
+		expect(AsyncResult.isSuccess(result)).toBe(true);
+		if (AsyncResult.isSuccess(result)) {
+			expect(result.value).toBe('data:image/jpeg;base64,Ag==');
+		}
+	});
+});

--- a/src/ui/fileList/solid/__tests__/derived-view.test.ts
+++ b/src/ui/fileList/solid/__tests__/derived-view.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import {
+	cacheMetadataForFile,
+	clearMetadataSession,
+	stageMetadataIntentPatch,
+} from '../../../metadataSession';
+import { fileListRegistry } from '../session';
+import { displayedArtistForFile, displayedTitleForFile, fileListViewAtom } from '../view';
+import { loadFileList, removeFile, reorderFiles, resetFileList } from '..';
+
+function makeFile(path: string): AudioFile {
+	return {
+		path,
+		inputId: path,
+		isValid: true,
+		duration: 60,
+		size: 1024,
+		format: 'm4b',
+	};
+}
+
+function makeFileList(...files: AudioFile[]): FileListInfo {
+	return {
+		files,
+		validCount: files.length,
+		invalidCount: 0,
+		totalDuration: files.reduce((sum, file) => sum + (file.duration || 0), 0),
+		totalSize: files.reduce((sum, file) => sum + (file.size || 0), 0),
+		selectedDecoders: files.map(() => null),
+	};
+}
+
+describe('Solid File List derived view', () => {
+	beforeEach(() => {
+		resetFileList();
+		clearMetadataSession();
+	});
+
+	it('uses analyzed tags only until metadata session truth exists', () => {
+		const tagged = {
+			...makeFile('/books/tagged.m4b'),
+			tagTitle: 'Analyzed Title',
+			tagArtist: 'Analyzed Artist',
+		};
+		expect(displayedTitleForFile(tagged)).toBe('Analyzed Title');
+		expect(displayedArtistForFile(tagged)).toBe('Analyzed Artist');
+
+		cacheMetadataForFile(tagged.path, { title: 'Session Title', artist: 'Session Artist' });
+		expect(displayedTitleForFile(tagged)).toBe('Session Title');
+		expect(displayedArtistForFile(tagged)).toBe('Session Artist');
+
+		stageMetadataIntentPatch(tagged.path, {
+			title: { op: 'clear' },
+			artist: { op: 'clear' },
+		});
+		expect(displayedTitleForFile(tagged)).toBe('tagged.m4b');
+		expect(displayedArtistForFile(tagged)).toBeNull();
+	});
+
+	it('reflects session reorder without manual view sync', () => {
+		loadFileList(
+			makeFileList(
+				makeFile('/books/alpha.m4b'),
+				makeFile('/books/beta.m4b'),
+				makeFile('/books/gamma.m4b'),
+			),
+		);
+		reorderFiles(0, 2);
+		expect(fileListRegistry.get(fileListViewAtom).files.map((file) => file.path)).toEqual([
+			'/books/beta.m4b',
+			'/books/gamma.m4b',
+			'/books/alpha.m4b',
+		]);
+	});
+
+	it('reflects session remove without manual view sync', () => {
+		loadFileList(makeFileList(makeFile('/books/alpha.m4b'), makeFile('/books/beta.m4b')));
+		removeFile(0);
+		const view = fileListRegistry.get(fileListViewAtom);
+		expect(view.files.map((file) => file.path)).toEqual(['/books/beta.m4b']);
+		expect(view.selectedIndices).toEqual([]);
+	});
+});

--- a/src/ui/fileList/solid/__tests__/order-lock-reorder.test.ts
+++ b/src/ui/fileList/solid/__tests__/order-lock-reorder.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import { fileListRegistry } from '../session';
+import {
+	fileListSessionAtom,
+	fileListViewAtom,
+	loadFileList,
+	reorderFiles,
+	resetFileList,
+	restoreImportOrder,
+	selectFile,
+	setOrderLocked,
+	toggleSort,
+} from '..';
+
+function makeFile(path: string): AudioFile {
+	return { path, inputId: path, isValid: true, duration: 1, size: 1, format: 'm4b' };
+}
+
+function makeFileList(...files: AudioFile[]): FileListInfo {
+	return {
+		files,
+		validCount: files.length,
+		invalidCount: 0,
+		totalDuration: files.length,
+		totalSize: files.length,
+		selectedDecoders: files.map(() => null),
+	};
+}
+
+describe('Solid File List order lock and reorder', () => {
+	beforeEach(() => {
+		resetFileList();
+		loadFileList(
+			makeFileList(
+				makeFile('/books/alpha.m4b'),
+				makeFile('/books/beta.m4b'),
+				makeFile('/books/gamma.m4b'),
+			),
+		);
+	});
+
+	it('hides sort/clear while order is locked', () => {
+		setOrderLocked(true);
+		const view = fileListRegistry.get(fileListViewAtom);
+		expect(view.orderLockVisible).toBe(true);
+		expect(view.sortDisabled).toBe(true);
+		expect(view.clearDisabled).toBe(true);
+		toggleSort();
+		expect(fileListRegistry.get(fileListSessionAtom).sortDirection).toBe('none');
+	});
+
+	it('keeps selected identity across reorder and restore', () => {
+		selectFile(0);
+		reorderFiles(0, 2);
+		expect(fileListRegistry.get(fileListViewAtom).files.map((file) => file.path)).toEqual([
+			'/books/beta.m4b',
+			'/books/gamma.m4b',
+			'/books/alpha.m4b',
+		]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(2);
+		restoreImportOrder();
+		expect(fileListRegistry.get(fileListViewAtom).files.map((file) => file.path)).toEqual([
+			'/books/alpha.m4b',
+			'/books/beta.m4b',
+			'/books/gamma.m4b',
+		]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(0);
+		expect(fileListRegistry.get(fileListViewAtom).orderDiffersFromImport).toBe(false);
+	});
+});

--- a/src/ui/fileList/solid/__tests__/public-strip.test.ts
+++ b/src/ui/fileList/solid/__tests__/public-strip.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import * as fileListSolid from '..';
+
+const EXPECTED_SOLID_FILE_LIST_EXPORTS = [
+	'clearFiles',
+	'clearSelection',
+	'coverThumbnailAtom',
+	'fileListSessionAtom',
+	'fileListViewAtom',
+	'loadFileList',
+	'removeFile',
+	'reorderFiles',
+	'resetFileList',
+	'restoreImportOrder',
+	'selectAll',
+	'selectFile',
+	'setCoverThumbnailLoader',
+	'setOrderLocked',
+	'toggleSort',
+] as const;
+
+describe('Solid File List public strip', () => {
+	it('pins a small atom-and-action export surface', () => {
+		expect(Object.keys(fileListSolid).sort()).toEqual([...EXPECTED_SOLID_FILE_LIST_EXPORTS].sort());
+	});
+});

--- a/src/ui/fileList/solid/__tests__/selection.test.ts
+++ b/src/ui/fileList/solid/__tests__/selection.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import { fileListRegistry } from '../session';
+import {
+	clearSelection,
+	fileListSessionAtom,
+	loadFileList,
+	resetFileList,
+	selectAll,
+	selectFile,
+} from '..';
+
+function makeFileList(count: number): FileListInfo {
+	const files: AudioFile[] = Array.from({ length: count }, (_, index) => ({
+		path: `/tmp/file-${index}.m4b`,
+		isValid: true,
+	}));
+	return {
+		files,
+		selectedDecoders: files.map(() => null),
+		totalDuration: 0,
+		totalSize: 0,
+		validCount: count,
+		invalidCount: 0,
+	};
+}
+
+function selectedIndices(): number[] {
+	return [...fileListRegistry.get(fileListSessionAtom).selectedFileIndices].sort((a, b) => a - b);
+}
+
+describe('Solid File List selection atoms', () => {
+	beforeEach(() => {
+		resetFileList();
+		loadFileList(makeFileList(5));
+	});
+
+	it('selects a single item and updates anchor', () => {
+		expect(selectFile(2, { multi: false, range: false })).toBe(true);
+		expect(selectedIndices()).toEqual([2]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(2);
+	});
+
+	it('toggles multi-select and maintains anchor', () => {
+		selectFile(1, { multi: false, range: false });
+		selectFile(3, { multi: true, range: false });
+		expect(selectedIndices()).toEqual([1, 3]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(3);
+
+		selectFile(3, { multi: true, range: false });
+		expect(selectedIndices()).toEqual([1]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(1);
+	});
+
+	it('selects a range from the anchor', () => {
+		selectFile(1, { multi: false, range: false });
+		selectFile(3, { multi: false, range: true });
+		expect(selectedIndices()).toEqual([1, 2, 3]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(3);
+	});
+
+	it('selects all files', () => {
+		expect(selectAll()).toBe(true);
+		expect(selectedIndices()).toEqual([0, 1, 2, 3, 4]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(0);
+	});
+
+	it('clears selection', () => {
+		selectFile(2, { multi: false, range: false });
+		expect(clearSelection()).toBe(true);
+		expect(selectedIndices()).toEqual([]);
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(-1);
+	});
+
+	it('ignores out-of-bounds selections', () => {
+		expect(selectFile(9, { multi: false, range: false })).toBe(false);
+		expect(fileListRegistry.get(fileListSessionAtom).currentFileList?.files.length).toBe(5);
+		expect(selectedIndices()).toEqual([]);
+	});
+
+	it('resets selection state when a fresh file list is loaded', () => {
+		selectFile(1, { multi: true, range: false });
+		loadFileList(makeFileList(2));
+		expect(fileListRegistry.get(fileListSessionAtom).selectedFileIndex).toBe(-1);
+		expect(selectedIndices()).toEqual([]);
+	});
+});

--- a/src/ui/fileList/solid/index.ts
+++ b/src/ui/fileList/solid/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Solid File List spike public strip: session/view/thumbnail atoms and the
+ * sync actions the island writes. Solid TSX, atom-solid hooks, and Tauri
+ * loaders stay private to `solid/`.
+ */
+import { resetFileList as resetSession } from './session';
+import { resetCoverThumbnailRuntime } from './thumbnails';
+
+export { fileListSessionAtom } from './session';
+export {
+	clearFiles,
+	clearSelection,
+	loadFileList,
+	removeFile,
+	reorderFiles,
+	restoreImportOrder,
+	selectAll,
+	selectFile,
+	setOrderLocked,
+	toggleSort,
+} from './session';
+export { fileListViewAtom } from './view';
+export { coverThumbnailAtom, setCoverThumbnailLoader } from './thumbnails';
+
+export function resetFileList(): void {
+	resetSession();
+	resetCoverThumbnailRuntime();
+}

--- a/src/ui/fileList/solid/main.ts
+++ b/src/ui/fileList/solid/main.ts
@@ -1,0 +1,9 @@
+import '../../../styles.css';
+import { mountFileListIsland } from './mount';
+
+const target = document.getElementById('file-list-solid');
+if (!target) {
+	throw new Error('File List Solid root #file-list-solid not found');
+}
+
+mountFileListIsland(target);

--- a/src/ui/fileList/solid/mount.tsx
+++ b/src/ui/fileList/solid/mount.tsx
@@ -1,0 +1,6 @@
+import { render } from 'solid-js/web';
+import { FileListIsland, type FileListIslandProps } from './FileListIsland';
+
+export function mountFileListIsland(el: HTMLElement, props: FileListIslandProps = {}): () => void {
+	return render(() => <FileListIsland {...props} />, el);
+}

--- a/src/ui/fileList/solid/session.ts
+++ b/src/ui/fileList/solid/session.ts
@@ -1,0 +1,307 @@
+import { pathBasename } from '../../../lib/path/basename';
+import type { AudioFile, FileListInfo } from '../../../types/audio';
+import { Atom, AtomRegistry } from '../../../lib/effect/appEffect';
+
+export type FileListSortDirection = 'none' | 'ascending' | 'descending';
+
+export type FileListSession = {
+	currentFileList: FileListInfo | null;
+	selectedFileIndex: number;
+	selectedFileIndices: ReadonlySet<number>;
+	sortDirection: FileListSortDirection;
+	orderLocked: boolean;
+};
+
+export type SelectionModifiers = { multi: boolean; range: boolean };
+
+const INITIAL_SESSION: FileListSession = {
+	currentFileList: null,
+	selectedFileIndex: -1,
+	selectedFileIndices: new Set<number>(),
+	sortDirection: 'none',
+	orderLocked: false,
+};
+
+export const fileListRegistry = AtomRegistry.make();
+
+export const fileListSessionAtom = Atom.make<FileListSession>({
+	...INITIAL_SESSION,
+	selectedFileIndices: new Set<number>(),
+}).pipe(Atom.keepAlive);
+
+const importOrdinalByPath = new Map<string, number>();
+let nextImportOrdinal = 0;
+
+function session(): FileListSession {
+	return fileListRegistry.get(fileListSessionAtom);
+}
+
+function write(next: FileListSession): void {
+	fileListRegistry.set(fileListSessionAtom, next);
+}
+
+function update(patch: (current: FileListSession) => FileListSession): void {
+	fileListRegistry.update(fileListSessionAtom, patch);
+}
+
+function fileIdentityKey(file: AudioFile): string {
+	return file.inputId ?? file.path;
+}
+
+function recordImportOrder(files: readonly AudioFile[]): void {
+	for (const file of files) {
+		if (!importOrdinalByPath.has(file.path)) {
+			importOrdinalByPath.set(file.path, nextImportOrdinal++);
+		}
+	}
+}
+
+export function getImportOrdinal(path: string): number | undefined {
+	return importOrdinalByPath.get(path);
+}
+
+function replaceFiles(sessionState: FileListSession, nextFiles: AudioFile[]): FileListSession {
+	const fileList = sessionState.currentFileList;
+	if (!fileList) return sessionState;
+	const validCount = nextFiles.filter((file) => file.isValid).length;
+	return {
+		...sessionState,
+		currentFileList: {
+			...fileList,
+			files: nextFiles,
+			validCount,
+			invalidCount: nextFiles.length - validCount,
+		},
+	};
+}
+
+function reindexAfterRemoval(selected: ReadonlySet<number>, removedIndex: number): Set<number> {
+	const next = new Set<number>();
+	for (const index of selected) {
+		if (index === removedIndex) continue;
+		next.add(index > removedIndex ? index - 1 : index);
+	}
+	return next;
+}
+
+function mapIndexForMove(index: number, fromIndex: number, toIndex: number): number {
+	if (index === fromIndex) return toIndex;
+	if (fromIndex < toIndex && index > fromIndex && index <= toIndex) return index - 1;
+	if (fromIndex > toIndex && index >= toIndex && index < fromIndex) return index + 1;
+	return index;
+}
+
+function ensureAnchor(
+	selected: ReadonlySet<number>,
+	anchor: number,
+): { selectedFileIndex: number; selectedFileIndices: ReadonlySet<number> } {
+	if (selected.size === 0) return { selectedFileIndex: -1, selectedFileIndices: selected };
+	if (anchor >= 0 && selected.has(anchor)) {
+		return { selectedFileIndex: anchor, selectedFileIndices: selected };
+	}
+	const sorted = [...selected].sort((a, b) => a - b);
+	const last = sorted[sorted.length - 1] ?? -1;
+	return { selectedFileIndex: last, selectedFileIndices: selected };
+}
+
+export function resetFileList(): void {
+	importOrdinalByPath.clear();
+	nextImportOrdinal = 0;
+	write({ ...INITIAL_SESSION, selectedFileIndices: new Set<number>() });
+}
+
+export function loadFileList(fileList: FileListInfo | null): void {
+	importOrdinalByPath.clear();
+	nextImportOrdinal = 0;
+	if (fileList) recordImportOrder(fileList.files);
+	write({
+		currentFileList: fileList,
+		selectedFileIndex: -1,
+		selectedFileIndices: new Set<number>(),
+		sortDirection: 'none',
+		orderLocked: session().orderLocked,
+	});
+}
+
+export function selectFile(
+	index: number,
+	modifiers: SelectionModifiers = { multi: false, range: false },
+): boolean {
+	const current = session();
+	const files = current.currentFileList?.files;
+	if (!files || index < 0 || index >= files.length) return false;
+	const { multi, range } = modifiers;
+	if (range && current.selectedFileIndex !== -1) {
+		const start = Math.min(current.selectedFileIndex, index);
+		const end = Math.max(current.selectedFileIndex, index);
+		const selectedFileIndices = new Set<number>();
+		for (let i = start; i <= end; i += 1) selectedFileIndices.add(i);
+		write({ ...current, selectedFileIndex: index, selectedFileIndices });
+		return true;
+	}
+	if (multi) {
+		const selectedFileIndices = new Set(current.selectedFileIndices);
+		if (selectedFileIndices.has(index)) selectedFileIndices.delete(index);
+		else {
+			selectedFileIndices.add(index);
+			write({ ...current, selectedFileIndex: index, selectedFileIndices });
+			return true;
+		}
+		write({ ...current, ...ensureAnchor(selectedFileIndices, current.selectedFileIndex) });
+		return true;
+	}
+	write({
+		...current,
+		selectedFileIndex: index,
+		selectedFileIndices: new Set([index]),
+	});
+	return true;
+}
+
+export function selectAll(): boolean {
+	const current = session();
+	const count = current.currentFileList?.files.length ?? 0;
+	if (count === 0) return false;
+	write({
+		...current,
+		selectedFileIndex: 0,
+		selectedFileIndices: new Set(Array.from({ length: count }, (_, i) => i)),
+	});
+	return true;
+}
+
+export function clearSelection(): boolean {
+	const current = session();
+	if (current.selectedFileIndices.size === 0 && current.selectedFileIndex === -1) return false;
+	write({ ...current, selectedFileIndex: -1, selectedFileIndices: new Set<number>() });
+	return true;
+}
+
+export function setOrderLocked(locked: boolean): void {
+	if (session().orderLocked === locked) return;
+	update((current) => ({ ...current, orderLocked: locked }));
+}
+
+export function reorderFiles(fromIndex: number, toIndex: number): void {
+	const current = session();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || fromIndex === toIndex) return;
+	if (fromIndex < 0 || toIndex < 0 || fromIndex >= files.length || toIndex >= files.length) return;
+	const nextFiles = [...files];
+	const [moved] = nextFiles.splice(fromIndex, 1);
+	nextFiles.splice(toIndex, 0, moved);
+	const selectedFileIndices = new Set(
+		[...current.selectedFileIndices].map((index) => mapIndexForMove(index, fromIndex, toIndex)),
+	);
+	const selectedFileIndex =
+		current.selectedFileIndex === -1
+			? -1
+			: mapIndexForMove(current.selectedFileIndex, fromIndex, toIndex);
+	write({
+		...replaceFiles(current, nextFiles),
+		sortDirection: 'none',
+		...ensureAnchor(selectedFileIndices, selectedFileIndex),
+	});
+}
+
+export function moveFile(index: number, delta: -1 | 1): void {
+	reorderFiles(index, index + delta);
+}
+
+export function removeFile(index: number): void {
+	const current = session();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || index < 0 || index >= files.length) return;
+	const removed = files[index];
+	if (removed) importOrdinalByPath.delete(removed.path);
+	const nextFiles = files.filter((_, fileIndex) => fileIndex !== index);
+	const selectedFileIndices = reindexAfterRemoval(current.selectedFileIndices, index);
+	write({
+		...replaceFiles(current, nextFiles),
+		...ensureAnchor(
+			selectedFileIndices,
+			current.selectedFileIndex === index ? -1 : current.selectedFileIndex,
+		),
+	});
+}
+
+export function clearFiles(): void {
+	const current = session();
+	if (current.orderLocked || !current.currentFileList) return;
+	importOrdinalByPath.clear();
+	nextImportOrdinal = 0;
+	write({
+		...replaceFiles(current, []),
+		selectedFileIndex: -1,
+		selectedFileIndices: new Set<number>(),
+		sortDirection: 'none',
+	});
+}
+
+export function toggleSort(): void {
+	const current = session();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || files.length <= 1) return;
+	const sortDirection: FileListSortDirection =
+		current.sortDirection === 'ascending' ? 'descending' : 'ascending';
+	const selectedKeys = new Set(
+		[...current.selectedFileIndices]
+			.map((index) => files[index])
+			.filter((file): file is AudioFile => Boolean(file))
+			.map(fileIdentityKey),
+	);
+	const anchorKey = files[current.selectedFileIndex]
+		? fileIdentityKey(files[current.selectedFileIndex])
+		: null;
+	const nextFiles = [...files].sort((left, right) => {
+		const comparison = pathBasename(left.path, { fallback: 'path' }).localeCompare(
+			pathBasename(right.path, { fallback: 'path' }),
+			undefined,
+			{ numeric: true, sensitivity: 'base' },
+		);
+		return sortDirection === 'descending' ? -comparison : comparison;
+	});
+	const selectedFileIndices = new Set(
+		nextFiles.flatMap((file, index) => (selectedKeys.has(fileIdentityKey(file)) ? [index] : [])),
+	);
+	const selectedFileIndex = anchorKey
+		? nextFiles.findIndex((file) => fileIdentityKey(file) === anchorKey)
+		: -1;
+	write({
+		...replaceFiles(current, nextFiles),
+		sortDirection,
+		selectedFileIndex,
+		selectedFileIndices,
+	});
+}
+
+export function restoreImportOrder(): void {
+	const current = session();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || files.length <= 1) return;
+	if (files.some((file) => getImportOrdinal(file.path) === undefined)) return;
+	const selectedKeys = new Set(
+		[...current.selectedFileIndices]
+			.map((index) => files[index])
+			.filter((file): file is AudioFile => Boolean(file))
+			.map(fileIdentityKey),
+	);
+	const anchorKey = files[current.selectedFileIndex]
+		? fileIdentityKey(files[current.selectedFileIndex])
+		: null;
+	const nextFiles = [...files].sort(
+		(left, right) => (getImportOrdinal(left.path) ?? 0) - (getImportOrdinal(right.path) ?? 0),
+	);
+	const selectedFileIndices = new Set(
+		nextFiles.flatMap((file, index) => (selectedKeys.has(fileIdentityKey(file)) ? [index] : [])),
+	);
+	const selectedFileIndex = anchorKey
+		? nextFiles.findIndex((file) => fileIdentityKey(file) === anchorKey)
+		: -1;
+	write({
+		...replaceFiles(current, nextFiles),
+		sortDirection: 'none',
+		selectedFileIndex,
+		selectedFileIndices,
+	});
+}

--- a/src/ui/fileList/solid/thumbnails.ts
+++ b/src/ui/fileList/solid/thumbnails.ts
@@ -10,38 +10,42 @@ export type CoverThumbnailLoader = (
 	signal: AbortSignal,
 ) => Promise<ReadonlyArray<number> | null | undefined>;
 
+type CoverThumbnailLoaderState = { readonly load: CoverThumbnailLoader };
+
 const defaultLoader: CoverThumbnailLoader = async (path) =>
 	tauriClient.readAudioCoverThumbnail(path);
 
-export const coverThumbnailLoaderAtom = Atom.make<CoverThumbnailLoader>(defaultLoader).pipe(
+const INITIAL_LOADER: CoverThumbnailLoaderState = { load: defaultLoader };
+
+export const coverThumbnailLoaderAtom = Atom.make<CoverThumbnailLoaderState>(INITIAL_LOADER).pipe(
 	Atom.keepAlive,
 );
 
 let activeCount = 0;
 const waiters: Array<() => void> = [];
 
-function acquireSlot(): Effect.Effect<void> {
-	return Effect.suspend(() => {
-		if (activeCount < FILE_LIST_COVER_THUMBNAIL_CONCURRENCY) {
+function acquireSlot(signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const abort = (): void => {
+			const index = waiters.indexOf(start);
+			if (index >= 0) waiters.splice(index, 1);
+			reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+		};
+		const start = (): void => {
+			signal.removeEventListener('abort', abort);
 			activeCount += 1;
-			return Effect.succeed(undefined);
+			resolve();
+		};
+		if (signal.aborted) {
+			abort();
+			return;
 		}
-		return Effect.callback<void>((resume, signal) => {
-			const wake = (): void => {
-				if (signal.aborted) return;
-				activeCount += 1;
-				resume(Effect.succeed(undefined));
-			};
-			waiters.push(wake);
-			signal.addEventListener(
-				'abort',
-				() => {
-					const index = waiters.indexOf(wake);
-					if (index >= 0) waiters.splice(index, 1);
-				},
-				{ once: true },
-			);
-		});
+		signal.addEventListener('abort', abort, { once: true });
+		if (activeCount < FILE_LIST_COVER_THUMBNAIL_CONCURRENCY) {
+			start();
+			return;
+		}
+		waiters.push(start);
 	});
 }
 
@@ -52,26 +56,32 @@ function releaseSlot(): void {
 }
 
 export function setCoverThumbnailLoader(loader: CoverThumbnailLoader): void {
-	fileListRegistry.set(coverThumbnailLoaderAtom, loader);
+	fileListRegistry.set(coverThumbnailLoaderAtom, { load: loader });
 }
 
 export function resetCoverThumbnailRuntime(): void {
 	activeCount = 0;
 	waiters.length = 0;
-	fileListRegistry.set(coverThumbnailLoaderAtom, defaultLoader);
+	fileListRegistry.set(coverThumbnailLoaderAtom, INITIAL_LOADER);
 }
 
 export const coverThumbnailAtom = Atom.family((path: string) =>
-	Atom.make((get) => {
-		const loader = get(coverThumbnailLoaderAtom);
-		return Effect.acquireRelease(acquireSlot(), () => Effect.sync(releaseSlot)).pipe(
-			Effect.flatMap(() =>
-				Effect.tryPromise({
-					try: (signal) => loader(path, signal),
-					catch: (cause) => cause,
-				}),
-			),
-			Effect.map((bytes) => (bytes ? coverArtBytesToDataUrl(Array.from(bytes)) : null)),
-		);
-	}),
+	Atom.make(() =>
+		Effect.tryPromise({
+			try: async (signal) => {
+				const loader = fileListRegistry.get(coverThumbnailLoaderAtom).load;
+				await acquireSlot(signal);
+				try {
+					const bytes = await loader(path, signal);
+					if (signal.aborted) {
+						throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+					}
+					return bytes ? coverArtBytesToDataUrl(Array.from(bytes)) : null;
+				} finally {
+					releaseSlot();
+				}
+			},
+			catch: (cause) => cause,
+		}),
+	),
 );

--- a/src/ui/fileList/solid/thumbnails.ts
+++ b/src/ui/fileList/solid/thumbnails.ts
@@ -1,0 +1,77 @@
+import { coverArtBytesToDataUrl } from '../../../lib/media/coverArtDataUrl';
+import { tauriClient } from '../../../lib/tauri/client';
+import { Atom, Effect } from '../../../lib/effect/appEffect';
+import { fileListRegistry } from './session';
+
+export const FILE_LIST_COVER_THUMBNAIL_CONCURRENCY = 2;
+
+export type CoverThumbnailLoader = (
+	path: string,
+	signal: AbortSignal,
+) => Promise<ReadonlyArray<number> | null | undefined>;
+
+const defaultLoader: CoverThumbnailLoader = async (path) =>
+	tauriClient.readAudioCoverThumbnail(path);
+
+export const coverThumbnailLoaderAtom = Atom.make<CoverThumbnailLoader>(defaultLoader).pipe(
+	Atom.keepAlive,
+);
+
+let activeCount = 0;
+const waiters: Array<() => void> = [];
+
+function acquireSlot(): Effect.Effect<void> {
+	return Effect.suspend(() => {
+		if (activeCount < FILE_LIST_COVER_THUMBNAIL_CONCURRENCY) {
+			activeCount += 1;
+			return Effect.succeed(undefined);
+		}
+		return Effect.callback<void>((resume, signal) => {
+			const wake = (): void => {
+				if (signal.aborted) return;
+				activeCount += 1;
+				resume(Effect.succeed(undefined));
+			};
+			waiters.push(wake);
+			signal.addEventListener(
+				'abort',
+				() => {
+					const index = waiters.indexOf(wake);
+					if (index >= 0) waiters.splice(index, 1);
+				},
+				{ once: true },
+			);
+		});
+	});
+}
+
+function releaseSlot(): void {
+	activeCount = Math.max(0, activeCount - 1);
+	const next = waiters.shift();
+	if (next) next();
+}
+
+export function setCoverThumbnailLoader(loader: CoverThumbnailLoader): void {
+	fileListRegistry.set(coverThumbnailLoaderAtom, loader);
+}
+
+export function resetCoverThumbnailRuntime(): void {
+	activeCount = 0;
+	waiters.length = 0;
+	fileListRegistry.set(coverThumbnailLoaderAtom, defaultLoader);
+}
+
+export const coverThumbnailAtom = Atom.family((path: string) =>
+	Atom.make((get) => {
+		const loader = get(coverThumbnailLoaderAtom);
+		return Effect.acquireRelease(acquireSlot(), () => Effect.sync(releaseSlot)).pipe(
+			Effect.flatMap(() =>
+				Effect.tryPromise({
+					try: (signal) => loader(path, signal),
+					catch: (cause) => cause,
+				}),
+			),
+			Effect.map((bytes) => (bytes ? coverArtBytesToDataUrl(Array.from(bytes)) : null)),
+		);
+	}),
+);

--- a/src/ui/fileList/solid/view.ts
+++ b/src/ui/fileList/solid/view.ts
@@ -1,0 +1,145 @@
+import { pathBasename } from '../../../lib/path/basename';
+import { formatFileSize, type AudioFile } from '../../../types/audio';
+import { Atom } from '../../../lib/effect/appEffect';
+import { companionSummaryForInputIds } from '../../remoteSource';
+import { displayedArtistForFile, displayedTitleForFile } from '../viewState.svelte';
+import { fileListSessionAtom, getImportOrdinal, type FileListSession } from './session';
+
+export type FileListInspectorView = {
+	contextText: string;
+	contextVariant: 'empty' | 'single' | 'multi';
+	contextDetail: string;
+	bitrateText: string;
+	sampleRateText: string;
+	channelsText: string;
+	codecText: string;
+	decoderText: string;
+	fileSizeText: string;
+	companionsText: string;
+	companionsTitle: string;
+};
+
+export type FileListView = {
+	files: AudioFile[];
+	selectedIndices: number[];
+	sortLabel: string;
+	sortState: FileListSession['sortDirection'];
+	showSortButton: boolean;
+	showClearButton: boolean;
+	sortDisabled: boolean;
+	clearDisabled: boolean;
+	orderLockVisible: boolean;
+	orderDiffersFromImport: boolean;
+	combinedSizeText: string;
+	inspector: FileListInspectorView;
+};
+
+const EMPTY_INSPECTOR: FileListInspectorView = {
+	contextText: 'No file selected',
+	contextVariant: 'empty',
+	contextDetail: '',
+	bitrateText: '---',
+	sampleRateText: '---',
+	channelsText: '---',
+	codecText: '---',
+	decoderText: '---',
+	fileSizeText: '---',
+	companionsText: '---',
+	companionsTitle: '',
+};
+
+function orderDiffersFromImport(files: readonly AudioFile[]): boolean {
+	if (files.length <= 1) return false;
+	let previous = -1;
+	for (const file of files) {
+		const ordinal = getImportOrdinal(file.path);
+		if (ordinal === undefined) return false;
+		if (ordinal < previous) return true;
+		previous = ordinal;
+	}
+	return false;
+}
+
+function optionalText(value: string | undefined): string {
+	const trimmed = value?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : 'N/A';
+}
+
+function sharedText(
+	files: readonly AudioFile[],
+	pick: (file: AudioFile) => string | undefined,
+): string {
+	if (files.length === 0) return '---';
+	const values = files.map((file) => {
+		const value = pick(file);
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+	});
+	if (values.some((value) => value === null)) return 'Mixed';
+	const unique = new Set(values);
+	return unique.size === 1 ? (values[0] ?? 'Mixed') : 'Mixed';
+}
+
+function inspectorFor(session: FileListSession): FileListInspectorView {
+	const files = session.currentFileList?.files ?? [];
+	const selected = [...session.selectedFileIndices]
+		.sort((a, b) => a - b)
+		.map((index) => files[index])
+		.filter((file): file is AudioFile => Boolean(file));
+	if (selected.length === 0) return EMPTY_INSPECTOR;
+	if (selected.length > 1) {
+		const companions = companionSummaryForInputIds(selected.map((file) => file.inputId));
+		return {
+			...EMPTY_INSPECTOR,
+			contextText: `${selected.length} files selected`,
+			contextVariant: 'multi',
+			codecText: sharedText(selected, (file) => file.codecLabel),
+			decoderText: sharedText(selected, (file) => file.selectedDecoder),
+			companionsText: companions.text,
+			companionsTitle: companions.title,
+		};
+	}
+	const file = selected[0];
+	const index = session.selectedFileIndex;
+	const companions = companionSummaryForInputIds([file.inputId]);
+	return {
+		contextText: pathBasename(file.path, { fallback: 'path' }),
+		contextVariant: 'single',
+		contextDetail: index >= 0 ? `${index + 1} of ${files.length}` : '',
+		bitrateText:
+			file.isValid && file.bitrate ? `${file.bitrate} kb/s` : file.isValid ? 'N/A' : '---',
+		sampleRateText:
+			file.isValid && file.sampleRate ? `${file.sampleRate} Hz` : file.isValid ? 'N/A' : '---',
+		channelsText:
+			file.isValid && file.channels ? `${file.channels} ch` : file.isValid ? 'N/A' : '---',
+		codecText: file.isValid ? optionalText(file.codecLabel) : '---',
+		decoderText: file.isValid ? optionalText(file.selectedDecoder) : '---',
+		fileSizeText:
+			file.isValid && file.size ? formatFileSize(file.size) : file.isValid ? 'N/A' : '---',
+		companionsText: companions.text,
+		companionsTitle: companions.title,
+	};
+}
+
+export const fileListViewAtom = Atom.make((get): FileListView => {
+	const session = get(fileListSessionAtom);
+	const files = session.currentFileList ? [...session.currentFileList.files] : [];
+	const locked = session.orderLocked;
+	return {
+		files,
+		selectedIndices: [...session.selectedFileIndices],
+		sortLabel: session.sortDirection === 'descending' ? 'Sort: Z-A' : 'Sort: A-Z',
+		sortState: session.sortDirection,
+		showSortButton: files.length > 1,
+		showClearButton: files.length > 0,
+		sortDisabled: locked,
+		clearDisabled: locked,
+		orderLockVisible: locked,
+		orderDiffersFromImport: orderDiffersFromImport(files),
+		combinedSizeText: session.currentFileList
+			? formatFileSize(session.currentFileList.totalSize)
+			: '--- MB',
+		inspector: inspectorFor(session),
+	};
+}).pipe(Atom.keepAlive);
+
+export { displayedArtistForFile, displayedTitleForFile };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"noEmit": true,
+		"jsx": "preserve",
+		"jsxImportSource": "solid-js",
 		"types": ["vite/client", "svelte"],
 
 		/* Linting */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
+import solid from 'vite-plugin-solid';
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -20,7 +21,12 @@ function removeCrossoriginPlugin(): Plugin {
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
-	plugins: [tailwindcss(), svelte(), removeCrossoriginPlugin()],
+	plugins: [
+		tailwindcss(),
+		solid({ include: ['**/fileList/solid/**'] }),
+		svelte(),
+		removeCrossoriginPlugin(),
+	],
 
 	// Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
 	//

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,15 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
+import solid from 'vite-plugin-solid';
 
 export default defineConfig({
-	plugins: [svelte(), svelteTesting()],
+	plugins: [solid({ include: ['**/fileList/solid/**'] }), svelte(), svelteTesting()],
 	test: {
 		// Use jsdom for DOM testing (statusPanel, fileList, etc.)
 		environment: 'jsdom',
 
-		include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'scripts/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/*.spec.ts', 'scripts/**/*.test.ts'],
 		environmentMatchGlobs: [['scripts/**', 'node']],
 
 		// Global setup for Tauri mocks


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Spike evidence for #464 lock 1 (Effect Atom + official `@effect/atom-solid` on Solid 1.9). Does **not** close #464. Does **not** stack on #465.

Room constraint applied on this island: greenfield seam is Click → Atom/action → Effect in the Atom runtime → AsyncResult is state → Solid paints. No `runAppEffect`. No Promise workflow façade. `commandSpecs` / `tauriClient` were not collapsed into a Backend service (that second seam would hide the 521 bar). Public strip stayed small.

## What mounted

File List as its own Solid 1.9 island — sibling Vite/TSX entry, not nested in today's Svelte shell.

- Harness: `file-list-solid.html` → `src/ui/fileList/solid/main.ts` → `mountFileListIsland` into `#file-list-solid`
- Official binding: `@effect/atom-solid@4.0.0-rc.110` + `solid-js@1.9.15` (`>=1.9.14 <2.0.0`, **not Solid 2**)
- `effect` stays exact `4.0.0-rc.112`
- Atoms run Effects; UI reads Atom/AsyncResult via `useAtomValue` / `RegistryContext`
- Live `src/ui/fileList/index.ts` public strip is unchanged. Spike strip is `solid/index.ts`: 3 atoms + 12 sync actions (`fileListSessionAtom`, `fileListViewAtom`, `coverThumbnailAtom`, plus load/select/sort/reorder/remove/lock/reset and `setCoverThumbnailLoader`). Solid TSX, `@effect/atom-solid`, and `tauriClient` stay private inside `solid/`

### Binding pin (not a peer-range lie)

`@effect/atom-solid@4.0.0-rc.112` **does** peer to `effect@^4.0.0-rc.112` and `solid-js@>=1.9.14 <2.0.0`. Bun's 10-day `minimumReleaseAge` blocked rc.112 (published 2026-08-25). This spike uses the newest age-eligible RC that still accepts the repo pin: **rc.110**.

## Thickness vs 521

Physical LOC = file line count (same definition as the 521 rune bar). Also nonempty lines and `\b(if|for|while|switch)\b|\?` tokens.

### (1) Old rune modules that owned File List view state

| File | physical | nonempty | branch tokens |
|---|---:|---:|---:|
| `state.svelte.ts` | 185 | 149 | 11 |
| `viewState.svelte.ts` | 110 | 99 | 22 |
| `inspectorState.svelte.ts` | 74 | 68 | 3 |
| `coverThumbnails.svelte.ts` | 152 | 149 | 23 |
| **Total** | **521** | **465** | **59** |

### (2) New Atom modules + Solid TSX island + atom-solid usage in our code

Atom modules:

| File | physical | nonempty | branch tokens |
|---|---:|---:|---:|
| `solid/session.ts` | 307 | 278 | 54 |
| `solid/view.ts` | 145 | 136 | 31 |
| `solid/thumbnails.ts` | 87 | 75 | 6 |
| `solid/index.ts` | 28 | 26 | 0 |
| **Atom subtotal** | **567** | **515** | **91** |

Solid TSX island:

| File | physical | nonempty | branch tokens |
|---|---:|---:|---:|
| `solid/FileListIsland.tsx` | 292 | 284 | 40 |
| `solid/mount.tsx` | 6 | 5 | 0 |
| **TSX subtotal** | **298** | **289** | **40** |

`@effect/atom-solid` usage in our code (not node_modules): 5 lines in `FileListIsland.tsx` (`import`, two `useAtomValue`, `RegistryContext.Provider` open/close).

**(2) total = 567 + 298 = 865 physical LOC vs (1) 521.**

Not counted toward the bar (called out so they are not hidden): `FileListIsland.css` (123), `main.ts` + `file-list-solid.html` harness, tests, Vite/tsconfig glue.

Atom modules **alone** are already 567 > 521. Official atom-solid replaced handmade Svelte store glue with 5 hook/provider lines; the island paint is in the counted total.

## Residual (named, not restacked)

- `Atom.make(fn)` treats a function as a derived read, not a writable value. The thumbnail loader is a `{ load }` record for that reason.
- Tracking `get(coverThumbnailLoaderAtom)` inside the family Effect restarted the fetch. Tests write the fake via `setCoverThumbnailLoader`; the Effect reads it with `fileListRegistry.get` inside `tryPromise` only.
- Atom.family reuses in-flight work. It does not recreate `coverThumbnails.svelte.ts`'s generation-stale ignore or 64-entry LRU. That queue was not restacked to win the number.
- `view.ts` still calls `displayedTitleForFile` / `displayedArtistForFile` from the live `viewState.svelte.ts` (not duplicated).

## Verdict

**Atom + official Solid adapter did not earn keep.** Same session/selection/sort/inspector/thumbnail seam, **865 vs 521** (~+66%). Stop here. Do not stack more islands, do not start #412 Slice 3 from this spike.

## Tests

- `bun run typecheck` — pass
- `bun run test -- src/ui/fileList/solid scripts/frontend-toolchain-layout.test.ts src/ui/fileList` — 17 files, 100 tests, pass

Did not run svelte-check. Did not run Tauri native smoke. Did not visually drive the empty Vite harness (`file-list-solid.html`); island behavior is pinned by `@solidjs/testing-library`. Live Svelte File List is untouched.

References #464 as spike evidence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a34fad64-7b07-402d-87f6-ec48af6bf06a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a34fad64-7b07-402d-87f6-ec48af6bf06a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

