### PR TITLE
spike(ui): File List Solid 2 owns island state (no Atom)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -67,7 +67,7 @@
 			}
 		},
 		{
-			"includes": ["src/**/*.test.ts", "src/test/**/*.ts"],
+			"includes": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*.ts"],
 			"linter": {
 				"rules": {
 					"style": {

--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,17 @@
     "": {
       "name": "audiobook-boss",
       "dependencies": {
+        "@solidjs/web": "2.0.0-rc.3",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "effect": "4.0.0-rc.112",
+        "solid-js": "2.0.0-rc.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.9",
+        "@solidjs/testing-library": "1.0.0-beta.2",
+        "@solidjs/vite-plugin": "3.0.0-next.34",
         "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@tailwindcss/vite": "^4.3.3",
         "@tauri-apps/cli": "^2.11.4",
@@ -39,6 +43,8 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
@@ -49,9 +55,41 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.5.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.9", "@biomejs/cli-darwin-x64": "2.5.9", "@biomejs/cli-linux-arm64": "2.5.9", "@biomejs/cli-linux-arm64-musl": "2.5.9", "@biomejs/cli-linux-x64": "2.5.9", "@biomejs/cli-linux-x64-musl": "2.5.9", "@biomejs/cli-win32-arm64": "2.5.9", "@biomejs/cli-win32-x64": "2.5.9" }, "bin": { "biome": "bin/biome" } }, "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g=="],
 
@@ -85,6 +123,12 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
+    "@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" } }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
+
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -108,6 +152,8 @@
     "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
 
@@ -142,6 +188,30 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@solidjs/babel-plugin": ["@solidjs/babel-plugin@2.0.0-rc.3", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2", "validate-html-nesting": "^1.2.1" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA=="],
+
+    "@solidjs/compiler": ["@solidjs/compiler@2.0.0-rc.3", "", { "optionalDependencies": { "@solidjs/compiler-darwin-arm64": "2.0.0-rc.3", "@solidjs/compiler-darwin-x64": "2.0.0-rc.3", "@solidjs/compiler-linux-arm64-gnu": "2.0.0-rc.3", "@solidjs/compiler-linux-x64-gnu": "2.0.0-rc.3", "@solidjs/compiler-wasm32-wasi": "2.0.0-rc.3", "@solidjs/compiler-win32-x64-msvc": "2.0.0-rc.3" } }, "sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg=="],
+
+    "@solidjs/compiler-darwin-arm64": ["@solidjs/compiler-darwin-arm64@2.0.0-rc.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ=="],
+
+    "@solidjs/compiler-darwin-x64": ["@solidjs/compiler-darwin-x64@2.0.0-rc.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg=="],
+
+    "@solidjs/compiler-linux-arm64-gnu": ["@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ=="],
+
+    "@solidjs/compiler-linux-x64-gnu": ["@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3", "", { "os": "linux", "cpu": "x64" }, "sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA=="],
+
+    "@solidjs/compiler-wasm32-wasi": ["@solidjs/compiler-wasm32-wasi@2.0.0-rc.3", "", { "dependencies": { "@emnapi/core": "1.11.3", "@emnapi/runtime": "1.11.3", "@napi-rs/wasm-runtime": "^1.1.6" } }, "sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw=="],
+
+    "@solidjs/compiler-win32-x64-msvc": ["@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3", "", { "os": "win32", "cpu": "x64" }, "sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA=="],
+
+    "@solidjs/signals": ["@solidjs/signals@2.0.0-rc.3", "", {}, "sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA=="],
+
+    "@solidjs/testing-library": ["@solidjs/testing-library@1.0.0-beta.2", "", { "dependencies": { "@testing-library/dom": "^10.4.1" }, "peerDependencies": { "@solidjs/web": ">=2.0.0", "solid-js": ">=2.0.0" } }, "sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ=="],
+
+    "@solidjs/vite-plugin": ["@solidjs/vite-plugin@3.0.0-next.34", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@babel/core": "^7.23.3", "@solidjs/babel-plugin": "^2.0.0-rc.3", "@solidjs/compiler": "^2.0.0-rc.3", "@types/babel__core": "^7.20.4", "merge-anything": "^5.1.7", "vitefu": "^1.0.4" }, "peerDependencies": { "@solidjs/start-devtools": "^1.0.0-next.2", "@solidjs/web": "^2.0.0-rc.0", "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^2.0.0-rc.0", "vite": "^8.0.0 || ^9.0.0" }, "optionalPeers": ["@solidjs/start-devtools", "@testing-library/jest-dom"] }, "sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A=="],
+
+    "@solidjs/web": ["@solidjs/web@2.0.0-rc.3", "", { "dependencies": { "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" }, "peerDependencies": { "solid-js": "^2.0.0-rc.3" } }, "sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -221,7 +291,17 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.5", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -301,7 +381,13 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.15", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA=="],
+
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -315,7 +401,11 @@
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -331,11 +421,15 @@
 
     "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.409", "", {}, "sha512-ChI4N44d0B4A6C8prnNjMOaGgE59fUyEVYcRYm2XEXIjMbbvF5i9UL1cblDbpGqiU0uS8FE8UcKxqZqTXdmzbQ=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
     "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
@@ -351,9 +445,13 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -361,11 +459,17 @@
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
+    "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
@@ -401,9 +505,13 @@
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
+    "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
 
@@ -412,6 +520,8 @@
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -449,7 +559,15 @@
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "solid-js": ["solid-js@2.0.0-rc.3", "", { "dependencies": { "@solidjs/signals": "^2.0.0-rc.3", "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -485,9 +603,15 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "typescript": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
+
+    "validate-html-nesting": ["validate-html-nesting@1.2.4", "", {}, "sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw=="],
 
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
@@ -509,7 +633,25 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@solidjs/babel-plugin/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -546,6 +688,14 @@
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@solidjs/babel-plugin/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 

--- a/file-list-solid2.html
+++ b/file-list-solid2.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>File List Solid 2 spike</title>
+	</head>
+	<body class="p-0">
+		<div id="file-list-solid2"></div>
+		<script type="module" src="/src/ui/fileList/solid2/main.ts"></script>
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -36,13 +36,17 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@solidjs/web": "2.0.0-rc.3",
 		"@tauri-apps/api": "^2.11.1",
 		"@tauri-apps/plugin-dialog": "^2.7.2",
 		"@tauri-apps/plugin-opener": "^2.5.4",
-		"effect": "4.0.0-rc.112"
+		"effect": "4.0.0-rc.112",
+		"solid-js": "2.0.0-rc.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.9",
+		"@solidjs/testing-library": "1.0.0-beta.2",
+		"@solidjs/vite-plugin": "3.0.0-next.34",
 		"@sveltejs/vite-plugin-svelte": "^7.3.0",
 		"@tailwindcss/vite": "^4.3.3",
 		"@tauri-apps/cli": "^2.11.4",

--- a/src/ui/fileList/AGENTS.md
+++ b/src/ui/fileList/AGENTS.md
@@ -24,6 +24,11 @@
   `viewState.svelte.ts`, `events.ts`, `selection.ts`,
   `metadataStaging.ts`, `metadataPanel.ts`, `appendResult.ts`,
   `inspectorState.svelte.ts`, `keyboardNavigation.ts`, `__tests__/`.
+- Spike sibling (do not import from live File List): `solid2/` is a Solid 2
+  island with its own Vite/TSX entry (`file-list-solid2.html`). It owns
+  files/selection/sort/inspector/thumbnail view state in Solid signals/stores.
+  No Atom, no `runAppEffect`, no `commandSpecs` collapse. Live Svelte File List
+  stays the public runtime strip above.
 
 ## Preferred Path
 

--- a/src/ui/fileList/solid2/FileListIsland.css
+++ b/src/ui/fileList/solid2/FileListIsland.css
@@ -1,0 +1,53 @@
+.file-list-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
+.file-management-container {
+	display: flex;
+	flex-direction: column;
+	min-height: 8rem;
+	overflow: hidden;
+	border: 1px solid var(--border-primary);
+	border-radius: 0.375rem;
+}
+
+.drop-zone-header {
+	padding: 0.5rem 1rem;
+	cursor: pointer;
+}
+
+.file-list-content:focus-visible {
+	outline: 2px solid var(--border-focus);
+	outline-offset: -2px;
+}
+
+.file-list-item {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.75rem;
+	cursor: pointer;
+}
+
+.file-list-item.selected {
+	background-color: var(--accent-primary);
+	color: var(--text-inverse);
+}
+
+.file-cover-thumbnail {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	overflow: hidden;
+}
+
+.file-cover-thumbnail img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}

--- a/src/ui/fileList/solid2/FileListIsland.tsx
+++ b/src/ui/fileList/solid2/FileListIsland.tsx
@@ -1,0 +1,188 @@
+import { createEffect, createMemo, For, Show } from 'solid-js';
+import { pathBasename } from '../../../lib/path/basename';
+import {
+	fileListNavigationCommandFromKey,
+	resolveFileListNavigationTarget,
+} from '../keyboardNavigation';
+import {
+	clearFiles,
+	clearSelection,
+	removeFile,
+	restoreImportOrder,
+	selectAll,
+	selectFile,
+	toggleSort,
+} from './session';
+import { displayedTitleForFile, readFileListView } from './view';
+import {
+	clearFileListCoverThumbnails,
+	getFileListCoverThumbnailState,
+	scheduleFileListCoverThumbnails,
+} from './thumbnails';
+import './FileListIsland.css';
+
+export type FileListIslandProps = {
+	isDragOver?: boolean;
+	supportText?: string;
+	onHeaderClick?: () => void;
+	onHeaderKeydown?: (event: KeyboardEvent) => void;
+};
+
+export function FileListIsland(props: FileListIslandProps) {
+	const view = createMemo(() => readFileListView());
+	createEffect(
+		() =>
+			view()
+				.files.filter((file) => file.isValid)
+				.map((file) => file.path),
+		(paths) => {
+			if (paths.length === 0) clearFileListCoverThumbnails();
+			else scheduleFileListCoverThumbnails(paths);
+		},
+	);
+
+	function onKeyDown(event: KeyboardEvent) {
+		const current = view();
+		if (!current.files.length) return;
+		const command = fileListNavigationCommandFromKey(event);
+		if (command) {
+			const targetIndex = resolveFileListNavigationTarget({
+				command,
+				fileCount: current.files.length,
+				selectedIndex: current.selectedIndices[current.selectedIndices.length - 1] ?? -1,
+			});
+			if (targetIndex === null) return;
+			event.preventDefault();
+			selectFile(targetIndex);
+			return;
+		}
+		const key = event.key.toLowerCase();
+		if ((event.metaKey || event.ctrlKey) && key === 'a') {
+			event.preventDefault();
+			selectAll();
+		} else if (key === 'escape') {
+			event.preventDefault();
+			clearSelection();
+		}
+	}
+
+	return (
+		<>
+			<div class="file-list-toolbar">
+				<span id="file-count-display">
+					{view().files.length} {view().files.length === 1 ? 'file' : 'files'}
+				</span>
+				<span
+					id="file-order-lock"
+					data-testid="file-order-lock"
+					style={{ display: view().orderLockVisible ? 'inline' : 'none' }}
+				>
+					Order locked while processing
+				</span>
+				<button
+					type="button"
+					id="sort-toggle-btn"
+					style={{ display: view().showSortButton ? 'block' : 'none' }}
+					disabled={view().sortDisabled}
+					aria-label={`Sort files ${view().sortState === 'ascending' ? 'descending' : 'ascending'}`}
+					onClick={() => toggleSort()}
+				>
+					{view().sortLabel}
+				</button>
+				<button
+					type="button"
+					id="restore-import-order-btn"
+					style={{ display: view().orderDiffersFromImport ? 'block' : 'none' }}
+					disabled={view().sortDisabled}
+					onClick={() => restoreImportOrder()}
+				>
+					Restore import order
+				</button>
+				<button
+					type="button"
+					id="clear-files-btn"
+					style={{ display: view().showClearButton ? 'block' : 'none' }}
+					disabled={view().clearDisabled}
+					onClick={() => clearFiles()}
+				>
+					Clear
+				</button>
+			</div>
+			<section class="file-management-container" aria-label="File list">
+				{/* biome-ignore lint/a11y: drop zone is a clickable region; Solid 2 JSX uses tabindex */}
+				<div
+					class={`drop-zone-header${props.isDragOver ? ' drag-over' : ''}`}
+					data-has-files={String(view().files.length > 0)}
+					role="button"
+					aria-label="Add audio files"
+					tabindex={0}
+					onClick={() => props.onHeaderClick?.()}
+					onKeyDown={(event) => props.onHeaderKeydown?.(event)}
+				>
+					<p>Drop files or folders here, click to choose files, or use Add Folder</p>
+					<p>{props.supportText ?? ''}</p>
+				</div>
+				<div
+					class="file-list-content"
+					role="listbox"
+					aria-label="Audio files"
+					aria-multiselectable="true"
+					tabindex={0}
+					onKeyDown={onKeyDown}
+				>
+					<For each={view().files} keyed={(file) => file.inputId ?? file.path}>
+						{(file, index) => {
+							const selected = () => view().selectedIndices.includes(index());
+							const readyUrl = () => {
+								const state = getFileListCoverThumbnailState(file().path);
+								return state.status === 'ready' ? state.dataUrl : undefined;
+							};
+							return (
+								// biome-ignore lint/a11y: listbox option uses Solid 2 tabindex; keyboard stays on the listbox
+								<div
+									data-file-index={index()}
+									class={`file-list-item${selected() ? ' selected' : ''}`}
+									role="option"
+									aria-selected={selected() ? 'true' : 'false'}
+									aria-label={pathBasename(file().path, { fallback: 'path' })}
+									tabindex={-1}
+									onClick={(event) =>
+										selectFile(index(), {
+											multi: event.ctrlKey || event.metaKey,
+											range: event.shiftKey,
+										})
+									}
+								>
+									<div class="file-cover-thumbnail" aria-hidden="true">
+										<Show when={readyUrl()} fallback={<span>Art</span>}>
+											{(url) => <img src={url()} alt="" />}
+										</Show>
+									</div>
+									<span>{file().isValid ? '✓' : '✗'}</span>
+									<span>{displayedTitleForFile(file())}</span>
+									<button
+										type="button"
+										class="remove-file-btn"
+										disabled={view().orderLockVisible}
+										onClick={(event) => {
+											event.stopPropagation();
+											removeFile(index());
+										}}
+									>
+										×
+									</button>
+								</div>
+							);
+						}}
+					</For>
+				</div>
+			</section>
+			<aside data-testid="file-list-inspector" aria-label="Selected file inspector">
+				<p data-testid="inspector-context">{view().inspector.contextText}</p>
+				<p data-testid="inspector-detail">{view().inspector.contextDetail}</p>
+				<p data-testid="inspector-size">{view().inspector.fileSizeText}</p>
+				<p data-testid="inspector-combined">{view().combinedSizeText}</p>
+			</aside>
+		</>
+	);
+}

--- a/src/ui/fileList/solid2/__tests__/FileListIsland.test.tsx
+++ b/src/ui/fileList/solid2/__tests__/FileListIsland.test.tsx
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import { FileListIsland, loadFileList, resetFileList, selectFile, setOrderLocked } from '..';
+
+function makeFileList(): FileListInfo {
+	const files: AudioFile[] = [
+		{ path: '/books/alpha.m4b', isValid: true, duration: 60, size: 1024, format: 'm4b' },
+		{ path: '/books/bravo.m4b', isValid: true, duration: 60, size: 2048, format: 'm4b' },
+	];
+	return {
+		files,
+		selectedDecoders: files.map(() => null),
+		totalDuration: 120,
+		totalSize: 3072,
+		validCount: files.length,
+		invalidCount: 0,
+	};
+}
+
+describe('Solid 2 File List island', () => {
+	beforeEach(() => {
+		resetFileList();
+		loadFileList(makeFileList());
+	});
+
+	afterEach(() => {
+		cleanup();
+		resetFileList();
+	});
+
+	it('handles keyboard actions only from the focusable FileList region', async () => {
+		render(() => <FileListIsland />);
+		const listbox = screen.getByRole('listbox', { name: 'Audio files' });
+
+		await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+		expect(screen.getByRole('option', { name: 'alpha.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+
+		await fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+		await fireEvent.keyDown(window, { key: 'ArrowDown' });
+		expect(screen.getByRole('option', { name: 'bravo.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'false',
+		);
+
+		await fireEvent.keyDown(listbox, { key: 'a', ctrlKey: true });
+		expect(screen.getByRole('option', { name: 'alpha.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+		expect(screen.getByRole('option', { name: 'bravo.m4b' })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+	});
+
+	it('paints inspector and sort from Solid view state', async () => {
+		selectFile(0);
+		render(() => <FileListIsland />);
+		expect(screen.getByTestId('inspector-context')).toHaveTextContent('alpha.m4b');
+		expect(screen.getByTestId('inspector-detail')).toHaveTextContent('1 of 2');
+		expect(screen.getByTestId('file-order-lock')).not.toBeVisible();
+
+		await fireEvent.click(screen.getByRole('button', { name: /Sort files/ }));
+		expect(screen.getByLabelText(/Sort files descending/)).toHaveTextContent('Sort: A-Z');
+
+		setOrderLocked(true);
+		expect(screen.getByTestId('file-order-lock')).toBeVisible();
+		expect(screen.getByRole('button', { name: 'Clear' })).toBeDisabled();
+	});
+});

--- a/src/ui/fileList/solid2/__tests__/coverThumbnails.test.ts
+++ b/src/ui/fileList/solid2/__tests__/coverThumbnails.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetFileList, setCoverThumbnailLoader } from '..';
+import {
+	FILE_LIST_COVER_THUMBNAIL_CONCURRENCY,
+	MAX_FILE_LIST_COVER_THUMBNAIL_CACHE_ENTRIES,
+	getFileListCoverThumbnailState,
+	removeFileListCoverThumbnail,
+	scheduleFileListCoverThumbnails,
+} from '../thumbnails';
+
+type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void };
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 20; i += 1) await Promise.resolve();
+}
+
+describe('Solid 2 File List cover thumbnails', () => {
+	beforeEach(() => {
+		resetFileList();
+	});
+
+	it('bounds loading to two paths and dedupes duplicate paths', async () => {
+		const requests: Array<Deferred<number[] | null>> = [];
+		const load = vi.fn(() => {
+			const request = deferred<number[] | null>();
+			requests.push(request);
+			return request.promise;
+		});
+		setCoverThumbnailLoader(load);
+		scheduleFileListCoverThumbnails(['/a', '/a', '/b', '/c']);
+		await flushMicrotasks();
+		expect(load).toHaveBeenCalledTimes(FILE_LIST_COVER_THUMBNAIL_CONCURRENCY);
+		expect(getFileListCoverThumbnailState('/c').status).toBe('queued');
+		requests[0]?.resolve([1]);
+		await flushMicrotasks();
+		expect(load).toHaveBeenCalledTimes(3);
+		requests[1]?.resolve([2]);
+		requests[2]?.resolve([3]);
+		await flushMicrotasks();
+		expect(getFileListCoverThumbnailState('/a')).toMatchObject({ status: 'ready' });
+	});
+
+	it('ignores stale completion after clear and re-add', async () => {
+		const stale = deferred<number[]>();
+		const fresh = deferred<number[]>();
+		const load = vi.fn().mockReturnValueOnce(stale.promise).mockReturnValueOnce(fresh.promise);
+		setCoverThumbnailLoader(load);
+		scheduleFileListCoverThumbnails(['/book']);
+		await flushMicrotasks();
+		resetFileList();
+		setCoverThumbnailLoader(load);
+		scheduleFileListCoverThumbnails(['/book']);
+		await flushMicrotasks();
+		stale.resolve([1]);
+		await flushMicrotasks();
+		expect(getFileListCoverThumbnailState('/book').status).toBe('loading');
+		fresh.resolve([2]);
+		await flushMicrotasks();
+		expect(getFileListCoverThumbnailState('/book')).toMatchObject({ status: 'ready' });
+	});
+
+	it('fetches fresh bytes after a ready thumbnail is removed and re-added', async () => {
+		const load = vi.fn().mockResolvedValueOnce([1]).mockResolvedValueOnce([2]);
+		setCoverThumbnailLoader(load);
+		scheduleFileListCoverThumbnails(['/book']);
+		await flushMicrotasks();
+		removeFileListCoverThumbnail('/book');
+		scheduleFileListCoverThumbnails(['/book']);
+		await flushMicrotasks();
+		expect(load).toHaveBeenCalledTimes(2);
+		expect(getFileListCoverThumbnailState('/book')).toMatchObject({
+			status: 'ready',
+			dataUrl: 'data:image/jpeg;base64,Ag==',
+		});
+	});
+
+	it('keeps the terminal thumbnail cache bounded even when every path is visible', async () => {
+		const paths = Array.from(
+			{ length: MAX_FILE_LIST_COVER_THUMBNAIL_CACHE_ENTRIES + 1 },
+			(_, index) => `/book-${index}`,
+		);
+		setCoverThumbnailLoader(async () => [1]);
+		scheduleFileListCoverThumbnails(paths);
+		for (let index = 0; index < 150; index += 1) await Promise.resolve();
+		expect(getFileListCoverThumbnailState(paths[0]).status).toBe('idle');
+		expect(getFileListCoverThumbnailState(paths[paths.length - 1]).status).toBe('ready');
+	});
+});

--- a/src/ui/fileList/solid2/__tests__/derived-view.test.ts
+++ b/src/ui/fileList/solid2/__tests__/derived-view.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import {
+	cacheMetadataForFile,
+	clearMetadataSession,
+	stageMetadataIntentPatch,
+} from '../../../metadataSession';
+import { displayedArtistForFile, displayedTitleForFile } from '../view';
+import { loadFileList, readFileListView, removeFile, reorderFiles, resetFileList } from '..';
+
+function makeFile(path: string): AudioFile {
+	return {
+		path,
+		inputId: path,
+		isValid: true,
+		duration: 60,
+		size: 1024,
+		format: 'm4b',
+	};
+}
+
+function makeFileList(...files: AudioFile[]): FileListInfo {
+	return {
+		files,
+		validCount: files.length,
+		invalidCount: 0,
+		totalDuration: files.reduce((sum, file) => sum + (file.duration || 0), 0),
+		totalSize: files.reduce((sum, file) => sum + (file.size || 0), 0),
+		selectedDecoders: files.map(() => null),
+	};
+}
+
+describe('Solid 2 File List derived view', () => {
+	beforeEach(() => {
+		resetFileList();
+		clearMetadataSession();
+	});
+
+	it('uses analyzed tags only until metadata session truth exists', () => {
+		const tagged = {
+			...makeFile('/books/tagged.m4b'),
+			tagTitle: 'Analyzed Title',
+			tagArtist: 'Analyzed Artist',
+		};
+		expect(displayedTitleForFile(tagged)).toBe('Analyzed Title');
+		expect(displayedArtistForFile(tagged)).toBe('Analyzed Artist');
+
+		cacheMetadataForFile(tagged.path, { title: 'Session Title', artist: 'Session Artist' });
+		expect(displayedTitleForFile(tagged)).toBe('Session Title');
+		expect(displayedArtistForFile(tagged)).toBe('Session Artist');
+
+		stageMetadataIntentPatch(tagged.path, {
+			title: { op: 'clear' },
+			artist: { op: 'clear' },
+		});
+		expect(displayedTitleForFile(tagged)).toBe('tagged.m4b');
+		expect(displayedArtistForFile(tagged)).toBeNull();
+	});
+
+	it('reflects session reorder without manual view sync', () => {
+		loadFileList(
+			makeFileList(
+				makeFile('/books/alpha.m4b'),
+				makeFile('/books/beta.m4b'),
+				makeFile('/books/gamma.m4b'),
+			),
+		);
+		reorderFiles(0, 2);
+		expect(readFileListView().files.map((file) => file.path)).toEqual([
+			'/books/beta.m4b',
+			'/books/gamma.m4b',
+			'/books/alpha.m4b',
+		]);
+	});
+
+	it('reflects session remove without manual view sync', () => {
+		loadFileList(makeFileList(makeFile('/books/alpha.m4b'), makeFile('/books/beta.m4b')));
+		removeFile(0);
+		const view = readFileListView();
+		expect(view.files.map((file) => file.path)).toEqual(['/books/beta.m4b']);
+		expect(view.selectedIndices).toEqual([]);
+	});
+});

--- a/src/ui/fileList/solid2/__tests__/order-lock-reorder.test.ts
+++ b/src/ui/fileList/solid2/__tests__/order-lock-reorder.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import {
+	loadFileList,
+	readFileListView,
+	reorderFiles,
+	resetFileList,
+	restoreImportOrder,
+	selectFile,
+	setOrderLocked,
+	toggleSort,
+} from '..';
+
+function makeFile(path: string): AudioFile {
+	return { path, inputId: path, isValid: true, duration: 1, size: 1, format: 'm4b' };
+}
+
+function makeFileList(...files: AudioFile[]): FileListInfo {
+	return {
+		files,
+		validCount: files.length,
+		invalidCount: 0,
+		totalDuration: files.length,
+		totalSize: files.length,
+		selectedDecoders: files.map(() => null),
+	};
+}
+
+describe('Solid 2 File List order lock and reorder', () => {
+	beforeEach(() => {
+		resetFileList();
+		loadFileList(
+			makeFileList(
+				makeFile('/books/alpha.m4b'),
+				makeFile('/books/beta.m4b'),
+				makeFile('/books/gamma.m4b'),
+			),
+		);
+	});
+
+	it('hides sort/clear while order is locked', () => {
+		setOrderLocked(true);
+		const view = readFileListView();
+		expect(view.orderLockVisible).toBe(true);
+		expect(view.sortDisabled).toBe(true);
+		expect(view.clearDisabled).toBe(true);
+		toggleSort();
+		expect(readFileListView().sortState).toBe('none');
+	});
+
+	it('keeps selected identity across reorder and restore', () => {
+		selectFile(0);
+		reorderFiles(0, 2);
+		expect(readFileListView().files.map((file) => file.path)).toEqual([
+			'/books/beta.m4b',
+			'/books/gamma.m4b',
+			'/books/alpha.m4b',
+		]);
+		expect(readFileListView().selectedFileIndex).toBe(2);
+		restoreImportOrder();
+		expect(readFileListView().files.map((file) => file.path)).toEqual([
+			'/books/alpha.m4b',
+			'/books/beta.m4b',
+			'/books/gamma.m4b',
+		]);
+		expect(readFileListView().selectedFileIndex).toBe(0);
+		expect(readFileListView().orderDiffersFromImport).toBe(false);
+	});
+});

--- a/src/ui/fileList/solid2/__tests__/public-strip.test.ts
+++ b/src/ui/fileList/solid2/__tests__/public-strip.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import * as fileListSolid2 from '..';
+
+const EXPECTED_SOLID2_FILE_LIST_EXPORTS = [
+	'FileListIsland',
+	'clearFiles',
+	'clearSelection',
+	'getFileListCoverThumbnailState',
+	'loadFileList',
+	'readFileListView',
+	'removeFile',
+	'reorderFiles',
+	'resetFileList',
+	'restoreImportOrder',
+	'selectAll',
+	'selectFile',
+	'setCoverThumbnailLoader',
+	'setOrderLocked',
+	'toggleSort',
+] as const;
+
+describe('Solid 2 File List public strip', () => {
+	it('pins a small action-and-read export surface', () => {
+		expect(Object.keys(fileListSolid2).sort()).toEqual(
+			[...EXPECTED_SOLID2_FILE_LIST_EXPORTS].sort(),
+		);
+	});
+});

--- a/src/ui/fileList/solid2/__tests__/selection.test.ts
+++ b/src/ui/fileList/solid2/__tests__/selection.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AudioFile, FileListInfo } from '../../../../types/audio';
+import {
+	clearSelection,
+	loadFileList,
+	readFileListView,
+	resetFileList,
+	selectAll,
+	selectFile,
+} from '..';
+
+function makeFileList(count: number): FileListInfo {
+	const files: AudioFile[] = Array.from({ length: count }, (_, index) => ({
+		path: `/tmp/file-${index}.m4b`,
+		isValid: true,
+	}));
+	return {
+		files,
+		selectedDecoders: files.map(() => null),
+		totalDuration: 0,
+		totalSize: 0,
+		validCount: count,
+		invalidCount: 0,
+	};
+}
+
+function selectedIndices(): number[] {
+	return [...readFileListView().selectedIndices].sort((a, b) => a - b);
+}
+
+describe('Solid 2 File List selection', () => {
+	beforeEach(() => {
+		resetFileList();
+		loadFileList(makeFileList(5));
+	});
+
+	it('selects a single item and updates anchor', () => {
+		expect(selectFile(2, { multi: false, range: false })).toBe(true);
+		expect(selectedIndices()).toEqual([2]);
+		expect(readFileListView().selectedFileIndex).toBe(2);
+	});
+
+	it('toggles multi-select and maintains anchor', () => {
+		selectFile(1, { multi: false, range: false });
+		selectFile(3, { multi: true, range: false });
+		expect(selectedIndices()).toEqual([1, 3]);
+		expect(readFileListView().selectedFileIndex).toBe(3);
+
+		selectFile(3, { multi: true, range: false });
+		expect(selectedIndices()).toEqual([1]);
+		expect(readFileListView().selectedFileIndex).toBe(1);
+	});
+
+	it('selects a range from the anchor', () => {
+		selectFile(1, { multi: false, range: false });
+		selectFile(3, { multi: false, range: true });
+		expect(selectedIndices()).toEqual([1, 2, 3]);
+		expect(readFileListView().selectedFileIndex).toBe(3);
+	});
+
+	it('selects all files', () => {
+		expect(selectAll()).toBe(true);
+		expect(selectedIndices()).toEqual([0, 1, 2, 3, 4]);
+		expect(readFileListView().selectedFileIndex).toBe(0);
+	});
+
+	it('clears selection', () => {
+		selectFile(2, { multi: false, range: false });
+		expect(clearSelection()).toBe(true);
+		expect(selectedIndices()).toEqual([]);
+		expect(readFileListView().selectedFileIndex).toBe(-1);
+	});
+
+	it('ignores out-of-bounds selections', () => {
+		expect(selectFile(9, { multi: false, range: false })).toBe(false);
+		expect(readFileListView().files.length).toBe(5);
+		expect(selectedIndices()).toEqual([]);
+	});
+
+	it('resets selection state when a fresh file list is loaded', () => {
+		selectFile(1, { multi: true, range: false });
+		loadFileList(makeFileList(2));
+		expect(readFileListView().selectedFileIndex).toBe(-1);
+		expect(selectedIndices()).toEqual([]);
+	});
+});

--- a/src/ui/fileList/solid2/index.ts
+++ b/src/ui/fileList/solid2/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Solid 2 File List spike public strip: session/view reads and sync actions.
+ * Solid TSX, compiler, and tauriClient stay private inside solid2/.
+ */
+import { resetFileListSession } from './session';
+import { resetCoverThumbnailRuntime } from './thumbnails';
+
+export { FileListIsland } from './FileListIsland';
+export {
+	clearFiles,
+	clearSelection,
+	loadFileList,
+	removeFile,
+	reorderFiles,
+	restoreImportOrder,
+	selectAll,
+	selectFile,
+	setOrderLocked,
+	toggleSort,
+} from './session';
+export { readFileListView } from './view';
+export { getFileListCoverThumbnailState, setCoverThumbnailLoader } from './thumbnails';
+
+export function resetFileList(): void {
+	resetFileListSession();
+	resetCoverThumbnailRuntime();
+}

--- a/src/ui/fileList/solid2/main.ts
+++ b/src/ui/fileList/solid2/main.ts
@@ -1,0 +1,9 @@
+import '../../../styles.css';
+import { mountFileListIsland } from './mount';
+
+const target = document.getElementById('file-list-solid2');
+if (!target) {
+	throw new Error('File List Solid 2 root #file-list-solid2 not found');
+}
+
+mountFileListIsland(target);

--- a/src/ui/fileList/solid2/mount.tsx
+++ b/src/ui/fileList/solid2/mount.tsx
@@ -1,0 +1,6 @@
+import { render } from '@solidjs/web';
+import { FileListIsland, type FileListIslandProps } from './FileListIsland';
+
+export function mountFileListIsland(el: HTMLElement, props: FileListIslandProps = {}): () => void {
+	return render(() => <FileListIsland {...props} />, el);
+}

--- a/src/ui/fileList/solid2/session.ts
+++ b/src/ui/fileList/solid2/session.ts
@@ -1,0 +1,291 @@
+import { createRoot, createSignal, flush } from 'solid-js';
+import { pathBasename } from '../../../lib/path/basename';
+import type { AudioFile, FileListInfo } from '../../../types/audio';
+import { clearFileListCoverThumbnails, removeFileListCoverThumbnail } from './thumbnails';
+
+export type FileListSortDirection = 'none' | 'ascending' | 'descending';
+
+export type FileListSession = {
+	currentFileList: FileListInfo | null;
+	selectedFileIndex: number;
+	selectedFileIndices: ReadonlySet<number>;
+	sortDirection: FileListSortDirection;
+	orderLocked: boolean;
+};
+
+export type SelectionModifiers = { multi: boolean; range: boolean };
+
+const INITIAL: FileListSession = {
+	currentFileList: null,
+	selectedFileIndex: -1,
+	selectedFileIndices: new Set<number>(),
+	sortDirection: 'none',
+	orderLocked: false,
+};
+
+const importOrdinalByPath = new Map<string, number>();
+let nextImportOrdinal = 0;
+
+const graph = createRoot(() => {
+	const [read, set] = createSignal<FileListSession>({
+		...INITIAL,
+		selectedFileIndices: new Set<number>(),
+	});
+	return {
+		read,
+		write(next: FileListSession) {
+			set(next);
+			flush();
+		},
+	};
+});
+
+export const fileListSession = graph.read;
+
+function write(next: FileListSession): void {
+	graph.write(next);
+}
+
+export function getImportOrdinal(path: string): number | undefined {
+	return importOrdinalByPath.get(path);
+}
+
+export function fileIdentityKey(file: AudioFile): string {
+	return file.inputId ?? file.path;
+}
+
+function recordImportOrder(files: readonly AudioFile[]): void {
+	for (const file of files) {
+		if (!importOrdinalByPath.has(file.path)) {
+			importOrdinalByPath.set(file.path, nextImportOrdinal++);
+		}
+	}
+}
+
+function replaceFiles(session: FileListSession, nextFiles: AudioFile[]): FileListSession {
+	const fileList = session.currentFileList;
+	if (!fileList) return session;
+	const validCount = nextFiles.filter((file) => file.isValid).length;
+	return {
+		...session,
+		currentFileList: {
+			...fileList,
+			files: nextFiles,
+			validCount,
+			invalidCount: nextFiles.length - validCount,
+		},
+	};
+}
+
+function ensureAnchor(
+	selected: ReadonlySet<number>,
+	anchor: number,
+): Pick<FileListSession, 'selectedFileIndex' | 'selectedFileIndices'> {
+	if (selected.size === 0) return { selectedFileIndex: -1, selectedFileIndices: selected };
+	if (anchor >= 0 && selected.has(anchor)) {
+		return { selectedFileIndex: anchor, selectedFileIndices: selected };
+	}
+	const sorted = [...selected].sort((a, b) => a - b);
+	return { selectedFileIndex: sorted[sorted.length - 1] ?? -1, selectedFileIndices: selected };
+}
+
+function remapSelection(
+	files: readonly AudioFile[],
+	nextFiles: readonly AudioFile[],
+	selected: ReadonlySet<number>,
+	anchor: number,
+): Pick<FileListSession, 'selectedFileIndex' | 'selectedFileIndices'> {
+	const keys = new Set(
+		[...selected]
+			.map((index) => files[index])
+			.filter((file): file is AudioFile => Boolean(file))
+			.map(fileIdentityKey),
+	);
+	const anchorKey = files[anchor] ? fileIdentityKey(files[anchor]) : null;
+	return {
+		selectedFileIndices: new Set(
+			nextFiles.flatMap((file, index) => (keys.has(fileIdentityKey(file)) ? [index] : [])),
+		),
+		selectedFileIndex: anchorKey
+			? nextFiles.findIndex((file) => fileIdentityKey(file) === anchorKey)
+			: -1,
+	};
+}
+
+function mapIndexForMove(index: number, fromIndex: number, toIndex: number): number {
+	if (index === fromIndex) return toIndex;
+	if (fromIndex < toIndex && index > fromIndex && index <= toIndex) return index - 1;
+	if (fromIndex > toIndex && index >= toIndex && index < fromIndex) return index + 1;
+	return index;
+}
+
+export function resetFileListSession(): void {
+	importOrdinalByPath.clear();
+	nextImportOrdinal = 0;
+	write({ ...INITIAL, selectedFileIndices: new Set<number>() });
+}
+
+export function loadFileList(fileList: FileListInfo | null): void {
+	importOrdinalByPath.clear();
+	nextImportOrdinal = 0;
+	if (fileList) recordImportOrder(fileList.files);
+	write({
+		currentFileList: fileList,
+		selectedFileIndex: -1,
+		selectedFileIndices: new Set<number>(),
+		sortDirection: 'none',
+		orderLocked: fileListSession().orderLocked,
+	});
+}
+
+export function selectFile(
+	index: number,
+	modifiers: SelectionModifiers = { multi: false, range: false },
+): boolean {
+	const current = fileListSession();
+	const files = current.currentFileList?.files;
+	if (!files || index < 0 || index >= files.length) return false;
+	if (modifiers.range && current.selectedFileIndex !== -1) {
+		const start = Math.min(current.selectedFileIndex, index);
+		const end = Math.max(current.selectedFileIndex, index);
+		const selectedFileIndices = new Set<number>();
+		for (let i = start; i <= end; i += 1) selectedFileIndices.add(i);
+		write({ ...current, selectedFileIndex: index, selectedFileIndices });
+		return true;
+	}
+	if (modifiers.multi) {
+		const selectedFileIndices = new Set(current.selectedFileIndices);
+		if (selectedFileIndices.has(index)) selectedFileIndices.delete(index);
+		else selectedFileIndices.add(index);
+		write({
+			...current,
+			...(selectedFileIndices.has(index)
+				? { selectedFileIndex: index, selectedFileIndices }
+				: ensureAnchor(selectedFileIndices, current.selectedFileIndex)),
+		});
+		return true;
+	}
+	write({ ...current, selectedFileIndex: index, selectedFileIndices: new Set([index]) });
+	return true;
+}
+
+export function selectAll(): boolean {
+	const current = fileListSession();
+	const count = current.currentFileList?.files.length ?? 0;
+	if (count === 0) return false;
+	write({
+		...current,
+		selectedFileIndex: 0,
+		selectedFileIndices: new Set(Array.from({ length: count }, (_, i) => i)),
+	});
+	return true;
+}
+
+export function clearSelection(): boolean {
+	const current = fileListSession();
+	if (current.selectedFileIndices.size === 0 && current.selectedFileIndex === -1) return false;
+	write({ ...current, selectedFileIndex: -1, selectedFileIndices: new Set<number>() });
+	return true;
+}
+
+export function setOrderLocked(locked: boolean): void {
+	const current = fileListSession();
+	if (current.orderLocked === locked) return;
+	write({ ...current, orderLocked: locked });
+}
+
+export function reorderFiles(fromIndex: number, toIndex: number): void {
+	const current = fileListSession();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || fromIndex === toIndex) return;
+	if (fromIndex < 0 || toIndex < 0 || fromIndex >= files.length || toIndex >= files.length) return;
+	const nextFiles = [...files];
+	const [moved] = nextFiles.splice(fromIndex, 1);
+	nextFiles.splice(toIndex, 0, moved);
+	const selectedFileIndices = new Set(
+		[...current.selectedFileIndices].map((index) => mapIndexForMove(index, fromIndex, toIndex)),
+	);
+	const selectedFileIndex =
+		current.selectedFileIndex === -1
+			? -1
+			: mapIndexForMove(current.selectedFileIndex, fromIndex, toIndex);
+	write({
+		...replaceFiles(current, nextFiles),
+		sortDirection: 'none',
+		...ensureAnchor(selectedFileIndices, selectedFileIndex),
+	});
+}
+
+export function removeFile(index: number): void {
+	const current = fileListSession();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || index < 0 || index >= files.length) return;
+	const removed = files[index];
+	if (removed) {
+		importOrdinalByPath.delete(removed.path);
+		removeFileListCoverThumbnail(removed.path);
+	}
+	const nextFiles = files.filter((_, fileIndex) => fileIndex !== index);
+	const selectedFileIndices = new Set<number>();
+	for (const selected of current.selectedFileIndices) {
+		if (selected === index) continue;
+		selectedFileIndices.add(selected > index ? selected - 1 : selected);
+	}
+	write({
+		...replaceFiles(current, nextFiles),
+		...ensureAnchor(
+			selectedFileIndices,
+			current.selectedFileIndex === index ? -1 : current.selectedFileIndex,
+		),
+	});
+}
+
+export function clearFiles(): void {
+	const current = fileListSession();
+	if (current.orderLocked || !current.currentFileList) return;
+	importOrdinalByPath.clear();
+	nextImportOrdinal = 0;
+	clearFileListCoverThumbnails();
+	write({
+		...replaceFiles(current, []),
+		selectedFileIndex: -1,
+		selectedFileIndices: new Set<number>(),
+		sortDirection: 'none',
+	});
+}
+
+export function toggleSort(): void {
+	const current = fileListSession();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || files.length <= 1) return;
+	const sortDirection: FileListSortDirection =
+		current.sortDirection === 'ascending' ? 'descending' : 'ascending';
+	const nextFiles = [...files].sort((left, right) => {
+		const comparison = pathBasename(left.path, { fallback: 'path' }).localeCompare(
+			pathBasename(right.path, { fallback: 'path' }),
+			undefined,
+			{ numeric: true, sensitivity: 'base' },
+		);
+		return sortDirection === 'descending' ? -comparison : comparison;
+	});
+	write({
+		...replaceFiles(current, nextFiles),
+		sortDirection,
+		...remapSelection(files, nextFiles, current.selectedFileIndices, current.selectedFileIndex),
+	});
+}
+
+export function restoreImportOrder(): void {
+	const current = fileListSession();
+	const files = current.currentFileList?.files;
+	if (current.orderLocked || !files || files.length <= 1) return;
+	if (files.some((file) => getImportOrdinal(file.path) === undefined)) return;
+	const nextFiles = [...files].sort(
+		(left, right) => (getImportOrdinal(left.path) ?? 0) - (getImportOrdinal(right.path) ?? 0),
+	);
+	write({
+		...replaceFiles(current, nextFiles),
+		sortDirection: 'none',
+		...remapSelection(files, nextFiles, current.selectedFileIndices, current.selectedFileIndex),
+	});
+}

--- a/src/ui/fileList/solid2/thumbnails.ts
+++ b/src/ui/fileList/solid2/thumbnails.ts
@@ -1,0 +1,184 @@
+import { createRoot, createStore, flush } from 'solid-js';
+import { coverArtBytesToDataUrl } from '../../../lib/media/coverArtDataUrl';
+import { createBoundedGenerationQueue } from '../../../lib/media/boundedGenerationQueue';
+import { tauriClient } from '../../../lib/tauri/client';
+
+export const FILE_LIST_COVER_THUMBNAIL_CONCURRENCY = 2;
+export const MAX_FILE_LIST_COVER_THUMBNAIL_CACHE_ENTRIES = 64;
+
+export type FileListCoverThumbnailState =
+	| { status: 'idle' }
+	| { status: 'queued' }
+	| { status: 'loading' }
+	| { status: 'ready'; dataUrl: string }
+	| { status: 'absent' }
+	| { status: 'error' };
+
+export type FileListCoverThumbnailLoader = (
+	path: string,
+) => Promise<ReadonlyArray<number> | null | undefined>;
+
+const graph = createRoot(() => createStore<Record<string, FileListCoverThumbnailState>>({}));
+const [thumbnailByPath, setThumbnailByPath] = graph;
+const inflightByPath = new Map<string, Promise<ReadonlyArray<number> | null | undefined>>();
+const cacheOrder: string[] = [];
+const thumbnailQueue = createBoundedGenerationQueue(FILE_LIST_COVER_THUMBNAIL_CONCURRENCY);
+let loadThumbnail: FileListCoverThumbnailLoader = (path) =>
+	tauriClient.readAudioCoverThumbnail(path);
+
+function put(path: string, state: FileListCoverThumbnailState): void {
+	setThumbnailByPath((draft) => {
+		draft[path] = state;
+	});
+	flush();
+}
+
+export function setCoverThumbnailLoader(loader: FileListCoverThumbnailLoader): void {
+	loadThumbnail = loader;
+}
+
+export function resetCoverThumbnailRuntime(): void {
+	clearFileListCoverThumbnails();
+	loadThumbnail = (path) => tauriClient.readAudioCoverThumbnail(path);
+}
+
+export function clearFileListCoverThumbnails(): void {
+	thumbnailQueue.cancel();
+	setThumbnailByPath((draft) => {
+		for (const path of Object.keys(draft)) delete draft[path];
+	});
+	cacheOrder.length = 0;
+	inflightByPath.clear();
+	flush();
+}
+
+export function removeFileListCoverThumbnail(path: string): void {
+	setThumbnailByPath((draft) => {
+		delete draft[path];
+	});
+	const cacheIndex = cacheOrder.indexOf(path);
+	if (cacheIndex >= 0) cacheOrder.splice(cacheIndex, 1);
+	inflightByPath.delete(path);
+	flush();
+}
+
+export function getFileListCoverThumbnailState(
+	path: string | null | undefined,
+): FileListCoverThumbnailState {
+	const state = path ? thumbnailByPath[path] : undefined;
+	if (!path || !thumbnailQueue.isCurrent(path, thumbnailQueue.currentGeneration())) {
+		return { status: 'idle' };
+	}
+	return state ?? { status: 'idle' };
+}
+
+export function scheduleFileListCoverThumbnails(paths: ReadonlyArray<string>): void {
+	thumbnailQueue.schedule(paths, {
+		visibleKeysChanged: (visiblePaths) => {
+			setThumbnailByPath((draft) => {
+				for (const path of Object.keys(draft)) {
+					if (visiblePaths.has(path)) continue;
+					const state = draft[path];
+					if (state?.status === 'queued' || state?.status === 'loading') delete draft[path];
+				}
+			});
+			flush();
+		},
+		prepare: (path, generation) => {
+			const state = thumbnailByPath[path];
+			if (isTerminal(state)) {
+				touch(path);
+				return false;
+			}
+			const inflight = inflightByPath.get(path);
+			if (inflight) {
+				put(path, { status: 'loading' });
+				attachInflight(path, inflight, generation);
+				return false;
+			}
+			put(path, { status: 'queued' });
+			return true;
+		},
+		start: (path, generation, complete) => startFetch(path, generation, complete),
+	});
+}
+
+function startFetch(
+	path: string,
+	generation: number,
+	onComplete: () => void,
+): Promise<ReadonlyArray<number> | null | undefined> {
+	put(path, { status: 'loading' });
+	let promise!: Promise<ReadonlyArray<number> | null | undefined>;
+	promise = loadThumbnail(path)
+		.then((bytes) => {
+			if (thumbnailQueue.isCurrent(path, generation)) commit(path, bytes);
+			return bytes;
+		})
+		.catch((error) => {
+			if (thumbnailQueue.isCurrent(path, generation)) {
+				put(path, { status: 'error' });
+				touch(path);
+				prune();
+			}
+			throw error;
+		})
+		.finally(() => {
+			if (inflightByPath.get(path) === promise) inflightByPath.delete(path);
+			onComplete();
+		});
+	inflightByPath.set(path, promise);
+	return promise;
+}
+
+function attachInflight(
+	path: string,
+	inflight: Promise<ReadonlyArray<number> | null | undefined>,
+	generation: number,
+): void {
+	void inflight
+		.then((bytes) => {
+			if (thumbnailQueue.isCurrent(path, generation)) commit(path, bytes);
+		})
+		.catch(() => {
+			if (thumbnailQueue.isCurrent(path, generation)) {
+				put(path, { status: 'error' });
+				touch(path);
+				prune();
+			}
+		});
+}
+
+function commit(path: string, bytes: ReadonlyArray<number> | null | undefined): void {
+	put(
+		path,
+		bytes
+			? { status: 'ready', dataUrl: coverArtBytesToDataUrl(Array.from(bytes)) }
+			: { status: 'absent' },
+	);
+	touch(path);
+	prune();
+}
+
+function isTerminal(
+	state: FileListCoverThumbnailState | undefined,
+): state is Extract<FileListCoverThumbnailState, { status: 'ready' | 'absent' | 'error' }> {
+	return state?.status === 'ready' || state?.status === 'absent' || state?.status === 'error';
+}
+
+function touch(path: string): void {
+	const index = cacheOrder.indexOf(path);
+	if (index >= 0) cacheOrder.splice(index, 1);
+	cacheOrder.push(path);
+}
+
+function prune(): void {
+	while (cacheOrder.length > MAX_FILE_LIST_COVER_THUMBNAIL_CACHE_ENTRIES) {
+		const path = cacheOrder.shift();
+		if (path) {
+			setThumbnailByPath((draft) => {
+				delete draft[path];
+			});
+		}
+	}
+}

--- a/src/ui/fileList/solid2/view.ts
+++ b/src/ui/fileList/solid2/view.ts
@@ -1,0 +1,145 @@
+import { pathBasename } from '../../../lib/path/basename';
+import { formatFileSize, type AudioFile } from '../../../types/audio';
+import { companionSummaryForInputIds } from '../../remoteSource';
+import { displayedArtistForFile, displayedTitleForFile } from '../viewState.svelte';
+import { fileListSession, getImportOrdinal, type FileListSession } from './session';
+
+export type FileListInspectorView = {
+	contextText: string;
+	contextVariant: 'empty' | 'single' | 'multi';
+	contextDetail: string;
+	bitrateText: string;
+	sampleRateText: string;
+	channelsText: string;
+	codecText: string;
+	decoderText: string;
+	fileSizeText: string;
+	companionsText: string;
+	companionsTitle: string;
+};
+
+export type FileListView = {
+	files: AudioFile[];
+	selectedIndices: number[];
+	selectedFileIndex: number;
+	sortLabel: string;
+	sortState: FileListSession['sortDirection'];
+	showSortButton: boolean;
+	showClearButton: boolean;
+	sortDisabled: boolean;
+	clearDisabled: boolean;
+	orderLockVisible: boolean;
+	orderDiffersFromImport: boolean;
+	combinedSizeText: string;
+	inspector: FileListInspectorView;
+};
+
+const EMPTY_INSPECTOR: FileListInspectorView = {
+	contextText: 'No file selected',
+	contextVariant: 'empty',
+	contextDetail: '',
+	bitrateText: '---',
+	sampleRateText: '---',
+	channelsText: '---',
+	codecText: '---',
+	decoderText: '---',
+	fileSizeText: '---',
+	companionsText: '---',
+	companionsTitle: '',
+};
+
+function orderDiffersFromImport(files: readonly AudioFile[]): boolean {
+	if (files.length <= 1) return false;
+	let previous = -1;
+	for (const file of files) {
+		const ordinal = getImportOrdinal(file.path);
+		if (ordinal === undefined) return false;
+		if (ordinal < previous) return true;
+		previous = ordinal;
+	}
+	return false;
+}
+
+function optionalText(value: string | undefined): string {
+	const trimmed = value?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : 'N/A';
+}
+
+function sharedText(
+	files: readonly AudioFile[],
+	pick: (file: AudioFile) => string | undefined,
+): string {
+	if (files.length === 0) return '---';
+	const values = files.map((file) => {
+		const value = pick(file);
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+	});
+	if (values.some((value) => value === null)) return 'Mixed';
+	return new Set(values).size === 1 ? (values[0] ?? 'Mixed') : 'Mixed';
+}
+
+function inspectorFor(session: FileListSession): FileListInspectorView {
+	const files = session.currentFileList?.files ?? [];
+	const selected = [...session.selectedFileIndices]
+		.sort((a, b) => a - b)
+		.map((index) => files[index])
+		.filter((file): file is AudioFile => Boolean(file));
+	if (selected.length === 0) return EMPTY_INSPECTOR;
+	if (selected.length > 1) {
+		const companions = companionSummaryForInputIds(selected.map((file) => file.inputId));
+		return {
+			...EMPTY_INSPECTOR,
+			contextText: `${selected.length} files selected`,
+			contextVariant: 'multi',
+			codecText: sharedText(selected, (file) => file.codecLabel),
+			decoderText: sharedText(selected, (file) => file.selectedDecoder),
+			companionsText: companions.text,
+			companionsTitle: companions.title,
+		};
+	}
+	const file = selected[0];
+	const companions = companionSummaryForInputIds([file.inputId]);
+	return {
+		contextText: pathBasename(file.path, { fallback: 'path' }),
+		contextVariant: 'single',
+		contextDetail:
+			session.selectedFileIndex >= 0 ? `${session.selectedFileIndex + 1} of ${files.length}` : '',
+		bitrateText:
+			file.isValid && file.bitrate ? `${file.bitrate} kb/s` : file.isValid ? 'N/A' : '---',
+		sampleRateText:
+			file.isValid && file.sampleRate ? `${file.sampleRate} Hz` : file.isValid ? 'N/A' : '---',
+		channelsText:
+			file.isValid && file.channels ? `${file.channels} ch` : file.isValid ? 'N/A' : '---',
+		codecText: file.isValid ? optionalText(file.codecLabel) : '---',
+		decoderText: file.isValid ? optionalText(file.selectedDecoder) : '---',
+		fileSizeText:
+			file.isValid && file.size ? formatFileSize(file.size) : file.isValid ? 'N/A' : '---',
+		companionsText: companions.text,
+		companionsTitle: companions.title,
+	};
+}
+
+export function readFileListView(): FileListView {
+	const session = fileListSession();
+	const files = session.currentFileList ? [...session.currentFileList.files] : [];
+	const locked = session.orderLocked;
+	return {
+		files,
+		selectedIndices: [...session.selectedFileIndices],
+		selectedFileIndex: session.selectedFileIndex,
+		sortLabel: session.sortDirection === 'descending' ? 'Sort: Z-A' : 'Sort: A-Z',
+		sortState: session.sortDirection,
+		showSortButton: files.length > 1,
+		showClearButton: files.length > 0,
+		sortDisabled: locked,
+		clearDisabled: locked,
+		orderLockVisible: locked,
+		orderDiffersFromImport: orderDiffersFromImport(files),
+		combinedSizeText: session.currentFileList
+			? formatFileSize(session.currentFileList.totalSize)
+			: '--- MB',
+		inspector: inspectorFor(session),
+	};
+}
+
+export { displayedArtistForFile, displayedTitleForFile };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"noEmit": true,
+		"jsx": "preserve",
+		"jsxImportSource": "@solidjs/web",
 		"types": ["vite/client", "svelte"],
 
 		/* Linting */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
+import solid from '@solidjs/vite-plugin';
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -20,7 +21,12 @@ function removeCrossoriginPlugin(): Plugin {
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
-	plugins: [tailwindcss(), svelte(), removeCrossoriginPlugin()],
+	plugins: [
+		tailwindcss(),
+		...solid({ include: ['**/fileList/solid2/**'] }),
+		svelte(),
+		removeCrossoriginPlugin(),
+	],
 
 	// Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
 	//

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,15 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
+import solid from '@solidjs/vite-plugin';
 
 export default defineConfig({
-	plugins: [svelte(), svelteTesting()],
+	plugins: [...solid({ include: ['**/fileList/solid2/**'] }), svelte(), svelteTesting()],
 	test: {
 		// Use jsdom for DOM testing (statusPanel, fileList, etc.)
 		environment: 'jsdom',
 
-		include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'scripts/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/*.spec.ts', 'scripts/**/*.test.ts'],
 		environmentMatchGlobs: [['scripts/**', 'node']],
 
 		// Global setup for Tauri mocks


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Solid 2 did not earn keep.** Same File List session/selection/sort/inspector/thumbnail behaviors, **841 vs 521** (~+61%). Stop here. Do not shop another kernel in this PR.

Spike evidence for #464 architecture B (Solid-centric island, Effect off this island’s view state). Does **not** close #464. Does **not** stack on #465/#466.

## What mounted

File List as its own Solid **2** island — sibling Vite/TSX entry, not nested in today’s Svelte shell.

- Harness: `file-list-solid2.html` → `src/ui/fileList/solid2/main.ts` → `mountFileListIsland` into `#file-list-solid2`
- Pins: `solid-js@2.0.0-rc.3`, `@solidjs/web@2.0.0-rc.3`, `@solidjs/vite-plugin@3.0.0-next.34` (peers `vite ^8 || ^9` and `solid-js ^2.0.0-rc.0`)
- Compiler: plugin default `native` (`@solidjs/compiler`); no `vite-plugin-solid`; no `@effect/atom-solid`
- View state lives in Solid signals / stores / memos / split `createEffect`. `flush()` after writes so public actions stay sync. No Atom. No `runAppEffect`. No Promise workflow façade for selection/sort. `commandSpecs` / `tauriClient` were not collapsed into a Backend service; thumbnail default loader still calls `tauriClient.readAudioCoverThumbnail`, tests inject a fake.
- Live `src/ui/fileList/index.ts` public strip is unchanged. Spike strip is `solid2/index.ts`: `FileListIsland` + `readFileListView` + load/select/sort/reorder/remove/reset/lock and thumbnail loader/read. Solid TSX, the Solid 2 compiler, and `tauriClient` stay private inside `solid2/`.

## Thickness vs 521

Physical LOC = file line count (same definition as the 521 rune bar and #466). Also nonempty lines and `\b(if|for|while|switch)\b|\?` tokens.

### (1) Old rune modules that owned File List view state

| File | physical | nonempty | branch tokens |
|---|---:|---:|---:|
| `state.svelte.ts` | 185 | 149 | 11 |
| `viewState.svelte.ts` | 110 | 99 | 22 |
| `inspectorState.svelte.ts` | 74 | 68 | 3 |
| `coverThumbnails.svelte.ts` | 152 | 149 | 23 |
| **Total** | **521** | **465** | **59** |

### (2) Solid 2 state modules + TSX island

State modules:

| File | physical | nonempty | branch tokens |
|---|---:|---:|---:|
| `solid2/session.ts` | 291 | 265 | 52 |
| `solid2/view.ts` | 145 | 136 | 31 |
| `solid2/thumbnails.ts` | 184 | 167 | 25 |
| `solid2/index.ts` | 27 | 25 | 0 |
| **State subtotal** | **647** | **593** | **108** |

Solid TSX island:

| File | physical | nonempty | branch tokens |
|---|---:|---:|---:|
| `solid2/FileListIsland.tsx` | 188 | 184 | 30 |
| `solid2/mount.tsx` | 6 | 5 | 0 |
| **TSX subtotal** | **194** | **189** | **30** |

**(2) total = 647 + 194 = 841 physical LOC vs (1) 521.**

State modules **alone** are already 647 > 521. The island paint is in the counted total per #466 rules.

Not counted toward the bar (called out so they are not hidden): `FileListIsland.css` (53), `main.ts` + `file-list-solid2.html` harness, tests, Vite/tsconfig/biome/package glue.

## Tests

- `bun run typecheck` — pass (TS7, `jsxImportSource: @solidjs/web`)
- `bun run test -- src/ui/fileList/solid2 scripts/frontend-toolchain-layout.test.ts src/ui/fileList` — 17 files, 102 tests, pass

Spike test list (`src/ui/fileList/solid2/__tests__/`):

- `selection.test.ts` — single/multi/range/select-all/clear/out-of-bounds/load-reset
- `derived-view.test.ts` — title/artist metadata truth, reorder/remove without manual view sync
- `order-lock-reorder.test.ts` — lock disables sort; identity preserved across reorder/restore
- `coverThumbnails.test.ts` — concurrency 2, stale generation ignore, remove+refetch, LRU 64
- `FileListIsland.test.tsx` — `@solidjs/testing-library`: keyboard stays on the listbox; inspector/sort/lock paint from Solid view state
- `public-strip.test.ts` — small export surface

Did not run svelte-check. Did not run Tauri native smoke. Did not visually drive the empty Vite harness (`file-list-solid2.html`); island behavior is pinned by `@solidjs/testing-library`. Live Svelte File List is untouched.

## Residual (named, not restacked)

- These RC packages are younger than `bunfig.toml` `minimumReleaseAge` (10 days). They were added with a one-shot `--minimum-release-age 0`; the standing bunfig policy is unchanged. Frozen lockfile install should still resolve the committed pins.
- `@solidjs/testing-library@1.0.0-beta.2` peers `solid-js >=2.0.0`, which does not include `2.0.0-rc.3`; it ran the island tests anyway.
- `displayedTitleForFile` / `displayedArtistForFile` are re-exported from the live `viewState.svelte.ts` (not duplicated), same as #466.
- Solid 2 JSX wants `tabindex` and `"true"`/`"false"` aria enums, not `tabIndex` / boolean `aria-selected`.

References #464 as spike evidence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc14146a-61ec-4a63-8326-6dfbbaea00ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc14146a-61ec-4a63-8326-6dfbbaea00ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

