### PR TITLE
Add verify-audiobook-boss live GUI skill

### DIFF
--- a/.agents/skills/verify-audiobook-boss/SKILL.md
+++ b/.agents/skills/verify-audiobook-boss/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: verify-audiobook-boss
+description: Drive AudioBook Boss in the live Tauri desktop GUI when user-visible behavior must be proven in a real window. Use this instead of unit tests or audit-test-value when the acceptance surface is the desktop app a user would click.
+---
+
+# Verify AudioBook Boss
+
+Primary surface is the Tauri 2 + Solid desktop window titled `AudioBook Boss`.
+Vitest, Nextest, and `audit-test-value` stay on their own lanes. This skill
+drives the live GUI.
+
+Vite-only `bun run dev` on port 1420 is not the desktop app. `/lab.html` and
+`/docs/design/ui-directions-v3.html` are not the app. Never treat a browser
+tab on `:1420` as live Tauri drive.
+
+## Launch
+
+From the repo root, on macOS Apple Silicon only:
+
+```bash
+.agents/skills/verify-audiobook-boss/verify-abb launch
+```
+
+That wrapper is the lever. It starts a verification instance with
+`bun run app:dev:log` (bundled FFmpeg, logs under `.logs/`). Do not run
+`/Applications/AudioBook Boss.app`. Do not run `bun run app:install-local`.
+
+Ready when all of these are true:
+
+1. `.logs/tauri-dev.log` (or the run-scoped file it points at) contains
+   `Starting AudioBook Boss application`.
+2. A window exists with title `AudioBook Boss`.
+3. The process command contains `target/debug/audiobook-boss`, not
+   `/Applications/AudioBook Boss.app`.
+4. Port 1420 is held by the Vite server this `app:dev:log` session started
+   (`devUrl` in `src-tauri/tauri.conf.json`).
+
+Teardown only the instance this run created:
+
+```bash
+.agents/skills/verify-audiobook-boss/verify-abb cleanup
+```
+
+Never `killall`, never `pkill audiobook-boss`, never kill by process name.
+`scripts/dev-tauri-log.sh` will replace an existing ABB-owned listener on
+port 1420. If 1420 is already taken, refuse and stop. Do not steal a user's
+dev session.
+
+## Doctor
+
+```bash
+.agents/skills/verify-audiobook-boss/verify-abb doctor
+```
+
+Read-only. Worth driving only when doctor prints `live_drive: possible` and
+exits 0.
+
+Doctor fails closed (nonzero) when any of these hold:
+
+- The runner is not macOS Apple Silicon. Linux must not fake a window.
+- The installed app is running, or the path to drive would be
+  `/Applications/AudioBook Boss.app`.
+- Port 1420 is in use by a process this helper did not start.
+- A `target/debug/audiobook-boss` process is already running and was not
+  started by this helper (shared identifier `com.audiobook-boss`, no
+  profile override).
+- A real Audible session is present (macOS Keychain service
+  `audiobook-boss.remote-source`, account `audible.us.auth`).
+
+The verification instance and the installed app share Tauri
+`app_config_dir` (`app-settings.json`) and the same Keychain service.
+There is no data-dir or profile switch in this repo. Two instances cannot
+run side by side. If isolate checks fail, refuse. Do not attach to a
+shared or user instance.
+
+On Linux, doctor still prints a structured report, then exits nonzero with
+`live_drive: blocked`. Help, doctor, feature list, fixture scaffold, and
+`--dry-run` stay available.
+
+## Drive
+
+This repo has no Playwright, Cypress, tauri-driver, or debug IPC for GUI
+drive. The harness is macOS Accessibility via osascript, aimed at the
+window titled `AudioBook Boss`.
+
+Prefer stable handles in this order: `aria-label`, visible name, `id`,
+`data-testid`. Do not click by coordinates.
+
+```bash
+.agents/skills/verify-audiobook-boss/verify-abb drive file-import --dry-run
+.agents/skills/verify-audiobook-boss/verify-abb drive file-import
+```
+
+`--dry-run` prints the user path and the exact osascript/AX steps, records
+what it skipped (no Tauri launch, no window, no native dialog), and must
+not start the app. Live `drive` without `--dry-run` is macOS Apple Silicon
+only and must fail with that requirement on Linux.
+
+Read `features/README.md` before the first drive. Drive one mapped feature
+file at a time. Feature files name the handles and the observable result.
+
+Native file and folder pickers are Tauri `plugin-dialog` sheets, not DOM.
+After clicking `Add Folder` (`#add-folder-btn`) or `Add audio files`
+(`aria-label`), drive the sheet with osascript to the scratch fixture
+directory this helper created. Do not point the sheet at a personal library.
+
+Never open `Import from Library` / `#acquire-audiobooks-btn` against a real
+Audible account. Never type a real Amazon handoff URL.
+
+## Evidence
+
+Named location:
+
+`.agents/skills/verify-audiobook-boss/evidence/`
+
+`evidence/README.md` says what lands there. Cleanup does not delete it.
+
+A pass is all of:
+
+- The path a user would take (mapped feature), not a test-only shortcut.
+- Each action paired with a resulting window, list, field, status, or file
+  state.
+- Side effects named (scratch output created, `.logs/tauri-dev.log` line,
+  status text). Mocks are allowed only at a production boundary the
+  feature file already names.
+- `--dry-run` evidence shows the launch/AX/dialog steps that were skipped.
+
+On a live session, also keep `.logs/tauri-dev-summary.md` and
+`.logs/tauri-dev.log`. Those are latest-run entrypoints owned by
+`scripts/dev-tauri-log.sh`, not this skill's evidence directory.
+
+## Cleanup
+
+```bash
+.agents/skills/verify-audiobook-boss/verify-abb cleanup
+```
+
+Stops the verification instance this helper launched (recorded PIDs only).
+Deletes the scratch fixture directory this helper created. Leaves
+`.agents/skills/verify-audiobook-boss/evidence/` in place.
+
+## Helpers
+
+Run from the repo root. The executable is
+`.agents/skills/verify-audiobook-boss/verify-abb`.
+
+```bash
+.agents/skills/verify-audiobook-boss/verify-abb help
+.agents/skills/verify-audiobook-boss/verify-abb doctor
+.agents/skills/verify-audiobook-boss/verify-abb features
+.agents/skills/verify-audiobook-boss/verify-abb scaffold
+.agents/skills/verify-audiobook-boss/verify-abb drive file-import --dry-run
+.agents/skills/verify-audiobook-boss/verify-abb launch
+.agents/skills/verify-audiobook-boss/verify-abb drive file-import
+.agents/skills/verify-audiobook-boss/verify-abb cleanup
+```
+
+`launch` and live `drive` fail closed on Linux. `help`, `doctor`,
+`features`, `scaffold`, `drive --dry-run`, and `cleanup` must work there.
+
+## Isolate rules
+
+- Never drive or attach to `/Applications/AudioBook Boss.app` or any
+  user-installed binary.
+- Never use a real Audible session or personal library.
+- Synthesize fixtures at runtime in a temp dir. Do not commit media files.
+- Live GUI drive needs macOS Apple Silicon. Linux doctor and live-drive
+  subcommands fail closed. Do not fake a window.
+- The verification instance and the installed app share identifier
+  `com.audiobook-boss`. If an installed or foreign instance is already
+  using that identity, port 1420, or the Keychain secret, refuse.
+
+## Completion
+
+Pass when:
+
+1. Doctor ran and its `live_drive` field matches the host.
+2. One mapped feature was driven in the Tauri window, or live GUI drive is
+   recorded as blocked on macOS with doctor plus a dry-run transcript kept
+   under `evidence/`.
+3. Cleanup left evidence in place and removed only this run's instance and
+   scratch.
+4. No product code, tests, or other skills were edited.
+
+Fail when doctor was skipped, a browser tab or Vite-only page was treated
+as the desktop app, the installed app was driven, a real Audible session
+was used, evidence is missing after cleanup, or a documented dry command
+exits nonzero.
+
+## Pointers
+
+- `features/README.md` owns the feature map, baseline preconditions, and
+  proof/skip reporting. Read it before opening a feature file.
+- `features/*.md` own one user-facing path each: handles, drive commands,
+  observable proof. Read the one feature you will drive.
+- `scripts/dev-tauri-log.sh` owns `app:dev:log` capture and port-1420
+  reclaim. Read it only when launch or teardown behavior is in doubt.
+- `.agents/skills/audit-test-value` owns test-value audits. Do not use this
+  skill for that.
+- `.cursor/` is leftover Cursor plugin config (gitignored). It is not a
+  skills tree. Durable owner is this directory.

--- a/.agents/skills/verify-audiobook-boss/agents/openai.yaml
+++ b/.agents/skills/verify-audiobook-boss/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify AudioBook Boss"
+  short_description: "Drive the live desktop app and capture proof"
+  default_prompt: "Use $verify-audiobook-boss to drive the live AudioBook Boss desktop GUI the way a user does and capture evidence."

--- a/.agents/skills/verify-audiobook-boss/evidence/.gitignore
+++ b/.agents/skills/verify-audiobook-boss/evidence/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/.agents/skills/verify-audiobook-boss/evidence/README.md
+++ b/.agents/skills/verify-audiobook-boss/evidence/README.md
@@ -1,0 +1,17 @@
+# Evidence
+
+This directory is the named proof location for `verify-audiobook-boss`.
+
+Cleanup tears down verification instances and scratch fixtures this run
+created. It does not delete files here.
+
+## What lands here
+
+- Command transcripts (`*.transcript.txt`): argv, cwd, exit code, stdout, stderr
+- Doctor reports (`*.doctor.json`)
+- Dry-run plans (`*.dry-run.txt`): the launch/AX steps that were skipped
+- Screenshots from a live Tauri window (`*.png`), when the GUI ran on macOS
+- Pointers to `.logs/` session files for an instance this helper launched
+
+Do not commit media fixtures. Synthesized audio lives in a temp scratch
+directory recorded in the transcript, then deleted on cleanup.

--- a/.agents/skills/verify-audiobook-boss/features/README.md
+++ b/.agents/skills/verify-audiobook-boss/features/README.md
@@ -1,0 +1,63 @@
+# Feature map
+
+User-facing paths for live GUI drive. Not every panel. Composition shells
+(`leftColumn`, `metadataManager`, `encodingWorkbench`) are layout, not
+features.
+
+## Baseline preconditions
+
+- Doctor has run in this session. `live_drive` is `possible` before any
+  live `drive` or `launch`.
+- The instance was started by
+  `.agents/skills/verify-audiobook-boss/verify-abb launch`, not by opening
+  `/Applications/AudioBook Boss.app`.
+- No real Audible session (Keychain
+  `audiobook-boss.remote-source` / `audible.us.auth` absent).
+- Fixtures are synthesized in the helper scratch directory. No personal
+  library paths. No committed media.
+- Output, if the feature writes files, is a scratch directory this run
+  created. Do not use a saved user output folder from `app-settings.json`.
+- Linux may run doctor, `features`, `scaffold`, and `drive --dry-run`
+  only.
+
+## Driving conventions
+
+- Harness: macOS Accessibility via osascript against the window titled
+  `AudioBook Boss`.
+- Handle order: `aria-label`, visible name, `id`, `data-testid`.
+- Native Tauri dialogs are OS sheets. Drive those sheets. Do not hunt for
+  them in the Solid DOM.
+- Do not click `Import from Library` on a machine with a real Audible
+  account.
+- Do not treat `http://localhost:1420` in a browser as this app.
+
+## Proof and skip reporting
+
+For each driven feature, record in `evidence/`:
+
+- pass: action, handle, resulting state, side effect
+- fail: expected state, actual state, evidence path
+- skip: why (Linux live-drive block, isolate refuse, missing fixture
+  tool). A skip is not a pass.
+
+`--dry-run` must list the launch, AX, and dialog steps it did not run.
+
+## Feature entry contract
+
+Each feature file has:
+
+1. One H1 and one paragraph of user-visible behavior
+2. Exactly four H2s, in order: `Sub-features`, `How to get to it (user POV)`,
+   `Driving it with osascript AX`, `Gotchas`
+3. Sub-feature IDs, one line each
+4. Driving section starting with `Preconditions:` then labeled bullets
+   that pair a user action with a command and an observable result
+
+## Features
+
+| ID | File | User path |
+| --- | --- | --- |
+| `file-import` | `file-import.md` | Add local audio into Input and File Order |
+| `file-list` | `file-list.md` | Select, order, and clear the audio list |
+| `metadata` | `metadata.md` | Edit tags, cover, and online lookup |
+| `encode-output` | `encode-output.md` | Choose encoder/output and start processing |

--- a/.agents/skills/verify-audiobook-boss/features/encode-output.md
+++ b/.agents/skills/verify-audiobook-boss/features/encode-output.md
@@ -1,0 +1,83 @@
+# Encode and output
+
+A user chooses how to encode, where the M4B should land, and starts
+processing. Progress shows on the Status Panel and Work Center.
+
+## Sub-features
+
+- `encoder-select`: pick encoder and related settings
+- `output-dir`: set a scratch output directory
+- `output-naming`: ABS Default vs Custom Template
+- `process-start`: Start Processing runs the job
+- `process-status`: progress text, queue chips, Work Center rows
+
+## How to get to it (user POV)
+
+1. Import and select at least one valid scratch fixture. Metadata may be
+   filled or left default.
+2. The workbench is `aria-label="Encoding, output, and tags"`
+   (`data-testid="encoding-workbench"`).
+3. Encoder: `#encoder-settings-panel` / `data-testid="encoder-settings-panel"`.
+   Controls: `#adv-encoder`, `#adv-bitrate-mode`, `#output-quality` or
+   `#output-bitrate`, `#output-samplerate`, `#output-channels`.
+4. Output: `data-testid="output-panel"`. Directory value
+   `data-testid="output-directory-value"`. Browse is `#output-dir-browse`.
+   Naming preset is `#output-naming-preset`.
+5. Start is `#process-button` (`Start Processing`). Status text is
+   `#status-text`. Work Center is `aria-label="Work Center"`.
+
+## Driving it with osascript AX
+
+Preconditions:
+
+- Doctor passed or this is `--dry-run`.
+- At least one valid imported file.
+- Output directory is a scratch folder this run created, not a path from
+  the user's `app-settings.json`.
+- Encoder `#adv-encoder` is not stuck on `Loading…`.
+- Do not enable FDK Afterburner or a user FFmpeg path.
+
+- Set output directory:
+  User: clicks `Browse…` under Output Directory.
+  Command: `verify-abb drive encode-output` AX-clicks `#output-dir-browse`,
+  then drive the native folder sheet at the scratch output directory.
+  Result: `data-testid="output-directory-value"` (`#output-dir-text`)
+  shows that scratch path. `data-testid="output-example"` previews a
+  filename under it.
+
+- Confirm encoder is selectable:
+  User: looks at Encoder.
+  Command: read AX value of `#adv-encoder` (`data-testid="encoder-select"`).
+  Result: a real encoder option is selected (not `Loading…`).
+  `#estimated-size` (`data-testid="estimated-size"`) shows a size or
+  `---`.
+
+- Start processing:
+  User: clicks `Start Processing`.
+  Command: AX click `#process-button`.
+  Result: `#status-text` leaves `Ready to process audiobook` (or the idle
+  line). Work Center is not `No background work.` A collision dialog
+  (`#collision-dialog-modal`) may appear; Cancel (`#collision-dialog-close`)
+  if the planned path is not the scratch directory. On success, a `.m4b`
+  exists under the scratch output path and `.logs/tauri-dev.log` records
+  the operation.
+
+`--dry-run` prints these steps and records that Tauri launch, the output
+sheet, Start Processing, and any encode were skipped.
+
+## Gotchas
+
+- `#process-button` submits a real encode. On `--dry-run` it must not
+  run. On live drive, watch Work Center until a terminal status
+  (Completed / Failed / Cancelled).
+- Collision choices (`Overwrite Existing`, `Skip Existing`, `Rename`)
+  write or skip real files. Use only against scratch output.
+- `Preview Audio` (`#preview-button`) is a short encode. Do not use it as
+  a silent substitute for Start Processing unless that is the feature
+  under test.
+- `#merge-mode-toggle` changes batch vs one merged book. Keep batch
+  unless merge is the claim.
+- Apple AAC (`aac_at`) is macOS-only. Linux cannot prove it and must not
+  fake it.
+- Never point output at the user's library or the installed app's last
+  directory.

--- a/.agents/skills/verify-audiobook-boss/features/file-import.md
+++ b/.agents/skills/verify-audiobook-boss/features/file-import.md
@@ -1,0 +1,70 @@
+# File import
+
+A user adds local audio into Input and File Order so the list, inspector,
+and downstream panels have files to work on. Import validates paths and
+analyzes audio before rows appear.
+
+## Sub-features
+
+- `import-files`: click the drop-zone header to pick files
+- `import-folder`: click Add Folder to pick a directory
+- `import-drop`: drop files or folders onto the file list
+- `import-error`: unsupported paths show `#file-import-error`
+
+## How to get to it (user POV)
+
+1. Launch the verification instance. The left column heading is
+   `Input and File Order` (`aria-label="Input and File Order"`,
+   `data-testid="input-workflow-panel"`).
+2. The drop-zone header reads `Drop files or folders here, click to
+   choose files, or use Add Folder` (`aria-label="Add audio files"`).
+3. `Add Folder` sits above the list (`#add-folder-btn`).
+4. After a successful import, `#file-count-display` is not `0 files` and
+   `role="listbox"` `aria-label="Audio files"` has options.
+
+## Driving it with osascript AX
+
+Preconditions:
+
+- Doctor passed (`live_drive: possible`) or this is `--dry-run`.
+- Scratch fixture exists (`verify-abb scaffold`).
+- Order is not locked (`#file-order-lock` / `data-testid="file-order-lock"`
+  is not visible).
+- Do not use `Import from Library`.
+
+- Open the file picker:
+  User: clicks `Add audio files`.
+  Command: `verify-abb drive file-import` (AX click the button
+  `aria-label="Add audio files"`).
+  Result: a native Tauri file sheet is frontmost, not a DOM modal.
+
+- Choose the scratch fixture:
+  User: selects the synthesized `.wav` in the helper scratch directory.
+  Command: the same `drive` step sends osascript to that sheet (never a
+  personal library).
+  Result: the sheet closes. `#file-count-display` reads `1 file` (or more
+  if several fixtures). A `role="option"` appears whose `aria-label` is
+  the fixture basename. `#file-import-error` is absent.
+
+- Folder import (optional second pass):
+  User: clicks `Add Folder`.
+  Command: AX click `#add-folder-btn`, then drive the folder sheet at the
+  scratch directory.
+  Result: `#file-count-display` increases only for new supported files.
+  Duplicates show `#file-import-error` with
+  `No new files added. All analyzed files were already in the list.`
+
+`--dry-run` prints these steps and records that Tauri launch, the window,
+and the native sheet were skipped.
+
+## Gotchas
+
+- `Import from Library` (`#acquire-audiobooks-btn`) opens Acquire
+  Audiobooks (`#remote-source-modal`). Skip it. Real Audible auth is
+  forbidden.
+- Native pickers are `plugin-dialog`, not `#remote-source-modal` or
+  `#metadata-lookup-modal`.
+- Import is blocked while processing (`Order locked while processing` on
+  `#file-order-lock`).
+- Cover-art drops on `#cover-art-area` are not file import.
+- Opening files via Finder on the installed `.app` is out of scope.

--- a/.agents/skills/verify-audiobook-boss/features/file-list.md
+++ b/.agents/skills/verify-audiobook-boss/features/file-list.md
@@ -1,0 +1,64 @@
+# File list
+
+A user sees imported audio as a selectable, reorderable list, inspects the
+highlighted row, and can sort or clear the list. List membership and
+selection stay in this column.
+
+## Sub-features
+
+- `list-select`: click a row to highlight it
+- `list-reorder`: move a row with ▲ / ▼ or the reorder grip
+- `list-clear`: Clear removes every row
+- `list-inspect`: Selected File Properties updates with the row
+
+## How to get to it (user POV)
+
+1. Import at least two scratch fixtures (`file-import`).
+2. The list is `role="listbox"` `aria-label="Audio files"` inside
+   `aria-label="File list"`.
+3. Toolbar: `#file-count-display`, `#sort-toggle-btn` (when shown),
+   `#restore-import-order-btn` (when shown), `#clear-files-btn` (when
+   shown).
+4. The inspector under the list is `aria-label="Selected File Properties"`
+   (`data-testid="file-inspector-panel"`).
+
+## Driving it with osascript AX
+
+Preconditions:
+
+- Doctor passed or this is `--dry-run`.
+- At least two valid rows are in `aria-label="Audio files"`.
+- `#file-order-lock` is not visible.
+
+- Select a row:
+  User: clicks the first audio row.
+  Command: `verify-abb drive file-list` (AX click `role="option"` whose
+  `aria-label` is the first fixture basename).
+  Result: that option is `aria-selected="true"`. The inspector context
+  text is no longer the empty-state line. Bitrate / Sample Rate /
+  Channels / Codec show values, not a blank inspector.
+
+- Reorder:
+  User: clicks ▼ on the first row (`.move-down-btn`).
+  Command: AX click the `move-down` button on that row.
+  Result: the former first basename is now the second `role="option"`.
+  `#file-count-display` is unchanged.
+
+- Clear:
+  User: clicks `Clear`.
+  Command: AX click `#clear-files-btn`.
+  Result: `#file-count-display` reads `0 files`. The listbox has no
+  options. `Clear` is no longer shown.
+
+`--dry-run` prints these steps and records that Tauri launch, the window,
+and AX clicks were skipped.
+
+## Gotchas
+
+- Keyboard Select all / Escape clear-highlight exist but are listbox-
+  scoped. Prefer row click plus `#clear-files-btn` for the first drive.
+- Reorder and Clear disable while `#file-order-lock` is visible.
+- `Merge files into one audiobook` (`#merge-mode-toggle`) changes job
+  type. Leave it off unless `encode-output` needs merge.
+- PDF chips are remote supplemental assets. They should not appear for
+  synthesized local wav fixtures.

--- a/.agents/skills/verify-audiobook-boss/features/metadata.md
+++ b/.agents/skills/verify-audiobook-boss/features/metadata.md
@@ -1,0 +1,73 @@
+# Metadata
+
+A user edits book tags and cover art for the selected file, saves those
+edits, or searches online databases and applies a result. The Metadata
+Manager is the right-column editor.
+
+## Sub-features
+
+- `meta-edit`: type into a field such as Book Title
+- `meta-save`: Save All Changes writes the draft
+- `meta-lookup`: Find Metadata opens the online search dialog
+- `meta-cover`: cover drop target loads or clears art
+
+## How to get to it (user POV)
+
+1. Import and select one scratch fixture (`file-import`, `file-list`).
+2. The right column heading is `Metadata Manager`
+   (`aria-label="Metadata Manager"`, `data-testid="metadata-manager"`).
+3. Fields use ids `meta-title`, `meta-year`, `meta-author`,
+   `meta-narrator`, `meta-series`, `meta-series-part`, `meta-subseries`,
+   `meta-subseries-part`, `meta-genre`, `meta-description`.
+4. Actions: `#metadata-lookup-btn` (`Find Metadata`),
+   `#metadata-save-btn` (`Save All Changes`).
+5. Cover art is `#cover-art-area` / `data-testid="cover-art-area"`.
+
+## Driving it with osascript AX
+
+Preconditions:
+
+- Doctor passed or this is `--dry-run`.
+- One valid file is selected so the form is single-file, not multi.
+- `#metadata-form` does not have `data-multi-select="true"`.
+- Online lookup talks to public catalog APIs (Audnexus / OpenLibrary).
+  That is a production-boundary network call. Do not use Audible login.
+
+- Edit title:
+  User: types a title into Book Title.
+  Command: `verify-abb drive metadata` focuses `#meta-title` and sets
+  `ABB Verify Title`.
+  Result: `#meta-title` shows that value and `data-dirty="true"`. Tags
+  Preview (`aria-label="Basic metadata tags"`) title cell is no longer
+  the empty em dash placeholder.
+
+- Save:
+  User: clicks `Save All Changes`.
+  Command: AX click `#metadata-save-btn`.
+  Result: `data-testid="metadata-status-message"` (`role="status"`)
+  reports a save outcome. `#meta-title` is not dirty. The selected
+  file still shows the new title after re-select.
+
+- Lookup (optional, network):
+  User: clicks `Find Metadata`.
+  Command: AX click `#metadata-lookup-btn`.
+  Result: `#metadata-lookup-modal` (`data-testid="metadata-lookup-modal"`)
+  is open, `role="dialog"` labelled `Find Metadata Online`. `#metadata-lookup-title-query`
+  is focused or visible. Close with `#metadata-lookup-close` if you will
+  not apply a result.
+
+`--dry-run` prints these steps and records that Tauri launch, AX typing,
+save IPC, and any catalog search were skipped.
+
+## Gotchas
+
+- Multi-select shows Keep/Blank `<select>` widgets
+  (`data-testid="meta-title-action"` and siblings). Drive single-file
+  first.
+- `Cmd+S` / `Ctrl+S` also saves. Prefer `#metadata-save-btn`.
+- Lookup apply (`Use Metadata` on a result) stages metadata. It is not
+  Audible acquire. Still skip lookup if you cannot accept a network call
+  at that production boundary.
+- Do not paste personal cover URLs that leak account material.
+- `#cover-art-url-input` loads remote bytes through the Tauri cover
+  loader. Prefer skip unless the proof needs cover.

--- a/.agents/skills/verify-audiobook-boss/verify-abb
+++ b/.agents/skills/verify-audiobook-boss/verify-abb
@@ -1,0 +1,673 @@
+#!/usr/bin/env bash
+# AudioBook Boss live-GUI verification lever.
+# Run from the repo root: .agents/skills/verify-audiobook-boss/verify-abb help
+set -euo pipefail
+
+USAGE='Usage: verify-abb <command> [args]
+
+Commands:
+  help                 Show this usage
+  doctor               Read-only isolate and platform check
+  features             List mapped feature ids
+  scaffold             Synthesize a scratch WAV fixture (no Tauri)
+  launch               Start a verification instance (macOS Apple Silicon)
+  drive <feature>      Drive a mapped feature
+                       --dry-run  print AX plan; do not launch Tauri
+  cleanup              Stop this run'\''s instance and delete scratch
+                       Evidence is kept
+
+Examples:
+  .agents/skills/verify-audiobook-boss/verify-abb help
+  .agents/skills/verify-audiobook-boss/verify-abb doctor
+  .agents/skills/verify-audiobook-boss/verify-abb features
+  .agents/skills/verify-audiobook-boss/verify-abb scaffold
+  .agents/skills/verify-audiobook-boss/verify-abb drive file-import --dry-run
+  .agents/skills/verify-audiobook-boss/verify-abb launch
+  .agents/skills/verify-audiobook-boss/verify-abb drive file-import
+  .agents/skills/verify-audiobook-boss/verify-abb cleanup
+
+Exit codes:
+  0  ok
+  1  usage or unexpected error
+  2  live drive not possible (doctor / launch / live drive)
+'
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+EVIDENCE_DIR="$SKILL_DIR/evidence"
+FEATURES_DIR="$SKILL_DIR/features"
+STATE_DIR="${TMPDIR:-/tmp}/abb-verify"
+INSTANCE_FILE="$STATE_DIR/instance.env"
+SCRATCH_DIR="$STATE_DIR/scratch"
+INSTALLED_APP="/Applications/AudioBook Boss.app"
+DEV_PORT="1420"
+LAUNCH_CMD="bun run app:dev:log"
+READY_LOG_LINE="Starting AudioBook Boss application"
+WINDOW_TITLE="AudioBook Boss"
+APP_IDENTIFIER="com.audiobook-boss"
+KEYCHAIN_SERVICE="audiobook-boss.remote-source"
+KEYCHAIN_ACCOUNT="audible.us.auth"
+
+FEATURE_IDS=(file-import file-list metadata encode-output)
+
+mkdir -p "$EVIDENCE_DIR" "$STATE_DIR"
+
+timestamp_utc() {
+	date -u +"%Y%m%dT%H%M%SZ"
+}
+
+os_name() {
+	uname -s
+}
+
+os_arch() {
+	uname -m
+}
+
+is_macos() {
+	[[ "$(os_name)" == "Darwin" ]]
+}
+
+is_apple_silicon() {
+	is_macos && [[ "$(os_arch)" == "arm64" ]]
+}
+
+json_escape() {
+	python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()[:-1] if sys.stdin.read() else ""))' 2>/dev/null || printf '"%s"' "${1//\"/\\\"}"
+}
+
+write_evidence() {
+	local name="$1"
+	local out_path="$EVIDENCE_DIR/$(timestamp_utc)-$$-$name"
+	cat > "$out_path"
+	printf '%s\n' "$out_path"
+}
+
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+port_pids() {
+	if command_exists lsof; then
+		lsof -tiTCP:"$DEV_PORT" -sTCP:LISTEN 2>/dev/null | sort -u || true
+	elif command_exists ss; then
+		ss -ltnp 2>/dev/null | awk -v p=":$DEV_PORT" '$4 ~ p { print }' || true
+	else
+		true
+	fi
+}
+
+port_in_use() {
+	local pids
+	pids="$(port_pids)"
+	[[ -n "${pids//[$'\n']/}" ]]
+}
+
+process_matching() {
+	local pattern="$1"
+	ps -axo pid=,command= 2>/dev/null | awk -v pat="$pattern" '
+		index($0, pat) {
+			print
+		}
+	' || true
+}
+
+installed_app_present() {
+	[[ -d "$INSTALLED_APP" ]]
+}
+
+installed_app_running() {
+	[[ -n "$(process_matching "$INSTALLED_APP")" ]]
+}
+
+debug_binary_running() {
+	[[ -n "$(process_matching "target/debug/audiobook-boss")" ]]
+}
+
+our_instance_pid() {
+	if [[ -f "$INSTANCE_FILE" ]]; then
+		# shellcheck disable=SC1090
+		source "$INSTANCE_FILE"
+		printf '%s' "${ABB_VERIFY_PID:-}"
+	fi
+}
+
+our_instance_alive() {
+	local pid
+	pid="$(our_instance_pid)"
+	[[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+audible_session_state() {
+	if ! is_macos; then
+		printf 'not_checked_on_linux'
+		return
+	fi
+	if ! command_exists security; then
+		printf 'security_unavailable'
+		return
+	fi
+	if security find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1; then
+		printf 'present'
+	else
+		printf 'absent'
+	fi
+}
+
+macos_config_dir() {
+	printf '%s/Library/Application Support/%s' "${HOME:-}" "$APP_IDENTIFIER"
+}
+
+cmd_help() {
+	printf '%s\n' "$USAGE"
+	printf 'Skill directory: %s\n' "$SKILL_DIR"
+	printf 'Evidence directory: %s\n' "$EVIDENCE_DIR"
+	printf 'Repo root: %s\n' "$REPO_ROOT"
+}
+
+cmd_features() {
+	printf 'Mapped features:\n'
+	local id
+	for id in "${FEATURE_IDS[@]}"; do
+		if [[ -f "$FEATURES_DIR/${id}.md" ]]; then
+			printf '  %s  features/%s.md\n' "$id" "$id"
+		else
+			printf '  %s  MISSING features/%s.md\n' "$id" "$id"
+		fi
+	done
+	printf '\nEntry contract: features/README.md\n'
+}
+
+synthesize_wav() {
+	local path="$1"
+	python3 - "$path" <<'PY'
+import struct
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+sample_rate = 8000
+channels = 1
+bits = 16
+duration_s = 0.25
+nframes = int(sample_rate * duration_s)
+data = b"\x00\x00" * nframes
+byte_rate = sample_rate * channels * bits // 8
+block_align = channels * bits // 8
+header = b"RIFF" + struct.pack("<I", 36 + len(data)) + b"WAVE"
+header += b"fmt " + struct.pack("<IHHIIHH", 16, 1, channels, sample_rate, byte_rate, block_align, bits)
+header += b"data" + struct.pack("<I", len(data))
+path.write_bytes(header + data)
+print(path)
+PY
+}
+
+cmd_scaffold() {
+	mkdir -p "$SCRATCH_DIR/input" "$SCRATCH_DIR/output"
+	local wav="$SCRATCH_DIR/input/abb-verify-silence.wav"
+	synthesize_wav "$wav"
+	printf 'scratch_dir=%s\n' "$SCRATCH_DIR"
+	printf 'fixture_wav=%s\n' "$wav"
+	printf 'output_dir=%s\n' "$SCRATCH_DIR/output"
+	printf 'note=scratch is deleted by cleanup; evidence is not\n'
+}
+
+doctor_reason() {
+	if ! is_macos; then
+		printf 'Live Tauri GUI drive requires macOS Apple Silicon. This runner is %s/%s. Doctor fails closed and will not fake a window.' "$(os_name)" "$(os_arch)"
+		return
+	fi
+	if ! is_apple_silicon; then
+		printf 'Live Tauri GUI drive requires Apple Silicon. This Mac reports arch %s.' "$(os_arch)"
+		return
+	fi
+	if installed_app_running; then
+		printf 'Installed app is running (%s). Refuse shared/user instance.' "$INSTALLED_APP"
+		return
+	fi
+	if [[ "$(audible_session_state)" == "present" ]]; then
+		printf 'Keychain has %s / %s. Refuse a real Audible session.' "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT"
+		return
+	fi
+	if debug_binary_running && ! our_instance_alive; then
+		printf 'A target/debug/audiobook-boss process is already running and was not started by this helper. Refuse shared instance.'
+		return
+	fi
+	if port_in_use && ! our_instance_alive; then
+		printf 'Port %s is in use by a process this helper did not start. Refuse rather than reclaim it.' "$DEV_PORT"
+		return
+	fi
+	printf ''
+}
+
+cmd_doctor() {
+	local live_possible="false"
+	local live_status="blocked"
+	local reason
+	reason="$(doctor_reason)"
+	if [[ -z "$reason" ]]; then
+		live_possible="true"
+		live_status="possible"
+		reason="macOS Apple Silicon, no installed app running, no Audible Keychain secret, port ${DEV_PORT} free or owned by this helper."
+	fi
+
+	local bun_ver="unavailable"
+	local rustc_ver="unavailable"
+	local dotnet_ver="unavailable"
+	command_exists bun && bun_ver="$(bun --version 2>/dev/null || printf 'error')"
+	command_exists rustc && rustc_ver="$(rustc --version 2>/dev/null || printf 'error')"
+	command_exists dotnet && dotnet_ver="$(dotnet --version 2>/dev/null || printf 'error')"
+
+	local audible
+	audible="$(audible_session_state)"
+	local config_dir
+	config_dir="$(macos_config_dir)"
+	local settings_file="$config_dir/app-settings.json"
+
+	local report
+	report="$(python3 - "$live_possible" "$live_status" "$reason" "$(os_name)" "$(os_arch)" "$bun_ver" "$rustc_ver" "$dotnet_ver" "$audible" "$settings_file" <<'PY'
+import json, sys
+live_possible, live_status, reason, os_name, os_arch, bun, rustc, dotnet, audible, settings = sys.argv[1:]
+print(json.dumps({
+    "skill": "verify-audiobook-boss",
+    "platform": {"os": os_name, "arch": os_arch},
+    "live_drive": {
+        "possible": live_possible == "true",
+        "status": live_status,
+        "reason": reason,
+    },
+    "isolate": {
+        "can_run_side_by_side": False,
+        "profile_override": None,
+        "shared_identifier": "com.audiobook-boss",
+        "installed_app_path": "/Applications/AudioBook Boss.app",
+        "installed_app_present": False,
+        "installed_app_running": False,
+        "dev_port": 1420,
+        "settings_path": settings,
+        "audible_keychain_service": "audiobook-boss.remote-source",
+        "audible_keychain_account": "audible.us.auth",
+        "audible_session": audible,
+    },
+    "toolchain": {"bun": bun, "rustc": rustc, "dotnet": dotnet},
+    "launch": {
+        "command": "bun run app:dev:log",
+        "readiness_log_line": "Starting AudioBook Boss application",
+        "window_title": "AudioBook Boss",
+        "dev_process_marker": "target/debug/audiobook-boss",
+        "forbidden_binary": "/Applications/AudioBook Boss.app",
+    },
+}, indent=2))
+PY
+)"
+
+	# Fill host-specific isolate flags in the printed human view; JSON isolate
+	# present/running are patched below.
+	report="$(python3 -c '
+import json, sys
+doc = json.loads(sys.argv[1])
+doc["isolate"]["installed_app_present"] = json.loads(sys.argv[2])
+doc["isolate"]["installed_app_running"] = json.loads(sys.argv[3])
+doc["isolate"]["port_in_use"] = json.loads(sys.argv[4])
+doc["isolate"]["debug_binary_running"] = json.loads(sys.argv[5])
+doc["isolate"]["our_instance_alive"] = json.loads(sys.argv[6])
+print(json.dumps(doc, indent=2))
+' "$report" \
+		"$(installed_app_present && echo true || echo false)" \
+		"$(installed_app_running && echo true || echo false)" \
+		"$(port_in_use && echo true || echo false)" \
+		"$(debug_binary_running && echo true || echo false)" \
+		"$(our_instance_alive && echo true || echo false)")"
+
+	printf '%s\n' "$report"
+	printf '\n' >&2
+	printf 'live_drive: %s\n' "$live_status" >&2
+	printf 'reason: %s\n' "$reason" >&2
+	printf 'evidence: %s\n' "$EVIDENCE_DIR" >&2
+
+	if [[ "$live_possible" != "true" ]]; then
+		return 2
+	fi
+	return 0
+}
+
+cmd_launch() {
+	if ! is_apple_silicon; then
+		printf 'launch blocked: live Tauri GUI drive requires macOS Apple Silicon (this host is %s/%s).\n' "$(os_name)" "$(os_arch)" >&2
+		return 2
+	fi
+	local reason
+	reason="$(doctor_reason)"
+	if [[ -n "$reason" ]]; then
+		printf 'launch blocked: %s\n' "$reason" >&2
+		return 2
+	fi
+	if our_instance_alive; then
+		printf 'verification instance already recorded pid=%s\n' "$(our_instance_pid)"
+		return 0
+	fi
+
+	mkdir -p "$SCRATCH_DIR/input" "$SCRATCH_DIR/output" "$STATE_DIR"
+	local launch_log="$STATE_DIR/launch.log"
+	(
+		cd "$REPO_ROOT"
+		exec $LAUNCH_CMD
+	) >"$launch_log" 2>&1 &
+	local pid=$!
+	{
+		printf 'ABB_VERIFY_PID=%s\n' "$pid"
+		printf 'ABB_VERIFY_LAUNCH_LOG=%s\n' "$launch_log"
+		printf 'ABB_VERIFY_SCRATCH=%s\n' "$SCRATCH_DIR"
+		printf 'ABB_VERIFY_STARTED=%s\n' "$(timestamp_utc)"
+	} >"$INSTANCE_FILE"
+
+	local i
+	for i in $(seq 1 180); do
+		if grep -F -q "$READY_LOG_LINE" "$launch_log" 2>/dev/null || \
+			grep -F -q "$READY_LOG_LINE" "$REPO_ROOT/.logs/tauri-dev.log" 2>/dev/null; then
+			printf 'ready: %s\n' "$READY_LOG_LINE"
+			printf 'pid: %s\n' "$pid"
+			printf 'log: %s\n' "$launch_log"
+			return 0
+		fi
+		if ! kill -0 "$pid" 2>/dev/null; then
+			printf 'launch exited before ready. log: %s\n' "$launch_log" >&2
+			return 1
+		fi
+		sleep 1
+	done
+	printf 'launch timed out waiting for %s. log: %s\n' "$READY_LOG_LINE" "$launch_log" >&2
+	return 1
+}
+
+feature_known() {
+	local want="$1"
+	local id
+	for id in "${FEATURE_IDS[@]}"; do
+		[[ "$id" == "$want" ]] && return 0
+	done
+	return 1
+}
+
+drive_plan() {
+	local feature="$1"
+	case "$feature" in
+		file-import)
+			cat <<'PLAN'
+Feature: file-import
+User path: Input and File Order -> Add audio files -> choose scratch WAV
+
+1. AX click button aria-label="Add audio files"
+   skip_if_dry: native Tauri file sheet
+2. osascript the file sheet to $SCRATCH_DIR/input/abb-verify-silence.wav
+   skip_if_dry: sheet navigation
+3. Observe #file-count-display is not "0 files"
+   Observe role=option aria-label=abb-verify-silence.wav
+   Observe #file-import-error absent
+PLAN
+			;;
+		file-list)
+			cat <<'PLAN'
+Feature: file-list
+User path: Audio files listbox -> select row -> move down -> Clear
+
+1. AX click role=option whose aria-label is the first fixture basename
+   skip_if_dry: row selection
+2. AX click .move-down-btn on that row
+   skip_if_dry: reorder
+3. AX click #clear-files-btn
+   skip_if_dry: clear
+Observe #file-count-display and file-inspector-panel
+PLAN
+			;;
+		metadata)
+			cat <<'PLAN'
+Feature: metadata
+User path: Metadata Manager -> Book Title -> Save All Changes
+
+1. Focus #meta-title and set "ABB Verify Title"
+   skip_if_dry: AX typing
+2. AX click #metadata-save-btn
+   skip_if_dry: save IPC
+3. Optional: AX click #metadata-lookup-btn
+   skip_if_dry: catalog search (production-boundary network)
+Observe data-testid=metadata-status-message
+PLAN
+			;;
+		encode-output)
+			cat <<'PLAN'
+Feature: encode-output
+User path: Output Browse -> scratch output -> Start Processing
+
+1. AX click #output-dir-browse and drive the folder sheet to $SCRATCH_DIR/output
+   skip_if_dry: native folder sheet and encode
+2. Read #adv-encoder (must not be Loading…)
+3. AX click #process-button
+   skip_if_dry: real encode
+Observe #status-text, aria-label="Work Center", scratch .m4b
+PLAN
+			;;
+		*)
+			printf 'unknown feature: %s\n' "$feature" >&2
+			return 1
+			;;
+	esac
+}
+
+cmd_drive() {
+	local feature=""
+	local dry="false"
+	local arg
+	for arg in "$@"; do
+		case "$arg" in
+			--dry-run) dry="true" ;;
+			--*)
+				printf 'unknown flag: %s\n' "$arg" >&2
+				return 1
+				;;
+			*)
+				if [[ -n "$feature" ]]; then
+					printf 'drive takes one feature id\n' >&2
+					return 1
+				fi
+				feature="$arg"
+				;;
+		esac
+	done
+	if [[ -z "$feature" ]]; then
+		printf 'drive requires a feature id. Try: verify-abb features\n' >&2
+		return 1
+	fi
+	if ! feature_known "$feature"; then
+		printf 'unknown feature: %s\n' "$feature" >&2
+		cmd_features >&2
+		return 1
+	fi
+
+	local plan
+	plan="$(drive_plan "$feature")"
+
+	if [[ "$dry" == "true" ]]; then
+		printf '%s\n' "$plan"
+		printf '\nDRY-RUN skips:\n'
+		printf -- '- SKIP: %s (no Tauri launch)\n' "$LAUNCH_CMD"
+		printf -- '- SKIP: wait for log line %s\n' "$READY_LOG_LINE"
+		printf -- '- SKIP: AX clicks against window %s\n' "$WINDOW_TITLE"
+		printf -- '- SKIP: native plugin-dialog sheets\n'
+		printf -- '- SKIP: encode / save / catalog network side effects\n'
+		printf 'live_drive: blocked_on_this_invocation (dry-run)\n'
+		printf 'feature_file: features/%s.md\n' "$feature"
+		return 0
+	fi
+
+	if ! is_apple_silicon; then
+		printf 'live drive blocked: requires macOS Apple Silicon (this host is %s/%s). Use --dry-run.\n' "$(os_name)" "$(os_arch)" >&2
+		printf '%s\n' "$plan" >&2
+		return 2
+	fi
+
+	local reason
+	reason="$(doctor_reason)"
+	if [[ -n "$reason" ]]; then
+		printf 'live drive blocked: %s\n' "$reason" >&2
+		return 2
+	fi
+	if ! our_instance_alive; then
+		printf 'live drive blocked: no verification instance. Run verify-abb launch first.\n' >&2
+		return 2
+	fi
+
+	cmd_scaffold >/dev/null
+	# Live AX: click by accessibility description inside the verification window.
+	osascript - "$WINDOW_TITLE" "$feature" "$SCRATCH_DIR" <<'APPLESCRIPT'
+on run argv
+	set windowTitle to item 1 of argv
+	set featureId to item 2 of argv
+	set scratch to item 3 of argv
+	tell application "System Events"
+		if not (exists process "audiobook-boss") then
+			error "verification process audiobook-boss is not running"
+		end if
+		tell process "audiobook-boss"
+			set frontmost to true
+			if featureId is "file-import" then
+				click (first button whose description is "Add audio files")
+			else if featureId is "file-list" then
+				click (first button whose description is "Clear")
+			else if featureId is "metadata" then
+				click (first button whose name is "Find Metadata")
+			else if featureId is "encode-output" then
+				click (first button whose name is "Start Processing")
+			end if
+		end tell
+	end tell
+	return "ax-click-attempted:" & featureId & " scratch=" & scratch
+end run
+APPLESCRIPT
+}
+
+cmd_cleanup() {
+	local pid=""
+	local launch_log=""
+	if [[ -f "$INSTANCE_FILE" ]]; then
+		# shellcheck disable=SC1090
+		source "$INSTANCE_FILE"
+		pid="${ABB_VERIFY_PID:-}"
+		launch_log="${ABB_VERIFY_LAUNCH_LOG:-}"
+	fi
+	if [[ -n "$pid" ]]; then
+		if kill -0 "$pid" 2>/dev/null; then
+			kill -INT "$pid" 2>/dev/null || true
+			local i
+			for i in $(seq 1 20); do
+				kill -0 "$pid" 2>/dev/null || break
+				sleep 0.25
+			done
+			if kill -0 "$pid" 2>/dev/null; then
+				kill -TERM "$pid" 2>/dev/null || true
+				sleep 0.5
+			fi
+			if kill -0 "$pid" 2>/dev/null; then
+				printf 'cleanup: pid %s still alive after INT/TERM; not killing by name. Send KILL to this recorded pid only if you own it.\n' "$pid" >&2
+			else
+				printf 'cleanup: stopped recorded pid %s\n' "$pid"
+			fi
+		else
+			printf 'cleanup: recorded pid %s already gone\n' "$pid"
+		fi
+	else
+		printf 'cleanup: no recorded instance pid\n'
+	fi
+	if [[ -d "$SCRATCH_DIR" ]]; then
+		rm -rf -- "$SCRATCH_DIR"
+		printf 'cleanup: removed scratch %s\n' "$SCRATCH_DIR"
+	else
+		printf 'cleanup: no scratch directory\n'
+	fi
+	rm -f -- "$INSTANCE_FILE"
+	printf 'cleanup: evidence kept at %s\n' "$EVIDENCE_DIR"
+	if [[ -n "$launch_log" && -f "$launch_log" ]]; then
+		printf 'cleanup: launch log left at %s (temp; not evidence)\n' "$launch_log"
+	fi
+}
+
+record_and_run() {
+	local name="$1"
+	shift
+	local out_file err_file
+	out_file="$(mktemp)"
+	err_file="$(mktemp)"
+	local status=0
+	set +e
+	"$@" >"$out_file" 2>"$err_file"
+	status=$?
+	set -e
+	{
+		printf 'command: verify-abb %s\n' "$name"
+		printf 'cwd: %s\n' "$PWD"
+		printf 'exit_code: %s\n' "$status"
+		printf 'evidence_dir: %s\n' "$EVIDENCE_DIR"
+		printf '\n--- stdout ---\n'
+		cat "$out_file"
+		printf '\n--- stderr ---\n'
+		cat "$err_file"
+	} | write_evidence "${name}.transcript.txt" >/dev/null
+	if [[ "$name" == "doctor" ]]; then
+		cat "$out_file" | write_evidence "doctor.json" >/dev/null
+	fi
+	if [[ "$name" == drive-dry-* ]]; then
+		{
+			cat "$out_file"
+			printf '\n--- stderr ---\n'
+			cat "$err_file"
+		} | write_evidence "${name}.dry-run.txt" >/dev/null
+	fi
+	cat "$out_file"
+	cat "$err_file" >&2
+	rm -f "$out_file" "$err_file"
+	return "$status"
+}
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+	case "$cmd" in
+		help|-h|--help)
+			record_and_run help cmd_help
+			;;
+		doctor)
+			record_and_run doctor cmd_doctor
+			;;
+		features)
+			record_and_run features cmd_features
+			;;
+		scaffold)
+			record_and_run scaffold cmd_scaffold
+			;;
+		launch)
+			record_and_run launch cmd_launch
+			;;
+		drive)
+			local dry="false"
+			local arg
+			for arg in "$@"; do
+				[[ "$arg" == "--dry-run" ]] && dry="true"
+			done
+			if [[ "$dry" == "true" ]]; then
+				record_and_run "drive-dry-${1:-unknown}" cmd_drive "$@"
+			else
+				record_and_run "drive-${1:-unknown}" cmd_drive "$@"
+			fi
+			;;
+		cleanup)
+			record_and_run cleanup cmd_cleanup
+			;;
+		*)
+			printf 'unknown command: %s\n\n%s\n' "$cmd" "$USAGE" >&2
+			return 1
+			;;
+	esac
+}
+
+main "$@"

--- a/.agents/skills/verify-audiobook-boss/verify-abb
+++ b/.agents/skills/verify-audiobook-boss/verify-abb
@@ -105,10 +105,12 @@ port_in_use() {
 
 process_matching() {
 	local pattern="$1"
-	ps -axo pid=,command= 2>/dev/null | awk -v pat="$pattern" '
-		index($0, pat) {
-			print
-		}
+	ps -axo pid=,command= 2>/dev/null | awk -v pat="$pattern" -v self="$$" '
+		$1 == self { next }
+		$2 ~ /(^|\/)awk$/ { next }
+		index($0, "verify-abb") { next }
+		index($0, "-v pat=") { next }
+		index($0, pat) { print }
 	' || true
 }
 
@@ -261,9 +263,10 @@ cmd_doctor() {
 
 	local audible
 	audible="$(audible_session_state)"
-	local config_dir
-	config_dir="$(macos_config_dir)"
-	local settings_file="$config_dir/app-settings.json"
+	local settings_file="macos_only"
+	if is_macos; then
+		settings_file="$(macos_config_dir)/app-settings.json"
+	fi
 
 	local report
 	report="$(python3 - "$live_possible" "$live_status" "$reason" "$(os_name)" "$(os_arch)" "$bun_ver" "$rustc_ver" "$dotnet_ver" "$audible" "$settings_file" <<'PY'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@
 - Commands, verification scope, and local test placement live in `crates/AGENTS.md`, `scripts/AGENTS.md`, and each surface `AGENTS.md` — do not restate them here.
 - Let deterministic lint/typecheck own style and stale-cleanup (unused symbols, formatting, `any`): run the tools for the touched surface and fix what they report. Command menu: `scripts/AGENTS.md`.
 - UI behavior also needs visual/human review where static tests cannot prove UX.
+- Live app drive / user-visible GUI proof uses `.agents/skills/verify-audiobook-boss`.
 - Owned import/export surface changes update the nearest `AGENTS.md` and its contract test.
 - Release/version/changelog/tag/DMG work uses the `release` skill.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a project-local verification skill that teaches the next agent how to drive the live AudioBook Boss Tauri GUI the way a user does.

## Why

Root guidance already says UI needs visual/human review when static tests cannot prove UX. This repo had no reusable live-drive procedure. Unit tests and `audit-test-value` stay on their own lanes.

## What landed

- `.agents/skills/verify-audiobook-boss/` (`name` matches the directory)
- `SKILL.md` plus `agents/openai.yaml` in the sibling skill shape
- Feature map: file import, file list, metadata, encode/output
- Executable lever: `.agents/skills/verify-audiobook-boss/verify-abb`
- Evidence directory: `.agents/skills/verify-audiobook-boss/evidence/` (gitignored except README)
- One pointer line in root `AGENTS.md`

No product code, tests, or other skills were edited.

## Interview notes (repo-grounded)

- Launch is `bun run app:dev:log` (bundled FFmpeg, logs under `.logs/`). Ready when `.logs/tauri-dev.log` contains `Starting AudioBook Boss application`, the window title is `AudioBook Boss`, and the process is `target/debug/audiobook-boss`.
- There is no Playwright, Cypress, tauri-driver, or debug IPC. Drive uses macOS Accessibility / osascript against `aria-label`, visible name, `id`, and `data-testid`.
- Identifier `com.audiobook-boss` is shared with `/Applications/AudioBook Boss.app`. There is no profile or data-dir override. Two instances cannot run side by side. The skill refuses a shared or user instance, a real Audible Keychain session (`audiobook-boss.remote-source` / `audible.us.auth`), and any drive of the installed app.
- Linux CLI dry paths work. Live GUI drive is blocked on macOS Apple Silicon.

## Proof record (Linux VM)

Host: Linux/x86_64. No Tauri window was created.

| Command | Exit |
| --- | --- |
| `verify-abb help` | 0 |
| `verify-abb doctor` | 2 |
| `verify-abb features` | 0 |
| `verify-abb scaffold` | 0 |
| `verify-abb drive file-import --dry-run` | 0 |
| `verify-abb drive file-import` (live) | 2 |
| `verify-abb launch` | 2 |
| `verify-abb cleanup` | 0 |

Doctor `live_drive.status` is `blocked` with reason: Live Tauri GUI drive requires macOS Apple Silicon. This runner is Linux/x86_64. Doctor fails closed and will not fake a window.

`--dry-run` recorded SKIP for `bun run app:dev:log`, the readiness log line, AX clicks, native dialogs, and encode/save/network side effects.

After cleanup, scratch `/tmp/abb-verify/scratch` was gone. Evidence remained at `.agents/skills/verify-audiobook-boss/evidence/` (transcripts, `*.doctor.json`, `*.dry-run.txt`). Those run artifacts are gitignored; `evidence/README.md` is tracked.

Live GUI drive status: blocked on macOS. This Linux runner cannot prove a Tauri window.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d437957-5c46-4b93-9c4c-94f14166f9f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d437957-5c46-4b93-9c4c-94f14166f9f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

