### PR TITLE
fix: enforce owner and preview boundaries

### DIFF
--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -28,9 +28,8 @@
 - Keep TS↔Rust command contracts aligned through generated bindings and drift checks.
 - Run final batch/merge processing through `submit_processing_operation`
   (WorkRuntime). `process_audiobook_files` is the direct-preview command;
-  `src-tauri/src/processing/AGENTS.md` owns the remaining ingress hole for
-  omitted `preview_seconds`. Use dedicated auxiliary commands for
-  non-processing tasks.
+  it rejects an omitted `preview_seconds`. Use dedicated auxiliary commands
+  for non-processing tasks.
 - Use Clippy signal for code-shape drift; treat `too_many_lines`/`too_many_arguments` as prompts to re-check cohesion. Run command and workspace lint posture: `scripts/AGENTS.md` and root `Cargo.toml` `[workspace.lints]`.
 - Consult `docs/unsafe-code-register.md` before changing production Rust `unsafe`
   and update it when unsafe scope, purpose, or blast radius changes.

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -183,10 +183,19 @@ pub async fn set_max_concurrent_jobs(
     Ok(registry.update_max_concurrent(desired).await?)
 }
 
-/// Processes audiobook files with configurable encoder settings.
+fn require_preview_seconds(preview_seconds: Option<f64>) -> Result<f64, AppError> {
+    preview_seconds.ok_or_else(|| {
+        AppError::InvalidInput(
+            "Direct processing requires a preview duration; submit final processing through WorkRuntime"
+                .to_string(),
+        )
+    })
+}
+
+/// Processes a direct preview with configurable encoder settings.
 ///
-/// Supports parallel batch processing via the JobRegistry.
-/// Multiple invocations can run concurrently up to the configured limit.
+/// Final batch and merge work must enter through WorkRuntime so it has durable
+/// operation identity, snapshots, and operation-scoped cancellation.
 #[tauri::command]
 #[specta::specta]
 pub async fn process_audiobook_files(
@@ -196,6 +205,8 @@ pub async fn process_audiobook_files(
     metadata: Option<HashMap<String, MetadataIntentPatch>>,
     preview_seconds: Option<f64>,
 ) -> CommandResult<ProcessCommandResult> {
+    let preview_seconds = require_preview_seconds(preview_seconds)?;
+
     if registry.is_global_cancelled() && registry.get_aggregate_status().await.total_jobs == 0 {
         registry.reset_global_cancel();
     }
@@ -216,7 +227,24 @@ pub async fn process_audiobook_files(
         workspace_root,
         payload,
         metadata,
-        preview_seconds,
+        Some(preview_seconds),
     )
     .await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_preview_seconds;
+    use crate::errors::AppError;
+
+    #[test]
+    fn direct_processing_requires_preview_duration() {
+        match require_preview_seconds(None) {
+            Err(AppError::InvalidInput(message)) => assert_eq!(
+                message,
+                "Direct processing requires a preview duration; submit final processing through WorkRuntime"
+            ),
+            result => panic!("expected invalid-input error, got {result:?}"),
+        }
+    }
 }

--- a/src-tauri/src/processing/AGENTS.md
+++ b/src-tauri/src/processing/AGENTS.md
@@ -31,10 +31,9 @@
 - `processing-progress` and `processing-queue` are emitted by
   `process_audiobook_files`. They have no operation-id discriminator. Accepted
   background work publishes WorkRuntime snapshot events instead; do not mix the
-  two event families. Product callers pass `preview_seconds` for that command.
-  Ingress still accepts `None` and then runs as direct final processing without
-  WorkRuntime identity, snapshots, or operation-scoped cancellation. Do not add
-  callers to that hole.
+  two event families. Direct-preview callers must pass `preview_seconds`; ingress
+  rejects `None`. Final processing enters through WorkRuntime for operation
+  identity, snapshots, and operation-scoped cancellation.
 - Wire-stage authority is the Rust `EventStage` enum in `progress/mod.rs` (specta-generated into
   `src/lib/generated/tauri.ts`); event payload is `ProgressEvent` (same file). Emitters:
   `progress/emitter.rs` (`emit_event`, `emit_cancelled`) and

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -10,12 +10,12 @@ dispatch intent; they do not keep parallel business state.
 
 - Treat each owner as a deep module. `index.ts` is its exact Public API Strip;
   import from the owner root and do not reach into private state, workflow,
-  cache, binder, or helper files. App Runtime composition currently imports
-  constructors and owner types from each `owner.ts`; cross-owner production
-  modules import sibling owner types the same way; runtime isolation tests
-  still import Remote Source `state.ts` to prove module-global reset. Inspect
-  those call sites, do not add another private-file caller, and do not copy
-  that pattern.
+  cache, binder, or helper files. App Runtime composition and cross-owner
+  production modules use those owner roots. Existing isolation tests and
+  compatibility harnesses may still reach private files to prove module-global
+  state that an owning lifetime migration has not yet removed; inspect those
+  call sites, do not add another private-file caller, and do not copy that
+  pattern.
 - Prefer a small `view()` / accessor surface plus semantic intents such as
   import, select, stage, review, submit, cancel, or persist. Do not expose raw
   setters, refresh/poke functions, or one accessor per implementation field.

--- a/src/app/metadataLookup/owner.ts
+++ b/src/app/metadataLookup/owner.ts
@@ -1,6 +1,6 @@
 import { createSignal, type Accessor } from 'solid-js';
-import type { InputOwner } from '../inputSession/owner';
-import type { MetadataOwner } from '../metadataSession/owner';
+import type { InputOwner } from '../inputSession';
+import type { MetadataOwner } from '../metadataSession';
 import { makeProductionLookupServices } from './services';
 import {
 	createMetadataLookupQueueState,

--- a/src/app/metadataLookup/services.ts
+++ b/src/app/metadataLookup/services.ts
@@ -1,7 +1,7 @@
 import type { FileListInfo } from '../../types/audio';
 import type { AudiobookMetadata } from '../../types/metadata';
-import type { InputOwner } from '../inputSession/owner';
-import type { MetadataOwner } from '../metadataSession/owner';
+import type { InputOwner } from '../inputSession';
+import type { MetadataOwner } from '../metadataSession';
 import { getMetadataForFile, stageMetadataIntentPatch } from '../metadataSession';
 import type { MetadataLookupQueueState, MetadataLookupState } from './state';
 import type { MetadataLookupWorkflowServices } from './workflow';

--- a/src/app/metadataSession/owner.ts
+++ b/src/app/metadataSession/owner.ts
@@ -7,8 +7,8 @@ import {
 	liveMetadataCapability,
 	type MetadataCapability,
 } from '../../lib/tauri/capabilities/metadata';
-import type { InputOwner } from '../inputSession/owner';
-import { getStatusView } from '../processing/view';
+import type { InputOwner } from '../inputSession';
+import { getStatusView } from '../processing';
 import {
 	cacheMetadataForFile,
 	clearMetadataSession,

--- a/src/app/processing/AGENTS.md
+++ b/src/app/processing/AGENTS.md
@@ -29,10 +29,9 @@
   Settings. Metadata staging uses the Metadata public strip. Do not read
   leftover file-list or job-control stores.
 - Preview execution is direct `process_audiobook_files` with `previewSeconds`.
-  It does not enter WorkRuntime. Do not call that command with omitted
-  `previewSeconds`; ingress still accepts it as a direct final run. Background
-  batch/merge submits through WorkRuntime; Status Panel is not a WorkRuntime
-  consumer.
+  It does not enter WorkRuntime, and command ingress rejects an omitted preview
+  duration. Background batch/merge submits through WorkRuntime; Status Panel
+  is not a WorkRuntime consumer.
 - `processing-progress` and `processing-queue` are direct-preview events with
   no operation-id discriminator. Do not consume them as background-operation
   state; Work Operations consumes WorkRuntime snapshots instead.

--- a/src/app/processing/bind.ts
+++ b/src/app/processing/bind.ts
@@ -1,7 +1,7 @@
 import type { EncodingRequestConfig } from '../../types/audio';
-import type { SettingsOwner } from '../appSettings/owner';
-import type { InputOwner } from '../inputSession/owner';
-import type { MetadataOwner } from '../metadataSession/owner';
+import type { SettingsOwner } from '../appSettings';
+import type { InputOwner } from '../inputSession';
+import type { MetadataOwner } from '../metadataSession';
 
 let boundInput: InputOwner | undefined;
 let boundMetadata: MetadataOwner | undefined;

--- a/src/app/processing/owner.ts
+++ b/src/app/processing/owner.ts
@@ -1,8 +1,8 @@
 import { createEffect, createSignal, type Accessor } from 'solid-js';
 import type { EncodingRequestConfig } from '../../types/audio';
-import type { SettingsOwner } from '../appSettings/owner';
-import type { InputOwner } from '../inputSession/owner';
-import type { MetadataOwner } from '../metadataSession/owner';
+import type { SettingsOwner } from '../appSettings';
+import type { InputOwner } from '../inputSession';
+import type { MetadataOwner } from '../metadataSession';
 import {
 	bindProcessingEncoding,
 	bindProcessingInput,

--- a/src/app/processing/workflow.ts
+++ b/src/app/processing/workflow.ts
@@ -214,7 +214,7 @@ function processingCommand(
 	request: {
 		payload: ProcessPayload;
 		metadataIntentByPath: MetadataIntentByPath | null;
-		previewSeconds?: number;
+		previewSeconds: number;
 	},
 ): AppEffect<ProcessCommandResult, ProcessingWorkflowError> {
 	return Effect.tryPromise({

--- a/src/app/remoteSource/owner.ts
+++ b/src/app/remoteSource/owner.ts
@@ -1,6 +1,6 @@
 import { createSignal, type Accessor } from 'solid-js';
 import type { AudioFile } from '../../types/audio';
-import type { InputOwner } from '../inputSession/owner';
+import type { InputOwner } from '../inputSession';
 import { clearRemoteSourceCoverPreviewCache } from './coverPreview';
 import { makeProductionRemoteSourceServices } from './services';
 import {

--- a/src/app/runtime/index.ts
+++ b/src/app/runtime/index.ts
@@ -1,12 +1,12 @@
 import { createMemo, createRoot, createSignal, onCleanup } from 'solid-js';
-import { createSettingsOwner } from '../appSettings/owner';
-import { createMetadataLookupOwner } from '../metadataLookup/owner';
-import { createMetadataOwner } from '../metadataSession/owner';
-import { createOutputOwner } from '../outputPlan/owner';
-import { createProcessingOwner } from '../processing/owner';
-import { createInputOwner } from '../inputSession/owner';
-import { createRemoteSourceOwner } from '../remoteSource/owner';
-import { createWorkOperationsOwner } from '../workOperations/owner';
+import { createSettingsOwner } from '../appSettings';
+import { createInputOwner } from '../inputSession';
+import { createMetadataLookupOwner } from '../metadataLookup';
+import { createMetadataOwner } from '../metadataSession';
+import { createOutputOwner } from '../outputPlan';
+import { createProcessingOwner } from '../processing';
+import { createRemoteSourceOwner } from '../remoteSource';
+import { createWorkOperationsOwner } from '../workOperations';
 import {
 	estimateKbpsFromRequest,
 	readEncodingRequestConfig,

--- a/src/app/runtime/types.ts
+++ b/src/app/runtime/types.ts
@@ -1,14 +1,14 @@
 import type { InputCapability } from '../../lib/tauri/capabilities/input';
 import type { MetadataCapability } from '../../lib/tauri/capabilities/metadata';
 import type { SettingsCapability } from '../../lib/tauri/capabilities/settings';
-import type { SettingsOwner } from '../appSettings/owner';
-import type { InputOwner } from '../inputSession/owner';
-import type { MetadataLookupOwner } from '../metadataLookup/owner';
-import type { MetadataOwner } from '../metadataSession/owner';
-import type { OutputPlanOwner } from '../outputPlan/owner';
-import type { ProcessingOwner } from '../processing/owner';
-import type { RemoteSourceOwner } from '../remoteSource/owner';
-import type { WorkOperationsOwner } from '../workOperations/owner';
+import type { SettingsOwner } from '../appSettings';
+import type { InputOwner } from '../inputSession';
+import type { MetadataLookupOwner } from '../metadataLookup';
+import type { MetadataOwner } from '../metadataSession';
+import type { OutputPlanOwner } from '../outputPlan';
+import type { ProcessingOwner } from '../processing';
+import type { RemoteSourceOwner } from '../remoteSource';
+import type { WorkOperationsOwner } from '../workOperations';
 
 export type RuntimeCapabilities = {
 	readonly input?: InputCapability;

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -103,10 +103,10 @@ export const commands = {
 	/**  Updates the maximum concurrent jobs setting (requires idle state) */
 	setMaxConcurrentJobs: (maxConcurrent: number | null) => typedError<number, AppErrorEnvelope>(__TAURI_INVOKE("set_max_concurrent_jobs", { maxConcurrent })),
 	/**
-	 *  Processes audiobook files with configurable encoder settings.
+	 *  Processes a direct preview with configurable encoder settings.
 	 *
-	 *  Supports parallel batch processing via the JobRegistry.
-	 *  Multiple invocations can run concurrently up to the configured limit.
+	 *  Final batch and merge work must enter through WorkRuntime so it has durable
+	 *  operation identity, snapshots, and operation-scoped cancellation.
 	 */
 	processAudiobookFiles: (payload: ProcessPayload, metadata: { [key in string]: MetadataIntentPatch } | null, previewSeconds: number | null) => typedError<ProcessCommandResult, AppErrorEnvelope>(__TAURI_INVOKE("process_audiobook_files", { payload, metadata, previewSeconds })),
 	submitProcessingOperation: (request: SubmitProcessingOperationRequest) => typedError<WorkSubmissionAccepted, AppErrorEnvelope>(__TAURI_INVOKE("submit_processing_operation", { request })),

--- a/src/lib/tauri-client.test.ts
+++ b/src/lib/tauri-client.test.ts
@@ -283,7 +283,7 @@ describe('tauriClient nullish adapters', () => {
 					cover_art: { op: 'clear' },
 				},
 			},
-			previewSeconds: undefined,
+			previewSeconds: 30,
 		});
 
 		const lastCall = mockInvoke.mock.calls[mockInvoke.mock.calls.length - 1];
@@ -301,7 +301,7 @@ describe('tauriClient nullish adapters', () => {
 		expect(args.payload.outputNaming).toBeNull();
 		expect(args.metadata['/books/a.m4b']?.title).toEqual({ op: 'clear' });
 		expect(args.metadata['/books/a.m4b']?.cover_art).toEqual({ op: 'clear' });
-		expect(args.previewSeconds).toBeNull();
+		expect(args.previewSeconds).toBe(30);
 		expect(result.jobType).toBe('batch');
 		expect(result.summary).toEqual({ total: 1, succeeded: 1, cancelled: 0, failed: 0 });
 		expect(result.results).toHaveLength(1);
@@ -412,7 +412,7 @@ describe('tauriClient nullish adapters', () => {
 					artist: { op: 'set', value: 'Author X' },
 				},
 			},
-			previewSeconds: undefined,
+			previewSeconds: 30,
 		});
 
 		const lastCall = mockInvoke.mock.calls[mockInvoke.mock.calls.length - 1];
@@ -518,7 +518,7 @@ describe('tauriClient nullish adapters', () => {
 				outputNaming: undefined,
 			},
 			metadataIntent: null,
-			previewSeconds: undefined,
+			previewSeconds: 30,
 		});
 
 		expect(result.summary).toEqual({ total: 2, succeeded: 1, cancelled: 0, failed: 1 });

--- a/src/lib/tauri/client.ts
+++ b/src/lib/tauri/client.ts
@@ -280,7 +280,7 @@ export const tauriClient = {
 	processAudiobookFiles: (args: {
 		payload: ProcessPayload;
 		metadataIntent?: MetadataIntentByPath | null;
-		previewSeconds?: number | null;
+		previewSeconds: number;
 	}): Promise<ProcessCommandResult> => commandSpecs.process_audiobook_files(args),
 	submitProcessingOperation: (
 		args: SubmitProcessingOperationRequest,

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -292,13 +292,13 @@ export const commandSpecs = {
 	process_audiobook_files: (args: {
 		payload: ProcessPayload;
 		metadataIntent?: MetadataIntentByPath | null;
-		previewSeconds?: number | null;
+		previewSeconds: number;
 	}) =>
 		runGeneratedCommand(
 			generatedCommands.processAudiobookFiles(
 				denormalizeProcessPayload(args.payload),
 				compileMetadataIntentMap(args.metadataIntent),
-				args.previewSeconds ?? null,
+				args.previewSeconds,
 			),
 			normalizeProcessResult,
 		),


### PR DESCRIPTION
## Outcome

Closes #475.

- Routes App Runtime and cross-owner production imports through each owner public root.
- Makes the frontend direct-processing API require a preview duration.
- Rejects omitted preview duration at Rust command ingress with ABB typed invalid-input semantics.
- Leaves preflight and WorkRuntime duration optional, preserving their preview/final contract.
- Updates nearest owner guidance and generated command documentation.

## Scope decision

#471 remains the owner of module-global frontend state and test-harness private imports. #421 remains the owner of transition, snapshot, and persistence gaps. Neither is folded into this boundary patch because neither shares its invariant or proof surface.

## Verification

- `bun run typecheck`
- `bun run lint:check`
- `cargo fmt --all -- --check`
- `cargo clippy -p audiobook-boss --all-targets --features bundled-ffmpeg` (passes; one pre-existing `too_many_lines` warning in `metadata/embedded_cover.rs`)
- `cargo nextest run -p audiobook-boss --features bundled-ffmpeg --lib -E test(direct_processing_requires_preview_duration)`
- `bun run test -- src/app/runtime/runtime.test.ts src/app/processing/__tests__/processingWorkflow.test.ts src/lib/tauri-client.test.ts src/lib/tauri-public-api.contract.test.ts src/lib/tauri-client.generated-event-bindings.test.ts`
- `bun run test -- src/app/runtime/runtime.test.ts src/app/metadataSession/metadataSession.test.ts src/app/processing/__tests__/processingWorkflow.test.ts`
- `bash scripts/check-generated-bindings.sh --mode local`
- `bun scripts/check-tauri-runtime-boundary.ts`
- `git diff --check`