### PR TITLE
Add confirmed MP3/CUE chapter intake and preserve accepted plans through encoding

### DIFF
--- a/crates/abb-metadata-core/src/chapters.rs
+++ b/crates/abb-metadata-core/src/chapters.rs
@@ -1,0 +1,259 @@
+//! Accepted chapter positions use milliseconds, rounded once to nearest ms.
+use crate::MetadataCoreError;
+use serde::{Deserialize, Serialize};
+type Result<T> = std::result::Result<T, MetadataCoreError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ChapterSpec {
+    pub title: Option<String>,
+    pub start_ms: i64,
+    pub end_ms: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum CueInterpretation {
+    Frames75,
+    Hundredths,
+}
+
+#[derive(Debug, Clone)]
+pub struct CueSheet {
+    pub file_name: String,
+    pub interpretation: CueInterpretation,
+    pub chapters: Vec<ChapterSpec>,
+}
+
+fn invalid(line: usize, reason: &str) -> MetadataCoreError {
+    MetadataCoreError::InvalidInput(format!("CUE line {line}: {reason}"))
+}
+
+#[derive(Default)]
+struct Track {
+    title: Option<String>,
+    start: Option<(i64, i64, i64)>,
+    line: usize,
+}
+
+fn timestamp(value: &str, line: usize) -> Result<(i64, i64, i64)> {
+    let parts: Vec<_> = value.split(':').collect();
+    if parts.len() != 3
+        || parts
+            .iter()
+            .any(|p| p.is_empty() || !p.bytes().all(|c| c.is_ascii_digit()))
+    {
+        return Err(invalid(line, "expected minutes:seconds:frames"));
+    }
+    let values: Vec<i64> = parts
+        .iter()
+        .map(|p| p.parse().map_err(|_| invalid(line, "timestamp overflow")))
+        .collect::<Result<_>>()?;
+    if values[1] >= 60 || values[2] >= 100 {
+        return Err(invalid(
+            line,
+            "seconds must be 0–59; final field must be 0–99",
+        ));
+    }
+    Ok((values[0], values[1], values[2]))
+}
+
+fn quoted(value: &str, line: usize) -> Result<String> {
+    let value = value.trim();
+    let Some(rest) = value.strip_prefix('"') else {
+        return Err(invalid(line, "expected quoted text"));
+    };
+    let Some(end) = rest.find('"') else {
+        return Err(invalid(line, "unterminated quoted text"));
+    };
+    Ok(rest[..end].to_string())
+}
+
+/// Parse a single FILE/AUDIO sheet. Nonstandard fields propose hundredths;
+/// the runtime/UI must obtain explicit confirmation before accepting that plan.
+pub fn parse_cue(text: &str, duration_ms: i64) -> Result<CueSheet> {
+    let mut file_name = None;
+    let mut tracks: Vec<Track> = Vec::new();
+    let mut last_number = 0;
+    let mut needs_hundredths = false;
+    for (index, line) in text.trim_start_matches('\u{feff}').lines().enumerate() {
+        let line_number = index + 1;
+        let line = line.trim();
+        let (command, value) = line.split_once(char::is_whitespace).unwrap_or((line, ""));
+        match command.to_ascii_uppercase().as_str() {
+            "FILE" => {
+                if file_name.is_some() {
+                    return Err(invalid(line_number, "multiple FILE sheets are unsupported"));
+                }
+                let name = quoted(value, line_number)?;
+                if name.is_empty() || name.contains(['/', '\\', ':']) || name == "." || name == ".."
+                {
+                    return Err(invalid(
+                        line_number,
+                        "FILE must name a local sibling, not a directory or URL",
+                    ));
+                }
+                file_name = Some(name);
+            }
+            "TRACK" => {
+                let fields: Vec<_> = value.split_whitespace().collect();
+                let number = fields
+                    .first()
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .unwrap_or(0);
+                if file_name.is_none()
+                    || fields.len() != 2
+                    || fields[1] != "AUDIO"
+                    || number <= last_number
+                {
+                    return Err(invalid(
+                        line_number,
+                        "expected increasing AUDIO tracks after FILE",
+                    ));
+                }
+                last_number = number;
+                tracks.push(Track {
+                    line: line_number,
+                    ..Track::default()
+                });
+            }
+            "TITLE" => {
+                if let Some(track) = tracks.last_mut() {
+                    track.title = Some(quoted(value, line_number)?);
+                }
+            }
+            "INDEX" => {
+                let fields: Vec<_> = value.split_whitespace().collect();
+                if fields.len() != 2 {
+                    return Err(invalid(line_number, "expected INDEX number and timestamp"));
+                }
+                let track = tracks
+                    .last_mut()
+                    .ok_or_else(|| invalid(line_number, "INDEX before TRACK"))?;
+                let time = timestamp(fields[1], line_number)?;
+                needs_hundredths |= time.2 >= 75;
+                match fields[0] {
+                    "01" if track.start.is_none() => {
+                        track.start = Some(time);
+                        track.line = line_number;
+                    }
+                    "00" => {} // pregap index is not the supplied chapter start
+                    _ => {
+                        return Err(invalid(
+                            line_number,
+                            "duplicate or unsupported INDEX; expected one INDEX 01 per track",
+                        ))
+                    }
+                }
+            }
+            "PREGAP" | "POSTGAP" => {
+                return Err(invalid(line_number, "explicit gaps are unsupported"))
+            }
+            _ => {} // REM, performer, and other descriptive tags do not change the timeline
+        }
+    }
+    let file_name = file_name.ok_or_else(|| invalid(1, "missing FILE"))?;
+    if tracks.is_empty() {
+        return Err(invalid(1, "no AUDIO tracks"));
+    }
+    let interpretation = if needs_hundredths {
+        CueInterpretation::Hundredths
+    } else {
+        CueInterpretation::Frames75
+    };
+    let denominator = match interpretation {
+        CueInterpretation::Frames75 => 75,
+        CueInterpretation::Hundredths => 100,
+    };
+    let mut chapters = Vec::new();
+    for track in tracks {
+        let (minutes, seconds, fraction) = track
+            .start
+            .ok_or_else(|| invalid(track.line, "missing INDEX 01"))?;
+        let start = minutes
+            .checked_mul(60)
+            .and_then(|v| v.checked_add(seconds))
+            .and_then(|v| v.checked_mul(denominator))
+            .and_then(|v| v.checked_add(fraction))
+            .and_then(|v| v.checked_mul(1000))
+            .and_then(|v| v.checked_add(denominator / 2))
+            .map(|v| v / denominator)
+            .ok_or_else(|| invalid(track.line, "timestamp overflow"))?;
+        if start >= duration_ms
+            || chapters
+                .last()
+                .is_some_and(|c: &ChapterSpec| c.start_ms >= start)
+        {
+            return Err(invalid(
+                track.line,
+                "chapter starts must increase and precede the audio end",
+            ));
+        }
+        if let Some(previous) = chapters.last_mut() {
+            previous.end_ms = start;
+        }
+        chapters.push(ChapterSpec {
+            title: track.title,
+            start_ms: start,
+            end_ms: duration_ms,
+        });
+    }
+    validate_chapters(&chapters, duration_ms)?;
+    Ok(CueSheet {
+        file_name,
+        interpretation,
+        chapters,
+    })
+}
+
+pub fn validate_chapters(chapters: &[ChapterSpec], duration_ms: i64) -> Result<()> {
+    for (index, chapter) in chapters.iter().enumerate() {
+        if chapter.start_ms < 0
+            || chapter.end_ms <= chapter.start_ms
+            || chapter.end_ms > duration_ms
+            || index > 0 && chapters[index - 1].end_ms > chapter.start_ms
+        {
+            return Err(invalid(
+                index + 1,
+                "invalid, overlapping, or out-of-range chapter interval",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn cue_timestamp_interpretations_and_short_final_entry() {
+        let standard = parse_cue("FILE \"book.mp3\" MP3\nTRACK 01 AUDIO\nTITLE \"Opening\"\nINDEX 01 00:00:00\nTRACK 02 AUDIO\nINDEX 01 00:13:74", 20_000).expect("standard sheet");
+        assert_eq!(standard.interpretation, CueInterpretation::Frames75);
+        assert_eq!(standard.chapters[1].start_ms, 13_987);
+        assert_eq!(standard.chapters[0].end_ms, 13_987);
+        let pregap = parse_cue(
+            "FILE \"book.mp3\" MP3\nTRACK 01 AUDIO\nINDEX 00 00:00:94\nINDEX 01 00:01:50",
+            20_000,
+        )
+        .expect("whole-sheet interpretation includes pregap timestamps");
+        assert_eq!(pregap.interpretation, CueInterpretation::Hundredths);
+        assert_eq!(pregap.chapters[0].start_ms, 1_500);
+        let nonstandard = parse_cue("FILE \"Lost Time.mp3\" MP3\nTRACK 01 AUDIO\nTITLE \"Chapter 01\"\nINDEX 01 00:00:00\nTRACK 02 AUDIO\nTITLE \"Chapter 02\"\nINDEX 01 00:13:94\nTRACK 42 AUDIO\nTITLE \"Chapter 42\"\nINDEX 01 580:52:68", 34_852_687).expect("hundredths proposal");
+        assert_eq!(nonstandard.interpretation, CueInterpretation::Hundredths);
+        assert_eq!(nonstandard.chapters[1].start_ms, 13_940);
+        assert_eq!(
+            nonstandard.chapters[2],
+            ChapterSpec {
+                title: Some("Chapter 42".into()),
+                start_ms: 34_852_680,
+                end_ms: 34_852_687
+            }
+        );
+    }
+    #[test]
+    fn cue_rejects_unsafe_ambiguous_and_invalid_sheets() {
+        for text in ["FILE \"../book.mp3\" MP3", "FILE \"a.mp3\" MP3\nFILE \"b.mp3\" MP3", "FILE \"a.mp3\" MP3\nTRACK 01 AUDIO", "FILE \"a.mp3\" MP3\nTRACK 01 AUDIO\nINDEX 01 00:60:00", "FILE \"a.mp3\" MP3\nTRACK 01 AUDIO\nINDEX 01 00:00:100", "FILE \"a.mp3\" MP3\nTRACK 01 AUDIO\nINDEX 01 00:00:00\nINDEX 01 00:01:00", "FILE \"a.mp3\" MP3\nTRACK 01 AUDIO\nINDEX 01 00:02:00\nTRACK 02 AUDIO\nINDEX 01 00:01:00", "FILE \"a.mp3\" MP3\nTRACK 01 AUDIO\nINDEX 01 00:20:00"] {
+            assert!(parse_cue(text, 20_000).expect_err(text).to_string().contains("CUE line"));
+        }
+    }
+}

--- a/crates/abb-metadata-core/src/lib.rs
+++ b/crates/abb-metadata-core/src/lib.rs
@@ -765,6 +765,9 @@ fn scrub_invalid_series_part_for_naming(value: &mut Option<String>) {
     }
 }
 
+mod chapters;
+pub use chapters::{parse_cue, validate_chapters, ChapterSpec, CueInterpretation, CueSheet};
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/audio/AGENTS.md
+++ b/src-tauri/src/audio/AGENTS.md
@@ -22,7 +22,7 @@
   `SupportedAudioImportFormat`, `SupportedAudioImportMetadata`,
   `AacDecoderAvailability`, `EncoderSettings`, `EncoderType`, `BitrateMode`,
   `ChannelConfig`, `EncoderAvailability`, `EncoderCapabilitySource`.
-- Functions: `get_file_list_info`, `validate_input_audio_path`,
+- Functions: `get_file_list_info`, `apply_chapter_plans`, `validate_input_audio_path`,
   `validate_input_image_path`, `supported_audio_import_metadata`,
   `discover_audio_import_paths`, `validate_output_path`,
   `validate_sample_rate_config`, `validate_encoder_settings`,
@@ -134,3 +134,12 @@ When one appears, name the affected boundary, state the current assumption used 
 - Native AAC changes include a real-media probe when feasible: output codec/profile, sample rate, channels, duration, and at least one channel-level sanity check such as RMS/peak parity.
 - Audio correctness fixes run the focused audio/runtime checks warranted by the touched boundary before being presented as done; escalate only when the change crosses owners or uses real-media behavior the focused checks cannot prove.
 - Final notes distinguish structural correctness from subjective encoder quality when discussing Native AAC artifacts.
+
+## Chapter Intake
+
+Analysis attaches sibling CUE diagnostics and a source-fingerprinted candidate
+chapter plan to each MP3. `apply_chapter_plans` validates accepted payload plans
+against the audio identity and duration before dispatch. CUE confirmation or
+Ignore is explicit; multi-source CUE merging is rejected. Encoder adapters
+consume accepted chapters, while passthrough source probing remains for cover
+art and external artifact readers. Preview continues to omit chapters.

--- a/src-tauri/src/audio/file_list.rs
+++ b/src-tauri/src/audio/file_list.rs
@@ -75,6 +75,13 @@ fn validate_single_file(path: &Path) -> Result<ValidatedAudioFile> {
             audio_file.tag_title = properties.tag_title;
             audio_file.tag_artist = properties.tag_artist;
             audio_file.chapters = properties.chapters;
+            let (plan, cue) = crate::metadata::inspect_chapter_source(
+                &canonical_path,
+                (properties.duration * 1000.0).round() as i64,
+                &audio_file.chapters,
+            )?;
+            audio_file.chapter_plan = Some(plan);
+            audio_file.cue_source = cue;
             audio_file.selected_decoder = properties
                 .selected_decoder
                 .as_ref()
@@ -232,4 +239,33 @@ pub fn get_file_list_info<P: AsRef<Path>>(file_paths: &[P]) -> Result<FileListIn
         valid_count,
         invalid_count,
     })
+}
+
+/// Bind accepted chapter facts to freshly inspected audio, never to a reread CUE.
+pub fn apply_chapter_plans(
+    files: &mut FileListInfo,
+    plans: Option<&std::collections::HashMap<String, crate::metadata::ChapterPlan>>,
+    merging: bool,
+) -> Result<()> {
+    for file in files.files.iter_mut().filter(|file| file.is_valid) {
+        let accepted = plans.and_then(|plans| file.path.to_str().and_then(|path| plans.get(path)));
+        if let Some(plan) = accepted {
+            crate::metadata::validate_chapter_plan(
+                &file.path,
+                (file.duration.unwrap_or(0.0) * 1000.0).round() as i64,
+                plan,
+            )?;
+            file.chapter_plan = Some(plan.clone());
+            file.cue_source = None; // accepted intent supersedes inspection/confirmation status
+        } else if file.cue_source.is_some() {
+            return Err(AppError::InvalidInput(
+                "Review the sibling CUE in Input before processing, or explicitly ignore it."
+                    .into(),
+            ));
+        }
+        if merging && file.chapter_plan.as_ref().is_some_and(|plan| plan.from_cue) {
+            return Err(AppError::InvalidInput("Merging CUE-bearing inputs is not supported. Convert them as separate jobs or ignore their CUE chapters.".into()));
+        }
+    }
+    Ok(())
 }

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -52,23 +52,17 @@ pub struct AudioFile {
     /// Chapters embedded in this individual source file, normalized to milliseconds.
     #[serde(default)]
     pub chapters: Vec<AudioChapter>,
+    #[serde(default)]
+    pub chapter_plan: Option<crate::metadata::ChapterPlan>,
+    #[serde(default)]
+    pub cue_source: Option<crate::metadata::CueSource>,
     /// Validation status
     pub is_valid: bool,
     /// Error message if validation failed
     pub error: Option<String>,
 }
 
-/// Read-only chapter facts discovered while analyzing one audio file.
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
-#[serde(rename_all = "camelCase")]
-pub struct AudioChapter {
-    /// Embedded chapter title, when present in the source container.
-    pub title: Option<String>,
-    /// Chapter start in milliseconds from the beginning of this file.
-    pub start_ms: i64,
-    /// Chapter end in milliseconds from the beginning of this file.
-    pub end_ms: i64,
-}
+pub type AudioChapter = crate::metadata::ChapterSpec;
 
 /// Machine-readable decoder identity paired with the friendly display label.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, specta::Type)]
@@ -103,6 +97,8 @@ impl AudioFile {
             tag_title: None,
             tag_artist: None,
             chapters: Vec::new(),
+            chapter_plan: None,
+            cue_source: None,
             is_valid: false,
             error: None,
         }
@@ -120,7 +116,7 @@ pub enum SampleRateConfig {
 }
 
 // Audio Engine Deep Module Public API Strip.
-pub use file_list::{get_file_list_info, FileListInfo};
+pub use file_list::{apply_chapter_plans, get_file_list_info, FileListInfo};
 pub use imports::{
     discover_audio_import_paths, supported_audio_import_metadata, SupportedAudioImportFormat,
     SupportedAudioImportMetadata,

--- a/src-tauri/src/audio/processor/adapter.rs
+++ b/src-tauri/src/audio/processor/adapter.rs
@@ -180,6 +180,8 @@ mod tests {
         };
         let file_info = FileListInfo {
             files: vec![AudioFile {
+                chapter_plan: None,
+                cue_source: None,
                 input_id: "input-1".to_string(),
                 path: Path::new("/books/input.m4b").to_path_buf(),
                 size: Some(1.0),

--- a/src-tauri/src/audio/processor/encoder/context.rs
+++ b/src-tauri/src/audio/processor/encoder/context.rs
@@ -208,20 +208,8 @@ pub(crate) fn setup_encoder(
     // Skip in preview mode since chapters won't align with shortened output
     if !skip_chapter_passthrough {
         if let Some(p) = passthrough {
-            match crate::metadata::add_chapters_to_output(&mut octx, &p.chapters) {
-                Ok(count) if count > 0 => {
-                    log::info!("✓ Copied {} chapters from source files", count);
-                }
-                Ok(_) => {
-                    log::debug!("No chapters found to copy from source files");
-                }
-                Err(error) => {
-                    log::warn!(
-                        "Could not preserve passthrough chapters during native encoding: {}",
-                        error
-                    );
-                }
-            }
+            let count = crate::metadata::add_chapters_to_output(&mut octx, &p.chapters)?;
+            log::debug!("Copied {count} accepted chapters");
         }
     } else {
         log::debug!("Chapter passthrough skipped (preview mode)");

--- a/src-tauri/src/audio/processor/finalize.rs
+++ b/src-tauri/src/audio/processor/finalize.rs
@@ -119,9 +119,15 @@ pub(crate) fn finalize_processing(
     workflow: ProcessingWorkflow,
     merged_output: PathBuf,
     metadata: Option<AudiobookMetadata>,
+    passthrough: Option<&crate::metadata::PassthroughMetadata>,
 ) -> Result<String> {
     write_metadata_stage(context, &merged_output, metadata)?;
 
+    if context.preview.is_none() {
+        if let Some(passthrough) = passthrough {
+            crate::metadata::verify_chapters(&merged_output, &passthrough.chapters)?;
+        }
+    }
     complete_processing(context, workflow, merged_output)
 }
 

--- a/src-tauri/src/audio/processor/mod.rs
+++ b/src-tauri/src/audio/processor/mod.rs
@@ -94,11 +94,35 @@ pub(crate) fn passthrough_sources_from_audio_files(files: &[AudioFile]) -> Vec<P
             path: file.path.clone(),
             duration: file.duration,
             is_valid: file.is_valid,
+            chapters: Some(
+                file.chapter_plan
+                    .as_ref()
+                    .map_or_else(|| file.chapters.clone(), |plan| plan.chapters.clone()),
+            ),
         })
         .collect()
 }
 
 pub async fn execute_audio_engine(request: AudioExecutionRequest) -> Result<String> {
+    for file in request.file_info.files.iter().filter(|file| file.is_valid) {
+        if file.cue_source.as_ref().is_some_and(|cue| {
+            matches!(
+                cue.status,
+                crate::metadata::CueStatus::NeedsConfirmation | crate::metadata::CueStatus::Invalid
+            )
+        }) {
+            return Err(crate::errors::AppError::InvalidInput(
+                "Review or ignore the CUE before processing.".into(),
+            ));
+        }
+        if request.file_info.files.len() > 1
+            && file.chapter_plan.as_ref().is_some_and(|plan| plan.from_cue)
+        {
+            return Err(crate::errors::AppError::InvalidInput(
+                "CUE chapters require a single-source output.".into(),
+            ));
+        }
+    }
     let FileListInfo {
         files,
         selected_decoders,
@@ -206,8 +230,13 @@ fn process_audiobook_with_context(
     )?;
 
     // Stage 3: Finalize
-    let result =
-        finalize::finalize_processing(&context, workflow, merged_output, effective_metadata)?;
+    let result = finalize::finalize_processing(
+        &context,
+        workflow,
+        merged_output,
+        effective_metadata,
+        passthrough_metadata.as_ref(),
+    )?;
     let _ = workflow_cleanup.remove_path(&workflow_temp_dir);
 
     // Suppress full-run metrics summary during preview; log preview-specific stats instead

--- a/src-tauri/src/audio/processor/prepare.rs
+++ b/src-tauri/src/audio/processor/prepare.rs
@@ -96,6 +96,8 @@ mod tests {
 
     fn audio_file(name: &str, duration: Option<f64>, is_valid: bool) -> AudioFile {
         AudioFile {
+            chapter_plan: None,
+            cue_source: None,
             input_id: format!("{name}-input"),
             path: PathBuf::from(name),
             size: Some(1.0),

--- a/src-tauri/src/audio/toolchain/tests.rs
+++ b/src-tauri/src/audio/toolchain/tests.rs
@@ -183,6 +183,8 @@ fn external_decoder_contract_rejects_unsupported_named_decoder() {
         },
     };
     let files = vec![AudioFile {
+        chapter_plan: None,
+        cue_source: None,
         input_id: "input-1".to_string(),
         path: PathBuf::from("/books/input.m4b"),
         size: Some(1.0),

--- a/src-tauri/src/metadata/AGENTS.md
+++ b/src-tauri/src/metadata/AGENTS.md
@@ -75,3 +75,17 @@ For ABS/Plex/Apple tag-mapping, series-tag strategy, and folder conventions, use
   metadata boundary.
 - Changing canonical/mirrored/compatibility tag precedence, provider-degradation
   contract, or container routing without explicit evidence and doc updates.
+
+## CUE And Accepted Chapters
+
+- `abb-metadata-core` owns `parse_cue`, `validate_chapters`, `ChapterSpec`,
+  `CueInterpretation`, and `CueSheet`. CUE conversion rounds the checked rational
+  timestamp once to the nearest millisecond. Runtime `cue.rs` owns bounded
+  sibling discovery, diagnostics, and source fingerprints; FILE text never
+  chooses another audio path.
+- `ChapterPlan`, `CueSource`, and `CueStatus` carry intake facts. Audio consumes
+  crate-local `inspect_chapter_source` and `validate_chapter_plan`.
+- `PassthroughSource.chapters` carries accepted data when present; `None` is
+  container discovery for artifact readers. `verify_chapters` checks names,
+  starts, ends, and count after final metadata writes and before artifact commit.
+  Selected chapter write/readback failures propagate; they are not best effort.

--- a/src-tauri/src/metadata/contract_tests.rs
+++ b/src-tauri/src/metadata/contract_tests.rs
@@ -55,11 +55,13 @@ fn metadata_intent_plan_contract_rejects_invalid_publication_dates() {
 fn metadata_passthrough_contract_synthesizes_chapters_from_source_facts() {
     let sources = vec![
         PassthroughSource {
+            chapters: None,
             path: std::path::PathBuf::from("chapter-one.m4b"),
             duration: Some(60.0),
             is_valid: true,
         },
         PassthroughSource {
+            chapters: None,
             path: std::path::PathBuf::from("chapter-two.m4b"),
             duration: Some(90.0),
             is_valid: true,

--- a/src-tauri/src/metadata/cue.rs
+++ b/src-tauri/src/metadata/cue.rs
@@ -127,7 +127,13 @@ fn read_cue(path: &Path, parent: &Path, duration_ms: i64) -> Result<super::CueSh
         ));
     }
     let mut text = String::new();
-    file.take(1_048_577).read_to_string(&mut text)?;
+    file.take(1_048_577).read_to_string(&mut text).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::InvalidData {
+            AppError::InvalidInput("CUE text must be UTF-8. Save the sidecar as UTF-8 and import the MP3 again, or ignore CUE.".into())
+        } else {
+            error.into()
+        }
+    })?;
     if text.len() > 1_048_576 {
         return Err(AppError::InvalidInput(
             "CUE exceeds the 1 MiB text limit".into(),

--- a/src-tauri/src/metadata/cue.rs
+++ b/src-tauri/src/metadata/cue.rs
@@ -1,0 +1,237 @@
+//! Sibling CUE discovery and immutable, source-bound chapter intake facts.
+use super::{parse_cue, validate_chapters, ChapterSpec, CueInterpretation};
+use crate::errors::{AppError, Result};
+use std::io::Read;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ChapterPlan {
+    pub chapters: Vec<ChapterSpec>,
+    pub from_cue: bool,
+    pub source_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum CueStatus {
+    Ready,
+    NeedsConfirmation,
+    Invalid,
+    Ignored,
+    EmbeddedPreferred,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CueSource {
+    pub file_name: String,
+    pub status: CueStatus,
+    pub message: String,
+}
+
+pub(crate) fn source_fingerprint(path: &Path) -> Result<String> {
+    let stat = std::fs::metadata(path)?;
+    let modified = stat
+        .modified()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| AppError::InvalidInput("Audio modification time is invalid".into()))?;
+    Ok(format!("{}:{}", stat.len(), modified.as_nanos()))
+}
+
+pub(crate) fn inspect_chapter_source(
+    path: &Path,
+    duration_ms: i64,
+    embedded: &[ChapterSpec],
+) -> Result<(ChapterPlan, Option<CueSource>)> {
+    let mut plan = ChapterPlan {
+        chapters: embedded.to_vec(),
+        from_cue: false,
+        source_fingerprint: source_fingerprint(path)?,
+    };
+    if !path
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("mp3"))
+    {
+        return Ok((plan, None));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| AppError::InvalidInput("Audio has no parent directory".into()))?;
+    let mut matches = Vec::new();
+    for entry in std::fs::read_dir(parent)? {
+        let candidate = entry?.path();
+        if candidate
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("cue"))
+            && candidate.file_stem() == path.file_stem()
+        {
+            matches.push(candidate);
+        }
+    }
+    if matches.is_empty() {
+        return Ok((plan, None));
+    }
+    let mut cue = CueSource {
+        file_name: matches[0]
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+        status: CueStatus::Invalid,
+        message: String::new(),
+    };
+    if !embedded.is_empty() {
+        cue.status = CueStatus::EmbeddedPreferred;
+        cue.message = "Using embedded chapters; sibling CUE was not applied.".into();
+    } else if matches.len() != 1 {
+        cue.message =
+            "Multiple same-stem CUE files found. Keep one sidecar or explicitly ignore CUE.".into();
+    } else {
+        match read_cue(&matches[0], parent, duration_ms) {
+            Ok(sheet) => {
+                cue.status = match sheet.interpretation {
+                    CueInterpretation::Frames75 => CueStatus::Ready,
+                    CueInterpretation::Hundredths => CueStatus::NeedsConfirmation,
+                };
+                if path.file_name() != Some(std::ffi::OsStr::new(&sheet.file_name)) {
+                    cue.message = format!(
+                        "CUE FILE names ‘{}’; using the selected same-stem MP3.",
+                        sheet.file_name
+                    );
+                }
+                plan.chapters = sheet.chapters;
+                plan.from_cue = true;
+            }
+            Err(error) => cue.message = error.to_string(),
+        }
+    }
+    Ok((plan, Some(cue)))
+}
+
+fn read_cue(path: &Path, parent: &Path, duration_ms: i64) -> Result<super::CueSheet> {
+    if path.canonicalize()?.parent() != Some(parent) {
+        return Err(AppError::InvalidInput(
+            "CUE sidecar must remain in the audio directory".into(),
+        ));
+    }
+    if !std::fs::metadata(path)?.is_file() {
+        return Err(AppError::InvalidInput(
+            "CUE sidecar is not a regular file".into(),
+        ));
+    }
+    let file = std::fs::File::open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(AppError::InvalidInput(
+            "CUE sidecar is not a regular file".into(),
+        ));
+    }
+    let mut text = String::new();
+    file.take(1_048_577).read_to_string(&mut text)?;
+    if text.len() > 1_048_576 {
+        return Err(AppError::InvalidInput(
+            "CUE exceeds the 1 MiB text limit".into(),
+        ));
+    }
+    Ok(parse_cue(&text, duration_ms)?)
+}
+
+pub(crate) fn validate_chapter_plan(
+    path: &Path,
+    duration_ms: i64,
+    plan: &ChapterPlan,
+) -> Result<()> {
+    if source_fingerprint(path)? != plan.source_fingerprint {
+        return Err(AppError::InvalidInput(
+            "Audio changed since chapter inspection. Remove and import it again.".into(),
+        ));
+    }
+    validate_chapters(&plan.chapters, duration_ms)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn sibling_cue_association_diagnostics_and_accepted_plan_isolation() {
+        let tmp = tempfile::TempDir::new().expect("intake tempdir");
+        let dir = tmp.path().canonicalize().expect("canonical fixture parent");
+        let one = dir.join("one.mp3");
+        let two = dir.join("two.mp3");
+        std::fs::write(&one, b"one").expect("first audio identity");
+        std::fs::write(&two, b"two").expect("second audio identity");
+        std::fs::write(
+            dir.join("one.cue"),
+            "FILE \"stale.mp3\" MP3\nTRACK 01 AUDIO\nTITLE \"First\"\nINDEX 01 00:00:94",
+        )
+        .expect("nonstandard sidecar");
+        std::fs::write(
+            dir.join("two.cue"),
+            "FILE \"two.mp3\" MP3\nTRACK 01 AUDIO\nTITLE \"Second\"\nINDEX 01 00:01:00",
+        )
+        .expect("standard sidecar");
+        let (first, cue) = inspect_chapter_source(&one, 2000, &[]).expect("first intake");
+        let cue = cue.expect("first sidecar");
+        assert_eq!(cue.status, CueStatus::NeedsConfirmation);
+        assert!(cue.message.contains("stale.mp3"));
+        let (second, cue) = inspect_chapter_source(&two, 2000, &[]).expect("second intake");
+        assert_eq!(cue.expect("standard sidecar").status, CueStatus::Ready);
+        std::fs::write(dir.join("one.cue"), "FILE \"../unsafe.mp3\" MP3")
+            .expect("change sidecar after intake");
+        let files = [&one, &two].map(|path| {
+            let mut file = crate::audio::AudioFile::new(path.clone());
+            file.is_valid = true;
+            file.duration = Some(2.0);
+            file
+        });
+        let mut inputs = crate::audio::FileListInfo {
+            files: files.to_vec(),
+            selected_decoders: vec![None, None],
+            total_duration: 4.0,
+            total_size: 6.0,
+            valid_count: 2,
+            invalid_count: 0,
+        };
+        let accepted = std::collections::HashMap::from([
+            (one.to_string_lossy().into_owned(), first.clone()),
+            (two.to_string_lossy().into_owned(), second.clone()),
+        ]);
+        crate::audio::apply_chapter_plans(&mut inputs, Some(&accepted), false)
+            .expect("job handoff retains accepted data despite changed CUE");
+        assert_eq!(inputs.files[0].chapter_plan.as_ref(), Some(&first));
+        assert_eq!(inputs.files[1].chapter_plan.as_ref(), Some(&second));
+        assert_eq!(first.chapters[0].start_ms, 940);
+        assert_eq!(second.chapters[0].start_ms, 1000);
+        assert!(crate::audio::apply_chapter_plans(&mut inputs, Some(&accepted), true).is_err());
+        assert_eq!(
+            inspect_chapter_source(&one, 2000, &[])
+                .expect("invalid diagnostic")
+                .1
+                .expect("sidecar")
+                .status,
+            CueStatus::Invalid
+        );
+        std::fs::write(&one, b"changed audio").expect("mutate audio");
+        assert!(validate_chapter_plan(&one, 2000, &first).is_err());
+        std::fs::write(dir.join("two.CUE"), "duplicate").expect("ambiguous sidecar");
+        // On case-sensitive volumes these are two candidates; on insensitive
+        // volumes the second write changes the single candidate to invalid text.
+        assert_eq!(
+            inspect_chapter_source(&two, 2000, &[])
+                .expect("ambiguous diagnostic")
+                .1
+                .expect("sidecar")
+                .status,
+            CueStatus::Invalid
+        );
+        assert_eq!(
+            inspect_chapter_source(&two, 2000, &second.chapters)
+                .expect("embedded precedence")
+                .1
+                .expect("sidecar")
+                .status,
+            CueStatus::EmbeddedPreferred
+        );
+    }
+}

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -11,6 +11,12 @@ pub mod reader;
 pub(crate) mod tag_registry;
 
 mod container;
+mod cue;
+pub use abb_metadata_core::{
+    parse_cue, validate_chapters, ChapterSpec, CueInterpretation, CueSheet,
+};
+pub(crate) use cue::{inspect_chapter_source, validate_chapter_plan};
+pub use cue::{ChapterPlan, CueSource, CueStatus};
 #[cfg(test)]
 mod contract_tests;
 mod cover_art;
@@ -58,7 +64,8 @@ pub use cover_art::{
 pub use ffmpeg_dict::{set_container_metadata, validate_metadata_compatibility};
 pub(crate) use passthrough::prepare_output_cover_art;
 pub use passthrough::{
-    add_chapters_to_output, extract_passthrough_metadata, PassthroughMetadata, PassthroughSource,
+    add_chapters_to_output, extract_passthrough_metadata, verify_chapters, PassthroughMetadata,
+    PassthroughSource,
 };
 
 /// Applies an explicit metadata intent patch to a real file: validate/plan,
@@ -109,6 +116,9 @@ pub fn finalize_artifact_metadata(
         if should_write_finalized_metadata(path)? {
             write_finalized_metadata(path, metadata)?;
         }
+    }
+    if let Some(passthrough) = passthrough {
+        verify_chapters(path, &passthrough.chapters)?;
     }
     Ok(())
 }

--- a/src-tauri/src/metadata/passthrough.rs
+++ b/src-tauri/src/metadata/passthrough.rs
@@ -16,15 +16,10 @@ pub struct PassthroughSource {
     pub path: PathBuf,
     pub duration: Option<f64>,
     pub is_valid: bool,
+    pub chapters: Option<Vec<ChapterSpec>>,
 }
 
-/// Minimal chapter representation for passthrough (milliseconds time base).
-#[derive(Debug, Clone)]
-pub struct ChapterSpec {
-    pub title: Option<String>,
-    pub start_ms: i64,
-    pub end_ms: i64,
-}
+pub use super::ChapterSpec;
 
 /// Aggregated passthrough metadata collected from input files.
 #[derive(Debug, Clone, Default)]
@@ -147,7 +142,7 @@ pub fn extract_passthrough_metadata(files: &[PassthroughSource]) -> PassthroughM
         match ff::format::input(&file.path) {
             Ok(ictx) => {
                 // Collect chapters
-                if ictx.nb_chapters() > 0 {
+                if file.chapters.is_none() && ictx.nb_chapters() > 0 {
                     for chapter in ictx.chapters() {
                         let title = chapter.metadata().get("title").map(str::to_string);
                         let start_ms = rescale_to_ms(chapter.start(), chapter.time_base())
@@ -174,6 +169,16 @@ pub fn extract_passthrough_metadata(files: &[PassthroughSource]) -> PassthroughM
                     e
                 );
             }
+        }
+
+        if let Some(chapters) = &file.chapters {
+            passthrough
+                .chapters
+                .extend(chapters.iter().map(|chapter| ChapterSpec {
+                    title: chapter.title.clone(),
+                    start_ms: chapter.start_ms + cumulative_offset_ms,
+                    end_ms: chapter.end_ms + cumulative_offset_ms,
+                }));
         }
 
         // Update offset for next file using known duration (seconds).
@@ -234,6 +239,34 @@ pub fn add_chapters_to_output(
         }
     }
     Ok(copied)
+}
+
+/// Fail before artifact commit if finalization lost selected chapters.
+pub fn verify_chapters(path: &std::path::Path, expected: &[ChapterSpec]) -> Result<()> {
+    if expected.is_empty() {
+        return Ok(());
+    }
+    let input = ff::format::input(path)?;
+    let actual: Vec<_> = input
+        .chapters()
+        .map(|chapter| ChapterSpec {
+            title: chapter.metadata().get("title").map(str::to_string),
+            start_ms: rescale_to_ms(chapter.start(), chapter.time_base()),
+            end_ms: rescale_to_ms(chapter.end(), chapter.time_base()),
+        })
+        .collect();
+    if actual.len() != expected.len()
+        || actual.iter().zip(expected).any(|(a, e)| {
+            a.title.as_deref().unwrap_or("") != e.title.as_deref().unwrap_or("")
+                || a.start_ms != e.start_ms
+                || a.end_ms != e.end_ms
+        })
+    {
+        return Err(crate::errors::AppError::InvalidInput(
+            "Final output did not preserve the accepted chapter names and positions.".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn extract_attached_pic(ictx: &ff::format::context::Input) -> Option<Vec<u8>> {

--- a/src-tauri/src/metadata/remux.rs
+++ b/src-tauri/src/metadata/remux.rs
@@ -162,12 +162,7 @@ fn copy_chapters(
     passthrough: Option<&PassthroughMetadata>,
 ) -> Result<()> {
     if let Some(passthrough) = passthrough {
-        if let Err(error) = crate::metadata::add_chapters_to_output(octx, &passthrough.chapters) {
-            log::warn!(
-                "Could not preserve passthrough chapters during metadata remux: {}",
-                error
-            );
-        }
+        crate::metadata::add_chapters_to_output(octx, &passthrough.chapters)?;
         return Ok(());
     }
 

--- a/src-tauri/src/processing/plan.rs
+++ b/src-tauri/src/processing/plan.rs
@@ -422,6 +422,7 @@ mod tests {
 
     fn process_payload(overrides: impl FnOnce(&mut ProcessPayload)) -> ProcessPayload {
         let mut payload = ProcessPayload {
+            chapter_plans: None,
             input_files: vec!["/books/input.m4b".to_string()],
             input_ids: None,
             output_dir: "/tmp/out".to_string(),

--- a/src-tauri/src/processing/run.rs
+++ b/src-tauri/src/processing/run.rs
@@ -159,6 +159,7 @@ mod tests {
 
     fn process_payload(overrides: impl FnOnce(&mut ProcessPayload)) -> ProcessPayload {
         let mut payload = ProcessPayload {
+            chapter_plans: None,
             input_files: vec!["/books/input.m4b".to_string()],
             input_ids: None,
             output_dir: "/tmp/out".to_string(),

--- a/src-tauri/src/processing/run/run_dispatch.rs
+++ b/src-tauri/src/processing/run/run_dispatch.rs
@@ -80,7 +80,12 @@ async fn dispatch_merge_plan(
     }
 
     let paths: Vec<PathBuf> = payload.input_files.iter().map(PathBuf::from).collect();
-    let file_info = audio::get_file_list_info(&paths)?;
+    let mut file_info = audio::get_file_list_info(&paths)?;
+    audio::apply_chapter_plans(
+        &mut file_info,
+        payload.chapter_plans.as_ref(),
+        paths.len() > 1,
+    )?;
     let result = run_processing_job(ProcessingJobRequest {
         window,
         registry,
@@ -167,6 +172,7 @@ async fn dispatch_batch_plan(
         })?;
         let supplemental_assets = supplemental_assets_for_input(payload, input_index);
         let progress_listener = options.progress_listener.clone();
+        let chapter_plans = payload.chapter_plans.clone();
 
         scheduled_jobs.push(Box::pin(async move {
             if operation_cancel
@@ -175,7 +181,8 @@ async fn dispatch_batch_plan(
             {
                 return Err(AppError::cancelled());
             }
-            let file_info = audio::get_file_list_info(std::slice::from_ref(&path))?;
+            let mut file_info = audio::get_file_list_info(std::slice::from_ref(&path))?;
+            audio::apply_chapter_plans(&mut file_info, chapter_plans.as_ref(), false)?;
             run_processing_job(ProcessingJobRequest {
                 window: window_cloned,
                 registry: registry_cloned,

--- a/src-tauri/src/processing/run/run_validation.rs
+++ b/src-tauri/src/processing/run/run_validation.rs
@@ -28,7 +28,13 @@ pub(crate) fn resolve_sample_rate(payload: &ProcessPayload) -> Result<audio::Sam
 
 pub(crate) fn validate_external_processing_contract(payload: &ProcessPayload) -> Result<()> {
     let input_paths: Vec<PathBuf> = payload.input_files.iter().map(PathBuf::from).collect();
-    let file_info = audio::get_file_list_info(&input_paths)?;
+    let mut file_info = audio::get_file_list_info(&input_paths)?;
+    audio::apply_chapter_plans(
+        &mut file_info,
+        payload.chapter_plans.as_ref(),
+        payload.job_type == Some(crate::processing::JobType::Merge)
+            && payload.input_files.len() > 1,
+    )?;
     validate_external_processing_contract_with_file_info(payload, &file_info)
 }
 

--- a/src-tauri/src/processing/types.rs
+++ b/src-tauri/src/processing/types.rs
@@ -27,6 +27,7 @@ impl From<JobType> for OperationKind {
 #[serde(rename_all = "camelCase")]
 pub struct ProcessPayload {
     pub input_files: Vec<String>,
+    pub chapter_plans: Option<HashMap<String, crate::metadata::ChapterPlan>>,
     /// Session/workbench identities aligned to `input_files`; used for acquired
     /// source sidecars without replacing path as the filesystem source label.
     pub input_ids: Option<Vec<Option<String>>>,

--- a/src-tauri/tests/cases/integration_media_execution_tests.rs
+++ b/src-tauri/tests/cases/integration_media_execution_tests.rs
@@ -432,6 +432,7 @@ async fn artifact_finalize_preserves_series_tags_and_chapters_on_mp4_route() {
         .iter()
         .zip(durations)
         .map(|(path, duration)| PassthroughSource {
+            chapters: None,
             path: path.clone(),
             duration: Some(duration),
             is_valid: true,
@@ -495,6 +496,7 @@ async fn artifact_finalize_preserves_series_tags_and_chapters_on_mp4_route() {
 
     // Chapters written during finalize survive the MP4 tag rewrite.
     let artifact_chapters = extract_passthrough_metadata(&[PassthroughSource {
+        chapters: None,
         path: output.clone(),
         duration: None,
         is_valid: true,
@@ -559,6 +561,7 @@ fn minimal_jpg_bytes() -> Vec<u8> {
 
 fn chapters_of(path: &Path) -> Vec<(Option<String>, i64, i64)> {
     let passthrough = extract_passthrough_metadata(&[PassthroughSource {
+        chapters: None,
         path: path.to_path_buf(),
         duration: None,
         is_valid: true,
@@ -1095,4 +1098,33 @@ async fn stereo_merge_preserves_audio_in_both_channels() {
             "channel {ch} RMS {value} indicates missing or silent audio (expected ~0.21 for a 0.3-amplitude sine)"
         );
     }
+}
+
+/// One CUE case: supplied names/start positions survive encoding and final tags.
+#[tokio::test]
+async fn cue_chapters_survive_mp3_encoding_and_finalization() {
+    let tmp = TempDir::new().expect("CUE fixture directory");
+    let mp3 = tmp.path().join("book.mp3");
+    write_sine_mp3(&mp3, 1.5, 440.0);
+    fs::write(tmp.path().join("book.cue"), "FILE \"stale.mp3\" MP3\nTRACK 01 AUDIO\nTITLE \"Opening\"\nINDEX 01 00:00:00\nTRACK 02 AUDIO\nTITLE \"Near end\"\nINDEX 01 00:01:36\n").expect("write CUE");
+    let lane = MediaLane::for_inputs(vec![mp3]);
+    let output = lane
+        .process(Some(AudiobookMetadata {
+            title: Some("CUE book".into()),
+            ..Default::default()
+        }))
+        .await;
+    let chapters = chapters_of(&output);
+    assert_eq!(chapters.len(), 2);
+    assert_eq!(chapters[0].0.as_deref(), Some("Opening"));
+    assert_eq!(chapters[0].1, 0);
+    assert_eq!(chapters[1].0.as_deref(), Some("Near end"));
+    assert_eq!(chapters[1].1, 1_480);
+    assert!(chapters[1].2 > 1_480, "short last chapter remains");
+    let (duration, _, _) = timed_text_chapter_track(&output);
+    assert!(
+        duration > 1.48 && duration < 1.6,
+        "chapter track spans the audio: {duration}"
+    );
+    assert!(lane.residual_workspace_dirs().is_empty());
 }

--- a/src/app/inputSession/index.ts
+++ b/src/app/inputSession/index.ts
@@ -1,4 +1,4 @@
-export { createInputOwner } from './owner';
+export { createInputOwner, chapterPlansForProcessing } from './owner';
 export type { InputOwner, InputOwnerDeps } from './owner';
 export {
 	displayedArtistForFile,

--- a/src/app/inputSession/inputSession.test.ts
+++ b/src/app/inputSession/inputSession.test.ts
@@ -3,7 +3,7 @@ import type { AudioFile, FileListInfo, SupportedAudioImportMetadata } from '../.
 import { createTestAppRuntime } from '../runtime/harness';
 import type { InputCapability } from '../../lib/tauri/capabilities/input';
 import type { AppRuntime } from '../runtime';
-import { createInputOwner } from './owner';
+import { createInputOwner, chapterPlansForProcessing } from './index';
 import { emptyInputSession, type InputSessionState } from './types';
 
 const metadata: SupportedAudioImportMetadata = {
@@ -205,4 +205,59 @@ describe('input session support text hydrate', () => {
 		expect(runtime.input.view().files).toHaveLength(1);
 		expect(runtime.input.view().files[0]?.path).toBe('/books/chapter.m4b');
 	});
+});
+
+it('carries folder CUE confirmation and explicit ignore into independent processing plans', async () => {
+	const analyzed = analyzedFile('/books/book.mp3');
+	analyzed.files[0] = {
+		...analyzed.files[0]!,
+		cueSource: {
+			fileName: 'book.cue',
+			status: 'needsConfirmation',
+			message: 'Stale FILE name; using same-stem MP3.',
+		},
+		chapterPlan: {
+			sourceFingerprint: '100:200',
+			fromCue: true,
+			chapters: [{ title: 'Opening', startMs: 940, endMs: 120000 }],
+		},
+	};
+	analyzed.files.push({
+		...audioFile('/books/broken.mp3'),
+		inputId: 'broken',
+		cueSource: {
+			fileName: 'broken.cue',
+			status: 'invalid',
+			message: 'CUE line 2: multiple FILE sheets are unsupported',
+		},
+		chapterPlan: { sourceFingerprint: '200:300', fromCue: false, chapters: [] },
+	});
+	analyzed.validCount = 2;
+	const capability = fakeInput({
+		discoverAudioImportPaths: vi.fn(async () => ['/books/book.mp3', '/books/broken.mp3']),
+		analyzeAudioFiles: vi.fn(async () => analyzed),
+	});
+	const owner = createInputOwner({ capability });
+	await owner.importIntent({ type: 'pickFolder' });
+	expect(capability.discoverAudioImportPaths).toHaveBeenCalledWith(['/books']);
+	expect(owner.view().files[0]?.chapterPlan?.chapters).toHaveLength(1);
+	expect(owner.view().files[0]?.cueSource?.fileName).toBe('book.cue');
+	expect(() => chapterPlansForProcessing(owner.view().files, 'batch')).toThrow('confirm');
+	owner.chooseCue('input-1', 'confirmHundredths');
+	expect(() => chapterPlansForProcessing(owner.view().files, 'batch')).toThrow('broken.cue');
+	expect(owner.view().files[1]?.cueSource?.message).toContain('multiple FILE');
+	owner.chooseCue('broken', 'ignore');
+	const accepted = chapterPlansForProcessing(owner.view().files, 'batch');
+	expect(accepted?.['/books/book.mp3']?.chapters).toEqual([
+		{ title: 'Opening', startMs: 940, endMs: 120000 },
+	]);
+	expect(accepted?.['/books/broken.mp3']?.chapters).toEqual([]);
+	expect(() => chapterPlansForProcessing(owner.view().files, 'merge')).toThrow(
+		'Merging CUE-bearing',
+	);
+	owner.chooseCue('input-1', 'ignore');
+	expect(
+		chapterPlansForProcessing(owner.view().files, 'merge')?.['/books/book.mp3']?.chapters,
+	).toEqual([]);
+	expect(accepted?.['/books/book.mp3']?.chapters[0]?.startMs).toBe(940);
 });

--- a/src/app/inputSession/owner.ts
+++ b/src/app/inputSession/owner.ts
@@ -1,5 +1,5 @@
 import { createMemo, createSignal, type Accessor } from 'solid-js';
-import type { JobType } from '../../types/audio';
+import type { AudioFile, ProcessPayload, JobType } from '../../types/audio';
 import { runAppEffect } from '../../lib/effect/appEffect';
 import { liveInputCapability, type InputCapability } from '../../lib/tauri/capabilities/input';
 import { toInputView } from './display';
@@ -45,6 +45,7 @@ export type InputOwner = {
 	restoreImportOrder(): void;
 	setOrderLocked(orderLocked: boolean): void;
 	setJobType(jobType: JobType): void;
+	chooseCue(inputId: string, choice: 'confirmHundredths' | 'ignore'): void;
 	replaceSession(session: InputSessionState): void;
 	reset(): void;
 };
@@ -78,6 +79,28 @@ export function createInputOwner(deps: InputOwnerDeps = {}): InputOwner {
 		session,
 		jobType,
 		capability,
+		chooseCue(inputId, choice) {
+			if (session().orderLocked) return;
+			const current = session();
+			if (!current.fileList) return;
+			const files = current.fileList.files.map((file) => {
+				if (file.inputId !== inputId || !file.cueSource) return file;
+				if (choice === 'confirmHundredths' && file.cueSource.status === 'needsConfirmation') {
+					return { ...file, cueSource: { ...file.cueSource, status: 'ready' as const } };
+				}
+				if (choice === 'ignore' && file.cueSource.status !== 'embeddedPreferred') {
+					return {
+						...file,
+						cueSource: { ...file.cueSource, status: 'ignored' as const },
+						chapterPlan: file.chapterPlan
+							? { ...file.chapterPlan, fromCue: false, chapters: file.chapters ?? [] }
+							: undefined,
+					};
+				}
+				return file;
+			});
+			commit({ ...current, fileList: { ...current.fileList, files } });
+		},
 		async importIntent(intent) {
 			const next = await runAppEffect(runImportIntent(capability(), session(), intent));
 			commit({ ...next, orderLocked: session().orderLocked });
@@ -180,4 +203,32 @@ export function createInputOwner(deps: InputOwnerDeps = {}): InputOwner {
 			setJobTypeSignal('batch');
 		},
 	};
+}
+
+export function chapterPlansForProcessing(
+	files: readonly AudioFile[],
+	jobType: JobType,
+): ProcessPayload['chapterPlans'] {
+	const plans: NonNullable<ProcessPayload['chapterPlans']> = {};
+	for (const file of files.filter((file) => file.isValid)) {
+		if (file.cueSource?.status === 'needsConfirmation' || file.cueSource?.status === 'invalid') {
+			throw new Error(
+				`Review ${file.cueSource.fileName}: confirm its timestamp interpretation or ignore the CUE before converting.`,
+			);
+		}
+		if (jobType === 'merge' && files.length > 1 && file.chapterPlan?.fromCue) {
+			throw new Error(
+				'Merging CUE-bearing inputs is not supported. Convert separate jobs or ignore CUE chapters.',
+			);
+		}
+		if (file.chapterPlan)
+			plans[file.path] = {
+				...file.chapterPlan,
+				chapters: file.chapterPlan.chapters.map((chapter) => ({
+					...chapter,
+					title: chapter.title,
+				})),
+			};
+	}
+	return Object.keys(plans).length ? plans : undefined;
 }

--- a/src/app/processing/AGENTS.md
+++ b/src/app/processing/AGENTS.md
@@ -58,3 +58,8 @@
   build a process payload.
 - Converting Status Panel into a WorkRuntime consumer without a documented
   architecture decision.
+
+- Input's `chapterPlansForProcessing` owns confirmation/Ignore gating. Processing
+  includes the returned plans in the immutable submission; runtime validates
+  the source fingerprint and chapter intervals. Do not rediscover CUE in an
+  encoder adapter or reinterpret timestamps in the frontend.

--- a/src/app/processing/workflow.ts
+++ b/src/app/processing/workflow.ts
@@ -1,4 +1,5 @@
 import { pathBasename } from '../../lib/path/basename';
+import { chapterPlansForProcessing } from '../inputSession';
 import type {
 	ProcessCommandResult,
 	ProcessPayload,
@@ -410,6 +411,10 @@ export function processingWorkflowProgram(
 			processingRequestConfig,
 			jobType,
 			services.remoteSource.processingAssets(inputIds),
+		);
+		processPayload.chapterPlans = yield* workflowPromise(
+			async () => chapterPlansForProcessing(fileList.files, jobType),
+			'Review CUE chapters before processing.',
 		);
 		yield* ensureBatchMetadataLoaded(services, processPayload, workflowPromise);
 

--- a/src/app/remoteSource/AGENTS.md
+++ b/src/app/remoteSource/AGENTS.md
@@ -10,19 +10,16 @@
 
 ## Public API Strip
 
-- Import session-asset coordination from `src/ui/remoteSource`.
-- Import acquire intents, lane helper (`providerIdFromLane`),
-  release/title filter helpers, and the Input handoff result type from
-  `src/app/remoteSource`.
-- `RemoteSourceOwner`: `open({ lane? })`, `selectLane`, `view`, workflow
-  `runAction`, and indexer connection settings intents (`loadIndexerConnectionSettings`,
-  `saveIndexerConnectionSettings`, `testIndexerConnection`, `indexerConnection`).
-- `index.ts` is the export surface. Do not import `workflow.ts`,
-  `sessionAssets.ts`, or `state.ts` from outside this owner.
-- State/listeners, workflow generation counters, cover-preview scheduling, and
-  Supplemental Asset maps are still module-global compatibility state. Do not
-  add callers, a reset API, another global, or a UI re-export; new state belongs
-  to each Remote Source owner.
+- `index.ts` is the export surface. Callers consume the composed
+  `RemoteSourceOwner`; private state, workflow, assets, and previews stay here.
+- `open({ lane? })` hydrates account/library state without a mounted view.
+  `selectLane`, title/PDF/release selection intents, and workflow actions own
+  transitions. `editSearch` accepts only user-editable search/filter fields;
+  connection edits accept only URL, API-key, and category drafts.
+- State, workflow generations, cover previews, and supplemental assets belong
+  to each owner instance. Reset/disposal invalidates that instance's work.
+- Nonvisual callers use the owner's companion, processing-asset, retention,
+  reconciliation, and terminal-work intents; the UI strip exports only its view.
 
 ## Hard Invariants
 
@@ -74,6 +71,6 @@
 
 ## Breaking-Change Triggers
 
-- Adding a caller to the public session-asset compatibility exports.
+- Exposing internal state mutation or moving asset coordination into the UI.
 - Dual-writing `fileListSessionState` or adding a parallel remote file list.
 - Cancelling acquisition from dialog close.

--- a/src/app/remoteSource/index.ts
+++ b/src/app/remoteSource/index.ts
@@ -12,8 +12,6 @@ export {
 } from './display';
 export {
 	selectedRemoteTitleSummaryText,
-	toggledRemoteTitleSelection,
-	toggledSupplementalPdfPreference,
 	visibleRemoteReleases,
 	visibleRemoteTitles,
 } from './selection';

--- a/src/app/remoteSource/indexerConnection.test.ts
+++ b/src/app/remoteSource/indexerConnection.test.ts
@@ -57,11 +57,13 @@ describe('Indexer connection owner intents', () => {
 			.mockResolvedValue({ providerId: 'indexer', status: 'connected' });
 		runtime = createTestAppRuntime();
 		const owner = runtime.remoteSource;
-		owner.patch({
-			isOpen: true,
+		vi.spyOn(tauriClient, 'listRemoteSourceProviders').mockResolvedValue([]);
+		vi.mocked(tauriClient.getRemoteSourceAccountState).mockResolvedValueOnce({
 			providerId: 'indexer',
-			accountState: { providerId: 'indexer', status: 'needsAuth' },
+			status: 'needsAuth',
 		});
+		await owner.open({ lane: 'indexer' });
+		expect(owner.view().accountState?.status).toBe('needsAuth');
 		owner.patchIndexerConnectionSettings({ baseUrlDraft: configured.baseUrl!, apiKeyDraft: 'key' });
 		await owner.saveIndexerConnectionSettings();
 		expect(account).toHaveBeenCalledWith('indexer');
@@ -119,11 +121,13 @@ describe('Indexer connection owner intents', () => {
 		});
 		runtime = createTestAppRuntime();
 		const owner = runtime.remoteSource;
-		owner.patch({
-			isOpen: true,
+		vi.spyOn(tauriClient, 'listRemoteSourceProviders').mockResolvedValue([]);
+		vi.mocked(tauriClient.getRemoteSourceAccountState).mockResolvedValueOnce({
 			providerId: 'indexer',
-			accountState: { providerId: 'indexer', status: 'needsAuth' },
+			status: 'needsAuth',
 		});
+		await owner.open({ lane: 'indexer' });
+		expect(owner.view().accountState?.status).toBe('needsAuth');
 		owner.patchIndexerConnectionSettings({
 			baseUrlDraft: configured.baseUrl!,
 			apiKeyDraft: 'first-key',

--- a/src/app/remoteSource/indexerConnection.test.ts
+++ b/src/app/remoteSource/indexerConnection.test.ts
@@ -70,6 +70,22 @@ describe('Indexer connection owner intents', () => {
 		expect(owner.view().accountState?.status).toBe('connected');
 	});
 
+	it('reports a failed post-save refresh while retaining successful persistence', async () => {
+		vi.spyOn(tauriClient, 'updateRemoteSourceIndexerConnection').mockResolvedValue(configured);
+		vi.spyOn(tauriClient, 'listRemoteSourceProviders').mockResolvedValue([]);
+		vi.spyOn(tauriClient, 'getRemoteSourceAccountState')
+			.mockResolvedValueOnce({ providerId: 'indexer', status: 'needsAuth' })
+			.mockRejectedValueOnce(new Error('Account refresh unavailable'));
+		runtime = createTestAppRuntime();
+		const owner = runtime.remoteSource;
+		await owner.open({ lane: 'indexer' });
+		owner.patchIndexerConnectionSettings({ baseUrlDraft: configured.baseUrl!, apiKeyDraft: 'key' });
+		await expect(owner.saveIndexerConnectionSettings()).resolves.toBeUndefined();
+		expect(owner.indexerConnection().saveState).toBe('saved');
+		expect(owner.indexerConnection().apiKeyDraft).toBe('');
+		expect(owner.view().statusMessage).toContain('Connection saved, but account refresh failed.');
+	});
+
 	it('does not let initial loading overwrite edits made before the load returns', async () => {
 		let finish!: (connection: RemoteIndexerConnection) => void;
 		vi.spyOn(tauriClient, 'getRemoteSourceIndexerConnection').mockReturnValue(

--- a/src/app/remoteSource/owner.ts
+++ b/src/app/remoteSource/owner.ts
@@ -2,6 +2,8 @@ import { createSignal, type Accessor } from 'solid-js';
 import type { AcquisitionLane } from '../../types/appSettings';
 import type { AudioFile, SupplementalProcessingAsset } from '../../types/audio';
 import { tauriClient } from '../../lib/tauri/client';
+import type { RemoteRelease } from '../../types/remoteSource';
+import { toggledRemoteTitleSelection, toggledSupplementalPdfPreference } from './selection';
 import type { InputOwner } from '../inputSession';
 import {
 	createRemoteSourceCoverPreviews,
@@ -34,11 +36,33 @@ type InputId = string | undefined;
 export type RemoteSourceOwner = {
 	readonly view: Accessor<RemoteSourceView>;
 	readonly indexerConnection: Accessor<IndexerConnectionSettingsView>;
-	open(options?: { readonly lane?: AcquisitionLane }): void;
+	open(options?: { readonly lane?: AcquisitionLane }): Promise<void>;
 	selectLane(lane: AcquisitionLane): Promise<void>;
 	close(): void;
-	patch(patch: Partial<RemoteSourceView>): void;
-	runAction(action: RemoteSourceWorkflowAction): Promise<void>;
+	editSearch(
+		patch: Partial<
+			Pick<
+				RemoteSourceView,
+				| 'handoffPath'
+				| 'titleFilter'
+				| 'showSupplementalPdfOnly'
+				| 'hideUnavailableTitles'
+				| 'indexerAuthorQuery'
+				| 'indexerTitleQuery'
+				| 'releaseFilter'
+			>
+		>,
+	): void;
+	toggleTitle(titleId: string): void;
+	clearTitleSelection(): void;
+	toggleSupplementalPdf(titleId: string): void;
+	selectRelease(release: Pick<RemoteRelease, 'guid' | 'indexerId'>): void;
+	runAction(
+		action: Exclude<
+			RemoteSourceWorkflowAction,
+			{ type: 'hydrateOpenDialog' | 'refreshAccount' | 'selectLane' }
+		>,
+	): Promise<void>;
 	coverPreview(coverUrl: string | null | undefined): RemoteSourceCoverPreviewState;
 	scheduleCoverPreviews(coverUrls: ReadonlyArray<string | null | undefined>): void;
 	cancelCoverPreviews(): void;
@@ -53,7 +77,11 @@ export type RemoteSourceOwner = {
 		readonly completedInputIds: readonly string[];
 	}): Promise<void>;
 	loadIndexerConnectionSettings(): Promise<void>;
-	patchIndexerConnectionSettings(patch: Partial<IndexerConnectionSettingsView>): void;
+	patchIndexerConnectionSettings(
+		patch: Partial<
+			Pick<IndexerConnectionSettingsView, 'baseUrlDraft' | 'apiKeyDraft' | 'categoryIdsDraft'>
+		>,
+	): void;
 	saveIndexerConnectionSettings(): Promise<void>;
 	testIndexerConnection(): Promise<void>;
 	reconcileWithInput(files: ReadonlyArray<AudioFile>): Promise<void>;
@@ -106,7 +134,7 @@ export function createRemoteSourceOwner(deps: RemoteSourceOwnerDeps): RemoteSour
 			return snapshot;
 		},
 		indexerConnection: indexerConnection.view,
-		open(options) {
+		async open(options) {
 			const lane = options?.lane ?? 'audible';
 			state.patch({
 				isOpen: true,
@@ -114,17 +142,50 @@ export function createRemoteSourceOwner(deps: RemoteSourceOwnerDeps): RemoteSour
 				...(state.current().providerId !== providerIdFromLane(lane)
 					? { ...laneSelectionResetPatch(), accountState: null }
 					: {}),
-				didHydrateOpenDialog: false,
 			});
+			await workflow.run({ type: 'hydrateOpenDialog' });
 		},
 		selectLane(lane) {
-			return this.runAction({ type: 'selectLane', lane });
+			return workflow.run({ type: 'selectLane', lane });
 		},
 		close() {
-			state.patch({ isOpen: false, didHydrateOpenDialog: false });
+			state.patch({ isOpen: false });
 		},
-		patch(patch) {
+		editSearch(patch) {
 			state.patch(patch);
+		},
+		toggleTitle(titleId) {
+			const current = state.current();
+			const title = current.titles.find((item) => item.titleId === titleId);
+			if (title)
+				state.patch({
+					selectedTitleIds: toggledRemoteTitleSelection(current.selectedTitleIds, title),
+				});
+		},
+		clearTitleSelection() {
+			state.patch({ selectedTitleIds: new Set() });
+		},
+		toggleSupplementalPdf(titleId) {
+			const current = state.current();
+			if (
+				current.titles.some((title) => title.titleId === titleId && title.supplementalPdfAvailable)
+			) {
+				state.patch({
+					includePdfByTitleId: toggledSupplementalPdfPreference(
+						current.includePdfByTitleId,
+						titleId,
+					),
+				});
+			}
+		},
+		selectRelease(identity) {
+			const release = state
+				.current()
+				.releases.find(
+					(item) => item.guid === identity.guid && item.indexerId === identity.indexerId,
+				);
+			if (release)
+				state.patch({ selectedRelease: { guid: release.guid, indexerId: release.indexerId } });
 		},
 		async runAction(action) {
 			try {
@@ -169,7 +230,7 @@ export function createRemoteSourceOwner(deps: RemoteSourceOwnerDeps): RemoteSour
 		async saveIndexerConnectionSettings() {
 			const saved = await indexerConnection.save();
 			if (saved && state.current().isOpen && state.current().providerId === 'indexer') {
-				await this.runAction({ type: 'refreshAccount' });
+				await workflow.run({ type: 'refreshAccount' });
 			}
 		},
 		testIndexerConnection() {

--- a/src/app/remoteSource/runtime-api-contract.test.ts
+++ b/src/app/remoteSource/runtime-api-contract.test.ts
@@ -14,8 +14,6 @@ const EXPECTED_APP_REMOTE_SOURCE_EXPORTS = [
 	'releaseProtocolLabel',
 	'selectedRemoteTitleSummaryText',
 	'titleAvailability',
-	'toggledRemoteTitleSelection',
-	'toggledSupplementalPdfPreference',
 	'visibleRemoteReleases',
 	'visibleRemoteTitles',
 ] as const;

--- a/src/app/remoteSource/types.ts
+++ b/src/app/remoteSource/types.ts
@@ -16,7 +16,6 @@ export type RemoteInputHandoffResult =
 
 export type AcquisitionState = {
 	isBusy: boolean;
-	didHydrateOpenDialog: boolean;
 	providerId: ProviderId;
 	providers: RemoteSourceProviderCapabilities[];
 	accountState: RemoteSourceAccountState | null;
@@ -50,7 +49,6 @@ export function providerIdFromLane(lane: AcquisitionLane): ProviderId {
 export function createInitialAcquisitionState(): AcquisitionState {
 	return {
 		isBusy: false,
-		didHydrateOpenDialog: false,
 		providerId: 'audible',
 		providers: [],
 		accountState: null,

--- a/src/app/remoteSource/workflow.test.ts
+++ b/src/app/remoteSource/workflow.test.ts
@@ -275,14 +275,15 @@ describe('remote source acquisition workflow', () => {
 	it('rekeys supplemental PDFs through the Input file list after a successful handoff', async () => {
 		const services = makeServices();
 		const owner = makeOwner(services);
-		owner.patch({ selectedTitleIds: new Set(['B000000001']) });
+		await owner.open();
+		owner.toggleTitle('B000000001');
 
 		await owner.runAction({
 			type: 'acquireSelected',
 		});
 
 		expect(services.startAcquisition).toHaveBeenCalledWith('audible', [
-			{ titleId: 'B000000001', includeSupplementalPdf: false },
+			{ titleId: 'B000000001', includeSupplementalPdf: true },
 		]);
 		expect(services.importMaterializedPaths).toHaveBeenCalledWith(['/session/book.m4b']);
 		expect(services.purgeSession).not.toHaveBeenCalled();
@@ -332,7 +333,8 @@ describe('remote source acquisition workflow', () => {
 			}),
 		});
 		owner = makeOwner(services);
-		owner.patch({ selectedTitleIds: new Set(['B000000001']) });
+		await owner.open();
+		owner.toggleTitle('B000000001');
 		await owner.runAction({ type: 'acquireSelected' });
 
 		expect(published).toContainEqual({
@@ -353,7 +355,8 @@ describe('remote source acquisition workflow', () => {
 			})),
 		});
 		const owner = makeOwner(services);
-		owner.patch({ selectedTitleIds: new Set(['B000000001']) });
+		await owner.open();
+		owner.toggleTitle('B000000001');
 
 		await owner.runAction({
 			type: 'acquireSelected',
@@ -380,10 +383,8 @@ describe('remote source acquisition workflow', () => {
 			}),
 		});
 		owner = makeOwner(services);
-		owner.patch({
-			isOpen: true,
-			selectedTitleIds: new Set(['B000000001']),
-		});
+		await owner.open();
+		owner.toggleTitle('B000000001');
 
 		await owner.runAction({
 			type: 'acquireSelected',
@@ -395,9 +396,13 @@ describe('remote source acquisition workflow', () => {
 	});
 
 	it('cancels only through the explicit cancel action', async () => {
-		const services = makeServices();
+		const poll = createDeferred<AcquisitionJob>();
+		const services = makeServices({ getAcquisitionStatus: vi.fn(() => poll.promise) });
 		const owner = makeOwner(services);
-		owner.patch({ activeJob: runningJob() });
+		await owner.open();
+		owner.toggleTitle('B000000001');
+		const acquiring = owner.runAction({ type: 'acquireSelected' });
+		await vi.waitFor(() => expect(services.getAcquisitionStatus).toHaveBeenCalled());
 
 		await owner.runAction({
 			type: 'cancelActiveAcquisition',
@@ -405,6 +410,8 @@ describe('remote source acquisition workflow', () => {
 
 		expect(services.cancelAcquisition).toHaveBeenCalledWith('remote-job-1');
 		expect(owner.view().statusMessage).toBe('Cancelled.');
+		poll.resolve(runningJob());
+		await acquiring;
 	});
 
 	it('does not let a late acquisition poll overwrite native cancellation', async () => {
@@ -413,7 +420,8 @@ describe('remote source acquisition workflow', () => {
 			getAcquisitionStatus: vi.fn(() => latePoll.promise),
 		});
 		const owner = makeOwner(services);
-		owner.patch({ selectedTitleIds: new Set(['B000000001']) });
+		await owner.open();
+		owner.toggleTitle('B000000001');
 
 		const acquisition = owner.runAction({
 			type: 'acquireSelected',
@@ -437,8 +445,10 @@ describe('remote source acquisition workflow', () => {
 	it('keeps acquisition state and supplemental assets isolated across owners', async () => {
 		const first = makeOwner(makeServices());
 		const second = makeOwner(makeServices());
-		first.patch({ selectedTitleIds: new Set(['B000000001']) });
-		second.patch({ selectedTitleIds: new Set(['B000000001']), isOpen: true });
+		await first.open();
+		first.toggleTitle('B000000001');
+		await second.open();
+		second.toggleTitle('B000000001');
 
 		await first.runAction({ type: 'acquireSelected' });
 		await second.runAction({ type: 'acquireSelected' });
@@ -456,8 +466,10 @@ describe('remote source acquisition workflow', () => {
 		const secondServices = makeServices();
 		const first = makeOwner(firstServices);
 		const second = makeOwner(secondServices);
-		first.patch({ selectedTitleIds: new Set(['B000000001']) });
-		second.patch({ selectedTitleIds: new Set(['B000000001']) });
+		await first.open();
+		first.toggleTitle('B000000001');
+		await second.open();
+		second.toggleTitle('B000000001');
 		await first.runAction({ type: 'acquireSelected' });
 		await second.runAction({ type: 'acquireSelected' });
 		await first.reconcileWithInput(fileList().files);
@@ -497,11 +509,8 @@ describe('remote source acquisition workflow', () => {
 	it('searches indexer releases from author, title, or both without requiring both', async () => {
 		const services = makeServices();
 		const owner = makeOwner(services);
-		owner.patch({
-			providerId: 'indexer',
-			accountState: { providerId: 'indexer', status: 'connected' },
-			indexerAuthorQuery: 'David Crouse',
-		});
+		await owner.open({ lane: 'indexer' });
+		owner.editSearch({ indexerAuthorQuery: 'David Crouse' });
 
 		await owner.runAction({ type: 'searchReleases' });
 		expect(services.searchReleases).toHaveBeenCalledWith({
@@ -510,7 +519,7 @@ describe('remote source acquisition workflow', () => {
 			query: undefined,
 		});
 
-		owner.patch({ indexerAuthorQuery: '', indexerTitleQuery: 'Way of Kings' });
+		owner.editSearch({ indexerAuthorQuery: '', indexerTitleQuery: 'Way of Kings' });
 		await owner.runAction({ type: 'searchReleases' });
 		expect(services.searchReleases).toHaveBeenCalledWith({
 			author: undefined,
@@ -518,7 +527,7 @@ describe('remote source acquisition workflow', () => {
 			query: undefined,
 		});
 
-		owner.patch({
+		owner.editSearch({
 			indexerAuthorQuery: 'Brandon Sanderson',
 			indexerTitleQuery: 'The Way of Kings',
 		});
@@ -535,11 +544,15 @@ describe('remote source acquisition workflow', () => {
 		const owner = makeOwner(services);
 		const first = indexerRelease({ indexerId: 1 });
 		const chosen = indexerRelease({ indexerId: 2 });
-		owner.patch({
+		vi.mocked(services.searchReleases).mockResolvedValue({
 			providerId: 'indexer',
 			releases: [first, chosen],
-			selectedRelease: { guid: chosen.guid, indexerId: chosen.indexerId },
+			diagnostics: [],
 		});
+		await owner.open({ lane: 'indexer' });
+		owner.editSearch({ indexerTitleQuery: 'Example' });
+		await owner.runAction({ type: 'searchReleases' });
+		owner.selectRelease(chosen);
 		await owner.runAction({ type: 'grabSelectedRelease' });
 		expect(services.grabRelease).toHaveBeenCalledExactlyOnceWith({ release: chosen });
 		expect(services.startAcquisition).not.toHaveBeenCalled();
@@ -564,11 +577,10 @@ describe('remote source acquisition workflow', () => {
 			});
 			const owner = makeOwner(services);
 			const release = indexerRelease();
-			owner.patch({
-				providerId: 'indexer',
-				releases: [release],
-				selectedRelease: { guid: release.guid, indexerId: release.indexerId },
-			});
+			await owner.open({ lane: 'indexer' });
+			owner.editSearch({ indexerTitleQuery: 'Example' });
+			await owner.runAction({ type: 'searchReleases' });
+			owner.selectRelease(release);
 			await owner.runAction({ type: 'grabSelectedRelease' });
 			expect(owner.view().statusMessage).toContain(
 				outcome === 'error' ? 'Failed to grab release.' : 'No download client',
@@ -586,8 +598,7 @@ describe('remote source acquisition workflow', () => {
 			})),
 		});
 		const owner = makeOwner(services);
-		owner.open({ lane: 'indexer' });
-		await owner.runAction({ type: 'hydrateOpenDialog' });
+		await owner.open({ lane: 'indexer' });
 		expect(owner.view().accountState?.status).toBe('needsAuth');
 		expect(services.loadLibrary).not.toHaveBeenCalled();
 		expect(owner.view().isBusy).toBe(false);
@@ -597,11 +608,9 @@ describe('remote source acquisition workflow', () => {
 		const poll = createDeferred<AcquisitionJob>();
 		const services = makeServices({ getAcquisitionStatus: vi.fn(() => poll.promise) });
 		const owner = makeOwner(services);
-		owner.patch({
-			selectedTitleIds: new Set(['B000000001']),
-			releases: [indexerRelease()],
-			releaseFilter: 'old',
-		});
+		await owner.open();
+		owner.toggleTitle('B000000001');
+		owner.editSearch({ releaseFilter: 'old' });
 		const acquiring = owner.runAction({ type: 'acquireSelected' });
 		await vi.waitFor(() => expect(services.getAcquisitionStatus).toHaveBeenCalled());
 		await owner.selectLane('indexer');
@@ -616,13 +625,14 @@ describe('remote source acquisition workflow', () => {
 		expect(owner.view().providerId).toBe('indexer');
 	});
 
-	it('preserves selection on ordinary reopen and resets it when opening another lane', () => {
+	it('preserves selection on ordinary reopen and resets it when opening another lane', async () => {
 		const owner = makeOwner(makeServices());
-		owner.patch({ selectedTitleIds: new Set(['B000000001']) });
+		await owner.open();
+		owner.toggleTitle('B000000001');
 		owner.close();
-		owner.open({ lane: 'audible' });
+		await owner.open({ lane: 'audible' });
 		expect([...owner.view().selectedTitleIds]).toEqual(['B000000001']);
-		owner.open({ lane: 'indexer' });
+		await owner.open({ lane: 'indexer' });
 		expect(owner.view().selectedTitleIds.size).toBe(0);
 		expect(owner.view().providerId).toBe('indexer');
 	});

--- a/src/app/remoteSource/workflow.ts
+++ b/src/app/remoteSource/workflow.ts
@@ -245,7 +245,15 @@ export function createRemoteSourceWorkflow(deps: {
 	): Promise<void> {
 		switch (action.type) {
 			case 'refreshAccount': {
-				await refreshAccountState(deps.state.current().providerId, isWorkflowCurrent);
+				try {
+					await refreshAccountState(deps.state.current().providerId, isWorkflowCurrent);
+				} catch (cause) {
+					setAcquisitionErrorWhenCurrent(
+						isWorkflowCurrent,
+						cause,
+						'Connection saved, but account refresh failed. Reopen Acquire to retry.',
+					);
+				}
 				return;
 			}
 			case 'hydrateOpenDialog': {

--- a/src/app/remoteSource/workflow.ts
+++ b/src/app/remoteSource/workflow.ts
@@ -249,7 +249,7 @@ export function createRemoteSourceWorkflow(deps: {
 				return;
 			}
 			case 'hydrateOpenDialog': {
-				patchWhenCurrent(isWorkflowCurrent, { isBusy: true, didHydrateOpenDialog: true });
+				patchWhenCurrent(isWorkflowCurrent, { isBusy: true });
 				try {
 					const providers = await deps.services.listProviders();
 					if (!patchWhenCurrent(isWorkflowCurrent, { providers })) return;

--- a/src/app/runtime/runtime.test.ts
+++ b/src/app/runtime/runtime.test.ts
@@ -151,7 +151,7 @@ describe('app runtime', () => {
 
 	it('resets Remote Source owner state on dispose so a remount does not keep the dialog open', () => {
 		const runtime = createAppRuntime();
-		runtime.remoteSource.patch({ isOpen: true, statusMessage: 'stale remote' });
+		void runtime.remoteSource.open();
 		expect(runtime.remoteSource.view().isOpen).toBe(true);
 		runtime.dispose();
 		expect(runtime.remoteSource.view().isOpen).toBe(false);
@@ -164,8 +164,31 @@ describe('app runtime', () => {
 		const runtime = createAppRuntime({ remoteSource: { services } });
 		const other = createAppRuntime();
 		dispose = () => other.dispose();
-		other.remoteSource.patch({ isOpen: true, statusMessage: 'other runtime' });
-		runtime.remoteSource.patch({ selectedTitleIds: new Set(['B000000001']) });
+		void other.remoteSource.open();
+		other.remoteSource.editSearch({ titleFilter: 'other runtime' });
+		vi.mocked(services.getAccountState).mockResolvedValue({
+			providerId: 'audible',
+			status: 'connected',
+		});
+		vi.mocked(services.loadLibrary).mockResolvedValue({
+			providerId: 'audible',
+			diagnostics: [],
+			titles: [
+				{
+					providerId: 'audible',
+					titleId: 'B000000001',
+					title: 'Book',
+					authors: [],
+					narrators: [],
+					supplementalPdfAvailable: false,
+					acquired: false,
+					availability: { acquirable: true, status: 'available', label: 'Available' },
+					unsupportedReasons: [],
+				},
+			],
+		});
+		await runtime.remoteSource.open();
+		runtime.remoteSource.toggleTitle('B000000001');
 		const acquisition = runtime.remoteSource.runAction({
 			type: 'acquireSelected',
 		});
@@ -178,6 +201,6 @@ describe('app runtime', () => {
 		expect(runtime.remoteSource.view().activeJob).toBeNull();
 		expect(runtime.remoteSource.view().statusMessage).toBe('');
 		expect(other.remoteSource.view().isOpen).toBe(true);
-		expect(other.remoteSource.view().statusMessage).toBe('other runtime');
+		expect(other.remoteSource.view().titleFilter).toBe('other runtime');
 	});
 });

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -210,16 +210,6 @@ export type AppSettingsPatch = {
 	defaultAcquisitionLane: AcquisitionLane | null,
 };
 
-/**  Read-only chapter facts discovered while analyzing one audio file. */
-export type AudioChapter = {
-	/**  Embedded chapter title, when present in the source container. */
-	title: string | null,
-	/**  Chapter start in milliseconds from the beginning of this file. */
-	startMs: number,
-	/**  Chapter end in milliseconds from the beginning of this file. */
-	endMs: number,
-};
-
 /**  Represents an audio file with metadata */
 export type AudioFile = {
 	/**  Stable workbench/session identity for joins that must survive reorder/remove operations. */
@@ -247,7 +237,9 @@ export type AudioFile = {
 	/**  Artist tag discovered during input analysis (None if unavailable) */
 	tagArtist: string | null,
 	/**  Chapters embedded in this individual source file, normalized to milliseconds. */
-	chapters?: AudioChapter[],
+	chapters?: ChapterSpec[],
+	chapterPlan?: ChapterPlan | null,
+	cueSource?: CueSource | null,
 	/**  Validation status */
 	isValid: boolean,
 	/**  Error message if validation failed */
@@ -282,6 +274,18 @@ export type BitrateModeKind = "cbr" | "cvbr" | "vbr";
 /**  Channel selection strategy */
 export type ChannelConfig = "auto" | "mono" | "stereo";
 
+export type ChapterPlan = {
+	chapters: ChapterSpec[],
+	fromCue: boolean,
+	sourceFingerprint: string,
+};
+
+export type ChapterSpec = {
+	title: string | null,
+	startMs: number,
+	endMs: number,
+};
+
 export type ChildJobSnapshot = {
 	childJobId: string,
 	operationId: OperationId,
@@ -303,6 +307,14 @@ export type ChildJobStatus = "queued" | "running" | "completed" | "skipped" | "c
 export type CollisionPolicy = "fail" | "replace_existing" | "rename_new" | "skip_existing";
 
 export type ConcurrencyPreference = { mode: "auto" } | { mode: "fixed"; value: number };
+
+export type CueSource = {
+	fileName: string,
+	status: CueStatus,
+	message: string,
+};
+
+export type CueStatus = "ready" | "needsConfirmation" | "invalid" | "ignored" | "embeddedPreferred";
 
 /**  Machine-readable decoder identity paired with the friendly display label. */
 export type DecoderSelection = {
@@ -646,6 +658,7 @@ export type ProcessCommandResult = {
 
 export type ProcessPayload = {
 	inputFiles: string[],
+	chapterPlans: { [key in string]: ChapterPlan } | null,
 	/**
 	 *  Session/workbench identities aligned to `input_files`; used for acquired
 	 *  source sidecars without replacing path as the filesystem source label.

--- a/src/lib/tauri-client.generated-event-bindings.test.ts
+++ b/src/lib/tauri-client.generated-event-bindings.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { EVENTS } from '../types/events';
 import type {
 	AcquisitionProgress,
-	AudioChapter,
+	ChapterSpec,
 	FileListInfo,
 	MaterializedSourceFile,
 	MaxConcurrentJobsCapabilities,
@@ -59,7 +59,7 @@ describe('tauriClient generated event bindings', () => {
 
 	it('keeps bounded wide Rust values in the numeric IPC contract', () => {
 		expectTypeOf<AcquisitionProgress['percentage']>().toEqualTypeOf<number>();
-		expectTypeOf<AudioChapter['startMs']>().toEqualTypeOf<number>();
+		expectTypeOf<ChapterSpec['startMs']>().toEqualTypeOf<number>();
 		expectTypeOf<MaterializedSourceFile['sizeBytes']>().toEqualTypeOf<number>();
 		expectTypeOf<MetadataSaveResultEntry['inputIndex']>().toEqualTypeOf<number>();
 		expectTypeOf<OperationSnapshot['sequence']>().toEqualTypeOf<number>();

--- a/src/lib/tauri-client.test.ts
+++ b/src/lib/tauri-client.test.ts
@@ -287,6 +287,13 @@ describe('tauriClient nullish adapters', () => {
 		const result = await tauriClient.processAudiobookFiles({
 			payload: {
 				inputFiles: ['/books/a.m4b'],
+				chapterPlans: {
+					'/books/a.m4b': {
+						fromCue: true,
+						sourceFingerprint: '123:456',
+						chapters: [{ title: 'Opening', startMs: 0, endMs: 1000 }],
+					},
+				},
 				outputDir: '/tmp/out',
 				settings: defaultEncoderSettings(),
 				sampleRate: undefined,
@@ -312,6 +319,13 @@ describe('tauriClient nullish adapters', () => {
 			},
 		];
 		expect(commandName).toBe('process_audiobook_files');
+		expect(args.payload.chapterPlans).toEqual({
+			'/books/a.m4b': {
+				fromCue: true,
+				sourceFingerprint: '123:456',
+				chapters: [{ title: 'Opening', startMs: 0, endMs: 1000 }],
+			},
+		});
 		expect(args.payload.sampleRate).toBeNull();
 		expect(args.payload.jobType).toBeNull();
 		expect(args.payload.outputNaming).toBeNull();

--- a/src/lib/tauri/normalizers.ts
+++ b/src/lib/tauri/normalizers.ts
@@ -71,6 +71,7 @@ const METADATA_FIELDS = [
 ] as const satisfies readonly (keyof GeneratedAudiobookMetadata)[];
 
 const PROCESS_PAYLOAD_NULLABLE_FIELDS = [
+	'chapterPlans',
 	'inputIds',
 	'sampleRate',
 	'jobType',

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -1,6 +1,6 @@
 // TypeScript interfaces for audio processing
 import type {
-	AudioChapter as GeneratedAudioChapter,
+	ChapterSpec as GeneratedAudioChapter,
 	BitrateMode as GeneratedBitrateMode,
 	ChannelConfig as GeneratedChannelConfig,
 	AudioFile as GeneratedAudioFile,

--- a/src/ui/fileList/FileListView.tsx
+++ b/src/ui/fileList/FileListView.tsx
@@ -3,7 +3,7 @@ import { interpretFileListKeyDown } from '../../app/inputSession/keyboardNavigat
 import { pathBasename } from '../../lib/path/basename';
 import { useAppRuntime } from '../../app/runtime';
 import { Button } from '../foundation';
-import { createSignal, createEffect, For, onCleanup, type JSX } from 'solid-js';
+import { createSignal, createEffect, Show, For, onCleanup, type JSX } from 'solid-js';
 import {
 	clearFileListCoverThumbnails,
 	getFileListCoverThumbnailState,
@@ -265,6 +265,60 @@ export function FileListView(props: {
 												) : null}
 											</div>
 											<div class="file-details">{formatFileDetails(file)}</div>
+											<Show when={file.cueSource}>
+												{(cue) => (
+													<div class="file-cue-details">
+														<span>
+															{file.chapterPlan?.chapters.length ?? 0} chapters from{' '}
+															{cue().status === 'embeddedPreferred'
+																? 'embedded audio'
+																: cue().fileName}
+														</span>
+														<Show when={cue().message}>
+															<p>{cue().message}</p>
+														</Show>
+														<Show when={cue().status === 'needsConfirmation'}>
+															<p>
+																This CUE uses nonstandard timestamps. Interpret the final field as
+																hundredths of a second?
+															</p>
+															<button
+																type="button"
+																disabled={view().orderLocked}
+																onClick={(event) => {
+																	event.stopPropagation();
+																	if (file.inputId)
+																		runtime.input.chooseCue(file.inputId, 'confirmHundredths');
+																}}
+															>
+																Use hundredths
+															</button>
+														</Show>
+														<Show when={cue().status === 'ignored'}>
+															<p>CUE ignored. Converting without its chapters.</p>
+														</Show>
+														<Show when={cue().status === 'ready'}>
+															<p>CUE chapters accepted.</p>
+														</Show>
+														<Show
+															when={
+																cue().status !== 'ignored' && cue().status !== 'embeddedPreferred'
+															}
+														>
+															<button
+																type="button"
+																disabled={view().orderLocked}
+																onClick={(event) => {
+																	event.stopPropagation();
+																	if (file.inputId) runtime.input.chooseCue(file.inputId, 'ignore');
+																}}
+															>
+																Ignore CUE
+															</button>
+														</Show>
+													</div>
+												)}
+											</Show>
 										</div>
 										<button
 											class="move-up-btn"

--- a/src/ui/fileList/fileList.css
+++ b/src/ui/fileList/fileList.css
@@ -308,3 +308,15 @@
 	color: var(--text-inverse);
 	opacity: 0.8;
 }
+
+.file-cue-details {
+	margin-top: var(--space-1, 4px);
+	font-size: var(--font-size-sm, 12px);
+	white-space: normal;
+}
+.file-cue-details p {
+	margin: 4px 0;
+}
+.file-cue-details button {
+	margin-right: 8px;
+}

--- a/src/ui/remoteSource/AGENTS.md
+++ b/src/ui/remoteSource/AGENTS.md
@@ -2,36 +2,18 @@
 
 ## Public API Strip
 
-- Import session-asset coordination from `src/ui/remoteSource`.
-- Exports: `companionSummaryForInputIds`, `hasSupplementalAssetsForInputId`,
-  `purgeRemoteSourceSessionsForInputIds`, `releaseRemoteSourceSessionRetainers`,
-  `retainRemoteSourceSessionsForInputIds`, `registerRemoteSourceSupplementalAssets`,
-  `subscribeRemoteSourceSupplementalAssets`,
-  `supplementalAssetsByInputIdForProcessing`, `CompanionAssetSummary` (type).
-- Do not re-export acquisition workflow symbols or private session-asset
-  helpers such as `supplementalAssetsForInputIds` from the index.
-- These non-view session-asset exports are current compatibility rails.
-  Do not add callers; after migration, nonvisual consumers import the App
-  Runtime Remote Source owner and this UI index exposes the dialog view.
-- The acquire dialog is `RemoteSourceAcquireView.tsx`. File Import composes
-  it. Import acquire intents and lane selection import from `src/app/remoteSource`.
-  The Source control switches Audible library mode vs Indexer search/grab mode
-  in one dialog instance.
+- `index.ts` exports `RemoteSourceAcquireView`; File Import composes it.
+- Nonvisual consumers use the App Runtime Remote Source owner from
+  `src/app/remoteSource`. Session assets and acquisition lifecycle stay there.
 
 ## Private Cluster
 
-- Files: `RemoteSourceAcquireView.tsx`, `remoteSourceAcquire.css`.
+`RemoteSourceAcquireView.tsx` and `remoteSourceAcquire.css` own dialog rendering
+and event wiring. The Source control switches Audible library and Indexer
+search/Grab in one dialog. User edits and selections dispatch owner intents;
+the view does not hydrate account state or construct selection-state patches.
 
-Owner truth lives in `src/app/remoteSource`. This directory renders it. The
-current session-asset re-exports for Processing, File List, and inspector
-callers must be removed rather than preserved as a second public seam when
-their remaining callers migrate.
-
-Remote source IPC must route through `src/lib/tauri/client.ts`. Materialized
-audio imports through Input Session; processing remains user-triggered.
-
-## Shape
-
-Solid owns rendering and event wiring. Effect owns account/acquisition
-workflows. Pure display and selection policy belong in
-`src/app/remoteSource` helpers.
+Cover-preview scheduling follows the visible titles and is cancelled when the
+view no longer needs it. Resources and caches remain private to the owner.
+Remote source IPC routes through `src/lib/tauri/client.ts`. Materialized audio
+imports through Input Session; processing remains user-triggered.

--- a/src/ui/remoteSource/RemoteSourceAcquireView.test.tsx
+++ b/src/ui/remoteSource/RemoteSourceAcquireView.test.tsx
@@ -95,6 +95,33 @@ function remoteTitle(): RemoteTitle {
 	};
 }
 
+async function openConnected(
+	runtime: AppRuntime,
+	lane: 'audible' | 'indexer',
+	releases?: RemoteRelease[],
+) {
+	vi.spyOn(tauriClient, 'listRemoteSourceProviders').mockResolvedValue(providerCapabilities());
+	vi.spyOn(tauriClient, 'getRemoteSourceAccountState').mockImplementation(async (providerId) => ({
+		providerId,
+		status: 'connected',
+	}));
+	vi.spyOn(tauriClient, 'loadRemoteSourceLibrary').mockResolvedValue({
+		providerId: 'audible',
+		titles: [remoteTitle()],
+		diagnostics: [],
+	});
+	await runtime.remoteSource.open({ lane });
+	if (releases) {
+		vi.spyOn(tauriClient, 'searchRemoteSourceReleases').mockResolvedValue({
+			providerId: 'indexer',
+			releases,
+			diagnostics: [],
+		});
+		runtime.remoteSource.editSearch({ indexerTitleQuery: 'Example' });
+		await runtime.remoteSource.runAction({ type: 'searchReleases' });
+	}
+}
+
 describe('RemoteSourceAcquireView close wiring', () => {
 	let runtime: AppRuntime | undefined;
 
@@ -140,13 +167,8 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			accountState: { providerId: 'audible', status: 'connected' },
-			titles: [remoteTitle()],
-			selectedTitleIds: new Set(['B000000001']),
-		});
+		await openConnected(runtime, 'audible');
+		runtime.remoteSource.toggleTitle('B000000001');
 		await Promise.resolve();
 
 		await fireEvent.click(screen.getByRole('button', { name: 'Acquire Selected' }));
@@ -169,14 +191,7 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			providerId: 'audible',
-			providers: providerCapabilities(),
-			accountState: { providerId: 'audible', status: 'connected' },
-			titles: [remoteTitle()],
-		});
+		await openConnected(runtime, 'audible');
 		await Promise.resolve();
 
 		expect(screen.getByLabelText('Source')).toBeEnabled();
@@ -207,13 +222,11 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			providerId: 'audible',
-			providers: providerCapabilities(),
-			accountState: { providerId: 'audible', status: 'connected' },
-			titles: [remoteTitle()],
+		await openConnected(runtime, 'audible');
+		vi.mocked(tauriClient.getRemoteSourceAccountState).mockResolvedValue({
+			providerId: 'indexer',
+			status: 'needsAuth',
+			message: 'Configure Indexer URL and API key in Settings before searching.',
 		});
 		await Promise.resolve();
 
@@ -234,13 +247,7 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			providerId: 'indexer',
-			providers: providerCapabilities(),
-			accountState: { providerId: 'indexer', status: 'connected' },
-		});
+		await openConnected(runtime, 'indexer');
 		await Promise.resolve();
 
 		expect(screen.queryByTestId('remote-indexer-settings-needed')).not.toBeInTheDocument();
@@ -256,13 +263,7 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			providerId: 'indexer',
-			providers: providerCapabilities(),
-			accountState: { providerId: 'indexer', status: 'connected' },
-		});
+		await openConnected(runtime, 'indexer');
 		await Promise.resolve();
 		runAction.mockClear();
 
@@ -281,26 +282,19 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			providerId: 'indexer',
-			providers: providerCapabilities(),
-			accountState: { providerId: 'indexer', status: 'connected' },
-			releases: [
-				{
-					providerId: 'indexer',
-					guid: 'extinction-1',
-					indexerId: 7,
-					title: 'Extinction by David Crouse [ENG / M4B]',
-					indexer: 'MyAnonymouse',
-					sizeBytes: 550_000_000,
-					protocol: 'torrent',
-					seeders: 72,
-					categories: [{ id: 3030, name: 'Audio/Audiobook' }],
-				},
-			],
-		});
+		await openConnected(runtime, 'indexer', [
+			{
+				providerId: 'indexer',
+				guid: 'extinction-1',
+				indexerId: 7,
+				title: 'Extinction by David Crouse [ENG / M4B]',
+				indexer: 'MyAnonymouse',
+				sizeBytes: 550_000_000,
+				protocol: 'torrent',
+				seeders: 72,
+				categories: [{ id: 3030, name: 'Audio/Audiobook' }],
+			},
+		]);
 		await Promise.resolve();
 
 		expect(screen.getByText('torrent')).toHaveClass('remote-release-tag-torrent');
@@ -333,14 +327,7 @@ describe('RemoteSourceAcquireView close wiring', () => {
 				<RemoteSourceAcquireView />
 			</AppRuntimeProvider>
 		));
-		runtime.remoteSource.patch({
-			isOpen: true,
-			didHydrateOpenDialog: true,
-			providerId: 'indexer',
-			providers: providerCapabilities(),
-			accountState: { providerId: 'indexer', status: 'connected' },
-			releases,
-		});
+		await openConnected(runtime, 'indexer', releases);
 		await fireEvent.click(screen.getByRole('button', { name: /Release from 8/ }));
 		expect(screen.getByRole('option', { name: /Release from 7/ })).toHaveAttribute(
 			'aria-selected',

--- a/src/ui/remoteSource/RemoteSourceAcquireView.tsx
+++ b/src/ui/remoteSource/RemoteSourceAcquireView.tsx
@@ -11,8 +11,6 @@ import {
 	releaseProtocolLabel,
 	selectedRemoteTitleSummaryText,
 	titleAvailability,
-	toggledRemoteTitleSelection,
-	toggledSupplementalPdfPreference,
 	visibleRemoteReleases,
 	visibleRemoteTitles,
 } from '../../app/remoteSource';
@@ -65,18 +63,10 @@ export function RemoteSourceAcquireView(): JSX.Element {
 	const view = remoteSource.view;
 	const runAction = remoteSource.runAction;
 	const close = remoteSource.close;
-	const patchView = remoteSource.patch;
+	const editSearch = remoteSource.editSearch;
 
 	const isAudibleLane = () => view().providerId === 'audible';
 	const isIndexerLane = () => view().providerId === 'indexer';
-
-	createEffect(() => {
-		const current = view();
-		if (current.isOpen && !current.didHydrateOpenDialog) {
-			patchView({ didHydrateOpenDialog: true });
-			void runAction({ type: 'hydrateOpenDialog' });
-		}
-	});
 
 	createEffect(() => {
 		const current = view();
@@ -110,7 +100,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 		});
 
 	function handleLaneChange(lane: AcquisitionLane): void {
-		void runAction({ type: 'selectLane', lane });
+		void remoteSource.selectLane(lane);
 	}
 
 	function submitIndexerSearchOnEnter(event: KeyboardEvent): void {
@@ -184,7 +174,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 											type="text"
 											placeholder="Final Amazon URL or handoff file path"
 											value={view().handoffPath}
-											onInput={(event) => patchView({ handoffPath: event.currentTarget.value })}
+											onInput={(event) => editSearch({ handoffPath: event.currentTarget.value })}
 										/>
 									</div>
 									<div class="remote-source-toolbar-field remote-source-toolbar-button">
@@ -222,7 +212,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 									type="search"
 									placeholder="Filter loaded titles"
 									value={view().titleFilter}
-									onInput={(event) => patchView({ titleFilter: event.currentTarget.value })}
+									onInput={(event) => editSearch({ titleFilter: event.currentTarget.value })}
 								/>
 							</div>
 							<div class="remote-source-toolbar-field remote-source-toolbar-toggle remote-source-pdf-filter">
@@ -231,7 +221,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 										type="checkbox"
 										checked={view().showSupplementalPdfOnly}
 										onChange={(event) =>
-											patchView({ showSupplementalPdfOnly: event.currentTarget.checked })
+											editSearch({ showSupplementalPdfOnly: event.currentTarget.checked })
 										}
 									/>
 									<span class="option-label">Supplemental PDF only</span>
@@ -243,7 +233,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 										type="checkbox"
 										checked={view().hideUnavailableTitles}
 										onChange={(event) =>
-											patchView({ hideUnavailableTitles: event.currentTarget.checked })
+											editSearch({ hideUnavailableTitles: event.currentTarget.checked })
 										}
 									/>
 									<span class="option-label">Hide unavailable</span>
@@ -261,7 +251,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 								type="text"
 								placeholder="Author"
 								value={view().indexerAuthorQuery}
-								onInput={(event) => patchView({ indexerAuthorQuery: event.currentTarget.value })}
+								onInput={(event) => editSearch({ indexerAuthorQuery: event.currentTarget.value })}
 								onKeyDown={submitIndexerSearchOnEnter}
 							/>
 						</div>
@@ -273,7 +263,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 								type="text"
 								placeholder="Title"
 								value={view().indexerTitleQuery}
-								onInput={(event) => patchView({ indexerTitleQuery: event.currentTarget.value })}
+								onInput={(event) => editSearch({ indexerTitleQuery: event.currentTarget.value })}
 								onKeyDown={submitIndexerSearchOnEnter}
 							/>
 						</div>
@@ -294,7 +284,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 								type="search"
 								placeholder="Filter loaded releases"
 								value={view().releaseFilter}
-								onInput={(event) => patchView({ releaseFilter: event.currentTarget.value })}
+								onInput={(event) => editSearch({ releaseFilter: event.currentTarget.value })}
 							/>
 						</div>
 						<div class="remote-source-toolbar-field remote-source-toolbar-button">
@@ -339,7 +329,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 								class="remote-clear-selection"
 								type="button"
 								disabled={view().isBusy}
-								onClick={() => patchView({ selectedTitleIds: new Set() })}
+								onClick={() => remoteSource.clearTitleSelection()}
 							>
 								Clear selection
 							</button>
@@ -399,14 +389,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 										type="button"
 										class="remote-title-button"
 										disabled={!isTitleAcquirable(title)}
-										onClick={() =>
-											patchView({
-												selectedTitleIds: toggledRemoteTitleSelection(
-													view().selectedTitleIds,
-													title,
-												),
-											})
-										}
+										onClick={() => remoteSource.toggleTitle(title.titleId)}
 									>
 										<span class="remote-title-name">{title.title}</span>
 										<span class="remote-title-meta">{title.authors.join(', ')}</span>
@@ -427,14 +410,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 												type="checkbox"
 												disabled={!isTitleAcquirable(title)}
 												checked={view().includePdfByTitleId[title.titleId] ?? true}
-												onChange={() =>
-													patchView({
-														includePdfByTitleId: toggledSupplementalPdfPreference(
-															view().includePdfByTitleId,
-															title.titleId,
-														),
-													})
-												}
+												onChange={() => remoteSource.toggleSupplementalPdf(title.titleId)}
 											/>
 											PDF
 										</label>
@@ -460,11 +436,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 										view().selectedRelease?.guid === release.guid &&
 										view().selectedRelease?.indexerId === release.indexerId
 									}
-									onSelect={() =>
-										patchView({
-											selectedRelease: { guid: release.guid, indexerId: release.indexerId },
-										})
-									}
+									onSelect={() => remoteSource.selectRelease(release)}
 								/>
 							)}
 						</For>


### PR DESCRIPTION
## Behavior

Import a chapterless MP3 with its same-stem CUE to produce an M4B with the supplied chapter names and positions. Standard 75-frame sheets apply directly; nonstandard hundredths require per-input confirmation or explicit Ignore. Unsafe, ambiguous, multi-file, and invalid sheets receive diagnostics. Embedded chapters take precedence; CUE-bearing merges remain unsupported.

Input Session carries accepted chapter data into each job. Both encoder paths consume that plan, and selected chapter write/readback failures prevent successful artifact commit. Remote Source separately owns hydration and selection transitions through a narrowed mutation interface, with corrected owner guidance.

## Proof

- Pure metadata core: 28 tests pass; runtime sibling association and accepted-plan isolation pass.
- Existing media lane: 18 tests pass with only one new CUE case; latest focused CUE and finalization checks pass in 0.38 s. No new test infrastructure.
- Focused frontend owner/contract checks, typecheck, generated binding parity, runtime boundary, formatting, and Clippy pass. Existing embedded-cover function-length warning remains.
- User converted the full Lost Time MP3 through Native AAC, Apple AAC, and external FDK. Independent output inspection confirms all 42 names, starts, and ends against the accepted hundredths CUE, including Chapter 02 at 13.940 s and the near-EOF Chapter 42. Original MP3/CUE hashes are unchanged. User confirmed chapters in all three outputs in Apple Books.

## Acceptance limits

This feature transfers supplied markers; it does not discover spoken boundaries or edit CUE files. Spoken alignment is not claimed. The ABS test entry grouped the test output with two existing audiobooks, so isolated ABS playback remains unproven. The user accepts that limitation for this feature. Work Center records all conversions completed; detailed console logs were not captured for the Finder-launched run.

The late INDEX 00 whole-sheet inference correction is covered by the core test; this fixture does not exercise that edge.

Closes #481.
