### PR TITLE
Clarify agent ownership and streamline skill procedures

### DIFF
--- a/.agents/skills/abb-library-research/SKILL.md
+++ b/.agents/skills/abb-library-research/SKILL.md
@@ -1,87 +1,54 @@
 ---
 name: abb-library-research
-description: Resolve ABB external-library/API uncertainty for Effect, Solid, Tauri, Specta, or tauri-specta when implementation, IPC contracts, codegen, resolved-version behavior, or upstream changes affect the work. Ground answers in lockfiles and exact package source; use focused documentation or primary-source discovery only as needed.
+description: Resolve version-sensitive Effect, Solid, Tauri, Specta, or tauri-specta behavior when an ABB implementation or contract decision needs external-library evidence.
 ---
 
 # ABB Library Research
 
-Answer external-library questions that affect an ABB implementation or contract decision. Smallest source-backed answer — not a survey.
+Resolve the active library question and return the answer to its ABB owner.
+Repository paths below are relative to the ABB root.
 
-## Boundary
+## Evidence
 
-Resolved lockfile versions, installed or registry-packaged source, route cards,
-exact public package docs, focused documentation, and primary-source discovery.
+Start with the owning ABB code, tests, and contract, then identify the resolved
+package version and source in `bun.lock` or `Cargo.lock`. Manifests state the
+intended range; lockfiles select the version.
 
-ABB owners retain metadata, processing, output artifacts, audio engine behavior,
-path safety, job lifecycle, IPC guardrails, and release. Research an external
-library only when its behavior is the active blocker, then return the answer to
-the owning ABB boundary. No durable artifacts. Do not commit upstream source
-snapshots as research material. The patched FFmpeg sys crate under `vendor/` is
-build provenance, not this skill.
+Use installed declarations/source or exact registry-packaged source for
+version-sensitive behavior. Exact-version public documentation may be enough
+for a documented API; inspect implementation when the question depends on it.
+If installed files are absent or incomplete, retrieve the exact npm tarball or
+Cargo crate and verify its version and registry checksum as applicable.
 
-## Answer
+Load only the route card for the library involved:
 
-- **Behavior** for the active question
-- **ABB route** (owning boundary)
-- **Constraints** that change implementation
-- **Version or path** when version-sensitive
-- **Residual uncertainty** when evidence conflicts
+| Question | Reference |
+| --- | --- |
+| Effect workflows and APIs | [effect.md](references/effect.md) |
+| Solid rendering, reactivity, or component tests | [solid.md](references/solid.md) |
+| Tauri runtime, commands, capabilities, or bundling | [tauri.md](references/tauri.md) |
+| Installed Tauri plugins | [tauri-plugins.md](references/tauri-plugins.md) |
+| Rust type export and TypeScript generation | [specta.md](references/specta.md) |
+| Tauri command/event codegen integration | [tauri-specta.md](references/tauri-specta.md) |
 
-Version-sensitive answers must cite ABB's resolved lockfile version or say the
-version could not be proven. Record a commit SHA when exceptional upstream
-source was used.
+When package evidence leaves a material gap, use available documentation or
+search tools to find primary docs, source, issues, or history. Context7 can help
+with a known API; Exa or web search can discover sources. Resolve Context7 IDs
+live if using it; route-card IDs are hints. Neither tool is required. Reconcile
+current docs and search results to the resolved package before treating them
+as version proof.
 
-Stop when exact-version evidence answers the active behavior, the ABB owner and
-implementation constraints are named, and any research-aid evidence is either
-reconciled to the resolved package or labeled current-only, mismatched, or
-unproven.
+Read [source-retrieval.md](references/source-retrieval.md) when omitted tests,
+examples, codegen internals, or history require upstream retrieval. Root
+`AGENTS.md` owns the policy on upstream source snapshots; external research
+does not transfer product ownership out of ABB's local boundaries.
 
-## Lookup order
+## Finish
 
-1. ABB-owned truth: nearest `AGENTS.md`, ABB code and tests, generated
-   contracts, `bun.lock`, `Cargo.lock`, and manifests. Lockfiles identify the
-   resolved version and source. Manifests explain the intended range but do not
-   override the lockfile.
-2. Exact installed or registry-packaged source:
-   - JavaScript: exported `node_modules` package files and TypeScript
-     declarations; the exact npm package tarball when installed files are
-     absent or incomplete.
-   - Rust: the Cargo registry source selected by `Cargo.lock`. Verify crate
-     version and checksum before treating it as installed truth.
-3. Exact public package documentation at the resolved version (`docs.rs`, npm,
-   unpkg/jsDelivr). Effect `llms.txt` is current documentation, not versioned
-   evidence.
-4. Supplementary research only when the preceding evidence does not answer the
-   active question. Choose the narrowest lane:
-   - Context7 for focused usage guidance about a known library and concept.
-     Resolve the library ID live, then run one focused query that includes the
-     resolved ABB version. Treat default-branch, mismatched, or undisclosed
-     indexed versions as orientation rather than version proof.
-   - Exa, when available, to discover primary documentation, source, issues,
-     releases, or history when the route is unclear, Context7 is incomplete or
-     version-mismatched, or the question crosses source types. Validate a
-     selected primary source against ABB's resolved package or exact version.
-   - Use both only when the first lane leaves decision-changing uncertainty.
-     Search results and generated summaries are discovery evidence, not
-     authority for installed behavior.
-5. Exceptional upstream retrieval: see `references/source-retrieval.md`. Use
-   only when registry packages omit tests, examples, codegen internals, runtime
-   implementation, or history required by the question.
+Report the behavior, ABB owner, implementation-changing constraints, and
+version/source evidence. Record the commit SHA when upstream source was used.
+If evidence is unavailable or conflicts, label the answer current-only,
+version-mismatched, or unproven and state the remaining decision.
 
-Context7 library IDs in route cards are selection hints, not a substitute for
-live resolution. No broad surveys unless asked.
-
-## References
-
-`references/source-retrieval.md` for exceptional upstream clones.
-
-Route cards: `effect.md`, `solid.md`, `tauri.md`, `tauri-plugins.md`, `specta.md`, `tauri-specta.md`.
-
-Pattern files: `references/pattern-<library>-<topic>.md` only after repeated need.
-
-## Guardrails
-
-- Installed or registry-packaged source over current upstream documentation
-- `src/lib/tauri/*` is the Tauri IPC boundary
-- Effect workflow APIs stay private to owning workflows. Do not import
-  `effect/unstable/reactivity` or `@effect/atom-solid`.
+Stop once the active question is answered with adequate version evidence, or
+the missing evidence and its implementation consequence are explicit.

--- a/.agents/skills/abb-library-research/agents/openai.yaml
+++ b/.agents/skills/abb-library-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ABB Library Research"
   short_description: "Resolve ABB library behavior from exact sources"
-  default_prompt: "Use $abb-library-research to resolve version-sensitive external-library behavior from ABB lockfiles and exact package source, using Context7 for focused docs or Exa for primary-source discovery only when needed."
+  default_prompt: "Use $abb-library-research to resolve this library question against ABB's selected package version."

--- a/.agents/skills/abb-library-research/references/effect.md
+++ b/.agents/skills/abb-library-research/references/effect.md
@@ -1,52 +1,17 @@
-# Effect Route Card
+# Effect
 
-- ABB packages: `effect`
-- Upstream: `https://github.com/Effect-TS/effect.git`
-- Context7: `/llmstxt/effect_website_llms_txt` or `/effect-ts/effect`
+Read for Effect API, typed failure, dependency, scope, or cancellation questions.
 
-Resolve the installed version from `bun.lock` (do not cache it here).
+- Package: `effect`; resolve its version from `bun.lock`.
+- Installed declarations: `node_modules/effect/dist/<Module>.d.ts`, including
+  `Effect`, `Context`, `Layer`, `Scope`, and `Schema`.
+- Upstream: [Effect](https://github.com/Effect-TS/effect); package sources and
+  tests live under `packages/effect`.
+- Optional Context7 hints: `/llmstxt/effect_website_llms_txt` or
+  `/effect-ts/effect`. Current `llms.txt` guidance is not version proof.
 
-## Use For
-
-- Effect workflows, typed errors, service/context boundaries, layers, scopes,
-  streams, schedules, schemas, and Effect test idioms.
-- Idiomatic examples before designing ABB Effect owners or helpers.
-
-## Installed / registry entrypoints
-
-- `node_modules/effect/dist/index.d.ts`
-- `node_modules/effect/dist/Effect.d.ts`
-- `node_modules/effect/dist/Context.d.ts`
-- `node_modules/effect/dist/Layer.d.ts`
-- `node_modules/effect/dist/Scope.d.ts`
-- `node_modules/effect/dist/Schema.d.ts`
-- `node_modules/effect/dist/Stream.d.ts`
-- `node_modules/effect/dist/Schedule.d.ts`
-- npm/unpkg: `effect` at the lockfile version (`packages/effect` in the
-  upstream monorepo)
-
-## Exceptional upstream areas
-
-- `packages/effect/src/Effect.ts` and sibling modules
-- `packages/effect/test/Effect`, `Schema`, `Stream`, `Scope.test.ts`,
-  `Schedule.test.ts`
-
-## Avoid
-
-- Import the installed `effect` package, not unpublished monorepo paths.
-- Do not copy internal helpers from `src/internal` unless an exported installed
-  API proves the same capability exists.
-- Effect `llms.txt` is current documentation, not versioned evidence.
-
-## ABB Reconciliation
-
-- ABB is on Effect 4 (exact pin in `package.json`). Reconcile docs against
-  `bun.lock`. Workflow owners import Effect only through
-  `src/lib/effect/appEffect.ts`.
-- Check `package.json` and `bun.lock` for the resolved `effect` version.
-- Prefer installed TypeScript declarations and exported APIs over source-only
-  internals.
-- Keep Effect private to the owning ABB workflow until an explicit boundary
-  decision says otherwise.
-- For tests, verify whether ABB currently uses plain Vitest or `@effect/vitest`
-  before copying upstream test style.
+ABB's workflow import and lifetime conventions are owned by
+`src/lib/effect/AGENTS.md`; read that owner when applying research to a
+workflow. Check the installed package's exported surface before adopting an
+upstream idiom, especially across Effect major versions. For test examples,
+check ABB's live test dependencies before assuming `@effect/vitest` is used.

--- a/.agents/skills/abb-library-research/references/solid.md
+++ b/.agents/skills/abb-library-research/references/solid.md
@@ -1,38 +1,17 @@
-# Solid Route Card
+# Solid
 
-- ABB packages: `solid-js`, `vite-plugin-solid`, `@solidjs/testing-library`
-- Upstreams:
-  - `solid-js`: `https://github.com/solidjs/solid.git`
-  - `vite-plugin-solid`: `https://github.com/solidjs/vite-plugin-solid.git`
-  - `@solidjs/testing-library`:
-    `https://github.com/solidjs/solid-testing-library.git`
-- Context7: `/solidjs/solid` or `/websites/docs_solidjs_com`
+Read for Solid rendering, reactivity, disposal, or component-testing questions.
 
-Resolve installed versions from `bun.lock` (do not cache them here).
+- Packages: `solid-js`, `vite-plugin-solid`, `@solidjs/testing-library`;
+  resolve versions from this checkout's `bun.lock`.
+- Installed declarations: `node_modules/solid-js/types/index.d.ts`; check
+  package exports when another entrypoint is involved.
+- Upstreams: [Solid](https://github.com/solidjs/solid),
+  [Vite plugin](https://github.com/solidjs/vite-plugin-solid), and
+  [testing library](https://github.com/solidjs/solid-testing-library).
+- Optional Context7 hints: `/solidjs/solid` or `/websites/docs_solidjs_com`.
 
-## Use For
-
-- Solid rendering, signals, effects, and component tests.
-- Verifying whether ABB UI behavior follows current Solid patterns.
-
-## Installed / registry entrypoints
-
-- `node_modules/solid-js/types/index.d.ts`
-- npm/unpkg: `solid-js` at the lockfile version
-
-## Avoid
-
-- Do not treat upstream app/docs infrastructure as ABB UI architecture.
-- Do not copy runtime internals into ABB components.
-- Do not broaden diagnostics to alternate viewport behavior; ABB is desktop-only
-  unless a task explicitly asks otherwise.
-- Do not reintroduce `@effect/atom-solid` or `effect/unstable/reactivity`.
-
-## ABB Reconciliation
-
-- Check `package.json` and `bun.lock` for the resolved `solid-js` version.
-- Verify owner conventions in the nearest `src/app/<owner>/index.ts` strip
-  and Solid view before changing state shape.
-- Views take runtime owners from Solid context.
-- Use targeted frontend tests for deterministic behavior and browser/human
-  review for visual UX claims.
+Root `AGENTS.md` owns the checkout's Solid-major constraint.
+`src/app/AGENTS.md` owns session state and disposal; `src/AGENTS.md` owns
+frontend scope. Reconcile upstream examples with those owners and the installed
+public APIs before changing a view or owner interface.

--- a/.agents/skills/abb-library-research/references/source-retrieval.md
+++ b/.agents/skills/abb-library-research/references/source-retrieval.md
@@ -1,59 +1,27 @@
 # Exceptional Upstream Source Retrieval
 
-Use this reference when the active library-research question needs upstream
-tests, omitted examples, codegen internals, runtime implementation, or history
-that installed and registry packages do not contain.
+Read when the active question needs tests, examples, internals, or history
+omitted from the installed or registry package. Root `AGENTS.md` owns the
+policy on retaining upstream snapshots.
 
-## Control-Plane Rule
+Map the resolved package to its upstream revision using registry metadata,
+`.cargo_vcs_info.json`, or release evidence. A version string is not proof
+that an identically named tag matches the published package. Verify the
+packaged source/checksum as applicable and resolve the revision to a commit
+SHA before making exact-version claims.
 
-`abb-library-research` owns the reference-library workflow:
+Prefer an API or single-file fetch when it answers the question. For a tree,
+tests, or history, retrieve the verified commit into an ephemeral OS-temp
+checkout; use shallow, filtered, or sparse retrieval when useful. Read only the
+material needed, cite the SHA in the answer, and remove the task-created
+checkout after use.
 
-- resolved versions come from `bun.lock` and `Cargo.lock`
-- route cards live in this skill's `references/<library>.md`
-- task-specific pattern files, if needed, live as
-  `references/pattern-<library>-<topic>.md`
-- root `AGENTS.md` keeps the no-snapshot invariant; this file owns the
-  retrieval procedure
+If the published artifact cannot be tied to a revision, report the retrieved
+source as unproven for the installed version. Return the implementation
+consequence to the ABB owner instead of silently substituting upstream behavior.
 
-Do not create a second routing system under `repos/`, `docs/reference/`, or a
-repo-local ticket ledger. Do not write upstream checkouts into the ABB tree.
-
-## When To Retrieve Upstream Source
-
-Stay on installed or registry-packaged source plus Context7 and exact public
-docs unless the question cannot be answered from those.
-
-Never infer that a package version equals an upstream tag. Resolve the
-repository and a candidate tag or revision, verify that it corresponds to the
-published package, resolve it to a commit SHA, and record that SHA in the
-research answer.
-
-Prefer the GitHub API or a single-file fetch when targeted files are enough.
-Create an ephemeral OS-temp clone only when a tree, tests, or history is
-required. Prefer shallow, filtered, or sparse retrieval. Remove the temporary
-checkout after the task.
-
-## Retrieval Shape
-
-1. Read the resolved version from `bun.lock` or `Cargo.lock`.
-2. Identify the upstream repository from the route card or package metadata.
-3. Map version → candidate tag/revision using crates.io, npm, or GitHub
-   releases. Confirm the published artifact (checksum, packument, or crate
-   `.crate` source) matches that revision.
-4. Fetch the verified commit. Record the SHA in the answer.
-5. Read only the files needed for the question.
-6. Delete the temporary checkout before finishing.
-
-## Pattern Files
-
-Do not create pattern files speculatively. Create one only after a real ABB task
-shows repeated lookup friction for the same external-library idiom.
-
-Pattern files must:
-
-- live one level deep under `references/`
-- be named `pattern-<library>-<topic>.md`
-- cite concrete upstream source, test, or docs paths
-- describe practical ABB usage, not broad upstream documentation
-- include avoid-notes when they prevent likely misuse
-- be refreshed or deleted when cited source paths stop matching lockfile truth
+A maintained pattern reference earns a place here only after repeated ABB
+lookup friction. Before adding one, inspect existing callers and references;
+retain the decision-changing idiom and exact source pointer rather than an
+upstream tutorial. Refresh or remove it when its evidence no longer matches
+the selected package.

--- a/.agents/skills/abb-library-research/references/specta.md
+++ b/.agents/skills/abb-library-research/references/specta.md
@@ -1,45 +1,17 @@
-# Specta Route Card
+# Specta
 
-- ABB crates: `specta`, `specta-typescript`
-- Upstream: `https://github.com/specta-rs/specta.git`
-- Context7: none pinned; prefer `docs.rs` at the exact crate version
+Read for Rust type export, serde mapping, macros, or TypeScript generation.
 
-Resolve pinned versions from `Cargo.lock` (do not cache them here). ABB pins
-release candidates; upstream default branch is not proof.
+- Resolve `specta` and `specta-typescript` from `Cargo.lock`, including
+  their source/checksum; inspect features in `src-tauri/Cargo.toml`.
+- Use the selected Cargo registry sources or
+  `docs.rs/<crate>/<exact-version>`. Default-branch release-candidate docs
+  may differ from ABB's pinned release.
+- Upstream: [Specta](https://github.com/specta-rs/specta), including
+  `specta`, `specta-typescript`, `specta-macros`, and tests/examples.
 
-## Use For
-
-- Rust type export behavior, TypeScript generation, serde/type mapping, macro
-  behavior, and generated binding expectations.
-- Source-level confirmation for ABB's IPC type export path.
-
-## Installed / registry entrypoints
-
-- Cargo registry crates `specta` and `specta-typescript` at the `Cargo.lock`
-  versions and checksums
-- `docs.rs/specta/<exact-version>`
-- `docs.rs/specta-typescript/<exact-version>`
-
-## Exceptional upstream areas
-
-- `specta/src`
-- `specta-typescript/src`
-- `specta-macros/src`
-- `specta-serde/src`
-- `tests/tests`, `tests/tests/macro`, `tests/tests/snapshots`
-- `examples/basic-ts`, `examples/collect`
-
-## Avoid
-
-- Do not assume upstream default-branch docs match ABB's pinned release
-  candidates.
-- Do not hand-edit generated ABB bindings to match upstream examples.
-- Do not copy snapshot expectations without checking ABB's exporter command.
-
-## ABB Reconciliation
-
-- Check `src-tauri/Cargo.toml` and `Cargo.lock` for pinned `specta` and
-  `specta-typescript` versions.
-- Verify generated output through `bun run bindings:check` or the relevant
-  focused binding command before changing IPC contracts.
-- When Specta output affects TS/Rust parity, see `src-tauri/src/commands/AGENTS.md` and `src/lib/tauri/AGENTS.md`.
+Compare research with ABB's exporter and `src/lib/generated/tauri.ts`.
+If the answer changes TS/Rust shape, follow
+`src-tauri/src/commands/AGENTS.md`, `src/lib/tauri/AGENTS.md`, and the
+binding verification commands in `scripts/AGENTS.md`. Research alone does
+not require regeneration.

--- a/.agents/skills/abb-library-research/references/tauri-plugins.md
+++ b/.agents/skills/abb-library-research/references/tauri-plugins.md
@@ -1,45 +1,16 @@
-# Tauri Plugins Route Card
+# Tauri Plugins
 
-- ABB packages/crates: `@tauri-apps/plugin-dialog`, `@tauri-apps/plugin-opener`,
-  `tauri-plugin-dialog`, `tauri-plugin-opener`
-- Upstream: `https://github.com/tauri-apps/plugins-workspace.git`
-- Context7: `/tauri-apps/tauri-plugin-shell` for shell; prefer installed
-  package docs for dialog and opener
+Read for an installed plugin's guest API, Rust behavior, or permissions.
 
-Resolve installed versions from `bun.lock` and `Cargo.lock` (do not cache them
-here).
+Identify the plugin in `package.json` and `src-tauri/Cargo.toml`, then
+resolve both sides from `bun.lock` and `Cargo.lock`. Inspect its installed
+`@tauri-apps/plugin-*` package and exact `tauri-plugin-*` Cargo crate.
 
-## Use For
+[plugins-workspace](https://github.com/tauri-apps/plugins-workspace) contains
+`plugins/<name>/guest-js`, `src`, and `permissions`. Its other plugins are
+not automatically ABB dependencies. Prefer exact package docs or
+`docs.rs/<crate>/<exact-version>` for a public API question.
 
-- Tauri v2 plugin behavior, guest JS APIs, Rust plugin commands, permission
-  schemas, and plugin-specific examples.
-- ABB-installed plugins such as dialog and opener.
-
-## Installed / registry entrypoints
-
-- `node_modules/@tauri-apps/plugin-dialog`
-- `node_modules/@tauri-apps/plugin-opener`
-- Cargo registry crates `tauri-plugin-dialog` and `tauri-plugin-opener` at the
-  `Cargo.lock` versions and checksums
-- `docs.rs/tauri-plugin-dialog/<exact-version>`
-- `docs.rs/tauri-plugin-opener/<exact-version>`
-
-## Exceptional upstream areas
-
-- `plugins/dialog/guest-js`, `plugins/dialog/src`, `plugins/dialog/permissions`
-- `plugins/opener/guest-js`, `plugins/opener/src`, `plugins/opener/permissions`
-- `plugins/dialog/test`, `plugins/*/permissions/schemas`
-
-## Avoid
-
-- Do not treat every plugin in the workspace as an ABB dependency.
-- Do not copy permission files without comparing ABB capabilities.
-- Import installed `@tauri-apps/plugin-*` packages, not unpublished guest JS.
-
-## ABB Reconciliation
-
-- Check `package.json`, `bun.lock`, and `src-tauri/Cargo.toml` for installed
-  plugin versions.
-- Compare plugin permission requirements with `src-tauri/capabilities`.
-- Keep frontend plugin calls behind `src/lib/tauri/*` where ABB already owns the
-  runtime boundary.
+Compare permission requirements with `src-tauri/capabilities`. Apply
+frontend changes through the runtime boundary owned by
+`src/lib/tauri/AGENTS.md`.

--- a/.agents/skills/abb-library-research/references/tauri-specta.md
+++ b/.agents/skills/abb-library-research/references/tauri-specta.md
@@ -1,51 +1,18 @@
-# Tauri Specta Route Card
+# Tauri Specta
 
-- ABB crate: `tauri-specta`
-- Upstream: `https://github.com/specta-rs/tauri-specta.git`
-- Context7: resolve `tauri-specta` live. Prefer an exact-version library only
-  when it matches `Cargo.lock`; default-branch and mismatched RC snapshots are
-  orientation only.
-- Exa: discover primary docs, source, issues, releases, or history when exact
-  package documentation is incomplete. Validate the selected source against
-  the resolved crate before using it as implementation evidence.
+Read for command/event export, builder configuration, or Tauri/Specta integration.
 
-Resolve the pinned version from `Cargo.lock` (do not cache it here).
+- Resolve `tauri-specta` from `Cargo.lock`; inspect selected features in
+  `src-tauri/Cargo.toml`.
+- Prefer exact Cargo registry source and
+  `docs.rs/tauri-specta/<exact-version>`. The packaged
+  `.cargo_vcs_info.json`, when present, helps identify its source commit.
+- Upstream: [tauri-specta](https://github.com/specta-rs/tauri-specta).
+  Builder, command, event, and language-export implementation lives under
+  `src/`; use the verified revision to locate its tests/examples.
+- If using Context7, resolve the library ID live and check the indexed version.
+  Default-branch or mismatched RC material is orientation only.
 
-## Use For
-
-- Tauri command/event export behavior, builder setup, language output, and
-  integration between Tauri and Specta.
-- Confirming how command/event bindings should be emitted and consumed.
-
-## Installed / registry entrypoints
-
-- Cargo registry crate `tauri-specta` at the `Cargo.lock` version and checksum
-- Registry `.cargo_vcs_info.json`, when present, for the packaged source commit
-- `docs.rs/tauri-specta/<exact-version>`
-
-## Exceptional upstream areas
-
-- `src/lib.rs`, `src/builder.rs`, `src/commands.rs`, `src/event.rs`,
-  `src/lang/js_ts.rs`
-- `tests/tauri_command.rs`, `tests/test.rs`
-- `examples/app/src-tauri/src/main.rs`
-- `examples/app/src/bindings-ts-files`
-- `macros/`
-
-## Avoid
-
-- Do not let upstream examples override ABB's runtime-boundary ownership.
-- Do not change generated binding shape without proving TS/Rust parity.
-- Do not treat Context7 or default-branch docs as proof of ABB's pinned
-  release candidate.
-- Reconcile search-returned commits or default-branch source with the registry
-  package commit or exact packaged source before treating them as pinned-release
-  evidence.
-
-## ABB Reconciliation
-
-- Check `src-tauri/Cargo.toml` and `Cargo.lock` for the pinned
-  `tauri-specta` version and features.
-- Compare generated files with `src/lib/generated/tauri.ts`.
-- Use `bun run bindings:check` and focused contract tests for any binding
-  shape change.
+Compare findings with `src-tauri/src/ipc_contract.rs` and
+`src/lib/generated/tauri.ts`. Applying a binding-shape change follows the
+command/Tauri owner guidance and `scripts/AGENTS.md` proof routes.

--- a/.agents/skills/abb-library-research/references/tauri.md
+++ b/.agents/skills/abb-library-research/references/tauri.md
@@ -1,48 +1,17 @@
-# Tauri Route Card
+# Tauri
 
-- ABB packages/crates: `@tauri-apps/api`, `@tauri-apps/cli`, `tauri`,
-  `tauri-build`, `tauri-utils`
-- Upstream: `https://github.com/tauri-apps/tauri.git`
-- Context7: `/websites/v2_tauri_app`
+Read for runtime, command/event, capability, WebView, config, or bundling questions.
 
-Resolve installed versions from `bun.lock` and `Cargo.lock` (do not cache them
-here). Do not treat upstream `dev` as ABB truth until those versions match.
+- JS packages: `@tauri-apps/api`, `@tauri-apps/cli` from `bun.lock`.
+- Rust crates: `tauri`, `tauri-build`, `tauri-utils` from `Cargo.lock`.
+- Inspect installed JS exports and the selected Cargo registry crates;
+  `docs.rs/<crate>/<exact-version>` supplies versioned public API docs.
+- Upstream: [Tauri](https://github.com/tauri-apps/tauri), with JS in
+  `packages/api` and Rust under `crates/`.
+- Optional Context7 hint: `/websites/v2_tauri_app`.
 
-## Use For
-
-- Tauri runtime behavior, command/event APIs, JS API shapes, capabilities,
-  window/webview behavior, config, build, and bundling details.
-- Source-level confirmation when Context7/current docs leave contract behavior
-  ambiguous.
-
-## Installed / registry entrypoints
-
-- `node_modules/@tauri-apps/api`
-- Cargo registry crate `tauri` at the `Cargo.lock` version and checksum
-- `docs.rs/tauri/<exact-version>`
-- `docs.rs/tauri-utils/<exact-version>`
-
-## Exceptional upstream areas
-
-- `packages/api/src`
-- `crates/tauri/src`
-- `crates/tauri-runtime/src`
-- `crates/tauri-runtime-wry/src`
-- `crates/tauri-utils/src/config`
-- `crates/tauri-bundler/src`
-- `crates/tests`, `crates/tauri/test`, `examples/api`, `examples/commands`
-
-## Avoid
-
-- Do not bypass ABB's centralized runtime boundary in `src/lib/tauri/*`.
-- Do not copy Tauri example permission/config shapes without comparing ABB's
-  `src-tauri/capabilities` and `src-tauri/tauri.conf.json`.
-
-## ABB Reconciliation
-
-- Check `package.json`, `bun.lock`, `src-tauri/Cargo.toml`, and `Cargo.lock`
-  for installed Tauri versions.
-- Validate TS/Rust contract changes against `src/lib/generated/tauri.ts` and
-  `src-tauri/src/ipc_contract.rs`.
-- For command, event, binding, or runtime-boundary edits, see
-  `src-tauri/src/commands/AGENTS.md` and `src/lib/tauri/AGENTS.md`.
+For command/event questions, compare `src-tauri/src/ipc_contract.rs`,
+`src/lib/generated/tauri.ts`, and `src/lib/tauri/client.ts`. The command
+and frontend Tauri `AGENTS.md` files own adaptation rules. For permission
+or bundle questions, compare `src-tauri/capabilities` and
+`src-tauri/tauri.conf.json` before adopting upstream examples.

--- a/.agents/skills/audiobook-metadata/SKILL.md
+++ b/.agents/skills/audiobook-metadata/SKILL.md
@@ -1,42 +1,41 @@
 ---
 name: audiobook-metadata
-description: Canonical audiobook tag and interoperability strategy for Audiobook Boss. Use when changing tag mappings, folder conventions, or ABS/Plex/Apple compatibility; ordinary metadata intent and validation work follows the nearest owning AGENTS.md.
+description: Evaluate or change ABB tag mappings and folder conventions for Audiobookshelf, Plex, or Apple Books interoperability. Ordinary metadata intent and validation work follows its owning AGENTS.md.
 ---
 
 # Audiobook Metadata
 
-## Interop Invariant
+Preserve real-file interoperability while keeping compatibility claims tied to
+the writer, reader, and player behavior actually verified.
 
-External compatibility with ABS/Plex/Apple Books is required. Compatibility
-claims must match current code and product decisions.
+## Choose The Evidence
 
-ABB does not read or write Apple movement tags (`MVNM`/`MVIN`). Series uses
-ffprobe-visible tags plus mirrored mp4ameta freeform atoms.
+- For tag mapping or series compatibility, read
+  [tag-mapping.md](references/tag-mapping.md). It owns the retained interop
+  strategy and routes to the live field schema and container adapters.
+- For output organization or scanner folder parsing, read
+  [folder-conventions.md](references/folder-conventions.md). It routes to
+  ABB's naming owner and external scanner documentation.
 
-## Series Tag Strategy
+Repository paths in these references are relative to the ABB root. Metadata
+intent, validation, write planning, and runtime adaptation stay under
+`src-tauri/src/metadata/AGENTS.md` and `src/lib/tauri/AGENTS.md`. Output path
+policy stays under `src-tauri/src/output_artifact/AGENTS.md`.
 
-For series metadata, write both:
-- ffprobe-visible tags: `series`, `series-part`
-- mp4ameta freeforms: canonical `----:com.apple.iTunes:series` /
-  `----:com.apple.iTunes:series-part` plus uppercase iTunes mirrors
-  `----:com.apple.iTunes:SERIES` / `----:com.apple.iTunes:SERIES-PART`
+## Verify The Changed Handoff
 
-Intent semantics (`set | clear | noop`), the Outcome Plan, and naming-to-artifact
-flow are owned by `src-tauri/src/metadata/AGENTS.md` and `src/lib/tauri/AGENTS.md`.
+Use owner tests for mapping, clear/noop behavior, and atom precedence. For a
+changed writer or finalization path, inspect a generated M4B with:
 
-## Verification
-
-1. Verify ffprobe-visible tags:
 ```bash
-ffprobe -v quiet -print_format json -show_format output.m4b | jq '.format.tags'
+ffprobe -v quiet -print_format json -show_format output.m4b
 ```
-2. Verify freeform atoms with mp4 tooling (for example `AtomicParsley`).
-3. Validate behavior in ABS/Plex/Apple import workflows when modifying mappings.
 
-## References
+Use atom-aware readback for freeform mirrors that ffprobe cannot distinguish.
+When the claim is player/scanner compatibility, verify the affected import
+workflow and record the consumer version and relevant library settings. If
+that consumer is unavailable, report the artifact proof and the unverified
+compatibility claim separately.
 
-- Strategy and mappings: `references/tag-mapping.md`
-- Folder conventions: `references/folder-conventions.md`
-- Metadata model and outcome plan: `src-tauri/src/metadata/`
-- Boundary commands: `src-tauri/src/commands/metadata.rs`
-- Output artifact naming: `src-tauri/src/output_artifact/naming.rs`
+Finish with the changed mapping or convention, its owner, artifact/test
+evidence, and any remaining consumer-specific uncertainty.

--- a/.agents/skills/audiobook-metadata/references/folder-conventions.md
+++ b/.agents/skills/audiobook-metadata/references/folder-conventions.md
@@ -1,135 +1,35 @@
-# Folder Structure Conventions
+# Folder Interoperability
 
-ABS and Plex folder naming patterns for automatic metadata parsing.
+Read for output organization or scanner parsing changes. Repository paths are
+relative to the ABB root.
 
-## Recommended Structure
+## ABB Naming Owner
 
-Universal structure that works for ABS, Plex, and general file organization:
+`src-tauri/src/output_artifact/naming.rs` adapts the public preview call to
+`crates/abb-output-artifact-core/src/lib.rs`. The core owns ABS-default and
+custom-template rendering, optional series/subseries folders, year insertion,
+sanitization, fallback names, and template safety. Read its implementation and
+focused tests before changing naming; do not copy a sanitizer or template
+parser into a caller.
 
-```
-/Audiobooks
-  /Author Name
-    /Series Name
-      /Book Title
-        book.m4b
-        cover.jpg
-```
+Requested/resolved path safety, collision review, and final writes follow
+`src-tauri/src/output_artifact/AGENTS.md`. Folder compatibility does not
+replace that runtime authority.
 
-For standalone books (no series):
+## Scanner Evidence
 
-```
-/Audiobooks
-  /Author Name
-    /Book Title
-      book.m4b
-      cover.jpg
-```
+ABS documents `Author/Series/Book` and `Author/Book` organization. Read the
+[Book Library Structure guide](https://audiobookshelf.org/docs/documentation/libraries/book-library/directory-structure/)
+for the folder parser involved, including author separators, sequence/year
+syntax, narrator braces, and optional subtitle parsing. Check the relevant
+server settings when validating a naming change.
 
-## ABS Title Folder Patterns
+For Plex-specific organization, identify the user's library type and metadata
+agent before choosing a convention. The
+[Plex Audiobook Guide](https://github.com/seanap/Plex-Audiobook-Guide) is a
+community integration recipe; consult it when that setup is actually in use,
+and verify its claims against the affected installation.
 
-ABS parses metadata from folder names. Supported patterns:
-
-| Pattern | Example |
-|---------|---------|
-| Title only | `Wizards First Rule` |
-| With narrator | `Wizards First Rule {Sam Tsoutsouvas}` |
-| Year prefix | `1994 - Wizards First Rule` |
-| Sequence prefix | `Book 1 - Wizards First Rule` |
-| Sequence + year | `Vol 1 - 1994 - Wizards First Rule` |
-| With subtitle | `1994 - Wizards First Rule - A Subtitle` |
-
-### Parsing Rules
-
-- **Narrator**: Wrap in `{curly braces}`
-- **Year**: 4 digits, separated by ` - ` (space-dash-space)
-- **Sequence**: Prefix with `Book`, `Vol`, `Vol.`, or `Volume`
-- **Subtitle**: Separated by ` - ` (requires ABS server setting)
-
-### Sequence Prefix Examples
-
-All valid:
-```
-Book 1 - Title
-Book 1. Title
-Vol 1 - Title
-Vol. 1 - Title
-Volume 1 - Title
-```
-
-## ABS Author Folder Patterns
-
-Multiple formats supported:
-
-| Format | Example |
-|--------|---------|
-| First Last | `Terry Goodkind` |
-| Last, First | `Goodkind, Terry` |
-| Multiple (comma) | `Terry Goodkind, Brandon Sanderson` |
-| Multiple (ampersand) | `Terry Goodkind & Brandon Sanderson` |
-| Multiple (and) | `Terry Goodkind and Brandon Sanderson` |
-
-## Plex Considerations
-
-Plex treats audiobooks as music albums in a Music library:
-
-1. **Library type**: Music with "Store Track Progress" enabled
-2. **Disable online matching**: Plex will misidentify audiobooks
-3. **Preferred structure**: `Author/Book Title/audiobook.m4b`
-4. **Series**: No native support—relies on folder structure or custom agents
-
-For Plex compatibility, the Author folder is most important. Series organization is secondary.
-
-## Filename Sanitization
-
-Characters to remove or replace in folder/file names:
-
-| Character | Replacement | Reason |
-|-----------|-------------|--------|
-| `:` | ` -` or remove | Invalid on Windows |
-| `?` | remove | Invalid on Windows |
-| `*` | remove | Invalid on Windows |
-| `"` | `'` or remove | Invalid on Windows |
-| `<` | remove | Invalid on Windows |
-| `>` | remove | Invalid on Windows |
-| `\|` | ` -` or remove | Invalid on Windows |
-| `/` | ` -` or remove | Path separator |
-| `\` | ` -` or remove | Path separator (Windows) |
-
-### Sanitization Function (Pseudocode)
-
-```
-sanitize(name):
-  replace ":" with " -"
-  replace "," with " - " (except author)
-  replace "/" "\" with " "
-  remove "?" "*" "<" ">" "|"
-  collapse multiple spaces to single space
-  trim leading/trailing whitespace
-  return name
-```
-
-## audiobook-boss Implementation
-
-The output path generation is in `src-tauri/src/output_artifact/naming.rs`:
-
-```rust
-// build_output_path_preview()
-// Structure (ABS-compatible): output_dir / author / series (optional) / Book # - Title / Book # - Title.m4b
-```
-
-Current behavior:
-- ABS-compatible structure is the default.
-- Author folder: Uses `artist` from metadata (falls back to "Unknown Author").
-- Series folder: Uses `series` from metadata (skipped if empty).
-- Title folder + filename: Uses full `title` from metadata, sanitized for filesystem safety.
-- Author folder preserves commas; other components replace commas with ` - `.
-- Year appears only when explicitly enabled and metadata date is present.
-
-To modify folder structure behavior, edit `build_output_path_preview()` in `src-tauri/src/output_artifact/naming.rs` and its core implementation in `crates/abb-output-artifact-core/src/lib.rs`.
-
----
-
-Sources:
-- [ABS Docs - Title Folder Naming](https://www.audiobookshelf.org/docs/#book-title-folder-naming)
-- [ABS Docs - Author Folder Naming](https://www.audiobookshelf.org/docs/#book-author-folder-naming)
-- [Plex Audiobook Guide](https://github.com/seanap/Plex-Audiobook-Guide)
+Use generated path previews and core tests for ABB rendering behavior. Use the
+affected scanner's import result for a compatibility claim; one naming example
+does not establish universal ABS/Plex/Apple support.

--- a/.agents/skills/audiobook-metadata/references/tag-mapping.md
+++ b/.agents/skills/audiobook-metadata/references/tag-mapping.md
@@ -1,118 +1,59 @@
-# M4B Tag Mapping Reference
+# Tag Interoperability
 
-Current mapping of ABB-written MP4 metadata to Audiobookshelf, Plex, and Apple Books fields.
+Read for changes to ABB's tag mapping or consumer compatibility. Paths below
+are relative to the ABB root.
 
-## Standard Tags
+## Live Mapping Owners
 
-| MP4 Atom | ffmetadata key | ABS Field | Plex Field | Notes |
-|----------|----------------|-----------|------------|-------|
-| `©nam` | `title` | Title | Track Name | Book title |
-| `©ART` | `artist` | Author | Artist | Primary author |
-| `aART` | `album_artist` | Author | Album Artist | Fallback for author |
-| `©alb` | `album` | Title | Album | Fallback for title |
-| `©wrt` | `composer` | Narrator | Composer | **Use for narrator** |
-| `©day` | `date` | Publish Year | Year | Year only |
-| `©gen` | `genre` | Genres | Genre | Separate multiple with `/` or `;` |
-| `desc` | `description` | Description | — | Synopsis |
-| `©pub` | `publisher` | Publisher | — | Publisher name |
-| `©cmt` | `comment` | — | — | General comments |
+| Question | Source to inspect |
+| --- | --- |
+| Supported fields, read aliases, clear groups, FFmpeg keys | `src-tauri/src/metadata/field_schema.rs` |
+| Series key families and precedence | `src-tauri/src/metadata/tag_registry.rs` |
+| Field fan-outs, tuples, series/subseries projection | `src-tauri/src/metadata/metadata_ops.rs` |
+| Actual container writes and atom-level tests | `src-tauri/src/metadata/metadata_sinks.rs` |
+| MP4 reads, album sort, movement cleanup, artwork | `src-tauri/src/metadata/mp4ameta_bridge.rs` |
+| Date and series validation/normalization | `crates/abb-metadata-core/src/lib.rs` |
 
-## Series Tags (Critical)
+The schema describes ABB's supported fields. A field recognized by an external
+scanner is not evidence that ABB exposes or writes it. Preserve normalized
+publication dates through the owning sink; do not infer year-only storage from
+a container library method named `set_year`.
 
-These are the tags that matter most for series detection.
+## Retained Series Strategy
 
-### For ABS and Plex
+Write ffprobe-visible `series` / `series-part` keys and both MP4 freeform
+families under `com.apple.iTunes`:
 
-| Storage | Key / Atom | Purpose |
-|---------|------------|---------|
-| ffprobe / ffmetadata | `series` | Series name |
-| ffprobe / ffmetadata | `series-part` | Book number |
-| mp4ameta canonical freeform | `----:com.apple.iTunes:series` | Series name |
-| mp4ameta canonical freeform | `----:com.apple.iTunes:series-part` | Book number |
-| iTunes compatibility freeform | `----:com.apple.iTunes:SERIES` | Series name |
-| iTunes compatibility freeform | `----:com.apple.iTunes:SERIES-PART` | Book number |
+- canonical lowercase `series` / `series-part`;
+- uppercase interoperability mirrors `SERIES` / `SERIES-PART`.
 
-Read precedence prefers canonical lowercase `series` / `series-part`, then the
-uppercase iTunes mirrors, then legacy `show` / `episode_sort` fallbacks.
-`ffprobe -show_format` collapses freeform names that differ only by case, so
-unit tests around the mp4ameta sink are the proof that both lowercase canonical
-and uppercase mirror atoms exist.
+Read precedence favors lowercase canonical values, then uppercase mirrors,
+then legacy `show` / `episode_sort` values. Preserve legacy read compatibility;
+new writes use the canonical/mirrored families. Series/subseries projection and
+effective-metadata validation stay in their code owners above.
 
-Apple movement tags (`MVNM`/`MVIN`) are not currently written or read as ABB's
-series mechanism. Reintroduce them only with manual player evidence and an
+Apple movement tags (`MVNM`/`MVIN`) are not ABB's series read/write mechanism.
+The MP4 bridge removes movement fields when series-family writes apply.
+Adopting movement tags as a series mechanism requires player evidence and an
 explicit product decision.
 
-## iTunes Custom Atoms
+For MP4 finalization, follow `src-tauri/src/metadata/AGENTS.md`: its
+container-aware handoff owns preservation of tags the mov muxer drops. A bare
+FFmpeg command setting arbitrary dictionary keys is not equivalent evidence.
 
-Additional freeform atoms recognized by ABS:
+## Consumer Evidence
 
-| Atom | ffmetadata key | ABS Field |
-|------|----------------|-----------|
-| `----:com.apple.iTunes:ASIN` | `asin` | ASIN |
-| `----:com.apple.iTunes:AUDIBLE_ASIN` | `audible_asin` | ASIN |
-| `----:com.apple.iTunes:ISBN` | `isbn` | ISBN |
+For ABS mapping, consult the current
+[File Metadata documentation](https://audiobookshelf.org/docs/documentation/libraries/book-library/directory-structure/#file-metadata).
+For disagreements between disk tags and an existing library entry, inspect the
+[metadata priority settings](https://audiobookshelf.org/docs/documentation/libraries/book-library/book-metadata/#local-metadata-priority-order).
+Folder and sidecar precedence can override audio tags.
 
-## Writing with ffmpeg
+Plex and Apple Books claims need the affected player's import evidence.
+Distinguish ABB's chosen compatibility strategy from demonstrated support for
+a particular consumer version.
 
-### Basic metadata via ffmetadata file
-
-```ini
-;FFMETADATA1
-title=Book Title
-artist=Author Name
-composer=Narrator Name
-series=Series Name
-series-part=1
-genre=Science Fiction/Fantasy
-```
-
-Apply with:
-```bash
-ffmpeg -i input.m4b -i metadata.txt -map_metadata 1 -c copy output.m4b
-```
-
-### Direct command line
-
-```bash
-ffmpeg -i input.m4b \
-  -metadata title="Book Title" \
-  -metadata artist="Author Name" \
-  -metadata composer="Narrator Name" \
-  -metadata series="Series Name" \
-  -metadata series-part="1" \
-  -c copy output.m4b
-```
-
-## Writing with ffmpeg-next (Rust)
-
-audiobook-boss writes canonical ffprobe-visible keys plus iTunes freeform mirrors
-for series metadata. These are the series keys ABB currently owns in the FFmpeg
-dictionary path.
-
-```rust
-// Primary + mirrored keys written together
-dict.set("series", series_name);
-dict.set("----:com.apple.iTunes:SERIES", series_name);
-
-dict.set("series-part", book_number);
-dict.set("----:com.apple.iTunes:SERIES-PART", book_number);
-```
-
-The mp4ameta path writes the same logical values to lowercase canonical
-freeforms and uppercase iTunes mirrors. Keep both families unless player
-evidence and an explicit product decision replace this compatibility strategy.
-
-Series-part values should stay scanner-friendly. Slash-form values like `1/5`
-are rejected by validation.
-
-Validation checklist:
-1. Creating an M4B with these tags
-2. Running `ffprobe -show_format output.m4b`
-3. Confirming `series` and `series-part` appear in the tags (plus the freeform atom names)
-
-Legacy read compatibility remains (`show` / `episode_sort`) for older files,
-but write paths should use the canonical and freeform keys above.
-
----
-
-Source: [Audiobookshelf Docs - Audio Metadata](https://www.audiobookshelf.org/docs/#book-audio-metadata)
+`ffprobe -show_format` can collapse case-only freeform names. The atom-level
+sink tests/readback establish whether both families exist; a single visible
+series key does not. Report artifact evidence separately from player-import
+evidence.

--- a/.agents/skills/audit-test-value/SKILL.md
+++ b/.agents/skills/audit-test-value/SKILL.md
@@ -1,174 +1,76 @@
 ---
 name: audit-test-value
-description: Audit and tidy ABB tests so retained proofs protect observable behavior at the lowest owning boundary, then simplify production seams kept alive only by low-value tests. Use when the user explicitly asks to audit, prune, consolidate, clean up, or maintain tests or testing infrastructure; investigate stale, brittle, duplicative, false-green, or implementation-coupled tests; or follow test cleanup into production simplification. Do not use for ordinary feature or bug-fix test authoring.
+description: Audit or clean up ABB tests and test-only production seams for behavioral value, duplication, and proof cost. Use for test maintenance requests; ordinary feature or bug-fix test authoring follows owner guidance.
 ---
 
 # Audit Test Value
 
-Make every retained test name a plausible bug it would reveal. Treat stale,
-false-green, duplicative, misplaced, and costly tests as maintenance debt, just
-as suspect as stale production code.
+Recover useful regression protection at the lowest owning boundary, and remove
+complexity whose only purpose was supporting tests that do not earn keep.
 
-## 1. Establish Authority, Scope, And Baseline
+## Scope And Authority
 
-1. Read the root and nearest owner `AGENTS.md` files, test configuration,
-   manifests, registries, and `scripts/AGENTS.md` command menu.
-2. Resolve the authorization boundary:
-   - `audit`, `review`, `educate`, or `report` means read-only;
-   - `clean up`, `prune`, `refactor`, or `implement` authorizes in-scope edits.
-3. Separate the audit boundary from the change boundary. A repository-wide
-   census may still produce one owner-coherent change; a whole-repository
-   cleanup may span owners when the user explicitly wants all accepted value
-   recovered in one effort.
-4. Record branch, commit, worktree state, and pre-existing failures. Preserve
-   unrelated user state.
-5. Run only the cheapest meaningful baseline checks when their signal is worth
-   their cost. Do not use a broad suite as a freshness badge.
+Use the whole request to distinguish a report from authorized cleanup. An
+audit alone is read-only; an audit followed by requested fixes includes those
+edits. A repository-wide census does not by itself authorize production changes.
 
-Complete this stage when the inspected scope, mutation authority, exclusions,
-and baseline are explicit.
+Read applicable owner guidance and `scripts/AGENTS.md` for test placement and
+commands. Inspect the in-scope tests, fixtures, registries, configuration, and
+production callers. Use baseline execution when it provides useful evidence;
+distinguish existing failures from regressions.
 
-## 2. Inventory Tests And Claimed Contracts
+## Judge The Contract
 
-Inventory tracked, project-owned test surfaces in scope:
+Root `AGENTS.md` owns ABB's test-value bar and tier selection. For each
+challenged test or shared group, establish:
 
-- owner and tier;
-- registries, fixtures, snapshots, mocks, and generated-contract checks;
-- production exports, helpers, dependency injection, factories, or `cfg(test)`
-  seams used by those tests;
-- verification cost or false-green behavior already observed.
+- the plausible bug and observable contract it protects;
+- the stable owner and any distinct risk that justifies a second test tier;
+- what protection deletion would lose;
+- the disposition: `keep`, `move`, `consolidate`, `delete`, or `replace`;
+- any production seam kept alive by the test and its remaining production use.
 
-Exclude vendored or upstream suites unless the request includes them. Label
-lexical counts as approximate when tests were not executed.
+Source-text restatements, constructor/read-back checks, self-comparisons,
+test-authored algorithms, mock choreography, and structural snapshots are
+candidates for scrutiny. Interpret them in context: exact serialization,
+interaction order, externally observed copy, and independent Public API Strip
+expectations can be real contracts.
 
-For every challenged test, state the observable contract it claims to protect
-or mark it as having no behavioral contract. Complete the census before using
-candidate counts as conclusions.
+Measure cost when slow discovery, opaque output, flakiness, or target bloat is
+part of the finding. Lexical counts are approximate; do not present a sampled
+review as a complete census. Keep a ledger for a broad audit so dispositions
+and summary counts reconcile. A focused request can use a short finding list.
 
-## 3. Apply The Behavior-Value Bar
+Settle consequential uncertainty with a cheap, safe mutation experiment when
+useful. Otherwise retain the protection and name the unresolved evidence;
+uncertainty alone need not stop independent authorized cleanup.
 
-Retain a test when its failure would reveal at least one of:
+## Apply Authorized Cleanup
 
-- broken behavior visible through a stable owner boundary;
-- a security, privacy, data-integrity, cleanup, or resource-lifetime violation;
-- a broken contract between layers, processes, or external systems;
-- a plausible regression that could recur;
-- a meaningful edge or failure case best isolated at that tier.
+Choose an owner-coherent change set from the findings. Delete unsupported
+tests, consolidate duplicated contracts, and move proof to the lowest tier
+that can establish it. Add replacement coverage only for a meaningful gap.
 
-Give each contract one primary test owner. A second tier earns keep only for a
-distinct integration, serialization, platform, side-effect, or presentation
-risk. Push proof to the lowest deterministic ABB tier named in root guidance.
+After test changes, recheck production callers. Remove exports, wrappers,
+factories, or indirection whose only remaining purpose was test access when
+production simplification is in scope. Preserve seams that isolate real side
+effects, lifecycle transitions, platform variation, or external dependencies.
+Report out-of-scope simplifications with impact and owner.
 
-Treat these as strong candidates for deletion, movement, or consolidation:
+Keep procedure here and verification commands in `scripts/AGENTS.md`. Update
+owner guidance only when the change reveals a new local trap or changes an
+owned interface; root already carries the repo-wide value bar.
 
-- source text, private symbol, type declaration, CSS literal, fixture, or
-  configuration restatements;
-- constructor/read-back checks, self-comparisons, and compile-only shape tests;
-- expected values that reproduce the production algorithm or branch tree;
-- mock choreography without an observable result or boundary interaction;
-- the same contract repeated across core, runtime, contract, component, and
-  browser tiers without distinct risk;
-- structural snapshots or refactor detectors whose only plausible failure is
-  an intentional implementation change;
-- slow, opaque, target-bloated, or flaky proof routes whose cost exceeds their
-  regression signal.
+## Proof And Completion
 
-Interpret those signals in context. Exact copy, option values, serialization
-shape, interaction order, generated parity, and Public API Strips can be real
-contracts when ABB or an external consumer observes them. Independent Public
-API Strip expectations must not be derived from the registry they guard.
+Run the focused checks for changed owners, expanding only for crossed
+boundaries or a concrete unresolved risk. Proof must show that retained or
+moved tests exercise the named behavior and that simplified production seams
+preserve observable outcomes. Media, IPC, platform, or visual behavior needs
+its corresponding acceptance evidence when affected.
 
-For each candidate, establish:
-
-1. the plausible bug it reveals today;
-2. the stable owner of that behavior;
-3. whether another test already protects the same contract and whether its risk
-   is genuinely distinct;
-4. what regression protection deletion would lose;
-5. the safe disposition: `keep`, `move`, `consolidate`, `delete`, or `replace`;
-6. the affected production seam and its remaining production reason;
-7. confidence, validation needed, and residual risk.
-
-When evidence remains genuinely balanced, use a focused mutation experiment if
-the target is cheap and safe. Otherwise retain the test under an explicit human
-decision. Uncertainty may change the disposition; it may not leave a candidate
-unclassified.
-
-## 4. Adjudicate Before Editing
-
-Build one integrated ledger. Challenge non-obvious retain decisions as hard as
-deletion candidates. Reconcile conflicting audit lanes against production code,
-owner contracts, and actual test behavior.
-
-For large scopes, bounded read-only subagents may census independent owners.
-Each lane returns evidence and dispositions, not edits. The orchestrator owns
-cross-lane deduplication, owner selection, and the accepted change set.
-
-Do not optimize for a small diff. Select the least complexity that reaches the
-agreed end state. Finish adjudication only when every in-scope candidate and
-test-only seam is classified and every accepted finding is either in the change
-set or explicitly deferred with impact and owner.
-
-## 5. Prune, Move, And Simplify
-
-Implement accepted work in owner-coherent groups:
-
-1. delete tests with no justified contract;
-2. consolidate duplicate contracts under their stable owner;
-3. move valuable assertions to the lowest tier that proves the behavior;
-4. add replacement coverage only for a meaningful gap exposed by the cleanup;
-5. rescan production code after test changes;
-6. remove or collapse exports, aliases, wrappers, factories, parameters, or
-   indirection whose only remaining reason was test access.
-
-Retain seams that isolate real side effects, lifecycle transitions, external
-processes, platform variation, security boundaries, or resource cleanup.
-
-Use the minimum PR count, normally one, with commits separated by owner and
-causal dependency. A multi-owner audit does not justify leaving accepted value
-on the table merely to keep the diff visually small.
-
-During parallel implementation, give each lane disjoint path ownership and
-focused checks. The orchestrator integrates shared surfaces and owns the final
-cross-owner validation gate.
-
-## 6. Prove The Result
-
-After each coherent edit group, run the focused command for that owner. Then
-run the broadest proportionate integration checks justified by crossed
-boundaries and risk.
-
-Verification must demonstrate:
-
-- retained tests still exercise the named behavior;
-- moved proof fails at the owning boundary, not through test-authored logic;
-- removed tests did not expose an unprotected meaningful contract;
-- simplified production seams preserve observable behavior;
-- generated, IPC, media, platform, visual, or manual proof was run when that is
-  the actual acceptance surface;
-- pre-existing failures remain distinguished from regressions.
-
-## 7. Keep Recurrence Guidance Surgical
-
-Update root guidance only when the sweep reveals a repo-wide invariant not
-already stated. Update a local `AGENTS.md` only when ownership, placement, or a
-recurring local trap changed. Keep procedure in this skill and commands in
-`scripts/AGENTS.md`; do not duplicate the workflow across instruction files.
-
-## Report And Finish Line
-
-Report:
-
-- audit scope, census, and limitations;
-- summary disposition counts that reconcile with the detailed ledger;
-- tests deleted, moved, consolidated, replaced, or retained, with behavioral
-  justification;
-- production seams removed, simplified, or deliberately retained;
-- coherent commit or issue scope;
-- commands, results, pre-existing failures, and manual proof;
-- unresolved human choices and residual risk.
-
-Finish only when summary counts reconcile with the ledger, every in-scope test
-passed the behavior-value bar, every affected test-only seam was assessed,
-every accepted finding was handled, observable contracts remain protected, and
-proportionate verification ran.
+Finish when the requested scope has been assessed, each finding has a
+disposition, accepted in-scope edits are complete, and proportionate checks
+have run. Report changes, deliberately retained protection, any deferred work
+and owner, validation results, and residual risk. Reconcile counts with the
+ledger when reporting a census.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,74 +1,49 @@
 ---
 name: release
-description: Audiobook Boss release workflow for deciding whether changes need a formal version/changelog release, preparing release metadata, validating the local app or DMG artifact, tagging, and publishing manually. Use when the user mentions release, version bump, changelog, tag, GitHub Release, DMG, publish, ship, release notes, or asks whether a change should be released.
+description: Prepare ABB version/changelog changes, install a local build, package a DMG, or publish a GitHub Release when the user requests that release work or a release-scope decision.
 ---
 
 # Release
 
-## Overview
+State the accepted change's user-visible impact, the version or no-bump
+decision, and the requested artifact before executing release work.
 
-- Prefer human-readable `CHANGELOG.md` plus one mechanical version bump script.
-- Choose a release lane before running commands. Do not let "release" silently
-  mean every possible lane.
-- Developer install is local-machine truth: build FFmpeg for the compiling
-  Apple Silicon host and replace `/Applications/AudioBook Boss.app` without a
-  DMG.
-- Public release is distribution truth: version/changelog, tag, GitHub Release,
-  and a verified portable Apple Silicon DMG attachment.
-- Artifact-only is packaging truth: build and verify a DMG without publishing.
-- A tag alone is tag-only; GitHub will not show it as the latest release.
-- This skill owns release metadata and artifact proof. It does not impose a
-  broad test matrix by default; choose code validation from the touched owner
-  and concrete risk surface before release work, or skip it when the accepted
-  change has already been verified and the owner asks to avoid rerunning tests.
+## Version Decision
 
-## First Move
+Recommend a formal release for changes to shipped behavior, output files,
+metadata, media processing, packaging, runtime safety, or dependency/security
+posture. Guidance, tests, comments, and planning alone do not require a version
+bump or changelog entry unless requested.
 
-Before bumping a version, writing changelog, tagging, or building an artifact:
+When choosing a version, use patch for fixes, minor for added capability, and
+major for a breaking contract. Respect an explicit owner-selected version;
+explain a material mismatch with the impact instead of silently changing it.
 
-1. State the user-visible impact in one line from the accepted change.
-2. Apply the Decision Rule. If a version is needed, choose it from that line:
-   patch restores or fixes behavior, minor adds a capability, major breaks a
-   contract. Spoken "patch", "minor", or "major" is not the version. If the
-   user's word and the line disagree, stop and name the recommended `x.y.z`.
-3. Name the artifact: host-tuned `/Applications/AudioBook Boss.app`, portable
-   DMG, or both. Mixed "local" plus "DMG" plus "this machine" wording is this
-   choice, not a host-tuned DMG. Then pick the matching lane below.
+## Select The Requested Lane
 
-This step is complete when the version or no-bump decision and the lane are
-stated.
+| Requested outcome | Lane and effect |
+| --- | --- |
+| Developer/local install | Build for the compiling Apple Silicon host and replace `/Applications/AudioBook Boss.app`. |
+| DMG/package only | Build and verify a portable Apple Silicon DMG. |
+| Public/GitHub Release | Prepare metadata, build and verify the portable DMG, commit/tag/push the accepted release, and publish its verified asset. |
+| Public plus local install | Public Release plus a separate native developer install. |
+| Tag only | Create/push the requested tag; this does not create a GitHub Release. |
 
-## Lane Selection
+Use the whole request and prior authorization to select the lane. If “release”
+leaves the destination unclear, inspect the accepted change and prepare the
+version/lane recommendation, then resolve that choice before a build, install,
+or publication that depends on it. Public release alone does not request a
+local install. Temporary development testing uses `bun run app:dev:log`.
 
-After the first move names the artifact, choose exactly one lane unless the
-owner asked for both.
+## Execute And Verify
 
-| User wording | Lane | Meaning |
-| --- | --- | --- |
-| "dev release", "developer release", "local release", "install local" | Developer Install | Build current repo with native host tuning and silently replace `/Applications/AudioBook Boss.app`. |
-| "public release", "GitHub Release", "tag and publish", "ship DMG" | Public Release | Prepare metadata, build/verify a portable DMG, tag, push, and publish GitHub Release. |
-| "artifact release", "DMG only", "package only" | Artifact-Only | Build/verify a portable DMG and stop before tag/publish. |
-| "release" with no qualifier | Confirm lane if the request is interactive; if the owner is asking to ship a new version, run Public Release plus Developer Install. |
-| "all", "public and dev", "public plus local" | Public Release + Developer Install | Publish the verified portable DMG, then run a separate native developer install so `/Applications/AudioBook Boss.app` matches the release version. Do not run Artifact-Only separately because Public Release already builds the DMG. |
+Read the applicable sections of [execution.md](references/execution.md) for
+the selected lane. Check commands against `scripts/AGENTS.md` and live package
+scripts. That reference owns the portable-artifact and publication sequence;
+owner guidance determines any additional code verification.
 
-Never build or open a DMG for Developer Install. Use `bun run app:dev:log` for
-temporary development testing instead of creating a local installed release.
-
-## Decision Rule
-
-Treat a formal release as needed when an accepted change affects user-visible behavior, output files, metadata, audio processing, packaging, runtime safety, supported fixtures, or dependency/security posture.
-
-Use an internal changelog note without a version bump when the change is only repo guidance, tests, comments, docs, cleanup, or planning state and does not need a shipped build.
-
-When in doubt, name the impact and choose the smallest honest release scope. Do not bump version just to make a PR look complete.
-
-## Execute The Lane
-
-After the first move is complete, read
-[`references/execution.md`](references/execution.md) for the changelog, bump,
-build, install, tag, and publication sequence. Reconcile it with
-`scripts/AGENTS.md` and the live package scripts before running commands.
-
-## Final Verification
-
-End release work by reporting the version, tag, changelog entry, validation commands, DMG path, GitHub Release URL, attached asset name, and local/remote SHA parity. If publishing was intentionally tag-only, state that GitHub will not show it as the latest release.
+Complete the authorized lane, including artifact proof and remote verification
+when publishing. Report only applicable outcomes: version/changelog, installed
+app, DMG path, tag and commit, GitHub Release URL, asset verification, and
+local/remote SHA parity. If a required step fails, state the completed state
+and the exact remaining action.

--- a/.agents/skills/release/agents/openai.yaml
+++ b/.agents/skills/release/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Release"
-  short_description: "Ship ABB releases with minimal repo infra"
+  short_description: "Prepare, package, install, or publish ABB releases"
   default_prompt: "Use $release to decide whether this ABB change needs a version/changelog update and prepare the release surfaces."

--- a/.agents/skills/release/references/execution.md
+++ b/.agents/skills/release/references/execution.md
@@ -1,7 +1,7 @@
 # Release Execution
 
-Read this reference only after the first move has stated the version or
-no-bump decision and the lane. Before running a command, confirm it against
+Read the sections for the selected lane after stating the version or no-bump
+decision. Before running a command, check it against
 `scripts/AGENTS.md` and the live package scripts; the repository environment
 owns command truth.
 
@@ -66,7 +66,7 @@ tagging or publishing.
 
 ## Public Release
 
-1. Use the version and impact already stated in the first move.
+1. Use the selected version and accepted change's impact.
 2. Write the matching `CHANGELOG.md` section and run the version bump script.
 3. Run `bun run audit` so both Rust and JavaScript dependency graphs report
    before public packaging; any failure blocks the release. Run additional
@@ -83,10 +83,9 @@ tagging or publishing.
 
    Use `bun run app:build` only for explicit repo-local app validation; a normal
    DMG release already builds the app.
-5. For Public Release + Developer Install, run `bun run app:install-local` after
-   DMG verification. This native rebuild is expected: the published DMG stays
-   portable while the owner's installed app targets the local Mac. The DMG
-   lane may also remove the intermediate app; do not substitute
+5. If a local install was also requested, run `bun run app:install-local` after
+   DMG verification. This separate native rebuild is expected; the DMG lane
+   may remove the intermediate portable app. Do not substitute
    `app:install-local:existing`.
 6. Commit and tag the accepted release:
 
@@ -96,14 +95,15 @@ tagging or publishing.
    git tag v<x.y.z>
    ```
 
-7. Push intentionally:
+7. Verify the release commit and tag identify the accepted work on the intended
+   branch. For a release from `main`, push:
 
    ```bash
    git push origin main
    git push origin v<x.y.z>
    ```
 
-8. Unless the owner requested tag-only, publish the verified artifact with the
+8. Publish the verified artifact with the
    matching changelog section as release notes:
 
    ```bash
@@ -115,3 +115,14 @@ tagging or publishing.
 
    `verify-asset` must succeed for the exact local DMG that passed `hdiutil
    verify`; it confirms the GitHub asset is byte-for-byte the tested file.
+
+Check local/remote tag and branch SHA parity before reporting publication
+complete. If a push or publish result is uncertain, inspect remote state before
+retrying. An existing tag/release with conflicting content requires resolving
+the mismatch; do not force-move tags or overwrite assets to make a retry pass.
+
+## Tag Only
+
+Verify the requested commit, create the tag, and push that tag to the intended
+remote. Inspect the remote tag SHA before reporting completion. Build, install,
+and GitHub Release creation apply only if separately requested.

--- a/.agents/skills/resource-lifetime-audit/SKILL.md
+++ b/.agents/skills/resource-lifetime-audit/SKILL.md
@@ -1,78 +1,57 @@
 ---
 name: resource-lifetime-audit
-description: Read-only audit for Audiobook Boss resource-lifetime foot-guns with high bug potential. Use when reviewing or planning ABB changes across file handles, external processes, temp artifacts, replacement, cleanup ownership, validation-to-write, or FFmpeg/mp4ameta reopen boundaries, and when the user asks to hunt for lifecycle or cross-platform hazards. Apply fixes only with explicit implementation authority.
+description: Audit ABB resource ownership for file loss, false terminal outcomes, residue, or stuck cancellation across reopen, replacement, process, and cleanup transitions.
 ---
 
 # Resource Lifetime Audit
 
-## Scan Scope
+Trace the requested lifecycle boundary using its nearest `AGENTS.md` and live
+callers. An audit alone reports findings; apply fixes when the request also
+authorizes implementation. Loading this skill during a fix does not remove
+that authority or broaden the change into a repository-wide audit.
 
-Scan the highest-risk boundaries first: audio processing, metadata read/write/remux, output artifact commit, path validation, cleanup, cancellation, and external process handling.
+## Trace Ownership
 
-## Hunt Pattern
+Prioritize transitions that affect source audiobooks, final artifacts, or
+terminal outcomes:
 
-Search for code that crosses one lifecycle phase into another:
+- probe/open/read → reopen the same path, including FFmpeg → mp4ameta;
+- write temporary artifact → rename/copy/replace final path;
+- spawn process → read pipes → cancel/kill/wait;
+- register cleanup → transfer or drain ownership;
+- validate path → persist or write it.
 
-- probe/open/read -> reopen same path
-- FFmpeg context -> mp4ameta read/write on same path
-- write temp -> rename/copy/replace final path
-- spawn process -> read pipes -> cancel/kill/wait
-- register cleanup -> remove path from cleanup ownership
-- validate path -> persist or write path
+For each candidate, establish which resource is still alive, what touches it
+next, and whether platform behavior changes the outcome. A credible finding
+names the triggering path and impact: file loss, false success/failure,
+residue, or stuck jobs.
 
-For each candidate, ask:
+For cleanup, trace concrete path values through registration, removal,
+draining, overlapping guards, and startup backstops. A removal call alone does
+not prove ownership ended: compare registered and removed values and inspect
+every caller of the transition and every guard holding that resource.
 
-1. What resource is still alive?
-2. What opens, mutates, deletes, renames, or replaces the same resource next?
-3. Does this rely on macOS/POSIX behavior that may fail on Windows?
-4. Would a failure cause false success, file loss, residue, stuck jobs, or noisy retries?
-5. Is the fix local and testable?
+For post-commit cleanup, answer both before adjudicating the finding:
 
-For cleanup candidates, trace exact path values through registration, removal,
-draining, overlapping guards, and startup or other backstop owners. Evaluate
-terminal classification separately from residue retry or recovery. A cleanup
-removal call is not proof of ownership: prove that the registered and removed
-values match and identify every remaining owner.
-
-Do not close a post-commit cleanup candidate until both questions are answered:
-
-1. If the durable operation succeeded and cleanup fails, what terminal outcome
-   reaches the caller or user?
+1. If durable work succeeds and cleanup fails, which terminal outcome reaches
+   the caller or user?
 2. Which exact owner retains or reacquires the failed path for retry?
 
-A retry or startup backstop can limit residue without making a false terminal
-failure truthful.
+A retry backstop can limit residue while the reported terminal outcome remains
+wrong. Evaluate those consequences separately.
 
-Before concluding that no retry owner remains, enumerate every caller of the
-transition and every guard that registered the same concrete resource value.
+## Repair And Proof
 
-## Priority
+Recommend or implement the smallest repair at the owning transition. Reuse
+existing replacement, cleanup, and `AppError` mechanisms. The owning metadata,
+audio, processing, and output guidance supplies the applicable invariants;
+avoid adding a parallel lifecycle policy in callers.
 
-Prioritize findings that touch:
+For authorized changes, use the focused proof routes in `scripts/AGENTS.md`.
+Prefer deterministic filesystem/process tests when they prove the transition;
+use real media or platform evidence when the failure depends on those systems.
 
-- source audiobook files
-- final output artifacts
-- metadata writes and cover art
-- FFmpeg input/output contexts
-- external FFmpeg processes
-- cleanup/cancellation terminal paths
-
-Defer low-impact style cleanup unless it prevents repeated lifecycle mistakes.
-
-## Fix Shape
-
-Prefer explicit ownership transitions:
-
-- Drop FFmpeg probe contexts before reopening the same path.
-- Keep replacement behavior in the owning boundary.
-- Use backup/rollback or create-new semantics instead of assuming rename-over-existing is portable.
-- Remove cleanup ownership only after the durable artifact is committed.
-- Map file/path errors through existing `AppError` patterns.
-
-Add focused tests when behavior is deterministic without real media. Use the
-owner-scoped command menu from `README.md` / `scripts/AGENTS.md` for code
-changes.
-
-## Report Shape
-
-Lead with the category name, affected boundary, impact, and fix. Use "resource-lifetime foot-gun" for hazards that are not always active bugs but have credible cross-platform or edge-case failure paths.
+Report the boundary and code location, trigger, impact, evidence, and repair or
+disposition. Distinguish an observed bug from a plausible platform hazard.
+Finish when in-scope transitions have been traced, findings have dispositions,
+and any authorized repairs have their proportionate proof.

--- a/.agents/skills/resource-lifetime-audit/agents/openai.yaml
+++ b/.agents/skills/resource-lifetime-audit/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Resource Lifetime Audit"
-  short_description: "Find high-ROI handle lifetime foot-guns"
-  default_prompt: "Use $resource-lifetime-audit to find high-ROI file handle, process, temp file, and replacement lifetime foot-guns in this ABB change."
+  short_description: "Trace ABB resource ownership and cleanup hazards"
+  default_prompt: "Use $resource-lifetime-audit to trace resource ownership and terminal outcomes in this ABB change."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Start Here
 
-- Read this file first, then the nearest nested `AGENTS.md` for every path you
-  change. These files are routing and owner guidance, not substitutes for live
-  code, types, generated contracts, or tests.
+- Follow this file and the applicable nested `AGENTS.md` chain for changed
+  paths. Read related owners when the task crosses their boundaries; use live
+  code, types, generated contracts, and tests to verify implementation facts.
 - Read `docs/system-map.md` only for repository onboarding, unclear ownership,
   or work crossing frontend/backend or multiple product owners. Ordinary local
   changes should not load it.
@@ -13,15 +13,15 @@
   bindings; do not rely on a prose command/event inventory.
 - Cargo commands run from the repository root. Verification commands and scope
   live in `scripts/AGENTS.md`; frontend owner rules live in `src/app/AGENTS.md`.
-- When work crosses file-handle, external-process, temp-artifact, replacement,
-  or cleanup ownership, use `.agents/skills/resource-lifetime-audit`; nearest
-  local `AGENTS.md` files supply the current owners and invariants.
+- For lifecycle reviews or changes to resource transfer, reopen, replacement,
+  or cleanup semantics, use `.agents/skills/resource-lifetime-audit`. Routine
+  file I/O follows the local owner's invariants.
 - "Public API Strip" means an owned module's allowed import/export surface;
   callers use it instead of private implementation files.
 - Root owns repo-wide posture, proof, and cross-cutting invariants; local
   `AGENTS.md` files own path-specific surfaces and traps; skills own reusable
   procedures. Keep each meaning in one of those owners.
-- External-library research routes through
+- When an implementation or contract decision needs external-library evidence, use
   `.agents/skills/abb-library-research`. Do not commit upstream source
   snapshots as research material. Build provenance explicitly owned by ABB,
   such as the patched FFmpeg sys crate under `vendor/`, is a separate concern.
@@ -29,7 +29,9 @@
 ## Hard Invariants
 
 - Precedence: safety/data/contract invariants > explicit user request > completion bias > style.
-- Block and explain before changing when there is data-loss risk, ambiguous TS↔Rust contract parity, removed path-safety guarantees, or hidden bypass of an owning boundary.
+- Resolve safety and contract uncertainty from the owning code and proof before
+  changing behavior. Block and explain when data-loss risk, TS↔Rust parity,
+  path-safety guarantees, or an owning-boundary bypass remains unresolved.
 - Runtime IPC stays centralized in `src/lib/tauri/*`.
 - Metadata intent adaptation stays at the Tauri runtime boundary.
 - Canonical metadata validation/normalization routes through the Rust Metadata Outcome boundary.
@@ -65,6 +67,9 @@
 - Let deterministic lint/typecheck own style and stale-cleanup (unused symbols, formatting, `any`): run the tools for the touched surface and fix what they report. Command menu: `scripts/AGENTS.md`.
 - UI behavior also needs visual/human review where static tests cannot prove UX.
 - Owned import/export surface changes update the nearest `AGENTS.md` and its contract test.
+- Treat local boundary-change lists as prompts to update the owning interface
+  and proof within the authorized scope. Carry requested fixes through those
+  checks; an interface change alone does not require renewed permission.
 - Release/version/changelog/tag/DMG work uses the `release` skill.
 
 ## Planning And Capture

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -12,23 +12,17 @@ commands over invoking internals directly.
   It catches undeclared dependencies that a warm checkout can conceal; it is
   not a PR gate or broad test route. Rust and generated-binding proof stay
   local/release-owned through the commands below.
-- There is no repo-owned verification runner and no default broad review route.
-  Run native commands directly, one at a time, only for the touched owner or
-  explicit risk surface. Report the command, elapsed time when meaningful, exit
-  code, failing test/script line, and residual risk.
-- Broad workspace routes are not a freshness badge. Use them only when the
-  changed surface actually crosses owners or when the repo owner asks for that
-  cost.
+- Run native verification commands for the touched owner or explicit risk
+  surface. Keep expensive build/test routes sequential to avoid competing for
+  shared targets. Report failures with the command, exit code, and failing
+  test/script location; include elapsed time when cost is material.
 - If a proof/test/build command consumes disproportionate wall-clock, first-output
   latency, or agent tokens, classify the friction as `fix` unless a safety, data,
   or contract invariant requires finishing the current command.
-- Keep Rust binary checks out of broad Nextest discovery. Run generated binding
-  export and decoder-contract binaries through their explicit commands only.
-- AAC decoder capability contract: `bun run aac-decoder-contract:check`.
-- Avoid broad workspace and multi-package Nextest routes; they can discover or
-  list unrelated binaries such as `export_bindings` and
-  `verify_aac_decoder_contract`.
-- Media execution lane (issue #341 closeout: route `add`): real-media workflow
+- Package-select Nextest routes; broad workspace/multi-package discovery can
+  pull unrelated binaries into the target set. Binding export and
+  `bun run aac-decoder-contract:check` have explicit binary commands.
+- Media execution: real-media workflow
   tests live in `src-tauri/tests/cases/integration_media_execution_tests.rs`
   and run inside the normal runtime suite. Covers WAV, M4B, and MP3 inputs,
   the Native AAC and Apple AAC encoder routes (external FDK is excluded: it
@@ -39,7 +33,7 @@ commands over invoking internals directly.
   are synthesized at test time (WAV in Rust, MP3 via the external FFmpeg CLI, M4B from the
   engine's own output) — never commit media files. Focused command:
   `cargo nextest run -p audiobook-boss --features bundled-ffmpeg --test all_tests -E 'test(media_execution)'`
-  (runtime budget ~1s wall clock; shrink fixtures before widening it). Do not
+  (keep synthesized fixtures small). Do not
   add broad media gates or committed fixtures beyond this lane without a new
   owner decision.
 
@@ -124,7 +118,7 @@ commands over invoking internals directly.
   `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
   The no-import tripwires match `from 'typescript'` and the full `effect`
   package family, so ordinary multiline named imports count; do not require
-  the binding list to sit on one line.   Workflow APIs enter through
+  the binding list to sit on one line. Workflow APIs enter through
   `src/lib/effect/appEffect.ts`. The tripwire also rejects leftover
   `.svelte` / `.svelte.ts` sources under `src/` and leftover Tailwind or
   foundation-internal imports. The tripwire stays in `scripts/` so it does not

--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -1,65 +1,43 @@
 # Rust Backend Directives
 
-## Scope
+## Owner Routes
 
-- Applies to backend architecture and command behavior under `src-tauri/`.
-- Deep traps for specific subsystems are owned by local `AGENTS.md` files in those directories.
-
-## Preferred Path
-
-- Route media execution through the `crate::audio` Audio Engine Deep Module
-  public API; callers outside audio must not choose processor adapters or
-  import private audio engine files directly.
-- Route shared processing lifecycle vocabulary, queue/progress event shapes,
-  and terminal summaries through `crate::processing`; route accepted background
-  operation identity, snapshots, and operation-scoped cancellation through
+- Media execution crosses `crate::audio`; processor adapter selection and
+  engine internals stay private to Audio.
+- Shared lifecycle vocabulary, queue/progress events, active jobs, and terminal
+  summaries belong to `crate::processing`. Accepted operation identity,
+  snapshots, retention, and operation cancellation belong to
   `crate::work_runtime`.
-- Route durable app preference schema, defaults, merge, validation, and JSON
-  storage through `crate::app_settings`; commands and UI code must not invent a
-  parallel settings store.
-- Route remote source provider registry, auth, secrets, acquisition staging,
-  materialized source files, Supplemental Assets, and purge behavior through
-  `crate::remote_source`; provider-private details must not leak into
-  processing, metadata, audio, output, logs, or IPC payloads.
-- Route metadata reads and writes through the public `metadata` boundary; outside callers should request metadata outcomes, not choose private MP4/FFmpeg strategy modules.
-- Let the metadata boundary choose MP4-family atom handling versus generic FFmpeg behavior from actual container classification, not filename suffix or caller-side substitute behavior.
-- Use `JobRegistry` as the central active-job and cancellation surface.
-- Offload CPU-bound encoding and heavy synchronous work via `tokio::task::spawn_blocking` (or equivalent blocking-safe path).
-- Keep TS↔Rust command contracts aligned through generated bindings and drift checks.
-- Run final batch/merge processing through `submit_processing_operation`
-  (WorkRuntime). `process_audiobook_files` is the direct-preview command;
-  it rejects an omitted `preview_seconds`. Use dedicated auxiliary commands
-  for non-processing tasks.
-- Use Clippy signal for code-shape drift; treat `too_many_lines`/`too_many_arguments` as prompts to re-check cohesion. Run command and workspace lint posture: `scripts/AGENTS.md` and root `Cargo.toml` `[workspace.lints]`.
-- Consult `docs/unsafe-code-register.md` before changing production Rust `unsafe`
-  and update it when unsafe scope, purpose, or blast radius changes.
+- Durable preference schema, defaults, validation, and storage belong to
+  `crate::app_settings`; it consults runtime owners for accept/reject rules.
+- Remote provider registry, secrets, acquisition, staged files, Supplemental
+  Assets, and purge belong to `crate::remote_source`. Provider-private
+  details stay out of other owners, logs, and IPC payloads.
+- Metadata reads/writes cross `crate::metadata`. The metadata owner selects
+  container handling from actual media classification; callers request an
+  outcome rather than choosing MP4/FFmpeg strategy modules.
+- Final artifact paths, collision review, replacement, and commit truth cross
+  `crate::output_artifact`.
+- Final batch/merge processing enters WorkRuntime through
+  `submit_processing_operation`. `process_audiobook_files` is direct
+  preview and requires `preview_seconds`. Read the Processing owner guidance
+  when changing either lifecycle.
 
-## Hard Invariants
+## Runtime Constraints
 
-- Validate input audio paths at the boundary with
+- Validate input audio paths at ingress with
   `crate::audio::validate_input_audio_path()`.
-- Long-running stages must emit progress/failure states so UI status remains truthful.
-- Preserve external audiobook tag interoperability in metadata read/write behavior.
-- Provider degradation stays explicit in command responses and typed diagnostics.
-- Keep command and event shape parity with frontend boundary adapters.
-- Keep unsafe blocks narrow and owned by the FFmpeg/FFI boundary that requires
-  them; do not let unsafe details leak into product orchestration or IPC shape.
+- Use `JobRegistry` for active-job tracking and cancellation.
+- Run CPU-bound encoding and heavy synchronous work through
+  `tokio::task::spawn_blocking` or an equivalent blocking-safe path.
+- Keep long-running progress and terminal outcomes observable through the
+  owning lifecycle surface.
+- Before changing production Rust `unsafe`, read
+  `docs/unsafe-code-register.md`; update it if scope, purpose, or blast radius
+  changes. Unsafe details stay inside the required FFmpeg/FFI boundary.
+- Keep Clippy allowances local and justified. Code-shape thresholds live at
+  root; lint commands and workspace posture are in `scripts/AGENTS.md` and
+  root `Cargo.toml`.
 
-### Backend Shape Triggers
-
-- Route Rust shape questions through root Refactor Discipline.
-- Treat Clippy `too_many_lines` and `too_many_arguments` as prompts to re-check
-  cohesion, not as automatic split commands.
-- Keep clippy allowances local and justified; avoid broad crate-level suppressions for maintainability lints.
-
-## Hidden Coupling Traps
-
-- If backend behavior relies on implicit coupling across commands, processor stages, or registry state, name the ownership seam and working assumption.
-- Localize ownership when it is part of the active task; otherwise report the smallest invariant, test, or doc update that would prevent recurrence.
-- Block when ambiguity risks safety, data integrity, or contract parity.
-
-## Done Criteria
-
-- Processing, metadata, and concurrency edits follow the nearest local subsystem `AGENTS.md`.
-- Path validation, progress semantics, and contract parity remain intact.
-- Validation matches scope with direct commands from `README.md` and `scripts/AGENTS.md`.
+Use the nearest subsystem guidance for its public interface and traps, and
+`scripts/AGENTS.md` for checks matching the changed boundary.

--- a/src-tauri/src/app_settings/AGENTS.md
+++ b/src-tauri/src/app_settings/AGENTS.md
@@ -17,7 +17,7 @@
 - Durable preferences validate against the owning runtime APIs; App Settings
   must not duplicate encoder or JobRegistry accept/reject rules.
 
-## Allowed Agent Edits Without Escalation
+## Edit Rules
 
 - Change storage or merge internals when App Settings contract tests and runtime
   binding checks stay green.
@@ -26,7 +26,7 @@
 - Treat persisted user paths as preference data only. Runtime owners still
   validate paths before reads or writes.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming any Public API Strip symbol.
 - Moving runtime behavior ownership, output artifact truth, audio toolchain

--- a/src-tauri/src/audio/AGENTS.md
+++ b/src-tauri/src/audio/AGENTS.md
@@ -51,7 +51,7 @@
   `settings_encoder.rs`, and `toolchain/` (`mod.rs` = platform-neutral
   resolution/validation; `platform.rs` = the per-OS probe seam — candidate
   enumeration, binary-arch acceptance, and platform paths live ONLY there,
-  cfg-dispatched per the `remote_source/vault.rs` pattern with pure rules
+  cfg-dispatched per the `src-tauri/src/remote_source/vault.rs` pattern with pure rules
   unit-testable on any host).
 - The cluster owns local audio import metadata/discovery, decoder/toolchain
   selection, media inspection, decode/resample/encode/mux internals, staging,
@@ -76,7 +76,7 @@
 - Diagnostics and logs use sanitized display strings.
 - Lossy strings are allowed only for display ordering, never identity or command argv.
 
-## Allowed Agent Edits Without Escalation
+## Edit Rules
 
 - Change private implementation files when focused audio/processing tests stay
   green for the touched boundary.
@@ -85,7 +85,7 @@
 - Keep Native AAC, Apple AAC/AAC-AT, and external FDK adapter differences inside
   the private cluster unless a caller needs a stable capability fact.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming any Public API Strip symbol.
 - Moving job lifecycle ownership out of processing, final artifact commit truth

--- a/src-tauri/src/audio/processor/AGENTS.md
+++ b/src-tauri/src/audio/processor/AGENTS.md
@@ -41,12 +41,6 @@
 - Terminal paths clean app-owned temporary resources to avoid residue across retries.
 - Metadata finalize writes occur only for supported container paths and validated metadata payloads.
 
-## Stage-Coupling Traps
-
-- If processor behavior relies on implicit assumptions across execute/finalize/cancel stages, name the assumption and working behavior used.
-- Add or propose the smallest invariant, test, or doc guard that would prevent recurrence.
-- Block when ambiguity risks false success, file loss, or stuck cleanup.
-
 ## Done Criteria
 
 - Pipeline stages remain explicit and user-visible progress is truthful.

--- a/src-tauri/src/metadata/AGENTS.md
+++ b/src-tauri/src/metadata/AGENTS.md
@@ -58,7 +58,7 @@ For ABS/Plex/Apple tag-mapping, series-tag strategy, and folder conventions, use
   non-MP4 tag containers return no thumbnail instead of using an unbounded
   demux fallback.
 
-## Allowed Agent Edits Without Escalation
+## Edit Rules
 - Change pure intent internals when `cargo nextest run -p abb-metadata-core` stays green.
 - Change runtime/container adapters when targeted `audiobook-boss` Nextest and
   Public API Strip checks stay green.
@@ -68,7 +68,7 @@ For ABS/Plex/Apple tag-mapping, series-tag strategy, and folder conventions, use
 - Preserve external audiobook tag interoperability.
 - Drop FFmpeg probe/remux contexts before calling mp4ameta on the same path or replacing the source file.
 
-## Breaking-Change Triggers
+## Boundary Changes
 - Adding, removing, or renaming any Public API Strip symbol.
 - Making clear intent partial, lossy, or dependent on sentinel frontend values.
 - Moving publication-date or series/subseries sequence validation out of the

--- a/src-tauri/src/output_artifact/AGENTS.md
+++ b/src-tauri/src/output_artifact/AGENTS.md
@@ -12,7 +12,7 @@
 - Files: `artifact.rs`, `collision.rs`, `commit.rs`, `commit_tests.rs`, `naming.rs`, `parent_dirs.rs`, `parent_dirs_tests.rs`, `plan.rs`, `review.rs`, `supplemental.rs`, `types.rs`, `contract_tests.rs`.
 - The cluster owns artifact path derivation, collision detection, review signatures, parent-dir creation and cleanup of ABB-created empty parent dirs, final artifact commit behavior, destination-adjacent replacement temps, and final-sidecar Supplemental PDF commit behavior.
 
-## Allowed Agent Edits Without Escalation
+## Edit Rules
 - Change pure output planning rules when `cargo nextest run -p abb-output-artifact-core` stays green.
 - Change private implementation files when targeted `audiobook-boss` Nextest
   and Public API Strip checks stay green.
@@ -20,7 +20,7 @@
 - Keep final artifact writes and replacement policy here; processor code should ask this boundary for artifact truth.
 - Use explicit cross-platform replacement semantics for final artifacts; do not rely on Unix-only rename-over-existing behavior.
 
-## Breaking-Change Triggers
+## Boundary Changes
 - Adding, removing, or renaming any Public API Strip symbol.
 - Changing collision/review semantics, source-destination overlap handling, final commit behavior, or success message truth.
 - Moving final artifact commit truth outside this boundary.

--- a/src-tauri/src/processing/AGENTS.md
+++ b/src-tauri/src/processing/AGENTS.md
@@ -44,7 +44,7 @@
   discriminator the UI consumes; the internal `ProcessingStage` carries data (e.g. `Failed(String)`)
   and drives orchestration — keep them distinct.
 
-## Allowed Agent Edits Without Escalation
+## Edit Rules
 - Change pure processing classification/summarization when
   `cargo nextest run -p abb-processing-core` stays green.
 - Change planner or runner internals when targeted `audiobook-boss` Nextest and
@@ -58,7 +58,7 @@
   `OperationResultSummary` vocabulary while metadata write policy stays inside
   metadata-owned APIs.
 
-## Breaking-Change Triggers
+## Boundary Changes
 - Adding, removing, or renaming any Public API Strip symbol.
 - Changing preflight signature behavior, collision-review enforcement, metadata projection, path validation, or parent-dir side effects.
 - Moving artifact truth, metadata intent semantics, backend lifecycle ownership,

--- a/src-tauri/src/processing/job_registry/AGENTS.md
+++ b/src-tauri/src/processing/job_registry/AGENTS.md
@@ -26,12 +26,6 @@
 - Queue snapshot items must always become terminal outcomes (success or failed) so UI state never hangs on missing indices.
 - Concurrency reconfiguration is idle-only to prevent dangling permits and inconsistent UI job counts.
 
-## Lifecycle Ownership Traps
-
-- If ownership between scheduler, permit handling, and cancellation appears split or implicit, name the seam and working assumption.
-- Add or propose the smallest invariant, test, or doc guard that would prevent recurrence.
-- Block when ambiguity risks leaked permits, incorrect counts, or stuck cancellation.
-
 ## Done Criteria
 
 - Job lifecycle remains single-owner and terminal paths are complete.

--- a/src-tauri/src/work_runtime/AGENTS.md
+++ b/src-tauri/src/work_runtime/AGENTS.md
@@ -7,7 +7,7 @@
     `WorkSubmissionAccepted`).
   - inline metadata-save lifecycle hooks — `begin_metadata_save_operation`,
     `record_metadata_save_progress`, `finish_metadata_save_operation`,
-    `fail_metadata_save_operation` — orchestrated by `commands/metadata/save_batch.rs`
+    `fail_metadata_save_operation` — orchestrated by `src-tauri/src/commands/metadata/save_batch.rs`
     (the command owns the metadata executor; WorkRuntime owns the operation
     lifecycle/snapshots/cancellation).
 - `OperationId`

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,87 +1,42 @@
 # Frontend Directives
 
-## Scope
+## Routing
 
-- Applies to frontend runtime and UI work under `src/`.
-- Application owner interfaces, state lifetime, and workflow shape live in
-  `src/app/AGENTS.md`; read it before changing frontend session truth.
-- IPC adapters live under `src/lib/tauri/AGENTS.md`; canonical metadata
-  intent validation and normalization live in the Rust Metadata Outcome
-  boundary.
+- Application interfaces, session state, and workflow lifetime follow
+  `src/app/AGENTS.md`; read it when changing frontend session truth.
+- Runtime command/event/plugin adaptation follows `src/lib/tauri/AGENTS.md`.
+  UI/runtime callers use `tauriClient`; generated invokers stay inside that
+  boundary. Regenerate `src/lib/generated/tauri.ts` through the binding scripts.
+- Metadata intent adaptation stays at the Tauri boundary; canonical validation
+  and normalization stay with Rust Metadata Outcome. For metadata-save
+  lifecycle display, also read `src/app/workOperations/AGENTS.md`.
+- For Effect workflow or kernel changes, read `src/lib/effect/AGENTS.md`.
+- Durable preference hydration and persistence belong to `src/app/appSettings`.
+  The remaining UI persistence exception is documented in
+  `src/ui/appSettings/AGENTS.md`; use the Settings owner for new callers.
+- Remote acquisition belongs to `src/app/remoteSource`; its Solid dialog is
+  under `src/ui/remoteSource`. Materialized audio enters through Input's public
+  strip. Provider secrets and raw provider payloads stay backend-only.
 
-## Preferred Path
+## UI And State
 
-- Route every runtime Tauri command/event through `src/lib/tauri/client.ts` (`tauriClient`).
-- Route durable preference hydration and automatic persistence through
-  `src/app/appSettings`; owning controls expose semantic accepted values for
-  Settings to persist. `src/ui/appSettings` is a current compatibility
-  strip with hidden failure semantics—do not add callers.
-- Runtime settings controls consume backend capability facts for selectable
-  accept/reject rules; do not add frontend-owned encoder/concurrency option
-  matrices when a Rust owner validates the setting.
-- Remote acquisition lives under `src/app/remoteSource` with a Solid dialog in
-  `src/ui/remoteSource`. It may coordinate account state, library display,
-  selection, and acquired-file import handoff through Input's public strip.
-  Provider secrets and raw provider payloads stay backend-only.
-- Keep business logic in `.ts` modules and keep Solid views focused on
-  rendering and interaction.
-- Use `src/types/*` for boundary-safe frontend typing when crossing TS↔Rust surfaces.
-- Keep `src/styles.css` as a thin bootstrap: it loads the UI foundation and
-  owns app-shell layout only. Shared chrome and tokens live in
-  `src/ui/foundation`. Owner-specific layout lives in that owner's CSS.
-- Route UI done evidence through targeted tests for deterministic behavior and external browser-agent or human review when visual/UX judgment is the actual acceptance surface.
-- Audiobook Boss is desktop-only, so alternate viewport review is out of scope unless a task explicitly asks for it.
-- When touching metadata save/load IPC, patch intent, or boundary
-  normalization, open `src/lib/tauri/AGENTS.md` first; when touching
-  metadata-save lifecycle display, also open `src/app/workOperations/AGENTS.md`.
-- When touching Effect workflow owners or the AppEffect kernel, open
-  `src/lib/effect/AGENTS.md` first.
-- New or migrated session truth belongs to an owner composed by App Runtime and
-  consumed from Solid context. Presentation resources belong to their owner or
-  view instance. Existing module-global/lifetime exceptions are not precedent;
-  verify their current call sites before changing them and do not add another.
-  Do not reintroduce Effect Atom or add a process-wide owner singleton. Proof:
-  `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
-- Treat hard-to-scan or hard-to-test component scripts as a signal to extract helpers at user-facing behavior boundaries.
+- Keep business logic in TypeScript owners; Solid views render owner state and
+  dispatch semantic intent. Capability accept/reject facts come from their
+  Rust owner, including encoder and concurrency settings.
+- Keep `src/ui/App.tsx` and `src/main.tsx` declarative composition surfaces.
+- `src/styles.css` loads the foundation and owns app-shell layout. Shared
+  visual primitives and semantic tokens belong to `src/ui/foundation`; read
+  its `AGENTS.md` when changing shared visual behavior.
+- Owner layout lives in that owner's CSS. Consume public semantic tokens;
+  imports of another owner's CSS or foundation internals bypass ownership.
+- Update the design lab (`lab.html` + `src/lab/`, Vite dev only) when
+  changing foundation tokens or primitives.
+- Audiobook Boss is desktop-only. Alternate viewport review applies when the
+  task explicitly requests it.
 
-## UI Foundation
+## Proof
 
-- Shared visual behavior crosses `src/ui/foundation`. Read
-  `src/ui/foundation/AGENTS.md` before adding a primitive or token.
-- Owner CSS consumes public semantic tokens. It does not import another
-  owner's CSS or foundation internals.
-- The design lab (`lab.html` + `src/lab/`, Vite dev only) renders the retained
-  foundation vocabulary. Update the lab in the same change as a token or
-  primitive.
-
-## Hard Invariants
-
-- Runtime modules do not call command/event invokers directly from `src/lib/generated/tauri.ts`.
-- Do not hand-edit `src/lib/generated/tauri.ts`; regenerate or sync bindings through the standard scripts.
-- Keep runtime entry surfaces declarative: avoid new imperative DOM orchestration in `src/ui/App.tsx`, `src/main.tsx`, and `src/lib/**`.
-- UI-affecting changes are not “done” from static inspection alone; they must leave targeted test coverage or explicit visual/UX review evidence for the user-facing outcome.
-- Follow root Hard Invariants for boundary behavior; do not add hidden or caller-side substitute logic in frontend flows.
-- Keep TypeScript boundaries type-safe; avoid introducing new `any` escape paths in runtime IPC/state flows.
-
-### Frontend Shape Triggers
-
-- Route shape questions through root Refactor Discipline.
-- Split when scan cost, test cost, or ownership blur rises — at user-facing
-  behavior boundaries.
-- For linting upgrades, prioritize type-aware `typescript-eslint` rules that catch unsafe `any` propagation.
-
-## Hidden Coupling Traps
-
-- If frontend behavior depends on hidden coupling between UI modules and the Tauri boundary, name the coupling and working assumption used.
-- Localize the behavior behind the owning boundary when it is part of the active task; otherwise report the smallest docs or test guard that would prevent recurrence.
-- Continue only when the ambiguity does not threaten contract correctness or user data behavior.
-
-## Done Criteria
-
-- Tauri runtime calls are centralized through `tauriClient`.
-- Metadata and IPC changes align with `src/lib/tauri/AGENTS.md` invariants.
-- Shared chrome and tokens resolve through `src/ui/foundation`. App-shell
-  layout stays in `src/styles.css`. Owner-specific styling stays with the
-  owning Solid view.
-- UI-facing changes have targeted tests and, when needed, explicit visual/UX review evidence for the touched surface.
-- Validation matches scope with direct commands from `README.md` and `scripts/AGENTS.md`.
+Use `scripts/AGENTS.md` for focused frontend, type, and boundary checks.
+For UI changes, inspect the rendered behavior when layout, interaction, or
+visual judgment is part of acceptance. Add tests for concrete behavior or
+integration risk under root's test-value bar.

--- a/src/app/outputPlan/AGENTS.md
+++ b/src/app/outputPlan/AGENTS.md
@@ -27,12 +27,9 @@
   and `encodingEstimateKbps`. Do not read private Input/encoder state, sample
   `readEncodingRequestConfig()`, parse the encoder `Est: ~60 kbps` label, or
   cache a mirrored byte size.
-- Keep `estimateEncodedSizeBytes` as: non-positive duration → 0; bytes =
-  `durationSeconds * bitrateKbps * 1000 / 8`; ×1.5 when `channels === 'stereo'`;
-  ×1.03 overhead;   `Math.round`. On FDK VBR, `bitrateKbps` is the injected
-  `encodingEstimateKbps`, not the sticky request `encoderSettings.bitrateKbps`.
-  The encoder header is the only estimate consumer and keeps
-  `~ 12.3 MB` / `~ --- MB` (`formatEstimatedSizeText`).
+- `estimate.ts` and `estimate.test.ts` own the byte formula and empty-session
+  placeholder. On FDK VBR, use injected `encodingEstimateKbps`, not the sticky
+  request `encoderSettings.bitrateKbps`. The encoder header owns presentation.
 - Path preview is a Solid `createEffect` on public Input, Metadata, output
   directory, naming preset, year, and the **committed** template. Live template
   typing updates the input immediately and commits after 150 ms. Do not preview
@@ -67,7 +64,7 @@
 - `workflow.test.ts` pins stale preview suppression and review approve /
   cancel / hard-block.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a public export.
 - Reading private Input, Metadata, file-list, or encoder state to build

--- a/src/app/processing/AGENTS.md
+++ b/src/app/processing/AGENTS.md
@@ -51,7 +51,7 @@
   consumes. Do not import private Remote session or acquisition files here.
 - Status UI strip is pinned by `src/ui/statusPanel/__tests__/runtime-api-contract.test.ts`.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a public export.
 - Reading leftover file-list, job-control, encoder, or output private state to

--- a/src/app/remoteSource/AGENTS.md
+++ b/src/app/remoteSource/AGENTS.md
@@ -32,8 +32,7 @@
   `RemoteSourceAcquireView` renders its live percentage and Cancel.
   File List and the inspector observe Supplemental Assets through the composed
   Remote Source owner so PDF chips update after Input has already published the
-  new files. The current `subscribeRemoteSourceSupplementalAssets` export is a
-  compatibility rail, not the target interface.
+  new files. Consumers use the owner's reactive companion reads.
   Cancellation and app disposal invalidate the active acquisition generation
   so late Promise completions cannot overwrite terminal or reset state.
 - Materialized audio becomes a normal Input session through
@@ -63,13 +62,13 @@
 - `display.test.ts` pins terminal classification so polling cannot spin forever.
 - `selection.test.ts` pins filter/selection policy and Indexer release seeder
   order.
-- `RemoteSourceAcquireView.test.tsx` pins Escape/Close to the close intent,
+- `src/ui/remoteSource/RemoteSourceAcquireView.test.tsx` pins Escape/Close to the close intent,
   the polled owner-to-Solid progress path, Indexer release protocol/category
   tags, and Enter-to-search on the author and title fields.
 - When lifetime ownership changes, add two-runtime proof covering the affected
   state or resource: disposing A cannot cancel, purge, reset, or publish into B.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Exposing internal state mutation or moving asset coordination into the UI.
 - Dual-writing `fileListSessionState` or adding a parallel remote file list.

--- a/src/app/workOperations/AGENTS.md
+++ b/src/app/workOperations/AGENTS.md
@@ -43,7 +43,7 @@
 - Work Center UI strip is pinned by
   `src/ui/workCenter/__tests__/runtime-api-contract.test.ts`.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a public export.
 - Reintroducing `processing-progress` overlay consumption for background

--- a/src/lib/effect/AGENTS.md
+++ b/src/lib/effect/AGENTS.md
@@ -19,13 +19,13 @@ Keep Effect workflow APIs private to workflow owners:
   `bun run test -- scripts/frontend-toolchain-layout.test.ts`.
 - Public UI/runtime entrypoints expose Promise-returning functions or existing
   synchronous wrappers where callers already rely on them.
-- Workflow owners expose a local service interface, service tag, live layer
-  (co-located in the workflow file with `satisfies`), typed errors, program,
-  and Promise bridge. Processing keeps live deps in
+- When a workflow needs an Effect service layer, keep its service interface,
+  tag, live layer, typed errors, and Promise bridge private to that owner.
+  Co-locate the live layer with `satisfies`. Processing keeps live deps in
   `src/app/processing/workflow.deps.ts` (dynamic-imported) to preserve the
   cycle break.
-- Dependencies are injected through service objects so tests can provide fake
-  layers without Solid rendering or live Tauri.
+- Inject dependencies so tests can supply capabilities or fake layers without
+  Solid rendering or live Tauri.
 - State and event outputs stay explicit in the owner contract.
 - Public API Strip impact is stated by the wrapper: if callers do not need new
   symbols or changed return types, keep the existing public API stable.
@@ -35,8 +35,8 @@ Keep Effect workflow APIs private to workflow owners:
 
 ## Workflow Harness Helpers
 
-Workflow owners get their service tag, live-layer factory, tagged failure
-class, failure factory, and try-wrappers from one kernel kit (#389):
+Use `makeWorkflowKit` when an owner needs a service tag, live-layer factory,
+and tagged failure wrappers:
 
 ```ts
 const kit = makeWorkflowKit(
@@ -51,18 +51,21 @@ const kit = makeWorkflowKit(
   local `Effect.tryPromise` / `Effect.try` blocks or hand-copied
   `Data.TaggedError` trios.
 - The failure tag stays a per-owner string literal, so `Effect.catchTag`
-  discriminates owners exactly like hand-written classes (pinned by the kit
-  spike tests in `appEffect.test.ts`).
+  discriminates owners (pinned by `appEffect.test.ts`).
 - Escape hatch: an owner with genuinely unique failure mapping keeps its own
   factory built on `kit.Failed` (for example `ProcessingWorkflow` normalizes
   `AppError` into the message and forks a hand-written
   `ProcessingWorkflowCancelled`).
 - `workflowTryPromise` / `workflowTrySync` remain exported for the escape-hatch
   path; kit wrappers are the default.
+- A program whose existing capability already supplies its dependencies can
+  use the kernel directly, as in `src/app/inputSession/importWorkflow.ts`.
+  Introduce a service layer when it clarifies a real dependency or failure
+  boundary.
 
 ## Fake-Layer Harness Shape
 
-Workflow tests should run the Effect program directly with fake services:
+For service-layer workflows, run the Effect program directly with fake services:
 
 - Build a small `makeHarness` helper in the owner test file.
 - Provide dependencies through the owner service layer, not through Solid
@@ -76,21 +79,16 @@ Workflow tests should run the Effect program directly with fake services:
 
 ## Finding Workflow Owners
 
-Workflow owners live in `*Workflow*.ts` files beside their `__tests__/`; find the
-current set by searching the tree (e.g. `rg -l "Workflow" src/app --glob '*Workflow*.ts'`)
-rather than from a hand-maintained list that rots as owners move. Each owner
-co-locates its service interface, service tag, live layer (`satisfies`), program,
-and Promise bridge, and is exercised by a focused Vitest file next to it
-(`bun run test -- <owner test file>`).
-
-Public API Strip impact for these owners is intentionally narrow: callers keep
-existing UI/runtime Promise or synchronous wrapper shapes unless a milestone
-explicitly accepts a public API change.
+Find workflow files with
+`rg --files src/app -g '*workflow*.ts' -g '*Workflow*.ts'`.
+Tests may be siblings or under the owner's `__tests__/`; inspect the selected
+owner for its focused proof. The Processing live-layer exception is described
+above.
 
 ## Future Workflow Ingress
 
-- New frontend work that coordinates multiple real boundaries should start with
-  an explicit workflow owner, co-located service contract + live layer, and
-  fake-layer tests.
+- New multi-boundary coordination belongs to an explicit workflow owner with
+  injected dependencies and proof through its observable outcomes. Choose
+  direct capability injection or a service layer using the criteria above.
 - Plain local UI state, pure transforms, and single-boundary event handlers can
   stay vanilla TypeScript when Effect would not clarify ownership or testing.

--- a/src/lib/tauri/AGENTS.md
+++ b/src/lib/tauri/AGENTS.md
@@ -1,11 +1,9 @@
 # Tauri IPC Boundary
 
 ## Public API Strip
-- Public module exports: `tauriClient`, `TAURI_COMMAND_NAMES`, `TAURI_APP_EVENT_NAMES`, `TauriCommand`.
-- `tauriClient` methods are pinned by `src/lib/tauri-public-api.contract.test.ts`; add methods only as deliberate boundary changes.
-- Public-strip tests must pin an independent expected surface. Do not derive the
-  expected method, command, or event list from `commands.ts` or generated
-  bindings.
+- `client.ts` defines the public runtime surface;
+  `src/lib/tauri-public-api.contract.test.ts` independently pins it. Inspect
+  those sources for the exact exports and methods before changing the strip.
 - Runtime UI modules call `tauriClient`; generated command/event invokers stay private to `src/lib/tauri`.
 
 ## Frontend Utility Surface
@@ -27,7 +25,7 @@
 - Files: `client.ts`, `commands.ts`, `normalizers.ts`, `AGENTS.md`.
 - Generated bindings live at `src/lib/generated/tauri.ts`; do not hand-edit them.
 
-## Allowed Agent Edits Without Escalation
+## Edit Rules
 - Change private adapters when generated-binding, Public API Strip, and targeted
   runtime Vitest checks stay green.
 - Keep command and type names semantic; avoid `_v1`/`_v2` version suffixes and `_cmd` command suffixes. Breaking changes get a new product-meaningful name.
@@ -37,7 +35,7 @@
   rule tables.
 - Keep nullish and payload normalization centralized in the private cluster.
 
-## Breaking-Change Triggers
+## Boundary Changes
 - Adding, removing, or renaming a public export, `tauriClient` method, command name, event name, or generated overlap type.
 - Sending clear intent through sentinel frontend values instead of explicit patch ops.
 - Bypassing `tauriClient` with generated invokers or raw Tauri invoke/listen calls.

--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -2,8 +2,9 @@
 
 Each UI surface under `src/ui/<owner>/` keeps its own nested `AGENTS.md` where
 it has view-local interaction, presentation-resource lifetime, or contract
-truth (closest file wins). Application session/workflow truth lives under
-`src/app`; this file owns only rules shared by thin composition shells.
+truth. Nested guidance narrows the inherited rules. Application session/workflow
+truth lives under `src/app`; this file owns only rules shared by thin composition
+shells.
 
 ## Composition-only Shells
 
@@ -30,5 +31,6 @@ Rules for both:
   Center, file-management, metadata, and cover-art truth stay in their owners.
 - Preserve `leftColumn` height behavior: the input workflow flexes, the
   inspector stays pinned.
-- Structure changes need a focused composition test that pins the sibling-zone
-  arrangement plus a browser visual pass.
+- Review changed layout visually. Add composition proof only when it protects
+  an observable interaction or integration contract; static sibling order by
+  itself is not a test requirement.

--- a/src/ui/collisionDialog/AGENTS.md
+++ b/src/ui/collisionDialog/AGENTS.md
@@ -20,7 +20,7 @@
 - Import `Dialog` from `src/ui/foundation`. Do not add a second modal stack or
   a local collision store.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a Public API Strip export.
 - Reintroducing collision policy state in this folder.

--- a/src/ui/encoderPanel/AGENTS.md
+++ b/src/ui/encoderPanel/AGENTS.md
@@ -15,7 +15,7 @@
   `readEncoderDefaultsFromState`, `readEncodingRequestConfig`,
   `readFdkAfterburner`, `setFdkAfterburner`, `subscribeEncoderPanel`.
 - Do not add callers to `subscribeEncoderPanel`, `state.ts`,
-  `runtimeSettingsCapabilities.ts`, or the read/apply global functions. New
+  `src/ui/runtimeSettingsCapabilities.ts`, or the read/apply global functions. New
   callers use a runtime-scoped owner composed by App Runtime.
 
 ## Required Owner Boundary

--- a/src/ui/fileList/AGENTS.md
+++ b/src/ui/fileList/AGENTS.md
@@ -27,9 +27,8 @@
   module cache/listeners are a lifetime gap; the target resource is scoped
   to each `FileListView` and disposed with it. Do not add module resets or
   callers to `coverThumbnails.ts`.
-- PDF companion chips observe the runtime Remote Source owner. The current
-  `subscribeRemoteSourceSupplementalAssets` call is a compatibility rail;
-  do not assume an Input publish also rerenders supplemental assets.
+- PDF companion chips use the runtime Remote Source owner's reactive
+  `hasCompanions` read; supplemental changes can arrive after Input publishes.
 - Remote session purge tracks Input file identity through Remote Source. Do
   not dual-purge from this view.
 

--- a/src/ui/foundation/AGENTS.md
+++ b/src/ui/foundation/AGENTS.md
@@ -1,10 +1,10 @@
 # UI Foundation
 
-## Current state
+## Scope
 
 Shared visual behavior crosses `src/ui/foundation/index.ts`. Native CSS is the
-only styling language. Next action: change tokens or primitives here, then
-update `src/lab` in the same change.
+only styling language. When changing tokens or primitives, update `src/lab`
+in the same change.
 
 ## Public API Strip
 

--- a/src/ui/outputPanel/AGENTS.md
+++ b/src/ui/outputPanel/AGENTS.md
@@ -11,12 +11,9 @@
 
 - Import from `src/ui/outputPanel`. The runtime export surface is `index.ts`,
   pinned by `__tests__/runtime-api-contract.test.ts`.
-- Exports: `OutputView`, `applyOutputDefaultsFromSettings`,
-  `readOutputDefaultsFromState`, `readOutputRequestConfig`,
-  `runOutputPlanReviewWorkflow`.
-- The non-view exports are compatibility re-exports. Do not add callers;
-  after migration this index exports the view and any genuinely view-owned
-  types only. Processing and Settings use `runtime.output` directly.
+- The non-view exports are compatibility re-exports. New Processing and
+  Settings callers use `runtime.output` directly; do not extend that UI strip
+  for application coordination.
 
 ## Private Cluster
 
@@ -28,7 +25,7 @@
 - Estimated size is rendered in the encoder header from Output Plan. Do not
   add a second estimate readout here.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a Public API Strip export.
 - Reintroducing a poke API (`updateOutputPath`, `updateEstimatedSize`) or a

--- a/src/ui/previewAudio/AGENTS.md
+++ b/src/ui/previewAudio/AGENTS.md
@@ -20,7 +20,7 @@
 - Compact variant mounts in the tags header in `src/ui/App.tsx`.
 - Do not add a preview store or poke leftover job-control APIs.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a Public API Strip export.
 - Moving preview duration into a shared owner without a named need.

--- a/src/ui/statusPanel/AGENTS.md
+++ b/src/ui/statusPanel/AGENTS.md
@@ -10,9 +10,6 @@
 
 - Import from `src/ui/statusPanel`. The runtime export surface is `index.ts`,
   pinned by `__tests__/runtime-api-contract.test.ts`.
-- Exports: `StatusPanelView`, `initStatusPanel`, `isStatusPanelProcessing`,
-  `pushStatusPanelTransientStatus`, `readProcessingRequestConfig`,
-  `triggerCancelAllFromStatusPanel`, `triggerProcessFromStatusPanel`.
 - The non-view names are compatibility re-exports over process-wide
   Processing state. Do not add callers; the target index exports the view while
   callers use the runtime Processing owner.
@@ -27,7 +24,7 @@
   `processing.start`.
 - Do not add a local status store or restore `updateStatusPanelConcurrencyStatus`.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a Public API Strip export.
 - Reintroducing Status Panel as a WorkRuntime consumer or a poke API for

--- a/src/ui/tagPreview/AGENTS.md
+++ b/src/ui/tagPreview/AGENTS.md
@@ -9,7 +9,6 @@
 
 - Import from `src/ui/tagPreview`. The runtime export surface is `index.ts`,
   pinned by `__tests__/runtime-api-contract.test.ts`.
-- Exports: `TagPreviewView`.
 
 ## Private Cluster
 
@@ -22,7 +21,7 @@
   `src/app/metadataSession/tags.ts`. Do not add a local tag store, refresh
   function, or listener that copies those values.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a Public API Strip export.
 - Reintroducing a push or snapshot API that writes tag values outside

--- a/src/ui/workCenter/AGENTS.md
+++ b/src/ui/workCenter/AGENTS.md
@@ -10,7 +10,6 @@
 
 - Import from `src/ui/workCenter`. The runtime export surface is `index.ts`,
   pinned by `__tests__/runtime-api-contract.test.ts`.
-- Exports: `WorkCenterView`.
 
 ## Private Cluster
 
@@ -22,7 +21,7 @@
   `workOperations.cancel`.
 - Do not add a local operation store or subscribe to `processing-progress`.
 
-## Breaking-Change Triggers
+## Boundary Changes
 
 - Adding, removing, or renaming a Public API Strip export.
 - Reintroducing client-authored progress overlays for background operations.


### PR DESCRIPTION
## Changes

Agent guidance repeated ownership rules and imposed fixed research, audit, and approval procedures. Consolidate those meanings in their existing owners, make skill procedures proportional to the task, and preserve metadata, IPC, lifecycle, path-safety, and release invariants. Clarify when existing user authority permits completing requested changes.

## Validation

Validated the five repository skills and reviewed the instruction network, relative references, and final diff. Changes are guidance only; no product runtime files changed. The personal-skills behavioral benchmark is tracked separately and does not include ABB.
