### PR TITLE
Improve indexer discovery and connection security guidance

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,7 +17,7 @@
     },
     {
       "identifier": "opener:allow-open-url",
-      "allow": [{ "url": "https://*" }]
+      "allow": [{ "url": "http://*" }, { "url": "https://*" }]
     }
   ]
 }

--- a/src-tauri/src/remote_source/AGENTS.md
+++ b/src-tauri/src/remote_source/AGENTS.md
@@ -42,6 +42,7 @@ or infer provider-private Audible internals.
   acquisition jobs or materialize files into Input.
 - Release detail URLs are optional source-provided HTTP(S) links without embedded
   credentials; never infer them from a release GUID.
+- Indexer connection URLs reject embedded credentials before persistence or draft testing.
 - Indexer credentials are scoped to the normalized server URL in the vault;
   connection JSON never contains a key. Save persists changed JSON before
   changing that URL's key, and reports partial persistence if the vault fails.

--- a/src-tauri/src/remote_source/AGENTS.md
+++ b/src-tauri/src/remote_source/AGENTS.md
@@ -40,6 +40,8 @@ or infer provider-private Audible internals.
 - `providers/indexer/` owns Indexer connection persistence, release
   search/grab, and the first Prowlarr HTTP adapter. Indexer grabs do not create
   acquisition jobs or materialize files into Input.
+- Release detail URLs are optional source-provided HTTP(S) links without embedded
+  credentials; never infer them from a release GUID.
 - Indexer credentials are scoped to the normalized server URL in the vault;
   connection JSON never contains a key. Save persists changed JSON before
   changing that URL's key, and reports partial persistence if the vault fails.

--- a/src-tauri/src/remote_source/AGENTS.md
+++ b/src-tauri/src/remote_source/AGENTS.md
@@ -44,6 +44,8 @@ or infer provider-private Audible internals.
   credentials; never infer them from a release GUID.
 - Indexer connection URLs reject embedded credentials on load, save, and draft
   testing; invalid saved URLs never reach IPC or provider requests.
+- The private connection owner resolves URL, categories, and the host's key for
+  search/grab together; its credential-bearing result never crosses IPC.
 - Indexer credentials are scoped to the normalized server URL in the vault;
   connection JSON never contains a key. Save persists changed JSON before
   changing that URL's key, and reports partial persistence if the vault fails.

--- a/src-tauri/src/remote_source/AGENTS.md
+++ b/src-tauri/src/remote_source/AGENTS.md
@@ -42,7 +42,8 @@ or infer provider-private Audible internals.
   acquisition jobs or materialize files into Input.
 - Release detail URLs are optional source-provided HTTP(S) links without embedded
   credentials; never infer them from a release GUID.
-- Indexer connection URLs reject embedded credentials before persistence or draft testing.
+- Indexer connection URLs reject embedded credentials on load, save, and draft
+  testing; invalid saved URLs never reach IPC or provider requests.
 - Indexer credentials are scoped to the normalized server URL in the vault;
   connection JSON never contains a key. Save persists changed JSON before
   changing that URL's key, and reports partial persistence if the vault fails.

--- a/src-tauri/src/remote_source/providers/indexer/connection.rs
+++ b/src-tauri/src/remote_source/providers/indexer/connection.rs
@@ -12,7 +12,7 @@ use crate::remote_source::vault::SecretVault;
 pub(super) fn api_key_vault_key(base_url: &str) -> String {
     format!("indexer.api_key:{base_url}")
 }
-pub(super) const DEFAULT_CATEGORY_ID: u32 = 3030;
+pub(super) const DEFAULT_CATEGORY_IDS: &[u32] = &[3000, 3030];
 
 const CONNECTION_FILE_NAME: &str = "remote-source-indexer-connection.json";
 
@@ -35,7 +35,7 @@ impl Default for StoredIndexerConnection {
 }
 
 fn default_category_ids() -> Vec<u32> {
-    vec![DEFAULT_CATEGORY_ID]
+    DEFAULT_CATEGORY_IDS.to_vec()
 }
 
 fn normalize_category_ids(ids: Vec<u32>) -> Vec<u32> {
@@ -280,8 +280,25 @@ mod tests {
         let connection = get_connection(temp.path(), &vault).expect("connection");
 
         assert_eq!(connection.base_url, None);
-        assert_eq!(connection.category_ids, vec![3030]);
+        assert_eq!(connection.category_ids, vec![3000, 3030]);
         assert!(!connection.api_key_configured);
+    }
+
+    #[test]
+    fn preserves_explicit_categories_and_defaults_empty_categories() {
+        let temp = TempDir::new().expect("temp dir");
+        let vault = TestVault::default();
+        for (categories, expected) in [(vec![3030], vec![3030]), (vec![], vec![3000, 3030])] {
+            let mut change = update(None, None);
+            change.category_ids = Some(categories);
+            update_connection(temp.path(), &vault, change).expect("save categories");
+            assert_eq!(
+                get_connection(temp.path(), &vault)
+                    .expect("reload")
+                    .category_ids,
+                expected
+            );
+        }
     }
 
     #[test]
@@ -407,7 +424,7 @@ mod tests {
         assert!(results.into_iter().all(|result| result.is_err()));
         let saved = get_connection(temp.path(), &vault).expect("read saved connection");
         assert_eq!(saved.base_url.as_deref(), Some("http://old.test"));
-        assert_eq!(saved.category_ids, [3030]);
+        assert_eq!(saved.category_ids, [3000, 3030]);
         assert_eq!(
             std::fs::read_dir(temp.path())
                 .expect("list config files")

--- a/src-tauri/src/remote_source/providers/indexer/connection.rs
+++ b/src-tauri/src/remote_source/providers/indexer/connection.rs
@@ -214,6 +214,11 @@ fn normalize_base_url(base_url: String) -> Result<Option<String>> {
             "Indexer URL must use http or https.".to_string(),
         ));
     }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(AppError::InvalidInput(
+            "Indexer URL must not contain credentials. Use the API key field instead.".to_string(),
+        ));
+    }
     let mut normalized = format!("{}://{}", parsed.scheme(), parsed.authority());
     let path = parsed.path().trim_end_matches('/');
     if !path.is_empty() && path != "/" {
@@ -282,6 +287,38 @@ mod tests {
         assert_eq!(connection.base_url, None);
         assert_eq!(connection.category_ids, vec![3000, 3030]);
         assert!(!connection.api_key_configured);
+    }
+
+    #[test]
+    fn rejects_url_credentials_before_saving_or_testing() {
+        let temp = TempDir::new().expect("temp dir");
+        let vault = TestVault::default();
+        let saved = update_connection(
+            temp.path(),
+            &vault,
+            update(Some("https://indexer.test"), Some("saved-key")),
+        )
+        .expect("save valid connection");
+        for url in [
+            "https://user:password@indexer.test",
+            "http://user@indexer.test:9696",
+            "https://:password@indexer.test",
+        ] {
+            let change = || update(Some(url), Some("replacement-key"));
+            let error = update_connection(temp.path(), &vault, change())
+                .expect_err("URL credentials must not be persisted");
+            assert!(error.to_string().contains("must not contain credentials"));
+            assert!(!error.to_string().contains(url));
+            assert!(draft_credentials(temp.path(), &vault, change()).is_err());
+            assert_eq!(get_connection(temp.path(), &vault).expect("reload"), saved);
+            assert_eq!(
+                read_api_key(&vault, saved.base_url.as_deref())
+                    .expect("read key")
+                    .expect("saved key")
+                    .expose_secret(),
+                "saved-key"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/remote_source/providers/indexer/connection.rs
+++ b/src-tauri/src/remote_source/providers/indexer/connection.rs
@@ -117,10 +117,33 @@ fn update_api_key(
     }
 }
 
-pub(super) fn read_api_key(
+pub(super) struct ConfiguredIndexerConnection {
+    pub base_url: String,
+    pub category_ids: Vec<u32>,
+    pub api_key: SecretString,
+}
+
+pub(super) fn configured_connection(
+    config_dir: &Path,
     vault: &dyn SecretVault,
-    base_url: Option<&str>,
-) -> Result<Option<SecretString>> {
+) -> Result<ConfiguredIndexerConnection> {
+    let stored = load_stored_connection(config_dir)?;
+    let base_url = stored.base_url.ok_or_else(|| {
+        AppError::InvalidInput("Configure Indexer URL in Settings before continuing.".to_string())
+    })?;
+    let api_key = read_api_key(vault, Some(&base_url))?.ok_or_else(|| {
+        AppError::InvalidInput(
+            "Configure Indexer API key in Settings before continuing.".to_string(),
+        )
+    })?;
+    Ok(ConfiguredIndexerConnection {
+        base_url,
+        category_ids: stored.category_ids,
+        api_key,
+    })
+}
+
+fn read_api_key(vault: &dyn SecretVault, base_url: Option<&str>) -> Result<Option<SecretString>> {
     match base_url {
         Some(base_url) => vault.get_secret(&api_key_vault_key(base_url)),
         None => Ok(None),
@@ -250,11 +273,13 @@ mod tests {
     #[derive(Default)]
     struct TestVault {
         secrets: Mutex<HashMap<String, SecretString>>,
+        reads: Mutex<usize>,
         fail_writes: bool,
     }
 
     impl SecretVault for TestVault {
         fn get_secret(&self, key: &str) -> Result<Option<SecretString>> {
+            *self.reads.lock().expect("read counter lock") += 1;
             Ok(self
                 .secrets
                 .lock()
@@ -332,6 +357,25 @@ mod tests {
     }
 
     #[test]
+    fn configured_request_resolves_the_saved_host_key_once() {
+        let temp = TempDir::new().expect("temp dir");
+        let vault = TestVault::default();
+        update_connection(
+            temp.path(),
+            &vault,
+            update(Some("https://indexer.test/proxy/"), Some("saved-key")),
+        )
+        .expect("save connection");
+        *vault.reads.lock().expect("read counter lock") = 0;
+
+        let connection = configured_connection(temp.path(), &vault).expect("resolve connection");
+        assert_eq!(connection.base_url, "https://indexer.test/proxy");
+        assert_eq!(connection.category_ids, [3000, 3030]);
+        assert_eq!(connection.api_key.expose_secret(), "saved-key");
+        assert_eq!(*vault.reads.lock().expect("read counter lock"), 1);
+    }
+
+    #[test]
     fn rejects_persisted_url_credentials_before_exposing_or_using_them() {
         let temp = TempDir::new().expect("temp dir");
         let vault = TestVault::default();
@@ -353,6 +397,8 @@ mod tests {
             assert!(!message.contains("old-password"));
             assert!(!message.contains("indexer.test"));
         }
+        assert!(configured_connection(temp.path(), &vault).is_err());
+        assert_eq!(*vault.reads.lock().expect("read counter lock"), 0);
     }
 
     #[test]

--- a/src-tauri/src/remote_source/providers/indexer/connection.rs
+++ b/src-tauri/src/remote_source/providers/indexer/connection.rs
@@ -168,6 +168,16 @@ fn load_stored_connection(config_dir: &Path) -> Result<StoredIndexerConnection> 
             "Indexer connection settings are invalid. Remove remote-source-indexer-connection.json from the app configuration folder, then configure Indexer again. ({error})"
         ))
     })?;
+    stored.base_url = stored
+        .base_url
+        .map(normalize_base_url)
+        .transpose()
+        .map_err(|error| {
+            AppError::InvalidInput(format!(
+                "Stored Indexer URL is invalid: {error} Remove remote-source-indexer-connection.json from the app configuration folder, then configure Indexer again."
+            ))
+        })?
+        .flatten();
     stored.category_ids = normalize_category_ids(stored.category_ids);
     Ok(stored)
 }
@@ -318,6 +328,30 @@ mod tests {
                     .expose_secret(),
                 "saved-key"
             );
+        }
+    }
+
+    #[test]
+    fn rejects_persisted_url_credentials_before_exposing_or_using_them() {
+        let temp = TempDir::new().expect("temp dir");
+        let vault = TestVault::default();
+        std::fs::write(
+            connection_path(temp.path()),
+            r#"{"baseUrl":"https://user:old-password@indexer.test","categoryIds":[3030]}"#,
+        )
+        .expect("write previously accepted connection");
+
+        let errors = [
+            get_connection(temp.path(), &vault).expect_err("do not expose stored credentials"),
+            draft_credentials(temp.path(), &vault, update(None, Some("api-key")))
+                .expect_err("do not use stored credentials for a connection test"),
+        ];
+        for error in errors {
+            let message = error.to_string();
+            assert!(message.contains("must not contain credentials"));
+            assert!(message.contains("remote-source-indexer-connection.json"));
+            assert!(!message.contains("old-password"));
+            assert!(!message.contains("indexer.test"));
         }
     }
 

--- a/src-tauri/src/remote_source/providers/indexer/mod.rs
+++ b/src-tauri/src/remote_source/providers/indexer/mod.rs
@@ -3,8 +3,6 @@ mod prowlarr;
 
 use std::path::Path;
 
-use secrecy::SecretString;
-
 use crate::errors::{AppError, Result};
 use crate::remote_source::types::{
     AccountRef, ProviderId, RemoteAccountStatus, RemoteAcquisitionFailureKind, RemoteAuthFlow,
@@ -15,7 +13,7 @@ use crate::remote_source::types::{
 use crate::remote_source::vault::SecretVault;
 
 use connection::{
-    api_key_vault_key, draft_credentials, get_connection, read_api_key, update_connection,
+    api_key_vault_key, configured_connection, draft_credentials, get_connection, update_connection,
 };
 use prowlarr::{build_search_params, ProwlarrSearchOutcome};
 
@@ -96,10 +94,11 @@ impl IndexerProvider {
         adapter: &ReqwestProwlarrAdapter,
         request: RemoteReleaseSearchRequest,
     ) -> Result<RemoteReleaseSearchResponse> {
-        let connection = get_connection(config_dir, vault)?;
-        let (base_url, api_key) = require_connection(&connection, vault)?;
+        let connection = configured_connection(config_dir, vault)?;
         let params = build_search_params(&request, &connection.category_ids)?;
-        let outcome = adapter.search(&base_url, &api_key, &params).await?;
+        let outcome = adapter
+            .search(&connection.base_url, &connection.api_key, &params)
+            .await?;
         Ok(map_search_outcome(outcome))
     }
 
@@ -110,12 +109,11 @@ impl IndexerProvider {
         request: RemoteReleaseGrabRequest,
     ) -> Result<RemoteReleaseGrabResponse> {
         validate_grab_release(&request.release)?;
-        let connection = get_connection(config_dir, vault)?;
-        let (base_url, api_key) = require_connection(&connection, vault)?;
+        let connection = configured_connection(config_dir, vault)?;
         let outcome = adapter
             .grab(
-                &base_url,
-                &api_key,
+                &connection.base_url,
+                &connection.api_key,
                 &request.release.guid,
                 request.release.indexer_id,
             )
@@ -148,21 +146,6 @@ impl IndexerProvider {
         }
         Ok(())
     }
-}
-
-fn require_connection(
-    connection: &RemoteIndexerConnection,
-    vault: &dyn SecretVault,
-) -> Result<(String, SecretString)> {
-    let base_url = connection.base_url.clone().ok_or_else(|| {
-        AppError::InvalidInput("Configure Indexer URL in Settings before continuing.".to_string())
-    })?;
-    let api_key = read_api_key(vault, Some(&base_url))?.ok_or_else(|| {
-        AppError::InvalidInput(
-            "Configure Indexer API key in Settings before continuing.".to_string(),
-        )
-    })?;
-    Ok((base_url, api_key))
 }
 
 fn map_search_outcome(outcome: ProwlarrSearchOutcome) -> RemoteReleaseSearchResponse {

--- a/src-tauri/src/remote_source/providers/indexer/prowlarr.rs
+++ b/src-tauri/src/remote_source/providers/indexer/prowlarr.rs
@@ -772,22 +772,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn search_url_repeats_categories_for_each_id() {
-        let url = build_search_url(
-            "http://indexer.test",
-            &ProwlarrSearchParams {
-                query: "kings".to_string(),
-                category_ids: vec![3030, 3000],
-            },
-        )
-        .expect("url");
-        let query = url.query().expect("query");
-
-        assert!(query.contains("categories=3030"));
-        assert!(query.contains("categories=3000"));
-    }
-
     #[tokio::test]
     async fn search_maps_query_and_category_without_indexer_ids() {
         let (listener, addr) = start_listener().await;

--- a/src-tauri/src/remote_source/providers/indexer/prowlarr.rs
+++ b/src-tauri/src/remote_source/providers/indexer/prowlarr.rs
@@ -149,7 +149,7 @@ pub(super) fn build_search_params(
     Ok(ProwlarrSearchParams {
         query: joined,
         category_ids: if category_ids.is_empty() {
-            vec![connection::DEFAULT_CATEGORY_ID]
+            connection::DEFAULT_CATEGORY_IDS.to_vec()
         } else {
             category_ids.to_vec()
         },
@@ -325,6 +325,7 @@ fn map_release(
     }
 
     Some(RemoteRelease {
+        detail_url: release_detail_url(raw.info_url.as_deref(), raw.comment_url.as_deref()),
         provider_id: ProviderId::Indexer,
         guid: raw.guid,
         indexer_id: raw.indexer_id,
@@ -338,6 +339,20 @@ fn map_release(
             .map(|value| value as u32),
         categories: map_categories(raw.categories),
     })
+}
+
+fn release_detail_url(info_url: Option<&str>, comment_url: Option<&str>) -> Option<String> {
+    [info_url, comment_url]
+        .into_iter()
+        .flatten()
+        .find_map(|candidate| {
+            let url = Url::parse(candidate).ok()?;
+            (matches!(url.scheme(), "http" | "https")
+                && url.host_str().is_some()
+                && url.username().is_empty()
+                && url.password().is_none())
+            .then(|| url.to_string())
+        })
 }
 
 fn map_categories(entries: Vec<ProwlarrCategoryEntry>) -> Vec<RemoteReleaseCategory> {
@@ -424,6 +439,10 @@ struct ProwlarrReleaseRaw {
     title: String,
     #[serde(default)]
     indexer: String,
+    #[serde(rename = "infoUrl", default)]
+    info_url: Option<String>,
+    #[serde(rename = "commentUrl", default)]
+    comment_url: Option<String>,
     #[serde(default)]
     size: i64,
     #[serde(default)]
@@ -655,6 +674,58 @@ mod tests {
     }
 
     #[test]
+    fn release_details_use_only_valid_source_links() {
+        for (info, comment, expected) in [
+            (None, None, None),
+            (
+                Some("https://source.test/book"),
+                Some("https://source.test/comments"),
+                Some("https://source.test/book"),
+            ),
+            (
+                None,
+                Some("http://source.test/comments"),
+                Some("http://source.test/comments"),
+            ),
+            (
+                Some("/relative"),
+                Some("https://source.test/comments"),
+                Some("https://source.test/comments"),
+            ),
+            (Some("javascript:alert(1)"), None, None),
+            (
+                Some("https://user:secret@source.test/book"),
+                Some("https://source.test/comments"),
+                Some("https://source.test/comments"),
+            ),
+            (
+                Some("https://user@source.test/book"),
+                Some("file:///tmp/book"),
+                None,
+            ),
+        ] {
+            let raw: ProwlarrReleaseRaw = serde_json::from_value(serde_json::json!({
+                "guid": "https://source.test/not-a-detail-link",
+                "infoUrl": info,
+                "commentUrl": comment,
+            }))
+            .expect("release fixture");
+            let mut diagnostics = Vec::new();
+            let release = map_release(raw, &mut diagnostics).expect("release remains selectable");
+            assert_eq!(release.detail_url.as_deref(), expected);
+            assert!(diagnostics.is_empty());
+        }
+        let raw: ProwlarrReleaseRaw =
+            serde_json::from_str(r#"{"guid":"abc"}"#).expect("absent links");
+        assert_eq!(
+            map_release(raw, &mut Vec::new())
+                .expect("release")
+                .detail_url,
+            None
+        );
+    }
+
+    #[test]
     fn map_categories_accepts_named_objects_and_bare_ids() {
         let categories = map_categories(vec![
             ProwlarrCategoryEntry::Id(3000),
@@ -721,7 +792,7 @@ mod tests {
     async fn search_maps_query_and_category_without_indexer_ids() {
         let (listener, addr) = start_listener().await;
         let host = "prowlarr.test";
-        let body = br#"[{"guid":"abc","indexerId":7,"title":"Book Title","indexer":"Example","size":1234,"protocol":"torrent","seeders":12,"categories":[{"id":3030,"name":"Audio/Audiobook"}]}]"#;
+        let body = br#"[{"guid":"abc","indexerId":7,"title":"Book Title","indexer":"Example","size":1234,"protocol":"torrent","seeders":12,"infoUrl":"https://source.test/book/abc","commentUrl":"https://source.test/comments/abc","categories":[{"id":3030,"name":"Audio/Audiobook"}]}]"#;
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
             body.len()
@@ -737,7 +808,7 @@ mod tests {
                 &SecretString::from("secret-key".to_string()),
                 &ProwlarrSearchParams {
                     query: "way of kings".to_string(),
-                    category_ids: vec![3030],
+                    category_ids: vec![3000, 3030],
                 },
             )
             .await
@@ -756,9 +827,14 @@ mod tests {
         );
         assert!(request.path_and_query.contains("type=search"));
         assert!(request.path_and_query.contains("categories=3030"));
+        assert!(request.path_and_query.contains("categories=3000"));
         assert!(!request.path_and_query.contains("indexerIds"));
         assert_eq!(outcome.releases.len(), 1);
         assert_eq!(outcome.releases[0].guid, "abc");
+        assert_eq!(
+            outcome.releases[0].detail_url.as_deref(),
+            Some("https://source.test/book/abc")
+        );
         assert_eq!(outcome.releases[0].indexer, "Example");
         assert_eq!(outcome.releases[0].indexer_id, 7);
         assert_eq!(outcome.releases[0].protocol, RemoteReleaseProtocol::Torrent);

--- a/src-tauri/src/remote_source/types.rs
+++ b/src-tauri/src/remote_source/types.rs
@@ -140,6 +140,7 @@ pub struct RemoteRelease {
     pub indexer_id: i64,
     pub title: String,
     pub indexer: String,
+    pub detail_url: Option<String>,
     pub size_bytes: u64,
     pub protocol: RemoteReleaseProtocol,
     pub seeders: Option<u32>,

--- a/src/app/remoteSource/AGENTS.md
+++ b/src/app/remoteSource/AGENTS.md
@@ -14,7 +14,7 @@
   `RemoteSourceOwner`; private state, workflow, assets, and previews stay here.
 - `open({ lane? })` hydrates account/library state without a mounted view.
   `selectLane`, title/PDF/release selection intents, and workflow actions own
-  transitions. `editSearch` accepts only user-editable search/filter fields;
+  transitions. `editSearch` accepts only user-editable search/filter/sort fields;
   connection edits accept only URL, API-key, and category drafts.
 - State, workflow generations, cover previews, and supplemental assets belong
   to each owner instance. Reset/disposal invalidates that instance's work.
@@ -44,6 +44,8 @@
   provider path after handoff. Do not add a second file-list store.
 - Remote Source purges sessions for input ids that leave the public Input
   view. File Import keeps that lifetime subscription alive.
+- Indexer sort is session state: most seeders by default, or largest size with
+  seeders as the tie-breaker. Filtering and sorting preserve release selection.
 - Release selection is the `(indexerId, guid)` pair; GUID alone is not unique
   across indexers. Grab queues externally and never calls the Input handoff.
 - Frontend state may hold provider-neutral account, title, job, and

--- a/src/app/remoteSource/indexerConnection.ts
+++ b/src/app/remoteSource/indexerConnection.ts
@@ -32,7 +32,7 @@ export type IndexerConnectionServices = {
 function createInitialView(): IndexerConnectionSettingsView {
 	return {
 		baseUrlDraft: '',
-		categoryIdsDraft: [3030],
+		categoryIdsDraft: [3000, 3030],
 		apiKeyDraft: '',
 		apiKeyConfigured: false,
 		saveState: 'idle',

--- a/src/app/remoteSource/owner.ts
+++ b/src/app/remoteSource/owner.ts
@@ -50,6 +50,7 @@ export type RemoteSourceOwner = {
 				| 'indexerAuthorQuery'
 				| 'indexerTitleQuery'
 				| 'releaseFilter'
+				| 'releaseSort'
 			>
 		>,
 	): void;

--- a/src/app/remoteSource/selection.test.ts
+++ b/src/app/remoteSource/selection.test.ts
@@ -164,16 +164,24 @@ describe('remote source selection policy', () => {
 		];
 
 		expect(
-			visibleRemoteReleases(releases, { releaseFilter: 'way' }).map((item) => item.guid),
+			visibleRemoteReleases(releases, { releaseSort: 'seeders', releaseFilter: 'way' }).map(
+				(item) => item.guid,
+			),
 		).toEqual(['a']);
 		expect(
-			visibleRemoteReleases(releases, { releaseFilter: 'usenet' }).map((item) => item.guid),
+			visibleRemoteReleases(releases, { releaseSort: 'seeders', releaseFilter: 'usenet' }).map(
+				(item) => item.guid,
+			),
 		).toEqual(['b']);
 		expect(
-			visibleRemoteReleases(releases, { releaseFilter: 'nzb' }).map((item) => item.guid),
+			visibleRemoteReleases(releases, { releaseSort: 'seeders', releaseFilter: 'nzb' }).map(
+				(item) => item.guid,
+			),
 		).toEqual(['b']);
 		expect(
-			visibleRemoteReleases(releases, { releaseFilter: 'audiobook' }).map((item) => item.guid),
+			visibleRemoteReleases(releases, { releaseSort: 'seeders', releaseFilter: 'audiobook' }).map(
+				(item) => item.guid,
+			),
 		).toEqual(['a']);
 	});
 
@@ -191,12 +199,40 @@ describe('remote source selection policy', () => {
 			release({ guid: 'mam-72', title: 'Starsight 72', indexer: 'MyAnonamouse', seeders: 72 }),
 		];
 
-		expect(visibleRemoteReleases(releases, { releaseFilter: '' }).map((item) => item.guid)).toEqual(
-			['mam-72', 'tpb-25', 'tpb-4', 'nzbgeek'],
-		);
+		expect(
+			visibleRemoteReleases(releases, { releaseSort: 'seeders', releaseFilter: '' }).map(
+				(item) => item.guid,
+			),
+		).toEqual(['mam-72', 'tpb-25', 'tpb-4', 'nzbgeek']);
 		expect(releases.map((item) => item.guid)).toEqual(['tpb-25', 'tpb-4', 'nzbgeek', 'mam-72']);
 		expect(
-			visibleRemoteReleases(releases, { releaseFilter: 'pirate' }).map((item) => item.guid),
+			visibleRemoteReleases(releases, { releaseSort: 'seeders', releaseFilter: 'pirate' }).map(
+				(item) => item.guid,
+			),
 		).toEqual(['tpb-25', 'tpb-4']);
+	});
+	it('orders collections by size, breaks size ties by seeders, and restores seeder order', () => {
+		const releases = [
+			release({ guid: 'popular', title: 'Holmes single', sizeBytes: 100, seeders: 80 }),
+			release({ guid: 'pack-low', title: 'Holmes collection low', sizeBytes: 900, seeders: 2 }),
+			release({ guid: 'pack-high', title: 'Holmes collection high', sizeBytes: 900, seeders: 8 }),
+			release({ guid: 'unknown', title: 'Holmes unknown', sizeBytes: 0, seeders: 1 }),
+		];
+		expect(
+			visibleRemoteReleases(releases, { releaseFilter: '', releaseSort: 'size' }).map(
+				(r) => r.guid,
+			),
+		).toEqual(['pack-high', 'pack-low', 'popular', 'unknown']);
+		expect(
+			visibleRemoteReleases(releases, { releaseFilter: 'collection', releaseSort: 'size' }).map(
+				(r) => r.guid,
+			),
+		).toEqual(['pack-high', 'pack-low']);
+		expect(
+			visibleRemoteReleases(releases, { releaseFilter: '', releaseSort: 'seeders' }).map(
+				(r) => r.guid,
+			),
+		).toEqual(['popular', 'pack-high', 'pack-low', 'unknown']);
+		expect(releases.map((r) => r.guid)).toEqual(['popular', 'pack-low', 'pack-high', 'unknown']);
 	});
 });

--- a/src/app/remoteSource/selection.ts
+++ b/src/app/remoteSource/selection.ts
@@ -1,4 +1,5 @@
 import type { RemoteRelease, RemoteTitle } from '../../types/remoteSource';
+import type { RemoteSourceView } from './types';
 import { isTitleAcquirable, releaseProtocolLabel } from './display';
 
 export type RemoteTitleFilterOptions = {
@@ -7,9 +8,7 @@ export type RemoteTitleFilterOptions = {
 	hideUnavailableTitles: boolean;
 };
 
-export type RemoteReleaseFilterOptions = {
-	releaseFilter: string;
-};
+export type RemoteReleaseFilterOptions = Pick<RemoteSourceView, 'releaseFilter' | 'releaseSort'>;
 
 export function visibleRemoteTitles(
 	titles: RemoteTitle[],
@@ -54,7 +53,13 @@ export function visibleRemoteReleases(
 			)
 		: [...releases];
 
-	return visible.sort(compareReleasesBySeedersDesc);
+	return visible.sort((left, right) => {
+		if (options.releaseSort === 'size') {
+			const sizeDelta = right.sizeBytes - left.sizeBytes;
+			if (sizeDelta !== 0) return sizeDelta;
+		}
+		return compareReleasesBySeedersDesc(left, right);
+	});
 }
 
 function compareReleasesBySeedersDesc(left: RemoteRelease, right: RemoteRelease): number {

--- a/src/app/remoteSource/types.ts
+++ b/src/app/remoteSource/types.ts
@@ -30,6 +30,7 @@ export type AcquisitionState = {
 	indexerTitleQuery: string;
 	releases: RemoteRelease[];
 	releaseFilter: string;
+	releaseSort: 'seeders' | 'size';
 	selectedRelease: Pick<RemoteRelease, 'guid' | 'indexerId'> | null;
 	statusMessage: string;
 	activeJob: AcquisitionJobWithProgress | null;
@@ -63,6 +64,7 @@ export function createInitialAcquisitionState(): AcquisitionState {
 		indexerTitleQuery: '',
 		releases: [],
 		releaseFilter: '',
+		releaseSort: 'seeders',
 		selectedRelease: null,
 		statusMessage: '',
 		activeJob: null,
@@ -99,6 +101,7 @@ export function laneSelectionResetPatch(): Partial<AcquisitionState> {
 		indexerTitleQuery: '',
 		releases: [],
 		releaseFilter: '',
+		releaseSort: 'seeders',
 		selectedRelease: null,
 		statusMessage: '',
 	};

--- a/src/lib/generated/tauri.ts
+++ b/src/lib/generated/tauri.ts
@@ -827,6 +827,7 @@ export type RemoteRelease = {
 	indexerId: number,
 	title: string,
 	indexer: string,
+	detailUrl: string | null,
 	sizeBytes: number,
 	protocol: RemoteReleaseProtocol,
 	seeders: number | null,

--- a/src/lib/tauri-client.test.ts
+++ b/src/lib/tauri-client.test.ts
@@ -58,6 +58,18 @@ describe('tauriClient', () => {
 	});
 
 	describe('opener helpers', () => {
+		it('allows both web schemes used by source details without permitting other URL handlers', () => {
+			expect(
+				mainWindowCapability.permissions.find(
+					(permission) =>
+						typeof permission === 'object' && permission.identifier === 'opener:allow-open-url',
+				),
+			).toEqual({
+				identifier: 'opener:allow-open-url',
+				allow: [{ url: 'http://*' }, { url: 'https://*' }],
+			});
+		});
+
 		it('limits source and preview opening to user-owned or mounted paths', () => {
 			const openPathPermission = mainWindowCapability.permissions.find(
 				(permission) =>

--- a/src/ui/appSettings/AGENTS.md
+++ b/src/ui/appSettings/AGENTS.md
@@ -26,7 +26,9 @@
 - Default acquisition lane and Indexer connection fields dispatch through
   `src/app/appSettings` and `src/app/remoteSource` owner intents respectively.
   Indexer URL/categories persist via Remote Source IPC; the API key is write-only
-  in the Settings panel.
+  in the Settings panel. HTTPS is the recommended URL example; explicit HTTP
+  remains usable with visible transport guidance. Connection help is view-local,
+  and Escape dismisses it before dismissing Settings.
 - Persistence failure must be observable through App Settings and have an
   owner-level retry or restore outcome proved through its public interface;
   views do not decide that policy independently.

--- a/src/ui/appSettings/AppSettingsDialogView.test.tsx
+++ b/src/ui/appSettings/AppSettingsDialogView.test.tsx
@@ -136,7 +136,15 @@ describe('AppSettingsDialogView', () => {
 	});
 
 	it('lets the user enable both audiobook categories from the collapsed picker', async () => {
+		vi.spyOn(tauriClient, 'getRemoteSourceIndexerConnection').mockResolvedValue({
+			baseUrl: undefined,
+			categoryIds: [3030],
+			apiKeyConfigured: false,
+		});
 		await renderOpenDialog();
+		await vi.waitFor(() =>
+			expect(runtime!.remoteSource.indexerConnection().categoryIdsDraft).toEqual([3030]),
+		);
 
 		expect(screen.getByTestId('app-settings-indexer-category')).toHaveTextContent(
 			'Audiobooks (3030)',
@@ -150,6 +158,42 @@ describe('AppSettingsDialogView', () => {
 		expect(screen.getByTestId('app-settings-indexer-category')).toHaveTextContent(
 			'Audiobooks (3030), Audio (3000)',
 		);
+	});
+
+	it('recommends HTTPS while keeping an explicit HTTP connection usable', async () => {
+		vi.spyOn(tauriClient, 'getRemoteSourceIndexerConnection').mockResolvedValue({
+			baseUrl: 'http://saved:9696',
+			categoryIds: [3030],
+			apiKeyConfigured: true,
+		});
+		const r = await renderOpenDialog();
+		const url = screen.getByLabelText('URL');
+		await vi.waitFor(() => expect(url).toHaveValue('http://saved:9696'));
+		expect(url).toHaveAttribute('placeholder', 'https://prowlarr.example.com');
+		expect(screen.getByText('HTTP is unencrypted.')).toBeInTheDocument();
+		const test = vi.spyOn(r.remoteSource, 'testIndexerConnection').mockResolvedValue();
+		await fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+		expect(test).toHaveBeenCalledOnce();
+		await fireEvent.input(url, { target: { value: 'https://saved.example.com' } });
+		expect(screen.queryByText('HTTP is unencrypted.')).not.toBeInTheDocument();
+		expect(screen.getByText('HTTPS recommended.')).toBeInTheDocument();
+	});
+
+	it('opens connection help by click or focus and dismisses it before Settings on Escape', async () => {
+		const r = await renderOpenDialog();
+		const help = screen.getByRole('button', { name: 'About indexer connection security' });
+		expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+		await fireEvent.click(help);
+		expect(screen.getByRole('tooltip')).toHaveTextContent('Use HTTPS when available');
+		await fireEvent.keyDown(help, { key: 'Escape' });
+		expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+		expect(r.settings.dialog().isOpen).toBe(true);
+		await fireEvent.focusIn(help);
+		expect(screen.getByRole('tooltip')).toBeInTheDocument();
+		await fireEvent.focusOut(help, { relatedTarget: screen.getByLabelText('URL') });
+		expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+		await fireEvent.keyDown(help, { key: 'Escape' });
+		expect(r.settings.dialog().isOpen).toBe(false);
 	});
 
 	it('keeps Indexer drafts when another Settings field changes', async () => {

--- a/src/ui/appSettings/AppSettingsDialogView.tsx
+++ b/src/ui/appSettings/AppSettingsDialogView.tsx
@@ -134,6 +134,57 @@ function formatFdkSource(source: string): string {
 	}
 }
 
+function IndexerConnectionHelp(props: {
+	readonly open: boolean;
+	readonly setOpen: (open: boolean) => void;
+}): JSX.Element {
+	return (
+		<fieldset
+			class="app-settings-connection-help"
+			aria-label="Connection security help"
+			onMouseEnter={() => props.setOpen(true)}
+			onMouseLeave={(event) => {
+				if (!event.currentTarget.contains(document.activeElement)) props.setOpen(false);
+			}}
+			onFocusIn={() => props.setOpen(true)}
+			onFocusOut={(event) => {
+				if (
+					!(
+						event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)
+					)
+				) {
+					props.setOpen(false);
+				}
+			}}
+		>
+			<button
+				type="button"
+				class="app-settings-info-button"
+				aria-label="About indexer connection security"
+				aria-expanded={props.open}
+				aria-controls="app-settings-connection-help"
+				aria-describedby={props.open ? 'app-settings-connection-help' : undefined}
+				onClick={() => props.setOpen(true)}
+			>
+				i
+			</button>
+			<Show when={props.open}>
+				<div id="app-settings-connection-help" class="app-settings-help-content" role="tooltip">
+					<strong>Use HTTPS when available</strong>
+					<p>
+						HTTPS encrypts your API key, searches, and results and verifies the server’s identity.
+					</p>
+					<p>
+						Enable HTTPS on Prowlarr or your reverse proxy using a certificate trusted by this
+						device. Enter its matching HTTPS address here, then choose Test.
+					</p>
+					<p>HTTP remains available if you accept an unencrypted connection.</p>
+				</div>
+			</Show>
+		</fieldset>
+	);
+}
+
 export function AppSettingsDialogView(): JSX.Element {
 	const runtime = useAppRuntime();
 	const settings = runtime.settings;
@@ -141,6 +192,11 @@ export function AppSettingsDialogView(): JSX.Element {
 	const state = settings.dialog;
 	const isOpen = createMemo(() => state().isOpen);
 	const indexerConnection = remoteSource.indexerConnection;
+	const [indexerHelpOpen, setIndexerHelpOpen] = createSignal(false);
+	const usesHttp = () => /^http:\/\//i.test(indexerConnection().baseUrlDraft.trim());
+	createEffect(() => {
+		if (!isOpen()) setIndexerHelpOpen(false);
+	});
 	const [resetConfirming, setResetConfirming] = createSignal(false);
 	const [afterburnerRevision, setAfterburnerRevision] = createSignal(0);
 	let resetConfirmTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -205,7 +261,10 @@ export function AppSettingsDialogView(): JSX.Element {
 		<Dialog
 			id="app-settings-modal"
 			open={state().isOpen}
-			onClose={() => settings.closeDialog()}
+			onClose={() => {
+				if (indexerHelpOpen()) setIndexerHelpOpen(false);
+				else settings.closeDialog();
+			}}
 			labelledBy="app-settings-title"
 			testId="app-settings-modal"
 		>
@@ -332,10 +391,12 @@ export function AppSettingsDialogView(): JSX.Element {
 									</div>
 								</section>
 								<section class="app-settings-section">
-									<h4 class="app-settings-section-title">Indexer connection</h4>
+									<div class="app-settings-connection-heading">
+										<h4 class="app-settings-section-title">Indexer connection</h4>
+										<IndexerConnectionHelp open={indexerHelpOpen()} setOpen={setIndexerHelpOpen} />
+									</div>
 									<p class="muted-text">
-										Configure your Indexer URL, API key, and audiobook categories. The API key is
-										stored securely and is never shown again after save.
+										Your API key is stored in your operating system’s credential store.
 									</p>
 									<div class="app-settings-path-row">
 										<label class="app-settings-field-label" for="app-settings-indexer-url">
@@ -346,7 +407,8 @@ export function AppSettingsDialogView(): JSX.Element {
 											class="app-settings-path-input"
 											data-testid="app-settings-indexer-url"
 											type="text"
-											placeholder="http://192.168.0.20:9696"
+											placeholder="https://prowlarr.example.com"
+											aria-describedby="app-settings-connection-security"
 											value={indexerConnection().baseUrlDraft}
 											onInput={(event) =>
 												remoteSource.patchIndexerConnectionSettings({
@@ -355,6 +417,12 @@ export function AppSettingsDialogView(): JSX.Element {
 											}
 										/>
 									</div>
+									<p id="app-settings-connection-security" class="app-settings-connection-security">
+										<Show when={usesHttp()} fallback="HTTPS recommended.">
+											<strong>HTTP is unencrypted.</strong> Your API key, searches, and results
+											could be read or modified by someone able to intercept this connection.
+										</Show>
+									</p>
 									<div class="app-settings-path-row">
 										<label class="app-settings-field-label" for="app-settings-indexer-category">
 											Categories

--- a/src/ui/appSettings/appSettingsDialog.css
+++ b/src/ui/appSettings/appSettingsDialog.css
@@ -153,3 +153,76 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+.app-settings-connection-heading {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	position: relative;
+}
+
+.app-settings-connection-heading .app-settings-section-title {
+	margin-bottom: 0;
+}
+
+.app-settings-info-button {
+	display: grid;
+	place-items: center;
+	width: 1.15rem;
+	height: 1.15rem;
+	margin: 0;
+	padding: 0;
+	border: 1px solid var(--text-secondary);
+	border-radius: 50%;
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-secondary);
+	font-size: 0.75rem;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.app-settings-info-button:hover,
+.app-settings-info-button:focus-visible {
+	color: var(--text-primary);
+	border-color: var(--accent-primary);
+}
+
+.app-settings-info-button:focus-visible {
+	outline: 2px solid var(--accent-primary);
+	outline-offset: 2px;
+}
+
+.app-settings-help-content {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	z-index: 20;
+	width: min(24rem, 100%);
+	box-sizing: border-box;
+	padding: 0.75rem;
+	border: 1px solid var(--border-primary);
+	border-radius: 0.375rem;
+	background: var(--bg-panel);
+	color: var(--text-primary);
+	font-size: 0.78rem;
+	line-height: 1.5;
+}
+
+.app-settings-help-content p {
+	margin: 0.5rem 0 0;
+}
+
+.app-settings-connection-security {
+	margin: 0.35rem 0 0;
+	color: var(--text-secondary);
+	font-size: 0.76rem;
+	line-height: 1.45;
+}
+
+.app-settings-connection-help {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	min-width: 0;
+}

--- a/src/ui/remoteSource/AGENTS.md
+++ b/src/ui/remoteSource/AGENTS.md
@@ -15,5 +15,8 @@ the view does not hydrate account state or construct selection-state patches.
 
 Cover-preview scheduling follows the visible titles and is cancelled when the
 view no longer needs it. Resources and caches remain private to the owner.
+Indexer results are a list with separate selection buttons and source-page
+links; opening details preserves selection and the current search.
+
 Remote source IPC routes through `src/lib/tauri/client.ts`. Materialized audio
 imports through Input Session; processing remains user-triggered.

--- a/src/ui/remoteSource/RemoteSourceAcquireView.test.tsx
+++ b/src/ui/remoteSource/RemoteSourceAcquireView.test.tsx
@@ -329,15 +329,90 @@ describe('RemoteSourceAcquireView close wiring', () => {
 		));
 		await openConnected(runtime, 'indexer', releases);
 		await fireEvent.click(screen.getByRole('button', { name: /Release from 8/ }));
-		expect(screen.getByRole('option', { name: /Release from 7/ })).toHaveAttribute(
-			'aria-selected',
+		expect(screen.getByRole('button', { name: /Release from 7/ })).toHaveAttribute(
+			'aria-pressed',
 			'false',
 		);
-		expect(screen.getByRole('option', { name: /Release from 8/ })).toHaveAttribute(
-			'aria-selected',
+		expect(screen.getByRole('button', { name: /Release from 8/ })).toHaveAttribute(
+			'aria-pressed',
 			'true',
 		);
 		await fireEvent.click(screen.getByRole('button', { name: 'Grab' }));
 		await vi.waitFor(() => expect(grab).toHaveBeenCalledWith({ release: releases[1] }));
+	});
+	it('sorts loaded releases, opens source details, and preserves manual follow-up after a failed grab', async () => {
+		const releases: RemoteRelease[] = [
+			{
+				providerId: 'indexer',
+				guid: 'popular',
+				indexerId: 19,
+				title: 'Holmes single',
+				indexer: 'MyAnonamouse',
+				sizeBytes: 100,
+				protocol: 'torrent',
+				seeders: 80,
+				categories: [],
+			},
+			{
+				providerId: 'indexer',
+				guid: 'collection',
+				indexerId: 20,
+				title: 'Holmes collection',
+				indexer: 'AudioBookBay (Jackett)',
+				sizeBytes: 900,
+				protocol: 'torrent',
+				seeders: 1,
+				detailUrl: 'https://example.test/books/holmes',
+				categories: [{ id: 3000, name: 'Audio' }],
+			},
+		];
+		const openUrl = vi.spyOn(tauriClient, 'openUrl').mockResolvedValue(undefined);
+		const grab = vi.spyOn(tauriClient, 'grabRemoteSourceRelease').mockResolvedValue({
+			providerId: 'indexer',
+			accepted: false,
+			message: 'Indexer could not grab this release.',
+			diagnostics: [],
+		});
+		runtime = createTestAppRuntime();
+		render(() => (
+			<AppRuntimeProvider runtime={runtime!}>
+				<RemoteSourceAcquireView />
+			</AppRuntimeProvider>
+		));
+		await openConnected(runtime, 'indexer', releases);
+		const rows = () => screen.getAllByRole('button', { name: /Holmes/ });
+		expect(rows()[0]).toHaveTextContent('Holmes single');
+		await fireEvent.click(rows()[1]);
+		await fireEvent.change(screen.getByLabelText('Sort by'), { target: { value: 'size' } });
+		expect(rows()[0]).toHaveTextContent('Holmes collection');
+		expect(rows()[0]).toHaveAttribute('aria-pressed', 'true');
+		await fireEvent.input(screen.getByLabelText('Filter'), { target: { value: 'collection' } });
+		expect(rows()).toHaveLength(1);
+		const details = screen.getByRole('link', { name: 'View details for Holmes collection' });
+		await fireEvent.click(details);
+		expect(openUrl).toHaveBeenCalledExactlyOnceWith(releases[1].detailUrl);
+		expect(runtime.remoteSource.view().selectedRelease).toEqual({
+			guid: 'collection',
+			indexerId: 20,
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Grab' }));
+		await vi.waitFor(() =>
+			expect(screen.getByText('Indexer could not grab this release.')).toBeInTheDocument(),
+		);
+		expect(grab).toHaveBeenCalledExactlyOnceWith({ release: releases[1] });
+		expect(details).toHaveAttribute('href', releases[1].detailUrl);
+		await fireEvent.click(details);
+		expect(openUrl).toHaveBeenCalledTimes(2);
+		expect(screen.getByLabelText('Filter')).toHaveValue('collection');
+		await fireEvent.input(screen.getByLabelText('Filter'), { target: { value: '' } });
+		await fireEvent.change(screen.getByLabelText('Sort by'), { target: { value: 'seeders' } });
+		expect(rows()[0]).toHaveTextContent('Holmes single');
+		expect(screen.getAllByRole('link', { name: /View details/ })).toHaveLength(1);
+		openUrl.mockRejectedValueOnce(new Error('Browser unavailable'));
+		await fireEvent.click(details);
+		await vi.waitFor(() =>
+			expect(screen.getByText('Could not open the source page.')).toBeInTheDocument(),
+		);
+		expect(runtime.remoteSource.view().isOpen).toBe(true);
 	});
 });

--- a/src/ui/remoteSource/RemoteSourceAcquireView.tsx
+++ b/src/ui/remoteSource/RemoteSourceAcquireView.tsx
@@ -1,4 +1,6 @@
-import { createEffect, For, onCleanup, Show, type JSX } from 'solid-js';
+import { createEffect, createSignal, For, onCleanup, Show, type JSX } from 'solid-js';
+import { tauriClient } from '../../lib/tauri/client';
+import { toUserMessage } from '../../lib/tauri/appError';
 
 import type { AcquisitionLane } from '../../types/appSettings';
 import {
@@ -97,6 +99,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 	const visibleReleases = () =>
 		visibleRemoteReleases(view().releases, {
 			releaseFilter: view().releaseFilter,
+			releaseSort: view().releaseSort,
 		});
 
 	function handleLaneChange(lane: AcquisitionLane): void {
@@ -287,6 +290,21 @@ export function RemoteSourceAcquireView(): JSX.Element {
 								onInput={(event) => editSearch({ releaseFilter: event.currentTarget.value })}
 							/>
 						</div>
+						<div class="remote-source-toolbar-field remote-source-sort">
+							<label for="remote-source-release-sort">Sort by</label>
+							<select
+								id="remote-source-release-sort"
+								value={view().releaseSort}
+								onChange={(event) =>
+									editSearch({
+										releaseSort: event.currentTarget.value === 'size' ? 'size' : 'seeders',
+									})
+								}
+							>
+								<option value="seeders">Most seeders</option>
+								<option value="size">Largest first</option>
+							</select>
+						</div>
 						<div class="remote-source-toolbar-field remote-source-toolbar-button">
 							<Button
 								disabled={view().isBusy || !view().selectedRelease}
@@ -422,9 +440,8 @@ export function RemoteSourceAcquireView(): JSX.Element {
 				</Show>
 
 				<Show when={isIndexerLane() && view().accountState?.status === 'connected'}>
-					<div
+					<ul
 						class="app-modal-results remote-release-list"
-						role="listbox"
 						aria-label="Indexer releases"
 						data-testid="remote-release-list"
 					>
@@ -440,7 +457,7 @@ export function RemoteSourceAcquireView(): JSX.Element {
 								/>
 							)}
 						</For>
-					</div>
+					</ul>
 				</Show>
 			</Dialog.Body>
 		</Dialog>
@@ -455,16 +472,31 @@ function ReleaseRow(props: {
 	const seedersLabel = () =>
 		props.release.seeders == null ? null : `${props.release.seeders} seeders`;
 	const indexerLabel = () => props.release.indexer.trim();
+	const [detailError, setDetailError] = createSignal('');
+
+	async function openDetails(event: MouseEvent, url: string): Promise<void> {
+		event.preventDefault();
+		setDetailError('');
+		try {
+			await tauriClient.openUrl(url);
+		} catch (cause) {
+			setDetailError(
+				toUserMessage(cause, {
+					fallback: 'Could not open the source page.',
+					suppressUnknown: true,
+				}),
+			);
+		}
+	}
 
 	return (
-		<div
-			class="remote-release-row"
-			classList={{ selected: props.selected }}
-			role="option"
-			tabIndex={-1}
-			aria-selected={props.selected ? 'true' : 'false'}
-		>
-			<button type="button" class="remote-release-button" onClick={() => props.onSelect()}>
+		<li class="remote-release-row" classList={{ selected: props.selected }}>
+			<button
+				type="button"
+				class="remote-release-button"
+				aria-pressed={props.selected}
+				onClick={() => props.onSelect()}
+			>
 				<span class="remote-release-title">{props.release.title}</span>
 				<span class="remote-release-meta">
 					<span class={`remote-release-tag remote-release-tag-${props.release.protocol}`}>
@@ -486,6 +518,26 @@ function ReleaseRow(props: {
 					</span>
 				</span>
 			</button>
-		</div>
+			<Show when={props.release.detailUrl}>
+				{(url) => (
+					<div class="remote-release-details">
+						<a
+							href={url()}
+							target="_blank"
+							rel="noreferrer"
+							aria-label={`View details for ${props.release.title}`}
+							onClick={(event) => void openDetails(event, url())}
+						>
+							View details <span aria-hidden="true">↗</span>
+						</a>
+						<Show when={detailError()}>
+							<p class="remote-release-detail-error" role="status">
+								{detailError()}
+							</p>
+						</Show>
+					</div>
+				)}
+			</Show>
+		</li>
 	);
 }

--- a/src/ui/remoteSource/remoteSourceAcquire.css
+++ b/src/ui/remoteSource/remoteSourceAcquire.css
@@ -35,6 +35,7 @@
 }
 
 .remote-source-provider select,
+.remote-source-sort select,
 .remote-source-filter input[type="search"],
 .remote-source-handoff input,
 .remote-source-indexer-author input,
@@ -195,13 +196,22 @@
 	color: var(--text-secondary);
 }
 
+.remote-source-sort {
+	flex: 0 0 10rem;
+}
+
 .remote-release-list {
+	list-style: none;
+	margin: 0;
 	max-height: min(36rem, 55vh);
 	overflow-y: auto;
 	padding: 0;
 }
 
 .remote-release-row {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
 	border-bottom: 1px solid var(--border-primary);
 }
 
@@ -215,7 +225,8 @@
 
 .remote-release-button {
 	display: flex;
-	width: 100%;
+	flex: 1;
+	min-width: 0;
 	flex-direction: column;
 	gap: 0.125rem;
 	padding: 0.65rem 0.75rem;
@@ -288,4 +299,25 @@
 	.remote-source-toolbar-button {
 		flex: 1 1 100%;
 	}
+}
+
+.remote-release-details {
+	flex: 0 0 auto;
+	max-width: 12rem;
+	padding-right: 0.75rem;
+	font-size: 0.75rem;
+}
+
+.remote-release-details a {
+	color: var(--accent-primary);
+	white-space: nowrap;
+}
+
+.remote-release-details a:hover {
+	text-decoration: underline;
+}
+
+.remote-release-detail-error {
+	margin: 0.25rem 0 0;
+	color: var(--text-secondary);
 }


### PR DESCRIPTION
Indexer searches now offer **Most seeders** (default) and **Largest first** ordering, with seeders breaking size ties. Each release with a valid source URL has a **View details** link that opens the default browser while preserving the query, filter, ordering, and selection. A failed Prowlarr grab leaves that selection available for retry or manual source-page follow-up.

Prowlarr mapping carries an optional detail URL from `infoUrl`, falling back to `commentUrl`. It accepts HTTP/HTTPS URLs without embedded credentials and does not infer a source page from a GUID. New connections and empty category settings default to Audio (3000) plus Audiobook (3030); explicit saved categories remain respected. Generated bindings, the native opener capability, and owner guidance match the new surface.

Settings now recommend HTTPS, show a concise explanation of unencrypted HTTP traffic, and offer accessible connection-security help beside the indexer heading. Explicit HTTP connections remain supported. Connection validation rejects embedded URL credentials on load, save, and draft testing. Previously saved unsafe URLs return a credential-free error with instructions to remove the invalid configuration and reconnect, before settings IPC or provider requests can use them. API keys continue to use the operating-system credential store.

Validation:
- 21 focused Rust indexer tests passed, including HTTP request/response mapping, category defaults, and URL selection.
- Focused frontend selection/view tests passed (39), including sort/filter changes, source opening, grab failure, retained selection, and retry.
- Tauri contract tests, generated binding drift check, runtime-boundary check, typecheck, formatting, and lint passed.
- Workspace Clippy passed with one existing long-function warning in `metadata/embedded_cover.rs`; deferred to its metadata owner because it is unrelated to this change.
- Native macOS bundle: live search returned 337 releases; verified filtering, descending size ordering, selection, and an AudioBookBay source page opening in Safari with app state retained. No real download was queued during verification.
- Latest settings changes: 16 frontend tests passed, including HTTPS guidance, nonblocking HTTP, and help dismissal. Credential URL regression was reproduced with a failing test before the fix.
- Updated native macOS bundle built successfully; visually verified security-help layout and Escape dismissal while Settings remains open. Typecheck, formatting, lint, and workspace Clippy passed.
- Review finding follow-up: the persisted-URL regression failed before the fix and passed afterward. All 21 indexer tests passed (0.126s execution), and six relevant frontend files passed with 76 tests (1.49s). Rust formatting and Clippy passed, with the same pre-existing metadata warning.
